### PR TITLE
Add Solidity Coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,16 @@ jobs:
           command: npx truffle test --network ci
   coverage:
     docker:
-      # TODO(mrice32): we made a compromise here to get solidity-coverage to work. We're just creating a new build
-      # inside the trufflesuite/ganache-cli for solidity-coverage. This is because there were issues (not 100% sure
-      # about the cause) with getting solidity-coverage's testrpc to run correctly in the remote image. However,
-      # it cannot run locally without the opened 8545 port that this image has. So the solution we chose was to
-      # just run coverage within that docker image. Caching doesn't seem to work cross-image, so we have to re-checkout
-      # the repo and reinstall deps. We could have also run all the above tests inside this new image. However, we
-      # want to ensure that there is no implicit dependence on the bundled deps or setup inside the
-      # trufflesuite/ganache-cli image, so we want to continue generic testing against the bare node image.
+      # Note: we made a compromise here to get solidity-coverage to work. We're just creating a new build inside the
+      # trufflesuite/ganache-cli for solidity-coverage. This is because there were issues (not 100% sure about the
+      # cause) with getting solidity-coverage's testrpc to run correctly in the remote image. However, it cannot run
+      # locally without the opened 8545 port that this image has. So the solution we chose was to just run coverage
+      # within that docker image. Caching doesn't seem to work cross-image, so we have to re-checkout the repo and
+      # reinstall deps. We could have also run all the above tests inside this new image. However, we want to ensure
+      # that there is no implicit dependence on the bundled deps or setup inside the trufflesuite/ganache-cli image,
+      # so we want to continue generic testing against the bare node image.
+      # TODO(mrice32): we could probably fix this if we just created our own image on top of the node image that opens
+      # port 8545.
       - image: trufflesuite/ganache-cli
     working_directory: ~/protocol
     steps:


### PR DESCRIPTION
WIP - testing CI integration.

This took a decent amount of debugging to get it to work correctly. As such, this fragile setup should be in the CI process to ensure we don't break it in the future.

Note: CI runs coverage, but it does not publish the report anywhere. This is something we might want to add in the future if we want to:
1. Pay a vendor.
2. Do something like [this](https://github.com/envoyproxy/envoy/blob/master/ci/coverage_publish.sh) to publish to our own storage on GCloud or AWS.