### PR TITLE
Add mixed operations to fixed point library for uints

### DIFF
--- a/v1/contracts/FixedPoint.sol
+++ b/v1/contracts/FixedPoint.sol
@@ -83,4 +83,14 @@ library FixedPoint {
     function div(uint a, Unsigned memory b) internal pure returns (Unsigned memory) {
         return div(fromUnscaledUint(a), b);
     }
+
+    /** @dev Raises an `Unsigned` to the power of an unscaled uint, reverting on overflow. E.g., `b=2` squares `a`. */
+    function pow(Unsigned memory a, uint b) internal pure returns (Unsigned memory output) {
+        // TODO(ptare): Consider using the exponentiation by squaring technique instead:
+        // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+        output = fromUnscaledUint(1);
+        for (uint i = 0; i < b; i = i.add(1)) {
+            output = mul(output, a);
+        }
+    }
 }

--- a/v1/contracts/FixedPoint.sol
+++ b/v1/contracts/FixedPoint.sol
@@ -5,7 +5,6 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 /**
  * @title Library for fixed point arithmetic on uints
- * TODO(ptare): Add operations against non-fixed point number, e.g., add(Unsigned, uint).
  */
 library FixedPoint {
 
@@ -19,14 +18,34 @@ library FixedPoint {
         uint value;
     }
 
+    /** @dev Constructs an `Unsigned` from an unscaled uint, e.g., `b=5` gets stored internally as `5**18`. */
+    function fromUnscaledUint(uint a) internal pure returns (Unsigned memory) {
+        return Unsigned(a.mul(FP_SCALING_FACTOR));
+    }
+
     /** @dev Adds two `Unsigned`s, reverting on overflow. */
     function add(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
         return Unsigned(a.value.add(b.value));
     }
 
+    /** @dev Adds an `Unsigned` to an unscaled uint, reverting on overflow. */
+    function add(Unsigned memory a, uint b) internal pure returns (Unsigned memory) {
+        return add(a, fromUnscaledUint(b));
+    }
+
     /** @dev Subtracts two `Unsigned`s, reverting on underflow. */
     function sub(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
         return Unsigned(a.value.sub(b.value));
+    }
+
+    /** @dev Subtracts an unscaled uint from an `Unsigned`, reverting on underflow. */
+    function sub(Unsigned memory a, uint b) internal pure returns (Unsigned memory) {
+        return sub(a, fromUnscaledUint(b));
+    }
+
+    /** @dev Subtracts an `Unsigned` from an unscaled uint, reverting on underflow. */
+    function sub(uint a, Unsigned memory b) internal pure returns (Unsigned memory) {
+        return sub(fromUnscaledUint(a), b);
     }
 
     /** @dev Multiplies two `Unsigned`s, reverting on overflow. */
@@ -40,6 +59,11 @@ library FixedPoint {
         return Unsigned(a.value.mul(b.value) / FP_SCALING_FACTOR);
     }
 
+    /** @dev Multiplies an `Unsigned` by an unscaled uint, reverting on overflow. */
+    function mul(Unsigned memory a, uint b) internal pure returns (Unsigned memory) {
+        return Unsigned(a.value.mul(b));
+    }
+
     /** @dev Divides with truncation two `Unsigned`s, reverting on overflow or division by 0. */
     function div(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
         // There are two caveats with this computation:
@@ -48,5 +72,15 @@ library FixedPoint {
         // 2. Results that can't be represented exactly are truncated not rounded. E.g., 2 / 3 = 0.6 repeating, which
         // would round to 0.666666666666666667, but this computation produces the result 0.666666666666666666.
         return Unsigned(a.value.mul(FP_SCALING_FACTOR).div(b.value));
+    }
+
+    /** @dev Divides with truncation an `Unsigned` by an unscaled uint, reverting on division by 0. */
+    function div(Unsigned memory a, uint b) internal pure returns (Unsigned memory) {
+        return Unsigned(a.value.div(b));
+    }
+
+    /** @dev Divides with truncation an unscaled uint by an `Unsigned`, reverting on overflow or division by 0. */
+    function div(uint a, Unsigned memory b) internal pure returns (Unsigned memory) {
+        return div(fromUnscaledUint(a), b);
     }
 }

--- a/v1/contracts/test/FixedPointTest.sol
+++ b/v1/contracts/test/FixedPointTest.sol
@@ -56,4 +56,9 @@ contract FixedPointTest {
     function wrapMixedDivOpposite(uint a, uint b) external pure returns (uint) {
         return FixedPoint.div(a, FixedPoint.Unsigned(b)).value;
     }
+
+    // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapPow(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).pow(b).value;
+    }
 }

