### PR TITLE
Add basic API and placeholder implementation of fixed point library

### DIFF
--- a/v1/contracts/FixedPoint.sol
+++ b/v1/contracts/FixedPoint.sol
@@ -43,7 +43,8 @@ library FixedPoint {
     /** @dev Divides with truncation two `Unsigned`s, reverting on overflow or division by 0. */
     function div(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
         // There are two caveats with this computation:
-        // 1. Max value for the dividend `a` is ~10^41, otherwise an intermediate value overflows.
+        // 1. Max value for the number dividend `a` represents is ~10^41, otherwise an intermediate value overflows.
+        // 10^41 is stored internally as a uint 10^59.
         // 2. Results that can't be represented exactly are truncated not rounded. E.g., 2 / 3 = 0.6 repeating, which
         // would round to 0.666666666666666667, but this computation produces the result 0.666666666666666666.
         return Unsigned(a.value.mul(FP_SCALING_FACTOR).div(b.value));

--- a/v1/contracts/FixedPoint.sol
+++ b/v1/contracts/FixedPoint.sol
@@ -12,7 +12,7 @@ library FixedPoint {
     using SafeMath for uint;
 
     // Supports 18 decimals. E.g., 1e18 represents "1", 5e17 represents "0.5".
-    // Can represent a value up to (2^256 - 1)/10^18 = ~10^59.
+    // Can represent a value up to (2^256 - 1)/10^18 = ~10^59. 10^59 will be stored internally as uint 10^77.
     uint private constant FP_SCALING_FACTOR = 10**18;
 
     struct Unsigned {
@@ -32,8 +32,8 @@ library FixedPoint {
     /** @dev Multiplies two `Unsigned`s, reverting on overflow. */
     function mul(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
         // There are two caveats with this computation:
-        // 1. Max output is ~10^41 (vs ~10^59 as the max value that can be represented), otherwise an intermediate value
-        // overflows.
+        // 1. Max output for the represented number is ~10^41, otherwise an intermediate value overflows. 10^41 is
+        // stored internally as a uint ~10^59.
         // 2. Results that can't be represented exactly are truncated not rounded. E.g., 1.4 * 2e-18 = 2.8e-18, which
         // would round to 3, but this computation produces the result 2.
         // No need to use SafeMath because FP_SCALING_FACTOR != 0.

--- a/v1/contracts/FixedPoint.sol
+++ b/v1/contracts/FixedPoint.sol
@@ -1,0 +1,51 @@
+pragma solidity ^0.5.0;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+
+/**
+ * @title Library for fixed point arithmetic on uints
+ * TODO(ptare): Add operations against non-fixed point number, e.g., add(Unsigned, uint).
+ */
+library FixedPoint {
+
+    using SafeMath for uint;
+
+    // Supports 18 decimals. E.g., 1e18 represents "1", 5e17 represents "0.5".
+    // Can represent a value up to (2^256 - 1)/10^18 = ~10^59.
+    uint private constant FP_SCALING_FACTOR = 10**18;
+
+    struct Unsigned {
+        uint value;
+    }
+
+    /** @dev Adds two `Unsigned`s, reverting on overflow. */
+    function add(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
+        return Unsigned(a.value.add(b.value));
+    }
+
+    /** @dev Subtracts two `Unsigned`s, reverting on underflow. */
+    function sub(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
+        return Unsigned(a.value.sub(b.value));
+    }
+
+    /** @dev Multiplies two `Unsigned`s, reverting on overflow. */
+    function mul(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
+        // There are two caveats with this computation:
+        // 1. Max output is ~10^41 (vs ~10^59 as the max value that can be represented), otherwise an intermediate value
+        // overflows.
+        // 2. Results that can't be represented exactly are truncated not rounded. E.g., 1.4 * 2e-18 = 2.8e-18, which
+        // would round to 3, but this computation produces the result 2.
+        // No need to use SafeMath because FP_SCALING_FACTOR != 0.
+        return Unsigned(a.value.mul(b.value) / FP_SCALING_FACTOR);
+    }
+
+    /** @dev Divides with truncation two `Unsigned`s, reverting on overflow or division by 0. */
+    function div(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
+        // There are two caveats with this computation:
+        // 1. Max value for the dividend `a` is ~10^41, otherwise an intermediate value overflows.
+        // 2. Results that can't be represented exactly are truncated not rounded. E.g., 2 / 3 = 0.6 repeating, which
+        // would round to 0.666666666666666667, but this computation produces the result 0.666666666666666666.
+        return Unsigned(a.value.mul(FP_SCALING_FACTOR).div(b.value));
+    }
+}

--- a/v1/contracts/test/FixedPointTest.sol
+++ b/v1/contracts/test/FixedPointTest.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.5.0;
+
+import "../FixedPoint.sol";
+
+
+// Wraps the FixedPoint library for testing purposes.
+contract FixedPointTest {
+    using FixedPoint for FixedPoint.Unsigned;
+
+    function wrapAdd(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).add(FixedPoint.Unsigned(b)).value;
+    }
+
+    function wrapSub(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).sub(FixedPoint.Unsigned(b)).value;
+    }
+
+    function wrapMul(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).mul(FixedPoint.Unsigned(b)).value;
+    }
+
+    function wrapDiv(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).div(FixedPoint.Unsigned(b)).value;
+    }
+}

--- a/v1/test/FixedPoint.js
+++ b/v1/test/FixedPoint.js
@@ -1,0 +1,79 @@
+const { didContractThrow } = require("../../common/SolidityTestUtils.js");
+
+const FixedPointTest = artifacts.require("FixedPointTest");
+
+contract("FixedPoint", function(accounts) {
+  const uint_max = web3.utils.toBN("115792089237316195423570985008687907853269984665640564039457584007913129639935");
+
+  it("Addition", async function() {
+    const FixedPoint = await FixedPointTest.new();
+
+    // Additions below 10**18.
+    let sum = await FixedPoint.wrapAdd("99", "7");
+    assert.equal(sum, "106");
+
+    // Additions above 10**18.
+    sum = await FixedPoint.wrapAdd(web3.utils.toWei("99"), web3.utils.toWei("7"));
+    assert.equal(sum, web3.utils.toWei("106"));
+
+    // Reverts on overflow.
+    // (uint_max-10) + 11 will overflow.
+    assert(await didContractThrow(FixedPoint.wrapAdd(uint_max.sub(web3.utils.toBN("10")), web3.utils.toBN("11"))));
+  });
+
+  it("Subtraction", async function() {
+    const FixedPoint = await FixedPointTest.new();
+
+    // Subtractions below 10**18.
+    let sum = await FixedPoint.wrapSub("99", "7");
+    assert.equal(sum, "92");
+
+    // Subtractions above 10**18.
+    sum = await FixedPoint.wrapSub(web3.utils.toWei("99"), web3.utils.toWei("7"));
+    assert.equal(sum, web3.utils.toWei("92"));
+
+    // Reverts on underflow.
+    assert(await didContractThrow(FixedPoint.wrapSub("1", "2")));
+  });
+
+  it("Multiplication", async function() {
+    const FixedPoint = await FixedPointTest.new();
+
+    // Whole numbers above 10**18.
+    let product = await FixedPoint.wrapMul(web3.utils.toWei("5"), web3.utils.toWei("17"));
+    assert.equal(product.toString(), web3.utils.toWei("85"));
+
+    // Fractions, no precision loss.
+    product = await FixedPoint.wrapMul(web3.utils.toWei("0.0001"), web3.utils.toWei("5"));
+    assert.equal(product.toString(), web3.utils.toWei("0.0005"));
+
+    // Fractions, precision loss, rounding down.
+    // 1.2 * 2e-18 = 2.4e-18, which can't be represented and gets rounded down to 2.
+    product = await FixedPoint.wrapMul(web3.utils.toWei("1.2"), "2");
+    assert.equal(product.toString(), "2");
+
+    // Reverts on overflow.
+    // (uint_max - 1) * 2 overflows.
+    assert(await didContractThrow(FixedPoint.wrapMul(uint_max.sub(web3.utils.toBN("1")), web3.utils.toWei("2"))));
+  });
+
+  it("Division", async function() {
+    const FixedPoint = await FixedPointTest.new();
+
+    // Normal division case.
+    let quotient = await FixedPoint.wrapDiv(web3.utils.toWei("150.3"), web3.utils.toWei("3"));
+    assert.equal(quotient.toString(), web3.utils.toWei("50.1"));
+
+    // Divisor < 1.
+    quotient = await FixedPoint.wrapDiv(web3.utils.toWei("2"), web3.utils.toWei("0.01"));
+    assert.equal(quotient.toString(), web3.utils.toWei("200"));
+
+    // Fractions, precision loss, rounding down.
+    // 1 / 3 = 0.3 repeating, which can't be represented and gets rounded down to 0.333333333333333333.
+    quotient = await FixedPoint.wrapDiv(web3.utils.toWei("1"), web3.utils.toWei("3"));
+    assert.equal(quotient.toString(), "3".repeat(18));
+
+    // Reverts on division by zero.
+    assert(await didContractThrow(FixedPoint.wrapDiv("1", "0")));
+  });
+});


### PR DESCRIPTION
See comments for some cases that aren't handled.

Explicitly declaring a fixed point uint as the Unsigned type helps with
readability. It's also helpful to bury all this functionality in a
common place, where we can add more specialized methods or improve these
computations as needed.

Issue #351