### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
             - sec-toolbox-deps-{{ checksum "package.json" }}
             - sec-toolbox-deps-
       - run:
-          name: Grant Write Permissions
-          command: sudo chmod a+rwx /home/ethsec/.npm
+          name: Change user
+          command: sudo su - ethsec
       - run:
           name: Install Dependencies
           command: npm install --quiet
@@ -130,8 +130,8 @@ jobs:
             - sec-toolbox-deps-{{ checksum "package.json" }}
             - sec-toolbox-deps-
       - run:
-          name: Grant Write Permissions
-          command: sudo chmod a+rwx /home/ethsec/.npm
+          name: Change User
+          command: sudo su - ethsec
       - run:
           name: Install Dependencies
           command: npm install --quiet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   checkout_and_install:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
     working_directory: ~/protocol
     steps:
       - checkout
@@ -12,7 +12,7 @@ jobs:
             - v2-dependency-cache-
       - run:
           name: Install Dependencies
-          command: npm install --quiet --no-optional
+          command: npm install --quiet
       - save_cache:
           key: v2-dependency-cache-{{ checksum "package.json" }}
           paths:
@@ -23,7 +23,7 @@ jobs:
             - ~/protocol
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -37,7 +37,7 @@ jobs:
             - ~/protocol
   lint:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -76,7 +76,7 @@ jobs:
           command: ./ci/run_slither.sh
   test:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 6720000
     working_directory: ~/protocol
@@ -150,7 +150,7 @@ jobs:
           command: ./ci/run_echidna_tests.sh
   sponsor_dapp_test:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 6720000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
     working_directory: ~/protocol
@@ -186,7 +186,7 @@ jobs:
           command: ./ci/run_sponsor_dapp_tests.sh
   sponsor_dapp_build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
             - ~/protocol
   sponsor_dapp_deploy:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:11.5.0
     working_directory: ~/protocol
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,10 @@ jobs:
             - sec-toolbox-deps-
       - run:
           name: Change user
-          command: sudo su - ethsec
+          command: sudo su ethsec
+      - run:
+          name: Reclaim ownership
+          command: sudo chown -R $(whoami) ~/.npm
       - run:
           name: Install Dependencies
           command: npm install --quiet
@@ -130,8 +133,11 @@ jobs:
             - sec-toolbox-deps-{{ checksum "package.json" }}
             - sec-toolbox-deps-
       - run:
-          name: Change User
-          command: sudo su - ethsec
+          name: Change user
+          command: sudo su ethsec
+      - run:
+          name: Reclaim ownership
+          command: sudo chown -R $(whoami) ~/.npm
       - run:
           name: Install Dependencies
           command: npm install --quiet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
             - sec-toolbox-deps-{{ checksum "package.json" }}
             - sec-toolbox-deps-
       - run:
+          name: Grant Write Permissions
+          command: sudo chmod a+rwx /home/ethsec/.npm
+      - run:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
@@ -126,6 +129,9 @@ jobs:
           keys:
             - sec-toolbox-deps-{{ checksum "package.json" }}
             - sec-toolbox-deps-
+      - run:
+          name: Grant Write Permissions
+          command: sudo chmod a+rwx /home/ethsec/.npm
       - run:
           name: Install Dependencies
           command: npm install --quiet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependency-cache-{{ checksum "package.json" }}
-            - v1-dependency-cache-
+            - v2-dependency-cache-{{ checksum "package.json" }}
+            - v2-dependency-cache-
       - run:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "package.json" }}
+          key: v2-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - save_cache:
@@ -56,8 +56,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - sec-toolbox-deps-{{ checksum "package.json" }}
-            - sec-toolbox-deps-
+            - v2-sec-toolbox-deps-{{ checksum "package.json" }}
+            - v2-sec-toolbox-deps-
       - run:
           name: Change user
           command: sudo su ethsec
@@ -68,7 +68,7 @@ jobs:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: sec-toolbox-deps-{{ checksum "package.json" }}
+          key: v2-sec-toolbox-deps-{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:
@@ -107,13 +107,13 @@ jobs:
           command: apk update && apk add make git python g++ curl ca-certificates openssl && update-ca-certificates
       - restore_cache:
           keys:
-            - coverage-dependency-cache-{{ checksum "package.json" }}
-            - coverage-dependency-cache-
+            - v2-coverage-dependency-cache-{{ checksum "package.json" }}
+            - v2-coverage-dependency-cache-
       - run:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: coverage-dependency-cache-{{ checksum "package.json" }}
+          key: v2-coverage-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:
@@ -130,8 +130,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - sec-toolbox-deps-{{ checksum "package.json" }}
-            - sec-toolbox-deps-
+            - v2-sec-toolbox-deps-{{ checksum "package.json" }}
+            - v2-sec-toolbox-deps-
       - run:
           name: Change user
           command: sudo su ethsec
@@ -142,7 +142,7 @@ jobs:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: sec-toolbox-deps-{{ checksum "package.json" }}
+          key: v2-sec-toolbox-deps-{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:
@@ -162,14 +162,14 @@ jobs:
           command: $(npm bin)/truffle migrate --reset --network test
       - restore_cache:
           keys: 
-            - sponsor-dapp-dep-cache-{{ checksum "sponsor-dapp/package.json" }}
-            - sponsor-dapp-dep-cache-
+            - v2-sponsor-dapp-dep-cache-{{ checksum "sponsor-dapp/package.json" }}
+            - v2-sponsor-dapp-dep-cache-
       - run:
           name: Install Dependencies
           working_directory: ~/protocol/sponsor-dapp
           command: npm install
       - save_cache:
-          key: sponsor-dapp-dep-cache-{{ checksum "sponsor-dapp/package.json" }}
+          key: v2-sponsor-dapp-dep-cache-{{ checksum "sponsor-dapp/package.json" }}
           paths:
             - sponsor-dapp/node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             - v2-dependency-cache-
       - run:
           name: Install Dependencies
-          command: npm install --quiet
+          command: npm install --quiet --no-optional
       - save_cache:
           key: v2-dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -2,4 +2,4 @@
 
 sudo chmod -R a+rwx /usr/local/lib/node_modules
 truffle compile 
-slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether .
+slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether,reentrancy-eth .


### PR DESCRIPTION
CI was failing for a few reasons:
- node:latest was updated to 12.0.0, which caused versioning issues with some of our circleci caches and apparently causes one of the packages we depend on to no longer be able to install. I pinned our docker image to 11.5.0.
- ToB's eth security toolbox docker image was having some permissioning issues during `npm install` having to do with the ~/.npm folder, so I added a few commands to reclaim ownership of that directory.
- slither was failing because of a recent update, so I disabled one of their detectors that was failing. See crytic/slither#214. Note: this was not a false positive, this was a runtime issue in their code.