### PR TITLE
Use SafeMath for most uint operations

### DIFF
--- a/contracts/Derivative.sol
+++ b/contracts/Derivative.sol
@@ -8,6 +8,7 @@
 pragma solidity ^0.4.22;
 
 import "installed_contracts/oraclize-api/contracts/usingOraclize.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 
 // This interface allows us to get the Ethereum-USD exchange rate
@@ -17,6 +18,10 @@ contract VoteCoinInterface {
 
 
 contract Derivative {
+
+    // Note: SafeMath only works for uints right now.
+    using SafeMath for uint;
+
     // Financial information
     mapping(address => int256) public balances; // Stored in Wei
     int256 public defaultPenalty;  //
@@ -44,7 +49,7 @@ contract Derivative {
 
         // Contract states
         startTime = now;
-        endTime = startTime + _duration;
+        endTime = startTime.add(_duration);
         defaultPenalty = _defaultPenalty;
         requiredMargin = _requiredMargin;
         npv = setNpv();

--- a/contracts/Vote.sol
+++ b/contracts/Vote.sol
@@ -10,6 +10,7 @@
 */
 pragma solidity ^0.4.24;
 
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "installed_contracts/oraclize-api/contracts/usingOraclize.sol";
@@ -17,6 +18,9 @@ import "./Derivative.sol";
 
 
 contract VoteCoin is ERC20, usingOraclize {
+
+    // Note: SafeMath only works for uints right now.
+    using SafeMath for uint;
 
     struct DerivativeContract {
         address owner;
@@ -118,7 +122,7 @@ contract VoteCoin is ERC20, usingOraclize {
     }
 
     function newVote() private {
-        currVoteId++;
+        currVoteId = currVoteId.add(1);
 
         allVotes[currVoteId] = VoteYesNo(new address[](0), 0, false, now, now);
         emit NewVote(currVoteId);
@@ -137,13 +141,13 @@ contract VoteCoin is ERC20, usingOraclize {
             currVoter = allVotes[_voteId].voters[i];
             currProposalVote = allVotes[_voteId].votedFor[currVoter];
             currWeight = balanceOf(currVoter);
-            totalWeight = totalWeight + currWeight;
+            totalWeight = totalWeight.add(currWeight);
             if (currProposalVote == 1) {
-                voted1 = voted1 + currWeight;
+                voted1 = voted1.add(currWeight);
             }
         }
 
-        winningProposal = totalWeight-voted1 < voted1 ? 1 : 0;
+        winningProposal = totalWeight.sub(voted1) < voted1 ? 1 : 0;
     }
 
     function tallyVote(uint _voteId) private {


### PR DESCRIPTION
SafeMath adds checks to uint operations (signed ints coming soon! https://github.com/OpenZeppelin/openzeppelin-solidity/pull/835). Basically integer operations can create security bugs because integers can overflow or underflow given certain inputs. While SafeMath doesn't completely solve the issue, it does revert any transaction where an over/underflow occurs.

A few notes:
- SafeMath does add gas overhead in *most* cases (there may be one exception where a multiply by `0` is cheaper in SafeMath), but I think it's well worth the cost in offloading a certain class of security concerns.
- I didn't use SafeMath for `i++` in for loops because they are generally just adding `1` until they reach some number that is already a `uint`, so it's pretty clear that they won't overflow. Also the gas overhead might be non-negligible here.

Partially solves #3.