### PR TITLE
Add ManagedSecretProvider that wraps HDWalletProvider

### DIFF
--- a/scripts/ManagedSecretProvider.js
+++ b/scripts/ManagedSecretProvider.js
@@ -33,7 +33,8 @@ class ManagedSecretProvider {
 
   // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.
   send(...all) {
-    return getWrappedProviderOrThrow().send(...all);
+    // The underlying call appears to always throw.
+    throw "Use sendAsync instead of send";
   }
 
   // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.


### PR DESCRIPTION
Instead of reading key material from an environment variable, this
provider allows using a managed secret that must be fetched
asynchronously.

This implementation uses a secret managed by Google Cloud KMS.

I plan to do TODO #2 before submission, but wanted to get feedback first.