### PR TITLE
Copy over Registry contract and use MultiRole

### DIFF
--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -1,0 +1,133 @@
+pragma solidity ^0.5.0;
+
+import "./RegistryInterface.sol";
+import "./Withdrawable.sol";
+
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+pragma experimental ABIEncoderV2;
+
+
+contract Registry is RegistryInterface, Withdrawable {
+
+    using SafeMath for uint;
+
+    // Array of all registeredDerivatives that are approved to use the UMA Oracle.
+    RegisteredDerivative[] private registeredDerivatives;
+
+    // This enum is required because a WasValid state is required to ensure that derivatives cannot be re-registered.
+    enum PointerValidity {
+        Invalid,
+        Valid,
+        WasValid
+    }
+
+    struct Pointer {
+        PointerValidity valid;
+        uint128 index;
+    }
+
+    // Maps from derivative address to a pointer that refers to that RegisteredDerivative in registeredDerivatives.
+    mapping(address => Pointer) private derivativePointers;
+
+    // Note: this must be stored outside of the RegisteredDerivative because mappings cannot be deleted and copied
+    // like normal data. This could be stored in the Pointer struct, but storing it there would muddy the purpose
+    // of the Pointer struct and break separation of concern between referential data and data.
+    struct PartiesMap {
+        mapping(address => bool) parties;
+    }
+
+    // Maps from derivative address to the set of parties that are involved in that derivative.
+    mapping(address => PartiesMap) private derivativesToParties;
+
+    // Maps from derivative creator address to whether that derivative creator has been approved to register contracts.
+    mapping(address => bool) private derivativeCreators;
+
+    modifier onlyApprovedDerivativeCreator {
+        require(derivativeCreators[msg.sender]);
+        _;
+    }
+
+    function registerDerivative(address[] calldata parties, address derivativeAddress)
+        external
+        onlyApprovedDerivativeCreator
+    {
+        // Create derivative pointer.
+        Pointer storage pointer = derivativePointers[derivativeAddress];
+
+        // Ensure that the pointer was not valid in the past (derivatives cannot be re-registered or double
+        // registered).
+        require(pointer.valid == PointerValidity.Invalid);
+        pointer.valid = PointerValidity.Valid;
+
+        registeredDerivatives.push(RegisteredDerivative(derivativeAddress, msg.sender));
+
+        // No length check necessary because we should never hit (2^127 - 1) derivatives.
+        pointer.index = uint128(registeredDerivatives.length.sub(1));
+
+        // Set up PartiesMap for this derivative.
+        PartiesMap storage partiesMap = derivativesToParties[derivativeAddress];
+        for (uint i = 0; i < parties.length; i = i.add(1)) {
+            partiesMap.parties[parties[i]] = true;
+        }
+
+        address[] memory partiesForEvent = parties;
+        emit RegisterDerivative(derivativeAddress, partiesForEvent);
+    }
+
+    function addDerivativeCreator(address derivativeCreator) external onlyOwner {
+        if (!derivativeCreators[derivativeCreator]) {
+            derivativeCreators[derivativeCreator] = true;
+            emit AddDerivativeCreator(derivativeCreator);
+        }
+    }
+
+    function removeDerivativeCreator(address derivativeCreator) external onlyOwner {
+        if (derivativeCreators[derivativeCreator]) {
+            derivativeCreators[derivativeCreator] = false;
+            emit RemoveDerivativeCreator(derivativeCreator);
+        }
+    }
+
+    function isDerivativeRegistered(address derivative) external view returns (bool isRegistered) {
+        return derivativePointers[derivative].valid == PointerValidity.Valid;
+    }
+
+    function getRegisteredDerivatives(address party) external view returns (RegisteredDerivative[] memory derivatives) {
+        // This is not ideal - we must statically allocate memory arrays. To be safe, we make a temporary array as long
+        // as registeredDerivatives. We populate it with any derivatives that involve the provided party. Then, we copy
+        // the array over to the return array, which is allocated using the correct size. Note: this is done by double
+        // copying each value rather than storing some referential info (like indices) in memory to reduce the number
+        // of storage reads. This is because storage reads are far more expensive than extra memory space (~100:1).
+        RegisteredDerivative[] memory tmpDerivativeArray = new RegisteredDerivative[](registeredDerivatives.length);
+        uint outputIndex = 0;
+        for (uint i = 0; i < registeredDerivatives.length; i = i.add(1)) {
+            RegisteredDerivative storage derivative = registeredDerivatives[i];
+            if (derivativesToParties[derivative.derivativeAddress].parties[party]) {
+                // Copy selected derivative to the temporary array.
+                tmpDerivativeArray[outputIndex] = derivative;
+                outputIndex = outputIndex.add(1);
+            }
+        }
+
+        // Copy the temp array to the return array that is set to the correct size.
+        derivatives = new RegisteredDerivative[](outputIndex);
+        for (uint j = 0; j < outputIndex; j = j.add(1)) {
+            derivatives[j] = tmpDerivativeArray[j];
+        }
+    }
+
+    function getAllRegisteredDerivatives() external view returns (RegisteredDerivative[] memory derivatives) {
+        return registeredDerivatives;
+    }
+
+    function isDerivativeCreatorAuthorized(address derivativeCreator) external view returns (bool isAuthorized) {
+        return derivativeCreators[derivativeCreator];
+    }
+
+    event RegisterDerivative(address indexed derivativeAddress, address[] parties);
+    event AddDerivativeCreator(address indexed addedDerivativeCreator);
+    event RemoveDerivativeCreator(address indexed removedDerivativeCreator);
+
+}

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -56,16 +56,6 @@ contract Registry is RegistryInterface, MultiRole {
         _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Writer), new address[](0));
     }
 
