### PR TITLE
Rename V2Oracle to Oracle

### DIFF
--- a/contracts/CentralizedOracle.sol
+++ b/contracts/CentralizedOracle.sol
@@ -1,7 +1,7 @@
 /*
   CentralizedOracle implementation.
 
-  Implementation of V2OracleInterface that allows the owner to provide verified prices.
+  Implementation of OracleInterface that allows the owner to provide verified prices.
 */
 pragma solidity ^0.5.0;
 
@@ -9,12 +9,12 @@ pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./V2OracleInterface.sol";
+import "./OracleInterface.sol";
 import "./Testable.sol";
 
 
 // Implements an oracle that allows the owner to push prices for queries that have been made.
-contract CentralizedOracle is V2OracleInterface, Ownable, Testable {
+contract CentralizedOracle is OracleInterface, Ownable, Testable {
     using SafeMath for uint;
 
     // This contract doesn't implement the voting routine, and naively indicates that all requested prices will be

--- a/contracts/ContractCreator.sol
+++ b/contracts/ContractCreator.sol
@@ -5,12 +5,12 @@ import "./Registry.sol";
 
 contract ContractCreator {
     Registry internal registry;
-    address internal v2OracleAddress;
+    address internal oracleAddress;
     address internal priceFeedAddress;
 
-    constructor(address registryAddress, address _v2OracleAddress, address _priceFeedAddress) public {
+    constructor(address registryAddress, address _oracleAddress, address _priceFeedAddress) public {
         registry = Registry(registryAddress);
-        v2OracleAddress = _v2OracleAddress;
+        oracleAddress = _oracleAddress;
         priceFeedAddress = _priceFeedAddress;
     }
 

--- a/contracts/OracleInterface.sol
+++ b/contracts/OracleInterface.sol
@@ -1,13 +1,12 @@
 /*
-  V2OracleInterface contract.
+  OracleInterface contract.
   The interface that contracts use to query a verified, trusted price.
 */
 pragma solidity ^0.5.0;
 
 
 // This interface allows contracts to query a verified, trusted price.
-// TODO(ptare): Blow away OracleInterface and remove the V2 from this name.
-interface V2OracleInterface {
+interface OracleInterface {
     // Returns an Oracle-verified price for identifier if available, otherwise returns `timeForPrice`=0 and a
     // `verifiedTime` that corresponds to the next voting period after which a verified price will be available. If no
     // verified price will ever be available, returns `verifiedTime`=first Ethereum time.

--- a/contracts/TokenizedDerivative.sol
+++ b/contracts/TokenizedDerivative.sol
@@ -11,7 +11,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./ContractCreator.sol";
 import "./PriceFeedInterface.sol";
-import "./V2OracleInterface.sol";
+import "./OracleInterface.sol";
 
 
 contract ReturnCalculator {
@@ -96,7 +96,7 @@ contract TokenizedDerivative is ERC20 {
     // Other addresses/contracts
     address public sponsor;
     address public admin;
-    V2OracleInterface public v2Oracle;
+    OracleInterface public oracle;
     PriceFeedInterface public priceFeed;
     ReturnCalculator public returnCalculator;
 
@@ -150,7 +150,7 @@ contract TokenizedDerivative is ERC20 {
     constructor(
         address _sponsorAddress,
         address _adminAddress,
-        address _v2OracleAddress,
+        address _oracleAddress,
         address _priceFeedAddress,
         uint _defaultPenalty, // Percentage of nav*10^18
         uint _requiredMargin, // Percentage of nav*10^18
@@ -172,10 +172,10 @@ contract TokenizedDerivative is ERC20 {
         require(_startingTokenPrice <= uint(1 ether).mul(10**9));
 
         // Address information
-        v2Oracle = V2OracleInterface(_v2OracleAddress);
+        oracle = OracleInterface(_oracleAddress);
         priceFeed = PriceFeedInterface(_priceFeedAddress);
         // Verify that the price feed and oracle support the given product.
-        require(v2Oracle.isIdentifierSupported(_product));
+        require(oracle.isIdentifierSupported(_product));
         require(priceFeed.isIdentifierSupported(_product));
 
         sponsor = _sponsorAddress;
@@ -407,7 +407,7 @@ contract TokenizedDerivative is ERC20 {
     }
 
     function _settleVerifiedPrice() private {
-        (uint timeForPrice, int oraclePrice, ) = v2Oracle.getPrice(product, endTime);
+        (uint timeForPrice, int oraclePrice, ) = oracle.getPrice(product, endTime);
         require(timeForPrice != 0);
 
         _settle(oraclePrice);
@@ -493,7 +493,7 @@ contract TokenizedDerivative is ERC20 {
         }
 
     function _requestOraclePrice(uint requestedTime) private {
-        (uint time, , ) = v2Oracle.getPrice(product, requestedTime);
+        (uint time, , ) = oracle.getPrice(product, requestedTime);
         if (time != 0) {
             // The Oracle price is already available, settle the contract right away.
             settle();
@@ -537,9 +537,9 @@ contract TokenizedDerivative is ERC20 {
 
 
 contract TokenizedDerivativeCreator is ContractCreator {
-    constructor(address registryAddress, address _v2OracleAddress, address _priceFeedAddress)
+    constructor(address registryAddress, address _oracleAddress, address _priceFeedAddress)
         public
-        ContractCreator(registryAddress, _v2OracleAddress, _priceFeedAddress) {} // solhint-disable-line no-empty-blocks
+        ContractCreator(registryAddress, _oracleAddress, _priceFeedAddress) {} // solhint-disable-line no-empty-blocks
 
     function createTokenizedDerivative(
         address sponsor,
@@ -559,7 +559,7 @@ contract TokenizedDerivativeCreator is ContractCreator {
         TokenizedDerivative derivative = new TokenizedDerivative(
             sponsor,
             admin,
-            v2OracleAddress,
+            oracleAddress,
             priceFeedAddress,
             defaultPenalty,
             requiredMargin,

--- a/migrations/2_deploy_VoteCoin.js
+++ b/migrations/2_deploy_VoteCoin.js
@@ -34,7 +34,6 @@ const shouldUseMockOracle = network => {
 
 module.exports = function(deployer, network, accounts) {
   let oracleAddress;
-  let v2OracleAddress;
   let priceFeedAddress;
   let registry;
   if (isDerivativeDemo(network)) {
@@ -44,7 +43,7 @@ module.exports = function(deployer, network, accounts) {
       })
       .then(deployedRegistry => {
         registry = deployedRegistry;
-        return deployer.deploy(TokenizedDerivativeCreator, registry.address, v2OracleAddress, priceFeedAddress, {
+        return deployer.deploy(TokenizedDerivativeCreator, registry.address, oracleAddress, priceFeedAddress, {
           from: accounts[0],
           value: 0
         });
@@ -74,18 +73,18 @@ module.exports = function(deployer, network, accounts) {
         return deployer.deploy(CentralizedOracle, enableControllableTiming(network));
       })
       .then(centralizedOracle => {
-        v2OracleAddress = centralizedOracle.address;
+        oracleAddress = centralizedOracle.address;
         return CentralizedOracle.deployed();
       })
       .then(() => {
-        return deployer.deploy(Registry, v2OracleAddress, { from: accounts[0], value: 0 });
+        return deployer.deploy(Registry, oracleAddress, { from: accounts[0], value: 0 });
       })
       .then(() => {
         return Registry.deployed();
       })
       .then(deployedRegistry => {
         registry = deployedRegistry;
-        return deployer.deploy(DerivativeCreator, registry.address, v2OracleAddress, priceFeedAddress);
+        return deployer.deploy(DerivativeCreator, registry.address, oracleAddress, priceFeedAddress);
       })
       .then(() => {
         return DerivativeCreator.deployed();
@@ -94,7 +93,7 @@ module.exports = function(deployer, network, accounts) {
         return registry.addContractCreator(derivativeCreator.address);
       })
       .then(() => {
-        return deployer.deploy(TokenizedDerivativeCreator, registry.address, v2OracleAddress, priceFeedAddress);
+        return deployer.deploy(TokenizedDerivativeCreator, registry.address, oracleAddress, priceFeedAddress);
       })
       .then(() => {
         return TokenizedDerivativeCreator.deployed();
@@ -115,7 +114,7 @@ module.exports = function(deployer, network, accounts) {
       })
       .then(deployedRegistry => {
         registry = deployedRegistry;
-        return deployer.deploy(DerivativeCreator, registry.address, v2OracleAddress, priceFeedAddress);
+        return deployer.deploy(DerivativeCreator, registry.address, oracleAddress, priceFeedAddress);
       })
       .then(() => {
         return DerivativeCreator.deployed();
@@ -124,7 +123,7 @@ module.exports = function(deployer, network, accounts) {
         return registry.addContractCreator(derivativeCreator.address);
       })
       .then(() => {
-        return deployer.deploy(TokenizedDerivativeCreator, registry.address, v2OracleAddress, priceFeedAddress);
+        return deployer.deploy(TokenizedDerivativeCreator, registry.address, oracleAddress, priceFeedAddress);
       })
       .then(() => {
         return TokenizedDerivativeCreator.deployed();


### PR DESCRIPTION
The previous OracleInterface and OracleMock have been deleted.

Fixes #88 