### PR TITLE
Replace 1 ether with FP_SCALING_FACTOR

### DIFF
--- a/contracts/CentralizedStore.sol
+++ b/contracts/CentralizedStore.sol
@@ -16,6 +16,7 @@ contract CentralizedStore is StoreInterface, Withdrawable {
     using SafeMath for uint;
 
     uint private fixedOracleFeePerSecond; // Percentage of 10^18. E.g., 1e18 is 100% Oracle fee.
+    uint private constant FP_SCALING_FACTOR = 10**18;
 
     function payOracleFees() external payable {
         require(msg.value > 0);
@@ -31,14 +32,14 @@ contract CentralizedStore is StoreInterface, Withdrawable {
     // Sets a new Oracle fee per second.
     function setFixedOracleFeePerSecond(uint newOracleFee) external onlyOwner {
         // Oracle fees at or over 100% don't make sense.
-        require(newOracleFee < 1 ether);
+        require(newOracleFee < FP_SCALING_FACTOR);
         fixedOracleFeePerSecond = newOracleFee;
         emit SetFixedOracleFeePerSecond(newOracleFee);
     }
 
     function computeOracleFees(uint startTime, uint endTime, uint pfc) external view returns (uint oracleFeeAmount) {
         uint timeRange = endTime.sub(startTime);
-        return pfc.mul(fixedOracleFeePerSecond).mul(timeRange).div(1 ether);
+        return pfc.mul(fixedOracleFeePerSecond).mul(timeRange).div(FP_SCALING_FACTOR);
     }
 
     event SetFixedOracleFeePerSecond(uint newOracleFee);

--- a/contracts/LeveragedReturnCalculator.sol
+++ b/contracts/LeveragedReturnCalculator.sol
@@ -20,6 +20,7 @@ contract LeveragedReturnCalculator is ReturnCalculatorInterface, Withdrawable {
     // -1 -> unlevered short
     // -2 -> 2x levered short
     int internal leverageMultiplier;
+    int private constant FP_SCALING_FACTOR = 10**18;
 
     constructor(int _leverageMultiplier) public {
         require(_leverageMultiplier != 0);
@@ -33,10 +34,10 @@ contract LeveragedReturnCalculator is ReturnCalculatorInterface, Withdrawable {
         }
 
         // Compute the underlying asset return: +1% would be 1.01 (* 1 ether).
-        int underlyingAssetReturn = newPrice.mul(1 ether).div(oldPrice);
+        int underlyingAssetReturn = newPrice.mul(FP_SCALING_FACTOR).div(oldPrice);
 
         // Compute the RoR of the underlying asset and multiply by leverageMultiplier to get the modified return.
-        assetReturn = underlyingAssetReturn.sub(1 ether).mul(leverageMultiplier);
+        assetReturn = underlyingAssetReturn.sub(FP_SCALING_FACTOR).mul(leverageMultiplier);
 
 
         // If oldPrice is < 0, we need to flip the sign to keep returns positively correlated with

--- a/contracts/TokenizedDerivative.sol
+++ b/contracts/TokenizedDerivative.sol
@@ -170,7 +170,8 @@ library TokenizedDerivativeUtils {
     uint private constant SECONDS_PER_DAY = 86400;
     uint private constant SECONDS_PER_YEAR = 31536000;
     uint private constant INT_MAX = 2**255 - 1;
-    uint private constant FP_SCALING_FACTOR = 10**18;
+    uint private constant UINT_FP_SCALING_FACTOR = 10**18;
+    int private constant INT_FP_SCALING_FACTOR = 10**18;
 
     modifier onlySponsor(TDS.Storage storage s) {
         require(msg.sender == s.externalAddresses.sponsor);
@@ -203,8 +204,8 @@ library TokenizedDerivativeUtils {
         
         // Keep the starting token price relatively close to FP_SCALING_FACTOR to prevent users from unintentionally
         // creating rounding or overflow errors.
-        require(params.startingTokenPrice >= uint(FP_SCALING_FACTOR).div(10**9));
-        require(params.startingTokenPrice <= uint(FP_SCALING_FACTOR).mul(10**9));
+        require(params.startingTokenPrice >= UINT_FP_SCALING_FACTOR.div(10**9));
+        require(params.startingTokenPrice <= UINT_FP_SCALING_FACTOR.mul(10**9));
 
         // TODO(mrice32): we should have an ideal start time rather than blindly polling.
         (uint latestTime, int latestUnderlyingPrice) = s.externalAddresses.priceFeed.latestPrice(s.fixedParameters.product);
@@ -218,7 +219,7 @@ library TokenizedDerivativeUtils {
         require(latestTime != 0);
 
         // Keep the ratio in case it's needed for margin computation.
-        s.fixedParameters.initialTokenUnderlyingRatio = params.startingTokenPrice.mul(FP_SCALING_FACTOR).div(_safeUintCast(latestUnderlyingPrice));
+        s.fixedParameters.initialTokenUnderlyingRatio = params.startingTokenPrice.mul(UINT_FP_SCALING_FACTOR).div(_safeUintCast(latestUnderlyingPrice));
         require(s.fixedParameters.initialTokenUnderlyingRatio != 0);
 
         // Set end time to max value of uint to implement no expiry.
@@ -286,7 +287,7 @@ library TokenizedDerivativeUtils {
 
         // Value of the tokens is just the percentage of all the tokens multiplied by the balance of the investor
         // margin account.
-        uint tokenPercentage = tokensToRedeem.mul(FP_SCALING_FACTOR).div(initialSupply);
+        uint tokenPercentage = tokensToRedeem.mul(UINT_FP_SCALING_FACTOR).div(initialSupply);
         uint tokenMargin = _takePercentage(_safeUintCast(s.longBalance), tokenPercentage);
 
         s.longBalance = s.longBalance.sub(_safeIntCast(tokenMargin));
@@ -531,10 +532,10 @@ library TokenizedDerivativeUtils {
         require(params.returnType == TokenizedDerivativeParams.ReturnType.Compound || params.fixedYearlyFee == 0);
 
         // The default penalty must be less than the required margin.
-        require(params.defaultPenalty <= FP_SCALING_FACTOR);
+        require(params.defaultPenalty <= UINT_FP_SCALING_FACTOR);
 
         // Withdraw limit must be < 100%.
-        require(params.withdrawLimit < FP_SCALING_FACTOR);
+        require(params.withdrawLimit < UINT_FP_SCALING_FACTOR);
 
         s.fixedParameters.returnType = params.returnType;
         s.fixedParameters.defaultPenalty = params.defaultPenalty;
@@ -699,7 +700,7 @@ library TokenizedDerivativeUtils {
             beginningTokenState.underlyingPrice, latestUnderlyingPrice);
         int tokenReturn = underlyingReturn.sub(
             _safeIntCast(s.fixedParameters.fixedFeePerSecond.mul(recomputeTime.sub(beginningTokenState.time))));
-        int tokenMultiplier = tokenReturn.add(FP_SCALING_FACTOR);
+        int tokenMultiplier = tokenReturn.add(INT_FP_SCALING_FACTOR);
         
         // In the compound case, don't allow the token price to go below 0.
         if (s.fixedParameters.returnType == TokenizedDerivativeParams.ReturnType.Compound && tokenMultiplier < 0) {
@@ -830,8 +831,8 @@ library TokenizedDerivativeUtils {
 
         int effectiveNotional;
         if (s.fixedParameters.returnType == TokenizedDerivativeParams.ReturnType.Linear) {
-            int effectiveUnitsOfUnderlying = _safeIntCast(_totalSupply().mul(s.fixedParameters.initialTokenUnderlyingRatio).div(FP_SCALING_FACTOR)).mul(leverageMagnitude);
-            effectiveNotional = effectiveUnitsOfUnderlying.mul(tokenState.underlyingPrice).div(FP_SCALING_FACTOR);
+            int effectiveUnitsOfUnderlying = _safeIntCast(_totalSupply().mul(s.fixedParameters.initialTokenUnderlyingRatio).div(UINT_FP_SCALING_FACTOR)).mul(leverageMagnitude);
+            effectiveNotional = effectiveUnitsOfUnderlying.mul(tokenState.underlyingPrice).div(INT_FP_SCALING_FACTOR);
         } else {
             int currentNav = _computeNavForTokens(tokenState.tokenPrice, _totalSupply());
             effectiveNotional = currentNav.mul(leverageMagnitude);
@@ -895,7 +896,7 @@ library TokenizedDerivativeUtils {
     }
 
     function _computeNavForTokens(int tokenPrice, uint numTokens) private pure returns (int navNew) {
-        navNew = _safeIntCast(numTokens).mul(tokenPrice).div(FP_SCALING_FACTOR);
+        navNew = _safeIntCast(numTokens).mul(tokenPrice).div(INT_FP_SCALING_FACTOR);
     }
 
     function _totalSupply() private view returns (uint totalSupply) {
@@ -904,15 +905,15 @@ library TokenizedDerivativeUtils {
     }
 
     function _takePercentage(uint value, uint percentage) private pure returns (uint result) {
-        return value.mul(percentage).div(FP_SCALING_FACTOR);
+        return value.mul(percentage).div(UINT_FP_SCALING_FACTOR);
     }
 
     function _takePercentage(int value, uint percentage) private pure returns (int result) {
-        return value.mul(_safeIntCast(percentage)).div(FP_SCALING_FACTOR);
+        return value.mul(_safeIntCast(percentage)).div(INT_FP_SCALING_FACTOR);
     }
 
     function _takePercentage(int value, int percentage) private pure returns (int result) {
-        return value.mul(percentage).div(FP_SCALING_FACTOR);
+        return value.mul(percentage).div(INT_FP_SCALING_FACTOR);
     }
 
     function _safeIntCast(uint value) private pure returns (int result) {


### PR DESCRIPTION
Replace our use of 1 ether with `FP_SCALING_FACTOR` to be more explicit about units.