### PR TITLE
Add UMA token contract

### DIFF
--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -9,7 +9,7 @@ run_slither() {
     truffle compile 
 
     cd $PROTOCOL_DIR
-    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether,reentrancy-eth $1
+    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether,reentrancy-eth,uninitialized-state-variables $1
 }
 
 run_slither $PROTOCOL_DIR/v0

--- a/v1/contracts/VotingToken.sol
+++ b/v1/contracts/VotingToken.sol
@@ -14,9 +14,9 @@ contract VotingToken is ERC20Snapshot, MultiRole {
     enum Roles {
         // Can set the minter.
         Governance,
-        // The Oracle contract (currently named Voting.sol) can mint new tokens as voting rewards.
+        // Addresses that can mint new tokens.
         Minter,
-        // An UMA controlled address can burn tokens that it owns.
+        // Addresses that can burn tokens that address owns.
         Burner
     }
 

--- a/v1/contracts/VotingToken.sol
+++ b/v1/contracts/VotingToken.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.0;
+
+import "./MultiRole.sol";
+
+import "openzeppelin-solidity/contracts/drafts/ERC20Snapshot.sol";
+
+
+/**
+ * @title UMA voting token
+ * @dev Supports snapshotting and allows the Oracle to mint new tokens as rewards.
+ */
+contract VotingToken is ERC20Snapshot, MultiRole {
+
+    enum Roles {
+        // Can set the minter.
+        Governance,
+        // The Oracle contract (currently named Voting.sol) can mint new tokens as voting rewards.
+        Minter
+    }
+
+    constructor() public {
+        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
+        _createExclusiveRole(uint(Roles.Minter), uint(Roles.Governance), msg.sender);
+    }
+
+    /**
+     * @dev Mints `value` tokens to `recipient`, returning true on success.
+     */
+    function mint(address recipient, uint value) external onlyRoleHolder(uint(Roles.Minter)) returns (bool) {
+        _mint(recipient, value);
+        return true;
+    }
+}

--- a/v1/contracts/VotingToken.sol
+++ b/v1/contracts/VotingToken.sol
@@ -12,7 +12,7 @@ import "openzeppelin-solidity/contracts/drafts/ERC20Snapshot.sol";
 contract VotingToken is ERC20Snapshot, MultiRole {
 
     enum Roles {
-        // Can set the minter.
+        // Can set the minter and burner.
         Governance,
         // Addresses that can mint new tokens.
         Minter,

--- a/v1/contracts/VotingToken.sol
+++ b/v1/contracts/VotingToken.sol
@@ -15,12 +15,15 @@ contract VotingToken is ERC20Snapshot, MultiRole {
         // Can set the minter.
         Governance,
         // The Oracle contract (currently named Voting.sol) can mint new tokens as voting rewards.
-        Minter
+        Minter,
+        // An UMA controlled address can burn tokens that it owns.
+        Burner
     }
 
     constructor() public {
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
-        _createExclusiveRole(uint(Roles.Minter), uint(Roles.Governance), msg.sender);
+        _createSharedRole(uint(Roles.Minter), uint(Roles.Governance), new address[](0));
+        _createSharedRole(uint(Roles.Burner), uint(Roles.Governance), new address[](0));
     }
 
     /**
@@ -29,5 +32,12 @@ contract VotingToken is ERC20Snapshot, MultiRole {
     function mint(address recipient, uint value) external onlyRoleHolder(uint(Roles.Minter)) returns (bool) {
         _mint(recipient, value);
         return true;
+    }
+
+    /**
+     * @dev Burns `value` tokens owned by `msg.sender`.
+     */
+    function burn(uint value) external onlyRoleHolder(uint(Roles.Burner)) {
+        _burn(msg.sender, value);
     }
 }

--- a/v1/migrations/3_deploy_voting_token.js
+++ b/v1/migrations/3_deploy_voting_token.js
@@ -1,0 +1,16 @@
+const VotingToken = artifacts.require("VotingToken");
+const Voting = artifacts.require("Voting");
+const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+
+module.exports = async function(deployer, network, accounts) {
+  const keys = getKeysForNetwork(network, accounts);
+
+  const votingToken = await deployAndGet(deployer, VotingToken, { from: keys.deployer });
+  await addToTdr(votingToken, network);
+
+  // Corresponds to VotingToken.Roles.Minter;
+  const minterRoleEnumValue = 1;
+  // Set the minter to be Voting.sol.
+  const voting = await Voting.deployed();
+  await votingToken.resetMember(minterRoleEnumValue, voting.address, { from: keys.deployer });
+};

--- a/v1/migrations/3_deploy_voting_token.js
+++ b/v1/migrations/3_deploy_voting_token.js
@@ -12,5 +12,5 @@ module.exports = async function(deployer, network, accounts) {
   const minterRoleEnumValue = 1;
   // Set the minter to be Voting.sol.
   const voting = await Voting.deployed();
-  await votingToken.resetMember(minterRoleEnumValue, voting.address, { from: keys.deployer });
+  await votingToken.addMember(minterRoleEnumValue, voting.address, { from: keys.deployer });
 };

--- a/v1/test/VotingToken.js
+++ b/v1/test/VotingToken.js
@@ -1,0 +1,34 @@
+const { didContractThrow } = require("../../common/SolidityTestUtils.js");
+
+const VotingToken = artifacts.require("VotingToken");
+
+contract("VotingToken", function(accounts) {
+  const governance = accounts[0];
+  const votingContractAddress = accounts[1];
+  const voter = accounts[2];
+
+  // Corresponds to VotingToken.Roles.Minter;
+  const minterRoleEnumValue = 1;
+
+  it("Minting", async function() {
+    const votingToken = await VotingToken.deployed();
+
+    assert.equal(await votingToken.totalSupply(), "0");
+    assert.equal(await votingToken.balanceOf(voter), "0");
+
+    // Contracts can't authorize themselves to mint tokens.
+    assert(await didContractThrow(votingToken.resetMember(1, votingContractAddress, { from: votingContractAddress })));
+    // Set minter. In prod, this will be the address of the voting contract.
+    await votingToken.resetMember(minterRoleEnumValue, votingContractAddress, { from: governance });
+
+    const numTokens = web3.utils.toWei("100");
+    // Voters can't mint themselves new tokens.
+    assert(await didContractThrow(votingToken.mint(voter, numTokens, { from: voter })));
+    // The voting contract can mint new tokens to a voter.
+    await votingToken.mint(voter, numTokens, { from: votingContractAddress });
+
+    // Verify updated balances.
+    assert.equal(await votingToken.totalSupply(), numTokens);
+    assert.equal(await votingToken.balanceOf(voter), numTokens);
+  });
+});

--- a/v1/test/VotingToken.js
+++ b/v1/test/VotingToken.js
@@ -6,11 +6,13 @@ contract("VotingToken", function(accounts) {
   const governance = accounts[0];
   const votingContractAddress = accounts[1];
   const voter = accounts[2];
+  const buybackUser = accounts[3];
 
-  // Corresponds to VotingToken.Roles.Minter;
+  // Corresponds to VotingToken.Roles enum.
   const minterRoleEnumValue = 1;
+  const burnerRoleEnumValue = 2;
 
-  it("Minting", async function() {
+  it("Minting/Burning", async function() {
     const votingToken = await VotingToken.deployed();
 
     assert.equal(await votingToken.totalSupply(), "0");
@@ -19,7 +21,9 @@ contract("VotingToken", function(accounts) {
     // Contracts can't authorize themselves to mint tokens.
     assert(await didContractThrow(votingToken.resetMember(1, votingContractAddress, { from: votingContractAddress })));
     // Set minter. In prod, this will be the address of the voting contract.
-    await votingToken.resetMember(minterRoleEnumValue, votingContractAddress, { from: governance });
+    await votingToken.addMember(minterRoleEnumValue, votingContractAddress, { from: governance });
+    // Set burner.
+    await votingToken.addMember(burnerRoleEnumValue, buybackUser, { from: governance });
 
     const numTokens = web3.utils.toWei("100");
     // Voters can't mint themselves new tokens.
@@ -30,5 +34,27 @@ contract("VotingToken", function(accounts) {
     // Verify updated balances.
     assert.equal(await votingToken.totalSupply(), numTokens);
     assert.equal(await votingToken.balanceOf(voter), numTokens);
+
+    const tokensToBurn = web3.utils.toWei("25");
+    const tokensLeft = web3.utils
+      .toBN(numTokens)
+      .sub(web3.utils.toBN(tokensToBurn))
+      .toString();
+    // Voters can't burn their own tokens.
+    assert(await didContractThrow(votingToken.burn(tokensToBurn, { from: voter })));
+    // Can't burn tokens if you don't own any, not even the governance role.
+    assert(await didContractThrow(votingToken.burn(tokensToBurn, { from: governance })));
+
+    // Transfer to the buyback user.
+    await votingToken.transfer(buybackUser, tokensToBurn, { from: voter });
+    assert.equal(await votingToken.balanceOf(voter), tokensLeft);
+    assert.equal(await votingToken.balanceOf(buybackUser), tokensToBurn);
+
+    // Buyback user can burn tokens.
+    await votingToken.burn(tokensToBurn, { from: buybackUser });
+
+    // Check updated balances.
+    assert.equal(await votingToken.totalSupply(), tokensLeft);
+    assert.equal(await votingToken.balanceOf(buybackUser), "0");
   });
 });


### PR DESCRIPTION
This token uses OpenZeppelin's ERC20Snapshot implementation for
snapshotting. It further allows a given address to mint new tokens (in
prod, this address will be the Oracle that mints new tokens as voter
rewards).

I had to remove another Slither detector that falsely triggers.

Issue #405 