### PR TITLE
Fix CI Coverage

### DIFF
--- a/.solcover-ci.js
+++ b/.solcover-ci.js
@@ -1,7 +1,7 @@
 module.exports = {
   copyPackages: ["openzeppelin-solidity"],
-  compileCommand: "npx truffle compile",
-  testCommand: "npx truffle test --network ci_coverage",
+  compileCommand: "../node_modules/.bin/truffle compile",
+  testCommand: "../node_modules/.bin/truffle test --network ci_coverage",
   norpc: true,
   port: 8545
 };

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
   copyPackages: ["openzeppelin-solidity"],
-  compileCommand: "npx truffle compile",
-  testCommand: "npx truffle test --network coverage",
+  compileCommand: "../node_modules/.bin/truffle compile",
+  testCommand: "../node_modules/.bin/truffle test --network coverage",
   port: 8545,
 };

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     "ganache-cli": "^6.1.8",
     "node-fetch": "^2.3.0",
     "openzeppelin-solidity": "2.1.1",
-    "truffle": "^5.0.0",
-    "truffle-contract": "^4.0.0",
-    "truffle-hdwallet-provider": "^1.0.0-web3one.5",
-    "web3": "^1.0.0-beta.37"
+    "truffle": "5.0.2",
+    "truffle-contract": "4.0.2",
+    "truffle-hdwallet-provider": "1.0.0-web3one.5",
+    "web3": "1.0.0-beta.37",
+    "web3-core-promievent": "1.0.0-beta.37",
+    "web3-eth-abi": "1.0.0-beta.37",
+    "web3-utils": "1.0.0-beta.37"
   }
 }


### PR DESCRIPTION
- After a LOT of digging through npm dependencies and versioning, I discovered that the most recent web3 release (earlier today) broke the API between itself and various truffle packages in multiple ways. Because coverage pulls down new packages every run rather than relying on a circleci cache, it was the first to notice this update.
- npm's `^` operator won't protect us from picking up breaking changes in beta packages, like `web3@1.0.0-beta.XX`.
- `truffle-contract` depends on web3 sub-packages, like `web3-core-promievent`, that are installed separately and can have independent versions from the `web3` package. This was the part that was particularly difficult to dig out.
- To preempt `truffle-contract` from grabbing the most recent version of these web3 sub-packages, we explicitly pin the working versions of them in our `package.json` file despite the fact that nothing in our repository explicitly depends on them.
- Because the API between truffle and web3 is so sensitive, I'm pinning all of our truffle packages and the web3 sub-packages they depend on. It's necessary to pin the truffle packages because they will likely be updated soon to work with the new web3 API and break compatibility with the old one, which will break us again.

Sorry about the novel - I wanted to overexplain the issue here so if we ever need to reassess package versioning, we have a record of why we pinned these packages.