### PR TITLE
Update solidity-coverage

### DIFF
--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -6,11 +6,6 @@ TRUFFLE_DIR=$1
 
 PROTOCOL_DIR=$(pwd)
 
-# Note: the following is necessary because the vanilla solidity-coverage tool is outdated and not compatible with solidity 0.5.0+.
-# We can may be able to get rid of the curl below once solidity-parser merges PR #18.
-# There may also be an option to use solidity-coverage@beta package, but we have yet to test that.
-curl https://raw.githubusercontent.com/maxsam4/solidity-parser/solidity-0.5/build/parser.js > node_modules/solidity-parser-sc/build/parser.js
-
 # $1 is the truffle directory over which we want to run the coverage tool.
 cd $TRUFFLE_DIR
 cp -R $PROTOCOL_DIR/common ./

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "prettier": "^1.16.4",
     "solhint": "^1.5.0",
-    "solidity-coverage": "^0.5.11",
+    "solidity-coverage": "^0.6.0-beta.5",
     "truffle-deploy-registry": "^0.5.1"
   },
   "dependencies": {


### PR DESCRIPTION
Updated to the new solidity-coverage beta version now that it's being updated again. This should fix our parsing issues seen in #409 and allow us to remove some of the hacky patching that was being done before.