--- a/v1/contracts/test/FixedPointTest.sol
+++ b/v1/contracts/test/FixedPointTest.sol
@@ -6,6 +6,8 @@ import "../FixedPoint.sol";
 // Wraps the FixedPoint library for testing purposes.
 contract FixedPointTest {
     using FixedPoint for FixedPoint.Unsigned;
+    using FixedPoint for uint;
+    using SafeMath for uint;
 
     function wrapFromUnscaledUint(uint a) external pure returns (uint) {
         return FixedPoint.fromUnscaledUint(a).value;
@@ -31,7 +33,7 @@ contract FixedPointTest {
 
     // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedSubOpposite(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.sub(a, FixedPoint.Unsigned(b)).value;
+        return a.sub(FixedPoint.Unsigned(b)).value;
     }
 
     function wrapMul(uint a, uint b) external pure returns (uint) {
@@ -54,7 +56,7 @@ contract FixedPointTest {
 
     // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedDivOpposite(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.div(a, FixedPoint.Unsigned(b)).value;
+        return a.div(FixedPoint.Unsigned(b)).value;
     }
 
     // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.

--- a/v1/contracts/test/FixedPointTest.sol
+++ b/v1/contracts/test/FixedPointTest.sol
@@ -7,19 +7,54 @@ import "../FixedPoint.sol";
 contract FixedPointTest {
     using FixedPoint for FixedPoint.Unsigned;
 
+    function wrapFromUnscaledUint(uint a) external pure returns (uint) {
+        return FixedPoint.fromUnscaledUint(a).value;
+    }
+
     function wrapAdd(uint a, uint b) external pure returns (uint) {
         return FixedPoint.Unsigned(a).add(FixedPoint.Unsigned(b)).value;
+    }
+
+    // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedAdd(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).add(b).value;
     }
 
     function wrapSub(uint a, uint b) external pure returns (uint) {
         return FixedPoint.Unsigned(a).sub(FixedPoint.Unsigned(b)).value;
     }
 
+    // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedSub(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).sub(b).value;
+    }
+
+
+    // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedSubOpposite(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.sub(a, FixedPoint.Unsigned(b)).value;
+    }
+
     function wrapMul(uint a, uint b) external pure returns (uint) {
         return FixedPoint.Unsigned(a).mul(FixedPoint.Unsigned(b)).value;
     }
 
+    // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedMul(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).mul(b).value;
+    }
+
     function wrapDiv(uint a, uint b) external pure returns (uint) {
         return FixedPoint.Unsigned(a).div(FixedPoint.Unsigned(b)).value;
+    }
+
+    // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedDiv(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.Unsigned(a).div(b).value;
+    }
+
+    // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedDivOpposite(uint a, uint b) external pure returns (uint) {
+        return FixedPoint.div(a, FixedPoint.Unsigned(b)).value;
     }
 }

--- a/v1/contracts/test/FixedPointTest.sol
+++ b/v1/contracts/test/FixedPointTest.sol
@@ -29,7 +29,6 @@ contract FixedPointTest {
         return FixedPoint.Unsigned(a).sub(b).value;
     }
 
-
     // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedSubOpposite(uint a, uint b) external pure returns (uint) {
         return FixedPoint.sub(a, FixedPoint.Unsigned(b)).value;

--- a/v1/test/FixedPoint.js
+++ b/v1/test/FixedPoint.js
@@ -169,4 +169,23 @@ contract("FixedPoint", function(accounts) {
     // Reverts on division by zero.
     assert(await didContractThrow(fixedPoint.wrapMixedDivOpposite("1", "0")));
   });
+
+  it("Power", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    // 1.5^0 = 1
+    assert.equal(await fixedPoint.wrapPow(web3.utils.toWei("1.5"), "0"), web3.utils.toWei("1"));
+
+    // 1.5^1 = 1.5
+    assert.equal(await fixedPoint.wrapPow(web3.utils.toWei("1.5"), "1"), web3.utils.toWei("1.5"));
+
+    // 1.5^2 = 2.25.
+    assert.equal(await fixedPoint.wrapPow(web3.utils.toWei("1.5"), "2"), web3.utils.toWei("2.25"));
+
+    // 1.5^3 = 3.375
+    assert.equal(await fixedPoint.wrapPow(web3.utils.toWei("1.5"), "3"), web3.utils.toWei("3.375"));
+
+    // Reverts on overflow
+    assert(await didContractThrow(fixedPoint.wrapPow(web3.utils.toWei("10"), "60")));
+  });
 });

