### PR TITLE
Create circleci coverage artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,9 +119,6 @@ jobs:
     working_directory: ~/protocol
     steps:
       - checkout
-      - run:
-          name: Update Certificates
-          command: sudo update-ca-certificates
       - restore_cache:
           keys:
             - echidna-dependency-cache-{{ checksum "package.json" }}


### PR DESCRIPTION
This PR will allow us to start viewing the coverage report under the artifacts tab of every coverage run, so we shouldn't have to ever generate it locally.