### PR TITLE
Fix CI by providing custom params

### DIFF
--- a/sponsor-dapp/src/App.js
+++ b/sponsor-dapp/src/App.js
@@ -6,7 +6,7 @@ import Dashboard from "./components/Dashboard.js";
 import params from "./parameters.json";
 
 class App extends Component {
-  state = { params, network: undefined };
+  state = { network: undefined };
 
   componentDidMount() {
     document.title = "UMA Dashboard";
@@ -61,8 +61,15 @@ class App extends Component {
               return "Loading...";
             }
 
+            let newParams;
+            // Allow param override in props.
+            if (this.props.params) {
+              newParams = { ...this.props.params };
+            } else {
+              newParams = { ...params };
+            }
+
             // Copy params without network properties
-            const newParams = { ...params };
             delete newParams.main;
             delete newParams.ropsten;
             delete newParams.private;

--- a/sponsor-dapp/src/App.test.js
+++ b/sponsor-dapp/src/App.test.js
@@ -18,7 +18,9 @@ const getNewDrizzleInstance = () => {
 
 it("renders App without crashing", done => {
   const div = document.createElement("div");
-  ReactDOM.render(<App drizzle={getNewDrizzleInstance()} />, div);
+
+  const params = { identifiers: [] };
+  ReactDOM.render(<App drizzle={getNewDrizzleInstance()} params={params} />, div);
 
   // Note: timeout is to allow time for any async requests by the component to go through.
   setTimeout(() => {


### PR DESCRIPTION
CI was broken because the dapp was trying to query price feeds that had not had prices pushed to them. The simple solution was just to override the imported params with custom ones for testing. I'll add an issue to remove this in the future and publish sample prices to real price feeds in CI to test that code path.