### PR TITLE
First cut at the voting API

### DIFF
--- a/contracts/VoteInterface.sol
+++ b/contracts/VoteInterface.sol
@@ -26,7 +26,7 @@ contract VoteInterface {
     // Reveals the sender's previously committed vote for a particular poll.
     // Note: this function will fail if keccak256(abi.encodePacked(voteOption, salt)) doesn't match the secretHash,
     // this pollId is not currently active, or if the contract is not in the reveal period.
-    function revealVote(uint pollId, uint voteOption, uint salt) external;
+    function revealVote(uint pollId, bool voteOption, uint salt) external;
 
     // Returns the commit and reveal periods for the active polls. 
     function getCurrentCommitRevealPeriods() external view returns (Period commit, Period reveal);
@@ -34,9 +34,11 @@ contract VoteInterface {
     // Returns the current period type ("commit", "reveal", or "none").
     function getCurrentPeriodType() external view returns (string periodType);
 
-    // Gets the active or upcoming (if getCurrentPeriodType() type returns "none") pollId for this product.
-    // Note: this function will fail if this contract is not publishing prices for that symbol. 
-    function getPollIdForProduct(string product) external view returns (uint pollId);
+    // Gets the active pollId.
+    function getActivePoll() external view returns (uint pollId);
+
+    // Gets the product that the price votes apply to.
+    function getProduct() external view returns (string product);
 
     // Gets the proposed price-time pairs for a particular pollId.
     // Note: this function will fail if the pollId is not active.


### PR DESCRIPTION
This voting API assumes:
1. Commit-reveal.
2. All polls have the same commit reveal schedule.
3. All polls are for considering prices of string-specified symbols.

Please feel free to suggest simplifications and nit the comment language - this is certainly not the final version and we want this to be as simple and well specified as possible.