### PR TITLE
Publish BarChart prices using tradeTimestamp rather than currentTime

### DIFF
--- a/scripts/PublishPrices.js
+++ b/scripts/PublishPrices.js
@@ -54,6 +54,9 @@ async function getBarchartPrice(asset) {
 
   const tradeTime = jsonOutput.results[0].tradeTimestamp;
   const timestamp = web3.utils.toBN(Math.round(new Date(tradeTime).getTime() / 1000));
+  if (!timestamp) {
+    throw `Failed to get valid timestamp out of JSON response tradeTimestamp field [${tradeTime}]`;
+  }
 
   console.log(`Retrieved quote [${price}] at [${timestamp}] ([${tradeTime}]) from Barchart for asset [${asset}]`);
 


### PR DESCRIPTION
The BarChart price feed is delayed by 10 minutes, so the prices in the
ManualPriceFeed should reflect the timestamp of the price, not the
timestamp of the upload.

Note that because of a QPS limit for the BarChart API, we avoid making
calls to BarChart in cases where we know an updated price isn't
available.