### PR TITLE
Introduce state enum to supersede the bools and add prefunded logic

### DIFF
--- a/contracts/Derivative.sol
+++ b/contracts/Derivative.sol
@@ -214,7 +214,7 @@ contract Derivative {
         }
     }
 
-    // Gets the change change in balance for the owners account when the most recent NPV is applied.
+    // Gets the change in balance for the owners account when the most recent NPV is applied.
     // Note: there's a function for this because signage is tricky here, and it must be done the same everywhere.
     function getOwnerNpvDiff(int256 npvNew) internal view returns (int256 ownerNpvDiff) {
         return npv - npvNew;


### PR DESCRIPTION
This introduces a state enum to replace any booleans we were using to keep state. This will ultimately help us track the state of the contract more easily. I added added some logic to make the prefunded state make sense. There's also some minor cleanup done related to functioning out certain parts of the logic that are or will need to be reused, changing names of functions for clarity, and adding view to a few methods.