### PR TITLE
Fix Slither CI failure

### DIFF
--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -28,4 +28,4 @@ sudo rm -rf slither
 
 cd ~/protocol
 npx truffle compile
-python3.6 -m slither --truffle-version=latest --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send .
+python3.6 -m slither --truffle-version=latest --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,reentrancy-eth .


### PR DESCRIPTION
Slither started failing on master due to more sensitive reentrancy detection. This PR makes two changes:
1. Removes a real reentrancy issue that Slither detected. If the `Store` were malicious, it could've repeatedly called remargin to repeatedly take fees (we generally trust the `Store` and `Oracle`, so this wasn't really an issue, but it was worth changing nonetheless). I separated the balance deduction from the fee payment and moved the latter to the end of the _remargin() method.
2. Despite fixing the above issue, Slither still thinks that the Oracle fees cause reentrancy bugs because _remargin() is called before most non-view methods. These methods modify state after the Oracle fee is paid, so it thinks that they are vulnerable to reentrancy from the `Store`. They are not, however, because the _remargin() method makes all needed state changes related to fee payment before it pays the fee. This means I had to remove the `reentrancy-eth` detector from our CI to keep these errors from blocking PRs.