### PR TITLE
Limit decimal length for under-box text

### DIFF
--- a/sponsor-dapp/package.json
+++ b/sponsor-dapp/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
     "babel-core": "7.0.0-bridge.0",
+    "bignumber.js": "^8.1.1",
     "drizzle": "github:UMAprotocol/drizzle#1.3.0-fix1",
     "drizzle-react": "^1.2.0",
     "drizzle-react-components": "^1.2.1",

--- a/sponsor-dapp/src/components/ContractInteraction.js
+++ b/sponsor-dapp/src/components/ContractInteraction.js
@@ -75,16 +75,22 @@ class ContractInteraction extends Component {
     let withdrawHelper = "";
     let depositHelper = "";
     if (willDefault) {
+      // Round up on the deposit requirement.
       depositHelper = excessMargin
         ? "Deposit at least " +
-          formatWithMaxDecimals(formatWei(web3.utils.toBN(excessMargin).muln(-1), web3), 4) +
+          formatWithMaxDecimals(formatWei(web3.utils.toBN(excessMargin).muln(-1), web3), 4, true) +
           marginCurrencyText
         : "";
     } else {
-      withdrawHelper = excessMargin ? formatWithMaxDecimals(formatWei(excessMargin, web3), 4) + " available" : "";
+      // Round down on the amount available for withdrawal.
+      withdrawHelper = excessMargin
+        ? formatWithMaxDecimals(formatWei(excessMargin, web3), 4, false) + " available"
+        : "";
     }
+
+    // Round down on the number of tokens that will be created.
     const createHelper = estimatedCreateCurrency
-      ? "Est. " + formatWithMaxDecimals(formatWei(estimatedCreateCurrency, web3), 4) + " " + marginCurrencyText
+      ? "Est. " + formatWithMaxDecimals(formatWei(estimatedCreateCurrency, web3), 4, false) + " " + marginCurrencyText
       : "";
 
     // Check if the contract is empty (e.g., initial creation) and disallow withdrawals in that case. The logic to
@@ -93,7 +99,11 @@ class ContractInteraction extends Component {
 
     const ownedTokens = drizzleHelper.getCache(contractAddress, "balanceOf", [account]);
     const anyTokensToRedeem = ownedTokens ? web3.utils.toBN(ownedTokens).gt(zero) : false;
-    const redeemHelper = ownedTokens ? formatWithMaxDecimals(formatWei(ownedTokens, web3), 4) + " available" : "";
+
+    // Round down on the number of tokens that can be redeemed.
+    const redeemHelper = ownedTokens
+      ? formatWithMaxDecimals(formatWei(ownedTokens, web3), 4, false) + " available"
+      : "";
 
     const { state } = derivativeStorage;
     const isLive = state === ContractStateEnum.LIVE;

--- a/sponsor-dapp/src/components/ContractInteraction.js
+++ b/sponsor-dapp/src/components/ContractInteraction.js
@@ -76,7 +76,9 @@ class ContractInteraction extends Component {
     let depositHelper = "";
     if (willDefault) {
       depositHelper = excessMargin
-        ? "Deposit at least " + formatWithMaxDecimals(formatWei(web3.utils.toBN(excessMargin).muln(-1), web3), 4) + marginCurrencyText
+        ? "Deposit at least " +
+          formatWithMaxDecimals(formatWei(web3.utils.toBN(excessMargin).muln(-1), web3), 4) +
+          marginCurrencyText
         : "";
     } else {
       withdrawHelper = excessMargin ? formatWithMaxDecimals(formatWei(excessMargin, web3), 4) + " available" : "";

--- a/sponsor-dapp/src/components/ContractInteraction.js
+++ b/sponsor-dapp/src/components/ContractInteraction.js
@@ -7,7 +7,7 @@ import { withStyles } from "@material-ui/core/styles";
 import { ContractStateEnum } from "../utils/TokenizedDerivativeUtils";
 import DrizzleHelper from "../utils/DrizzleHelper";
 import { currencyAddressToName } from "../utils/ParameterLookupUtils.js";
-import { formatWei } from "../utils/FormattingUtils";
+import { formatWei, formatWithMaxDecimals } from "../utils/FormattingUtils";
 
 const styles = theme => ({
   button: {
@@ -76,13 +76,13 @@ class ContractInteraction extends Component {
     let depositHelper = "";
     if (willDefault) {
       depositHelper = excessMargin
-        ? "Deposit at least " + formatWei(web3.utils.toBN(excessMargin).muln(-1), web3) + marginCurrencyText
+        ? "Deposit at least " + formatWithMaxDecimals(formatWei(web3.utils.toBN(excessMargin).muln(-1), web3), 4) + marginCurrencyText
         : "";
     } else {
-      withdrawHelper = excessMargin ? formatWei(excessMargin, web3) + marginCurrencyText + " available" : "";
+      withdrawHelper = excessMargin ? formatWithMaxDecimals(formatWei(excessMargin, web3), 4) + " available" : "";
     }
     const createHelper = estimatedCreateCurrency
-      ? "Est. " + formatWei(estimatedCreateCurrency, web3) + " " + marginCurrencyText
+      ? "Est. " + formatWithMaxDecimals(formatWei(estimatedCreateCurrency, web3), 4) + " " + marginCurrencyText
       : "";
 
     // Check if the contract is empty (e.g., initial creation) and disallow withdrawals in that case. The logic to
@@ -91,7 +91,7 @@ class ContractInteraction extends Component {
 
     const ownedTokens = drizzleHelper.getCache(contractAddress, "balanceOf", [account]);
     const anyTokensToRedeem = ownedTokens ? web3.utils.toBN(ownedTokens).gt(zero) : false;
-    const redeemHelper = ownedTokens ? formatWei(ownedTokens, web3) + " token(s) available" : "";
+    const redeemHelper = ownedTokens ? formatWithMaxDecimals(formatWei(ownedTokens, web3), 4) + " available" : "";
 
     const { state } = derivativeStorage;
     const isLive = state === ContractStateEnum.LIVE;

--- a/sponsor-dapp/src/components/ContractInteraction.js
+++ b/sponsor-dapp/src/components/ContractInteraction.js
@@ -88,9 +88,9 @@ class ContractInteraction extends Component {
         : "";
     }
 
-    // Round down on the number of tokens that will be created.
+    // Round up on the amount of margin that will be required to create the tokens.
     const createHelper = estimatedCreateCurrency
-      ? "Est. " + formatWithMaxDecimals(formatWei(estimatedCreateCurrency, web3), 4, false) + " " + marginCurrencyText
+      ? "Est. " + formatWithMaxDecimals(formatWei(estimatedCreateCurrency, web3), 4, true) + " " + marginCurrencyText
       : "";
 
     // Check if the contract is empty (e.g., initial creation) and disallow withdrawals in that case. The logic to

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -1,3 +1,6 @@
+const BigNumber = require('bignumber.js');
+
+
 export function formatDate(timestampInSeconds, web3) {
   return new Date(
     parseInt(
@@ -20,19 +23,13 @@ export function formatWei(num, web3) {
 
 // Formats the input to round to decimalPlaces number of decimals.
 export function formatWithMaxDecimals(num, decimalPlaces, roundUp) {
-  const fullPrecisionFloat = Number.parseFloat(num);
-  let fixedPrecisionFloat = Number.parseFloat(fullPrecisionFloat.toFixed(decimalPlaces));
-
-  // Get the smallest representable unit in our fixed precision representation.
-  const smallestUnit = Math.pow(10, -decimalPlaces);
-
-  // Take the fixed precision float and ensure it's rounded the correct way.
-  // Note: this is necessary because toFixed() does rounding of its own.
-  if (roundUp && fixedPrecisionFloat < fullPrecisionFloat) {
-    fixedPrecisionFloat += smallestUnit;
-  } else if (!roundUp && fixedPrecisionFloat > fullPrecisionFloat) {
-    fixedPrecisionFloat -= smallestUnit;
+  if (roundUp) {
+    BigNumber.set({ ROUNDING_MODE: BigNumber.ROUND_UP });
+  } else {
+    BigNumber.set({ ROUNDING_MODE: BigNumber.ROUND_DOWN });
   }
 
+  const fullPrecisionFloat = BigNumber(num);
+  let fixedPrecisionFloat = BigNumber(fullPrecisionFloat.toFixed(decimalPlaces));
   return fixedPrecisionFloat.toString();
 }

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -19,10 +19,20 @@ export function formatWei(num, web3) {
 }
 
 // Formats the input to round to decimalPlaces number of decimals.
-export function formatWithMaxDecimals(num, decimalPlaces) {
-  const fixedPrecisionString = Number.parseFloat(num).toFixed(decimalPlaces);
+export function formatWithMaxDecimals(num, decimalPlaces, roundUp) {
+  const fullPrecisionFloat = Number.parseFloat(num);
+  let fixedPrecisionFloat = Number.parseFloat(fullPrecisionFloat.toFixed(decimalPlaces));
 
-  // Converting to float and back will truncate any extra 0s on the string.
-  const truncatedFloat = Number.parseFloat(fixedPrecisionString);
-  return truncatedFloat.toString();
+  // Get the smallest representable unit in our fixed precision representation.
+  const smallestUnit = Math.pow(10, -decimalPlaces);
+
+  // Take the fixed precision float and ensure it's rounded the correct way.
+  // Note: this is necessary because toFixed() does rounding of its own.
+  if (roundUp && fixedPrecisionFloat < fullPrecisionFloat) {
+    fixedPrecisionFloat += smallestUnit;
+  } else if (!roundUp && fixedPrecisionFloat > fullPrecisionFloat) {
+    fixedPrecisionFloat -= smallestUnit;
+  }
+
+  return fixedPrecisionFloat.toString();
 }

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -29,6 +29,8 @@ export function formatWithMaxDecimals(num, decimalPlaces, roundUp) {
   }
 
   const fullPrecisionFloat = BigNumber(num);
+
+  // Convert back to BN to truncate any trailing 0s that the toFixed() output would print.
   const fixedPrecisionFloat = BigNumber(fullPrecisionFloat.toFixed(decimalPlaces));
   return fixedPrecisionFloat.toString();
 }

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -21,7 +21,7 @@ export function formatWei(num, web3) {
 // Formats the input to round to decimalPlaces number of decimals.
 export function formatWithMaxDecimals(num, decimalPlaces) {
   const fixedPrecisionString = Number.parseFloat(num).toFixed(decimalPlaces);
-  
+
   // Converting to float and back will truncate any extra 0s on the string.
   const truncatedFloat = Number.parseFloat(fixedPrecisionString);
   return truncatedFloat.toString();

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -1,5 +1,4 @@
-const BigNumber = require('bignumber.js');
-
+const BigNumber = require("bignumber.js");
 
 export function formatDate(timestampInSeconds, web3) {
   return new Date(

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -17,3 +17,12 @@ export function formatWei(num, web3) {
   // See https://github.com/ethereum/web3.js/issues/1777.
   return web3.utils.fromWei(num.toString());
 }
+
+// Formats the input to round to decimalPlaces number of decimals.
+export function formatWithMaxDecimals(num, decimalPlaces) {
+  const fixedPrecisionString = Number.parseFloat(num).toFixed(decimalPlaces);
+  
+  // Converting to float and back will truncate any extra 0s on the string.
+  const truncatedFloat = Number.parseFloat(fixedPrecisionString);
+  return truncatedFloat.toString();
+}

--- a/sponsor-dapp/src/utils/FormattingUtils.js
+++ b/sponsor-dapp/src/utils/FormattingUtils.js
@@ -29,6 +29,6 @@ export function formatWithMaxDecimals(num, decimalPlaces, roundUp) {
   }
 
   const fullPrecisionFloat = BigNumber(num);
-  let fixedPrecisionFloat = BigNumber(fullPrecisionFloat.toFixed(decimalPlaces));
+  const fixedPrecisionFloat = BigNumber(fullPrecisionFloat.toFixed(decimalPlaces));
   return fixedPrecisionFloat.toString();
 }


### PR DESCRIPTION
When numbers with many decimals were shown under text boxes in `ContractDetails`, they would expand the text box and break the expected alignment.  This PR limits the number of decimals to 4. The alignment issue can still be triggered if the number is very large, but we don't expect that case to be as common.