### PR TITLE
Reduce number of arguments required for publishPrices

### DIFF
--- a/publishPrices.sh
+++ b/publishPrices.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Usage: ./publishPrices.sh <ManualPriceFeed address> <network>
-# Example:  ./publishPrices.s 0x5b48d54581246863913c704551b2CA6248223f32 develop
+# Usage: ./publishPrices.sh <network>
+# Example:  ./publishPrices.sh develop
 while sleep 15; do $(npm bin)/truffle exec ./scripts/PublishPrices.js --network $2 >>out.log 2>&1; done


### PR DESCRIPTION
Previous to this change, the user would have to provide 2 arguments, the first of which was unused by the script since it's now pulling the price feed address from the truffle build artifacts.