-    /*
-     * @notice Do not call this function.
-     * @dev Do not call, only used to make the coverage tool work.
-     */
-    function doNotCall() public {
-        require(false, "Do not call this method.");
-         _createExclusiveRole(500, 501, msg.sender);
-         _createSharedRole(600, 601, new address[](0));
-    }
-
     function registerDerivative(address[] calldata parties, address derivativeAddress)
         external
         onlyRoleHolder(uint(Roles.DerivativeCreator))
@@ -123,6 +113,16 @@ contract Registry is RegistryInterface, MultiRole {
 
     function getAllRegisteredDerivatives() external view returns (RegisteredDerivative[] memory derivatives) {
         return registeredDerivatives;
+    }
+
+    /*
+     * @notice Do not call this function.
+     * @dev Do not call, only used to make the coverage tool work.
+     */
+    function doNotCall() public {
+        require(false, "Do not call this method.");
+        _createExclusiveRole(500, 501, msg.sender);
+        _createSharedRole(600, 601, new address[](0));
     }
 
     event RegisterDerivative(address indexed derivativeAddress, address[] parties);

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -114,7 +114,8 @@ contract Registry is RegistryInterface, MultiRole {
 
     /*
      * @notice Do not call this function externally.
-     * @dev Only called from the constructor, and only extrated to a separate method to make the coverage tool work.
+     * @dev Only called from the constructor, and only extracted to a separate method to make the coverage tool work. If
+     * called again, the MultiRole checks will cause a revert.
      */
     function initializeRolesOnce() public {
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -50,10 +50,7 @@ contract Registry is RegistryInterface, MultiRole {
     mapping(address => PartiesMap) private derivativesToParties;
 
     constructor() public {
-        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
-        _createExclusiveRole(uint(Roles.Writer), uint(Roles.Governance), msg.sender);
-        // Start with no derivative creators registered.
-        _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Writer), new address[](0));
+        initializeRolesOnce();
     }
 
     function registerDerivative(address[] calldata parties, address derivativeAddress)
@@ -113,6 +110,17 @@ contract Registry is RegistryInterface, MultiRole {
 
     function getAllRegisteredDerivatives() external view returns (RegisteredDerivative[] memory derivatives) {
         return registeredDerivatives;
+    }
+
+    /*
+     * @notice Do not call this function externally.
+     * @dev Only called from the constructor, and only used to make the coverage tool work.
+     */
+    function initializeRolesOnce() public {
+        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
+        _createExclusiveRole(uint(Roles.Writer), uint(Roles.Governance), msg.sender);
+        // Start with no derivative creators registered.
+        _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Writer), new address[](0));
     }
 
     event RegisterDerivative(address indexed derivativeAddress, address[] parties);

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -114,7 +114,7 @@ contract Registry is RegistryInterface, MultiRole {
 
     /*
      * @notice Do not call this function externally.
-     * @dev Only called from the constructor, and only used to make the coverage tool work.
+     * @dev Only called from the constructor, and only extrated to a separate method to make the coverage tool work.
      */
     function initializeRolesOnce() public {
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -56,6 +56,16 @@ contract Registry is RegistryInterface, MultiRole {
         _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Writer), new address[](0));
     }
 
+    /*
+     * @notice Do not call this function.
+     * @dev Do not call, only used to make the coverage tool work.
+     */
+    function doNotCall() public {
+        require(false, "Do not call this method.");
+         _createExclusiveRole(500, 501, msg.sender);
+         _createSharedRole(600, 601, new address[](0));
+    }
+
     function registerDerivative(address[] calldata parties, address derivativeAddress)
         external
         onlyRoleHolder(uint(Roles.DerivativeCreator))

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -115,15 +115,5 @@ contract Registry is RegistryInterface, MultiRole {
         return registeredDerivatives;
     }
 
-    /*
-     * @notice Do not call this function.
-     * @dev Do not call, only used to make the coverage tool work.
-     */
-    function doNotCall() public {
-        require(false, "Do not call this method.");
-        _createExclusiveRole(500, 501, msg.sender);
-        _createSharedRole(600, 601, new address[](0));
-    }
-
     event RegisterDerivative(address indexed derivativeAddress, address[] parties);
 }

