### PR TITLE
Add Voting contract to migrations

### DIFF
--- a/v1/migrations/2_deploy_voting.js
+++ b/v1/migrations/2_deploy_voting.js
@@ -1,0 +1,9 @@
+const Voting = artifacts.require("Voting");
+const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+
+module.exports = async function(deployer, network, accounts) {
+  const keys = getKeysForNetwork(network, accounts);
+
+  const voting = await deployAndGet(deployer, Voting, { from: keys.deployer });
+  await addToTdr(voting, network);
+};

--- a/v1/test/Voting.js
+++ b/v1/test/Voting.js
@@ -13,7 +13,7 @@ contract("Voting", function(accounts) {
   };
 
   it("One voter, one request", async function() {
-    const voting = await Voting.new();
+    const voting = await Voting.deployed();
 
     const identifier = web3.utils.utf8ToHex("id");
     const time = "1000";
@@ -55,7 +55,7 @@ contract("Voting", function(accounts) {
   });
 
   it("Multiple voters", async function() {
-    const voting = await Voting.new();
+    const voting = await Voting.deployed();
 
     const identifier = web3.utils.utf8ToHex("id");
     const time = "1000";
@@ -98,7 +98,7 @@ contract("Voting", function(accounts) {
   });
 
   it("Overlapping request keys", async function() {
-    const voting = await Voting.new();
+    const voting = await Voting.deployed();
 
     // Verify that concurrent votes with the same identifier but different times, or the same time but different
     // identifiers don't cause any problems.


### PR DESCRIPTION
As discussed offline, we may want to rename the contract Voting.sol to
something like Oracle.sol, DecentralizedOracle.sol, v2Oracle.sol, etc.

Issue #381 