### PR TITLE
Add depositAndCreate

### DIFF
--- a/contracts/TokenizedDerivative.sol
+++ b/contracts/TokenizedDerivative.sol
@@ -371,7 +371,7 @@ contract TokenizedDerivative is ERC20 {
     }
 
     function _getRequiredEthMargin(int currentNav)
-        internal
+        private
         view
         returns (int requiredEthMargin)
     {
@@ -380,7 +380,7 @@ contract TokenizedDerivative is ERC20 {
 
     // Function is internally only called by `_settleAgreedPrice` or `_settleVerifiedPrice`. This function handles all 
     // of the settlement logic including assessing penalties and then moves the state to `Settled`.
-    function _settle(int price) internal {
+    function _settle(int price) private {
 
         // Remargin at whatever price we're using (verified or unverified).
         _updateBalances(_recomputeNav(price, endTime));
@@ -400,13 +400,13 @@ contract TokenizedDerivative is ERC20 {
         state = State.Settled;
     }
 
-    function _settleAgreedPrice() internal {
+    function _settleAgreedPrice() private {
         int agreedPrice = currentTokenState.underlyingPrice;
 
         _settle(agreedPrice);
     }
 
-    function _settleVerifiedPrice() internal {
+    function _settleVerifiedPrice() private {
         (uint timeForPrice, int oraclePrice, ) = v2Oracle.getPrice(product, endTime);
         require(timeForPrice != 0);
 
@@ -417,7 +417,7 @@ contract TokenizedDerivative is ERC20 {
     // The internal remargin method allows certain calls into the contract to
     // automatically remargin to non-current NAV values (time of expiry, last
     // agreed upon price, etc).
-    function _remargin(int navNew, uint latestTime) internal returns (bool inDefault) {
+    function _remargin(int navNew, uint latestTime) private returns (bool inDefault) {
         // Save the current NAV in case it's required to compute the default penalty.
         int previousNav = nav;
 
@@ -433,7 +433,7 @@ contract TokenizedDerivative is ERC20 {
         }
     }
 
-    function _updateBalances(int navNew) internal {
+    function _updateBalances(int navNew) private {
         // Compute difference -- Add the difference to owner and subtract
         // from counterparty. Then update nav state variable.
         int longDiff = _getLongNavDiff(navNew);
@@ -444,7 +444,7 @@ contract TokenizedDerivative is ERC20 {
     }
 
     function _satisfiesMarginRequirement(int balance, int currentNav)
-        internal
+        private
         view
         returns (bool doesSatisfyRequirement) 
     {
@@ -453,15 +453,15 @@ contract TokenizedDerivative is ERC20 {
 
     // Gets the change in balance for the long side.
     // Note: there's a function for this because signage is tricky here, and it must be done the same everywhere.
-    function _getLongNavDiff(int navNew) internal view returns (int longNavDiff) {
+    function _getLongNavDiff(int navNew) private view returns (int longNavDiff) {
         return navNew.sub(nav);
     }
 
-    function _getDefaultPenaltyEth() internal view returns (int penalty) {
+    function _getDefaultPenaltyEth() private view returns (int penalty) {
         return _takePercentage(navAtDefault, defaultPenalty);
     }
 
-    function _tokensFromNav(int currentNav, int unitNav) internal pure returns (int numTokens) {
+    function _tokensFromNav(int currentNav, int unitNav) private pure returns (int numTokens) {
         if (unitNav <= 0) {
             return 0;
         } else {

--- a/test/TokenizedDerivative.js
+++ b/test/TokenizedDerivative.js
@@ -299,7 +299,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative();
 
     // Sponsor initializes contract.
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.2", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.2", "ether")
+    });
 
     // Verify initial state, nav, and balances.
     const initialNav = await derivativeContract.nav();
@@ -361,7 +364,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative();
 
     // Sponsor initializes contract.
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.2", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.2", "ether")
+    });
 
     // Verify initial state, nav, and balances.
     const initialNav = await derivativeContract.nav();
@@ -406,7 +412,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative();
 
     // Sponsor initializes contract
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.2", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.2", "ether")
+    });
 
     let nav = await derivativeContract.nav();
     const disputeTime = (await deployedManualPriceFeed.latestPrice(identifierBytes))[0];
@@ -457,7 +466,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative();
 
     // Sponsor initializes contract
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.5", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.5", "ether")
+    });
 
     let nav = await derivativeContract.nav();
 
@@ -505,7 +517,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative(priceFeedUpdatesInterval);
 
     // Sponsor initializes contract
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.5", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.5", "ether")
+    });
 
     // Verify initial state.
     const initialNav = await derivativeContract.nav();
@@ -555,7 +570,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative(priceFeedUpdatesInterval);
 
     // Sponsor initializes contract
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.5", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.5", "ether")
+    });
 
     // Verify initial state.
     const initialNav = await derivativeContract.nav();
@@ -598,7 +616,10 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative(priceFeedUpdatesInterval * 3);
 
     // Sponsor initializes contract
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.5", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.5", "ether")
+    });
 
     // Verify initial nav and balances. No time based fees have been assessed yet.
     let expectedNav = web3.utils.toBN(web3.utils.toWei("1", "ether"));
@@ -680,24 +701,34 @@ contract("TokenizedDerivative", function(accounts) {
     await deployNewTokenizedDerivative(priceFeedUpdatesInterval);
 
     // Sponsor initializes contract
-    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.6", "ether") });
+    await derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+      from: sponsor,
+      value: web3.utils.toWei("1.6", "ether")
+    });
 
     // Push time forward, so that the contract will expire when remargin is called.
     await pushPrice(web3.utils.toWei("1", "ether"));
 
     // Tokens cannot be created because the contract has expired.
-    assert(await didContractThrow(derivativeContract.createTokens({ from: sponsor, value: web3.utils.toWei("1", "ether") })));
+    assert(
+      await didContractThrow(derivativeContract.createTokens({ from: sponsor, value: web3.utils.toWei("1", "ether") }))
+    );
   });
 
   it("DepositAndCreateTokens failure", async function() {
+    // A new TokenizedDerivative must be deployed before the start of each test case.
+    // One time step until expiry.
+    await deployNewTokenizedDerivative(priceFeedUpdatesInterval);
 
-      // A new TokenizedDerivative must be deployed before the start of each test case.
-      // One time step until expiry.
-      await deployNewTokenizedDerivative(priceFeedUpdatesInterval);
-
-      // Token creation should fail because the sponsor doesn't supply enough margin.
-      assert(await didContractThrow(derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), { from: sponsor, value: web3.utils.toWei("1.05", "ether") })));
-
+    // Token creation should fail because the sponsor doesn't supply enough margin.
+    assert(
+      await didContractThrow(
+        derivativeContract.depositAndCreateTokens(web3.utils.toWei("1", "ether"), {
+          from: sponsor,
+          value: web3.utils.toWei("1.05", "ether")
+        })
+      )
+    );
   });
 
   it("Unsupported product", async function() {


### PR DESCRIPTION
As a part of collapsing the investor and provider, we have a new convenience function to deposit short margin and create fresh tokens.

This change includes minor cleanup:
1. Moved some leftover instances of `provider` -> `sponsor`.
2. Corrected some instances of `didContractThrow()` that were being called without a preceding `await`.
3. Made all internal methods private since we're not inheriting from `TokenizedDerivative`, and we should be more restrictive wrt visibility until requirements force us to be less restrictive.