### PR TITLE
Add mnemonic option for mainnet and ropsten

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ export MNEMONIC="candy maple cake sugar pudding cream honey rich smooth crumble 
 4. Tune the default gas price in `truffle.js` (currently set to `20 Gwei`) to your liking.
 5. Run the following command to start a fresh deployment to mainnet:
 ```
-$(npm bin)/truffle migrate --reset --network mainnet
+$(npm bin)/truffle migrate --reset --network mainnet_mnemonic
 ```
 If you'd like to deploy to the Ropsten testnet instead, run the following command:
 ```
-$(npm bin)/truffle migrate --reset --network ropsten
+$(npm bin)/truffle migrate --reset --network ropsten_mnemonic
 ```
 5. To interact with the contracts you've deployed, run:
 ```
-$(npm bin)/truffle console --network <mainnet_or_ropsten>
+$(npm bin)/truffle console --network <network_name>
 ```
 This will open a node console with all contracts loaded along with a web3 instance connected to the network and
 preloaded with your private keys (loads the first two private keys for your mnemonic by default).

--- a/migrations/8_deploy_tokenized_derivative_creator.js
+++ b/migrations/8_deploy_tokenized_derivative_creator.js
@@ -47,7 +47,7 @@ module.exports = async function(deployer, network, accounts) {
   const returnCalculator = await LeveragedReturnCalculator.deployed();
   await returnCalculatorWhitelist.addToWhitelist(returnCalculator.address, { from: keys.returnCalculatorWhitelist });
 
-  if (network !== "mainnet" && network !== "ropsten") {
+  if (!network.startsWith("mainnet") && !network.startsWith("ropsten")) {
     await sponsorWhitelist.addToWhitelist(accounts[1], { from: keys.sponsorWhitelist });
   }
 };

--- a/migrations/MigrationUtils.js
+++ b/migrations/MigrationUtils.js
@@ -14,8 +14,8 @@ function enableControllableTiming(network) {
 function shouldCommitDeployment(network) {
   return (
     network === "ci" || // Just for testing the process of saving deployments.
-    network === "ropsten" ||
-    network === "mainnet"
+    network.startsWith("ropsten") ||
+    network.startsWith("mainnet")
   );
 }
 

--- a/truffle.js
+++ b/truffle.js
@@ -38,6 +38,12 @@ module.exports = {
       network_id: "*",
       gas: 6720000
     },
+    ropsten_mnemonic: {
+      provider: new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${infuraApiKey}`, 0, 2),
+      network_id: 3,
+      gas: 6720000,
+      gasPrice: 20000000000
+    },
     ropsten: {
       provider: new ManagedSecretProvider(
         GckmsConfig,
@@ -45,7 +51,13 @@ module.exports = {
         0,
         GckmsConfig.length
       ),
-      network_id: "*",
+      network_id: 3,
+      gas: 6720000,
+      gasPrice: 20000000000
+    },
+    mainnet_mnemonic: {
+      provider: new HDWalletProvider(mnemonic, `https://mainnet.infura.io/v3/${infuraApiKey}`, 0, 2),
+      network_id: 1,
       gas: 6720000,
       gasPrice: 20000000000
     },
@@ -56,7 +68,7 @@ module.exports = {
         0,
         GckmsConfig.length
       ),
-      network_id: "*",
+      network_id: 1,
       gas: 6720000,
       gasPrice: 20000000000
     }


### PR DESCRIPTION
To make the README consistent and the repo more usable for those without a google cloud account, we should make a deployment option for mainnet and ropsten that uses a mnemonic rather than keys stored in google cloud.

This also updates the network ID for mainnet and ropsten to match their real network IDs.