### PR TITLE
Fix publishPrices.sh to not automatically provide keys

### DIFF
--- a/v0/scripts/publishPrices.sh
+++ b/v0/scripts/publishPrices.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Usage: ./scripts/publishPrices.sh <network>
-# Example: ./scripts/publishPrices.sh develop
+# Usage: ./scripts/publishPrices.sh <args to pass to PublishPrices>
+# Example: ./scripts/publishPrices.sh --network mainnet --keys priceFeed
 # Note: this script must be run from the top level directory (not scripts/).
-while sleep 60; do $(npm bin)/truffle exec ./scripts/PublishPrices.js --network $1 --keys priceFeed >>out.log 2>&1; done
+
+while sleep 60; do $(npm bin)/truffle exec ./scripts/PublishPrices.js "$@" >>out.log 2>&1; done


### PR DESCRIPTION
It was previously hardcoding the `priceFeed` key which may not be necessary in mnemonic or test networks.