### PR TITLE
Deploy the monitoring + staging dapp version in CI

### DIFF
--- a/ci/deploy_staging_dapp.sh
+++ b/ci/deploy_staging_dapp.sh
@@ -26,5 +26,5 @@ REACT_APP_MODE=default ./scripts/deploy_dapp.sh sponsor-dapp/app.yaml -q
 # Copy the monitoring staging config into the sponsor-dapp dir.
 gsutil cp gs://staging-deployment-configuration/monitoring_app.yaml sponsor-dapp/monitoring_app.yaml
 
-# Deploy dapp
+# Deploy monitoring dapp
 REACT_APP_MODE=monitoring ./scripts/deploy_dapp.sh sponsor-dapp/monitoring_app.yaml -q

--- a/ci/deploy_staging_dapp.sh
+++ b/ci/deploy_staging_dapp.sh
@@ -21,4 +21,10 @@ gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 gsutil cp gs://staging-deployment-configuration/app.yaml sponsor-dapp/app.yaml
 
 # Deploy dapp
-./scripts/deploy_dapp.sh sponsor-dapp/app.yaml -q
+REACT_APP_MODE=default ./scripts/deploy_dapp.sh sponsor-dapp/app.yaml -q
+
+# Copy the monitoring staging config into the sponsor-dapp dir.
+gsutil cp gs://staging-deployment-configuration/monitoring_app.yaml sponsor-dapp/monitoring_app.yaml
+
+# Deploy dapp
+REACT_APP_MODE=monitoring ./scripts/deploy_dapp.sh sponsor-dapp/monitoring_app.yaml -q


### PR DESCRIPTION
This is mainly just so people can see a preview in staging even if they have no contracts or tokens.