--- a/v1/test/FixedPoint.js
+++ b/v1/test/FixedPoint.js
@@ -5,75 +5,168 @@ const FixedPointTest = artifacts.require("FixedPointTest");
 contract("FixedPoint", function(accounts) {
   const uint_max = web3.utils.toBN("115792089237316195423570985008687907853269984665640564039457584007913129639935");
 
+  it("Construction", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    assert.equal(await fixedPoint.wrapFromUnscaledUint("53"), web3.utils.toWei("53"));
+
+    // Reverts on overflow.
+    const tenToSixty = web3.utils.toBN("10").pow(web3.utils.toBN("60"));
+    assert(await didContractThrow(fixedPoint.wrapFromUnscaledUint(tenToSixty)));
+  });
+
   it("Addition", async function() {
-    const FixedPoint = await FixedPointTest.new();
+    const fixedPoint = await FixedPointTest.new();
 
     // Additions below 10**18.
-    let sum = await FixedPoint.wrapAdd("99", "7");
+    let sum = await fixedPoint.wrapAdd("99", "7");
     assert.equal(sum, "106");
 
     // Additions above 10**18.
-    sum = await FixedPoint.wrapAdd(web3.utils.toWei("99"), web3.utils.toWei("7"));
+    sum = await fixedPoint.wrapAdd(web3.utils.toWei("99"), web3.utils.toWei("7"));
     assert.equal(sum, web3.utils.toWei("106"));
 
     // Reverts on overflow.
     // (uint_max-10) + 11 will overflow.
-    assert(await didContractThrow(FixedPoint.wrapAdd(uint_max.sub(web3.utils.toBN("10")), web3.utils.toBN("11"))));
+    assert(await didContractThrow(fixedPoint.wrapAdd(uint_max.sub(web3.utils.toBN("10")), web3.utils.toBN("11"))));
+  });
+
+  it("Mixed addition", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    // Basic mixed addition.
+    const sum = await fixedPoint.wrapMixedAdd(web3.utils.toWei("1.5"), "4");
+    assert.equal(sum.toString(), web3.utils.toWei("5.5"));
+
+    // Reverts if uint (second argument) can't be represented as an Unsigned.
+    const tenToSixty = web3.utils.toBN("10").pow(web3.utils.toBN("60"));
+    assert(await didContractThrow(fixedPoint.wrapMixedAdd("0", tenToSixty)));
+
+    // Reverts if both arguments can be represented but the sum overflows.
+    // TODO: Add this annoying test case.
   });
 
   it("Subtraction", async function() {
-    const FixedPoint = await FixedPointTest.new();
+    const fixedPoint = await FixedPointTest.new();
 
     // Subtractions below 10**18.
-    let sum = await FixedPoint.wrapSub("99", "7");
+    let sum = await fixedPoint.wrapSub("99", "7");
     assert.equal(sum, "92");
 
     // Subtractions above 10**18.
-    sum = await FixedPoint.wrapSub(web3.utils.toWei("99"), web3.utils.toWei("7"));
+    sum = await fixedPoint.wrapSub(web3.utils.toWei("99"), web3.utils.toWei("7"));
     assert.equal(sum, web3.utils.toWei("92"));
 
     // Reverts on underflow.
-    assert(await didContractThrow(FixedPoint.wrapSub("1", "2")));
+    assert(await didContractThrow(fixedPoint.wrapSub("1", "2")));
+  });
+
+  it("Mixed subtraction", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    // Basic mixed subtraction case.
+    const difference = await fixedPoint.wrapMixedSub(web3.utils.toWei("11.5"), "2");
+    assert.equal(difference, web3.utils.toWei("9.5"));
+
+    // Reverts if uint (second argument) can't be represented as an Unsigned.
+    const tenToSixty = web3.utils.toBN("10").pow(web3.utils.toBN("60"));
+    // 10**70 is the scaled version of 10**52, which can be represented. In this test case, we want to make sure
+    // that the first argument is greater than the second, because that would be testing the underflow case instead.
+    const tenToSeventy = web3.utils.toBN("10").pow(web3.utils.toBN("70"));
+    assert(await didContractThrow(fixedPoint.wrapMixedSub(tenToSeventy, tenToSixty)));
+
+    // Reverts on underflow (i.e., second argument larger than first).
+    assert(await didContractThrow(fixedPoint.wrapMixedSub(web3.utils.toWei("1.5"), "2")));
+  });
+
+  it("Mixed subtraction opposite", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    // Basic mixed subtraction case.
+    const difference = await fixedPoint.wrapMixedSubOpposite("10", web3.utils.toWei("5.5"));
+    assert.equal(difference, web3.utils.toWei("4.5"));
+
+    // Reverts on underflow (i.e., second argument larger than first).
+    assert(await didContractThrow(fixedPoint.wrapMixedSub("5", web3.utils.toWei("5.5"))));
   });
 
   it("Multiplication", async function() {
-    const FixedPoint = await FixedPointTest.new();
+    const fixedPoint = await FixedPointTest.new();
 
     // Whole numbers above 10**18.
-    let product = await FixedPoint.wrapMul(web3.utils.toWei("5"), web3.utils.toWei("17"));
+    let product = await fixedPoint.wrapMul(web3.utils.toWei("5"), web3.utils.toWei("17"));
     assert.equal(product.toString(), web3.utils.toWei("85"));
 
     // Fractions, no precision loss.
-    product = await FixedPoint.wrapMul(web3.utils.toWei("0.0001"), web3.utils.toWei("5"));
+    product = await fixedPoint.wrapMul(web3.utils.toWei("0.0001"), web3.utils.toWei("5"));
     assert.equal(product.toString(), web3.utils.toWei("0.0005"));
 
     // Fractions, precision loss, rounding down.
     // 1.2 * 2e-18 = 2.4e-18, which can't be represented and gets rounded down to 2.
-    product = await FixedPoint.wrapMul(web3.utils.toWei("1.2"), "2");
+    product = await fixedPoint.wrapMul(web3.utils.toWei("1.2"), "2");
     assert.equal(product.toString(), "2");
 
     // Reverts on overflow.
     // (uint_max - 1) * 2 overflows.
-    assert(await didContractThrow(FixedPoint.wrapMul(uint_max.sub(web3.utils.toBN("1")), web3.utils.toWei("2"))));
+    assert(await didContractThrow(fixedPoint.wrapMul(uint_max.sub(web3.utils.toBN("1")), web3.utils.toWei("2"))));
+  });
+
+  it("Mixed multiplication", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    let product = await fixedPoint.wrapMixedMul(web3.utils.toWei("1.5"), "3");
+    assert.equal(product, web3.utils.toWei("4.5"));
+
+    // We can handle outputs up to 10^59.
+    const tenToSixty = web3.utils.toBN("10").pow(web3.utils.toBN("60"));
+    const tenToFiftyNine = web3.utils.toBN("10").pow(web3.utils.toBN("59"));
+    product = await fixedPoint.wrapMixedMul(web3.utils.toWei("0.1"), tenToSixty);
+    assert.equal(product.toString(), web3.utils.toWei(tenToFiftyNine.toString()));
+
+    // Reverts on overflow.
+    // (uint_max / 2) * 3 overflows.
+    assert(await didContractThrow(fixedPoint.wrapMixedMul(uint_max.div(web3.utils.toBN("2")), "3")));
   });
 
   it("Division", async function() {
-    const FixedPoint = await FixedPointTest.new();
+    const fixedPoint = await FixedPointTest.new();
 
     // Normal division case.
-    let quotient = await FixedPoint.wrapDiv(web3.utils.toWei("150.3"), web3.utils.toWei("3"));
+    let quotient = await fixedPoint.wrapDiv(web3.utils.toWei("150.3"), web3.utils.toWei("3"));
     assert.equal(quotient.toString(), web3.utils.toWei("50.1"));
 
     // Divisor < 1.
-    quotient = await FixedPoint.wrapDiv(web3.utils.toWei("2"), web3.utils.toWei("0.01"));
+    quotient = await fixedPoint.wrapDiv(web3.utils.toWei("2"), web3.utils.toWei("0.01"));
     assert.equal(quotient.toString(), web3.utils.toWei("200"));
 
     // Fractions, precision loss, rounding down.
     // 1 / 3 = 0.3 repeating, which can't be represented and gets rounded down to 0.333333333333333333.
-    quotient = await FixedPoint.wrapDiv(web3.utils.toWei("1"), web3.utils.toWei("3"));
+    quotient = await fixedPoint.wrapDiv(web3.utils.toWei("1"), web3.utils.toWei("3"));
     assert.equal(quotient.toString(), "3".repeat(18));
 
     // Reverts on division by zero.
-    assert(await didContractThrow(FixedPoint.wrapDiv("1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapDiv("1", "0")));
+  });
+
+  it("Mixed division", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    // Normal mixed division case.
+    let quotient = await fixedPoint.wrapMixedDiv(web3.utils.toWei("150.3"), "3");
+    assert.equal(quotient.toString(), web3.utils.toWei("50.1"));
+
+    // Reverts on division by zero.
+    assert(await didContractThrow(fixedPoint.wrapMixedDiv("1", "0")));
+  });
+
+  it("Mixed division opposite", async function() {
+    const fixedPoint = await FixedPointTest.new();
+
+    // Normal mixed division case.
+    let quotient = await fixedPoint.wrapMixedDivOpposite("120", web3.utils.toWei("3.2"));
+    assert.equal(quotient.toString(), web3.utils.toWei("37.5"));
+
+    // Reverts on division by zero.
+    assert(await didContractThrow(fixedPoint.wrapMixedDivOpposite("1", "0")));
   });
 });


### PR DESCRIPTION
Supports operations between an `Unsigned` and a regular `uint`. Note
that the `uint` does not have a scaling factor built in, e.g., "5" would
first get mapped to "5e18" before being operated on.

Issue #351 