--- a/v1/contracts/Registry.sol
+++ b/v1/contracts/Registry.sol
@@ -49,9 +49,6 @@ contract Registry is RegistryInterface, MultiRole {
     // Maps from derivative address to the set of parties that are involved in that derivative.
     mapping(address => PartiesMap) private derivativesToParties;
 
-    // Maps from derivative creator address to whether that derivative creator has been approved to register contracts.
-    mapping(address => bool) private derivativeCreators;
-
     constructor() public {
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
         _createExclusiveRole(uint(Roles.Writer), uint(Roles.Governance), msg.sender);

--- a/v1/contracts/RegistryInterface.sol
+++ b/v1/contracts/RegistryInterface.sol
@@ -1,0 +1,38 @@
+/*
+  Registry Interface
+*/
+pragma solidity ^0.5.0;
+
+pragma experimental ABIEncoderV2;
+
+
+interface RegistryInterface {
+    struct RegisteredDerivative {
+        address derivativeAddress;
+        address derivativeCreator;
+    }
+
+    // Registers a new derivative. Only authorized derivative creators can call this method.
+    function registerDerivative(address[] calldata counterparties, address derivativeAddress) external;
+
+    // Adds a new derivative creator to this list of authorized creators. Only the owner of this contract can call
+    // this method.   
+    function addDerivativeCreator(address derivativeCreator) external;
+
+    // Removes a derivative creator to this list of authorized creators. Only the owner of this contract can call this
+    // method.  
+    function removeDerivativeCreator(address derivativeCreator) external;
+
+    // Returns whether the derivative has been registered with the registry (and is therefore an authorized participant
+    // in the UMA system).
+    function isDerivativeRegistered(address derivative) external view returns (bool isRegistered);
+
+    // Returns a list of all derivatives that are associated with a particular party.
+    function getRegisteredDerivatives(address party) external view returns (RegisteredDerivative[] memory derivatives);
+
+    // Returns all registered derivatives.
+    function getAllRegisteredDerivatives() external view returns (RegisteredDerivative[] memory derivatives);
+
+    // Returns whether an address is authorized to register new derivatives.
+    function isDerivativeCreatorAuthorized(address derivativeCreator) external view returns (bool isAuthorized);
+}

--- a/v1/contracts/RegistryInterface.sol
+++ b/v1/contracts/RegistryInterface.sol
@@ -15,14 +15,6 @@ interface RegistryInterface {
     // Registers a new derivative. Only authorized derivative creators can call this method.
     function registerDerivative(address[] calldata counterparties, address derivativeAddress) external;
 
-    // Adds a new derivative creator to this list of authorized creators. Only the owner of this contract can call
-    // this method.   
-    function addDerivativeCreator(address derivativeCreator) external;
-
-    // Removes a derivative creator to this list of authorized creators. Only the owner of this contract can call this
-    // method.  
-    function removeDerivativeCreator(address derivativeCreator) external;
-
     // Returns whether the derivative has been registered with the registry (and is therefore an authorized participant
     // in the UMA system).
     function isDerivativeRegistered(address derivative) external view returns (bool isRegistered);
@@ -32,7 +24,4 @@ interface RegistryInterface {
 
     // Returns all registered derivatives.
     function getAllRegisteredDerivatives() external view returns (RegisteredDerivative[] memory derivatives);
-
-    // Returns whether an address is authorized to register new derivatives.
-    function isDerivativeCreatorAuthorized(address derivativeCreator) external view returns (bool isAuthorized);
 }

--- a/v1/test/Registry.js
+++ b/v1/test/Registry.js
@@ -1,0 +1,136 @@
+const { didContractThrow } = require("../../common/SolidityTestUtils.js");
+
+const truffleAssert = require("truffle-assertions");
+
+const Registry = artifacts.require("Registry");
+
+contract("Registry", function(accounts) {
+  // A deployed instance of the Registry contract, ready for testing.
+  let registry;
+
+  const owner = accounts[0];
+  const creator1 = accounts[1];
+  const creator2 = accounts[2];
+  const rando1 = accounts[3];
+  const rando2 = accounts[4];
+
+  beforeEach(async function() {
+    registry = await Registry.new();
+  });
+
+  const areAddressesEqual = (address1, address2) => {
+    return address1.toLowerCase() === address2.toLowerCase();
+  };
+
+  it("Derivative creation", async function() {
+    // No creators should be registered initially.
+    assert.isNotTrue(await registry.isDerivativeCreatorAuthorized(creator1));
+
+    // Only the owner should be able to add derivative creators.
+    assert(await didContractThrow(registry.addDerivativeCreator(creator1, { from: rando1 })));
+
+    // Register creator1, but not creator2.
+    let result = await registry.addDerivativeCreator(creator1, { from: owner });
+    assert.isTrue(await registry.isDerivativeCreatorAuthorized(creator1));
+    assert.isFalse(await registry.isDerivativeCreatorAuthorized(creator2));
+
+    // Ensure an AddDerivativeCreator event is logged.
+    truffleAssert.eventEmitted(result, "AddDerivativeCreator", ev => {
+      return web3.utils.toChecksumAddress(ev.addedDerivativeCreator) === web3.utils.toChecksumAddress(creator1);
+    });
+
+    // Add it a second time, but check that an event is not emitted.
+    result = await registry.addDerivativeCreator(creator1, { from: owner });
+    truffleAssert.eventNotEmitted(result, "AddDerivativeCreator");
+
+    // Try to register an arbitrary contract.
+    const arbitraryContract = web3.utils.randomHex(20);
+    const parties = [web3.utils.randomHex(20), web3.utils.randomHex(20)];
+
+    // Only approved creators can register contracts.
+    assert(await didContractThrow(registry.registerDerivative(parties, arbitraryContract, { from: creator2 })));
+
+    // creator1 should be able to register a new contract.
+    result = await registry.registerDerivative(parties, arbitraryContract, { from: creator1 });
+    assert.isTrue(await registry.isDerivativeRegistered(arbitraryContract));
+
+    // Make sure a RegisterDerivative event is emitted.
+    truffleAssert.eventEmitted(result, "RegisterDerivative", ev => {
+      return web3.utils.toChecksumAddress(ev.derivativeAddress) === web3.utils.toChecksumAddress(arbitraryContract);
+    });
+
+    // Remove the derivative creator.
+    result = await registry.removeDerivativeCreator(creator1, { from: owner });
+    assert.isFalse(await registry.isDerivativeCreatorAuthorized(creator1));
+
+    // Ensure an event was emitted.
+    truffleAssert.eventEmitted(result, "RemoveDerivativeCreator", ev => {
+      return web3.utils.toChecksumAddress(ev.removedDerivativeCreator) === web3.utils.toChecksumAddress(creator1);
+    });
+
+    // Creation should fail since creator1 is no longer approved.
+    const secondContract = web3.utils.randomHex(20);
+    assert(await didContractThrow(registry.registerDerivative(parties, secondContract, { from: creator1 })));
+
+    // A second removal should not trigger another event.
+    result = await registry.removeDerivativeCreator(creator1, { from: owner });
+    truffleAssert.eventNotEmitted(result, "RemoveDerivativeCreator");
+  });
+
+  it("Register and query derivatives", async function() {
+    await registry.addDerivativeCreator(creator1, { from: owner });
+    await registry.addDerivativeCreator(creator2, { from: owner });
+
+    // Register an arbitrary derivative.
+    const derivative1 = web3.utils.randomHex(20);
+    const derivative2 = web3.utils.randomHex(20);
+    const derivative3 = web3.utils.randomHex(20);
+    const party1 = web3.utils.randomHex(20);
+    const party2 = web3.utils.randomHex(20);
+    const party3 = web3.utils.randomHex(20);
+
+    // Register two derivatives with partially overlapping parties
+    await registry.registerDerivative([party1, party2], derivative1, { from: creator1 });
+    await registry.registerDerivative([party2, party3], derivative2, { from: creator2 });
+    await registry.registerDerivative([], derivative3, { from: creator1 });
+
+    // Query that derivative by party and ensure all parties see their correct derivatives.
+    const party1Derivatives = await registry.getRegisteredDerivatives(party1);
+    assert.equal(party1Derivatives.length, 1);
+    assert.isTrue(areAddressesEqual(party1Derivatives[0].derivativeAddress, derivative1));
+    assert.isTrue(areAddressesEqual(party1Derivatives[0].derivativeCreator, creator1));
+
+    const party2Derivatives = await registry.getRegisteredDerivatives(party2);
+    assert.equal(party2Derivatives.length, 2);
+    assert.isTrue(areAddressesEqual(party2Derivatives[0].derivativeAddress, derivative1));
+    assert.isTrue(areAddressesEqual(party2Derivatives[0].derivativeCreator, creator1));
+    assert.isTrue(areAddressesEqual(party2Derivatives[1].derivativeAddress, derivative2));
+    assert.isTrue(areAddressesEqual(party2Derivatives[1].derivativeCreator, creator2));
+
+    const party3Derivatives = await registry.getRegisteredDerivatives(party3);
+    assert.equal(party3Derivatives.length, 1);
+    assert.isTrue(areAddressesEqual(party3Derivatives[0].derivativeAddress, derivative2));
+    assert.isTrue(areAddressesEqual(party3Derivatives[0].derivativeCreator, creator2));
+
+    const allDerivatives = await registry.getAllRegisteredDerivatives();
+    assert.equal(allDerivatives.length, 3);
+    assert.isTrue(areAddressesEqual(allDerivatives[0].derivativeAddress, derivative1));
+    assert.isTrue(areAddressesEqual(allDerivatives[0].derivativeCreator, creator1));
+    assert.isTrue(areAddressesEqual(allDerivatives[1].derivativeAddress, derivative2));
+    assert.isTrue(areAddressesEqual(allDerivatives[1].derivativeCreator, creator2));
+    assert.isTrue(areAddressesEqual(allDerivatives[2].derivativeAddress, derivative3));
+    assert.isTrue(areAddressesEqual(allDerivatives[2].derivativeCreator, creator1));
+  });
+
+  it("Double-register derivative", async function() {
+    // Approve creator.
+    await registry.addDerivativeCreator(creator1, { from: owner });
+
+    // Register derivative.
+    const derivative1 = web3.utils.randomHex(20);
+    await registry.registerDerivative([], derivative1, { from: creator1 });
+
+    // Cannot register a derivative that is already registered.
+    assert(await didContractThrow(registry.registerDerivative([], derivative1, { from: creator1 })));
+  });
+});

--- a/v1/test/Registry.js
+++ b/v1/test/Registry.js
@@ -29,6 +29,11 @@ contract("Registry", function(accounts) {
     return address1.toLowerCase() === address2.toLowerCase();
   };
 
+  it("Initialize roles", async function() {
+    // Calling public initializeRolesOnce method fails.
+    assert(await didContractThrow(registry.initializeRolesOnce()));
+  });
+
   it("Derivative creation", async function() {
     // No creators should be registered initially.
     assert.isNotTrue(await registry.holdsRole(derivativeCreatorRole, creator1));


### PR DESCRIPTION
I went back and forth on whether to manage approved derivative creators via a MultiRole or keep what v0/Registry.sol did. Here's what it would look using MultiRole, let me know if you prefer another way.

It might be easiest to look at commit 1683dbb, which contains the actual changes from v0/contracts/Registry.sol.

Further improvements that we could make to the Registry in either this PR or in follow up PRs:
1. Remove PointerValidity enum
2. Add formatted documentation
3. Add to migrations

Issue #409 