### PR TITLE
Readme Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,17 @@ Before attempting to do anything with the v0 system, please run the following co
 
 Before starting this example, ensure you have done the [initial setup](#initial-setup) and are in the `v0` directory.
 
-1. Follow [these instructions](#deploying-to-ganache) to set up and deploy to ganache.
+1. Follow [these instructions](#deploying-to-ganache) to set up and deploy to ganache. Note: this means that you should
+be using the network `test` throughout these instructions.
 1. To configure the price feed to track BTC/ETH rather than futures contracts that require an API key, you'll need to
 change the names of two files:
 ```
 mv config/identifiers.json config/identifiersProdBackup.json
 mv config/identifiersTest.json config/identifiers.json
 ```
-1. Follow [these instructions](#upload-prices-to-the-manualpricefeed) to upload begin uploading BTC/ETH prices to your price feed. Note: your network
+1. Follow [these instructions](#upload-prices-to-the-manualpricefeed) to begin uploading BTC/ETH prices to your
+price feed.
+1. Follow [these instructions](#running-the-dapp) to begin running the dapp and launching contracts.
 
 ### Deploying to Ganache
 
@@ -41,21 +44,23 @@ mv config/identifiersTest.json config/identifiers.json
 $(npm bin)/truffle migrate --reset --network test
 ```
 
-5. To run the automated tests, run:
+4. To run the automated tests, run:
 ```
 $(npm bin)/truffle test --network test
 ```
+5. If you want to use the dapp with your ganache deployment, make sure you plug the mnemonic that it generates into
+Metamask instead of your normal ETH account.
 
 ### Mainnet/Ropsten Testnet Deployment
 
-1. Load your wallet mnemonic into your environment as such:
+1. Load your wallet mnemonic and Infura API key into your environment as such:
 ```
 export MNEMONIC="candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+export INFURA_API_KEY=1234abcd1234abcd1234abcd1234abcd
 ```
-2. Set your Infura API key as `INFURA_API_KEY` in your environment.
-3. Ensure your wallet has enough ETH to pay for the deployment (can take up to 0.4 ETH with the default gas settings).
-4. Tune the default gas price in `truffle.js` (currently set to `20 Gwei`) to your liking.
-5. Run the following command to start a fresh deployment to mainnet:
+2. Ensure your wallet has enough ETH to pay for the deployment (can take up to 0.4 ETH with the default gas settings).
+3. Tune the default gas price in `truffle.js` (currently set to `20 Gwei`) to your liking.
+4. Run the following command to start a fresh deployment to mainnet:
 ```
 $(npm bin)/truffle migrate --reset --network mainnet_mnemonic
 ```
@@ -63,48 +68,76 @@ If you'd like to deploy to the Ropsten testnet instead, run the following comman
 ```
 $(npm bin)/truffle migrate --reset --network ropsten_mnemonic
 ```
-6. To interact with the contracts you've deployed, run:
-```
-$(npm bin)/truffle console --network <network_name>
-```
-This will open a node console with all contracts loaded along with a web3 instance connected to the network and
-preloaded with your private keys (loads the first two private keys for your mnemonic by default).
 
-If you'd like to interact with the official UMA deployment instead of doing your own deployment, skip steps 1-5
-above and run the following commands instead:
+### Load UMA Mainnet and Testnet Deployments
+
+If you'd like to load the official UMA deployment instead of doing your own deployment, run the following commands:
 ```
 $(npm bin)/truffle compile
 $(npm bin)/apply-registry
 ```
-Please do not run any security tests against our mainnet deployment.
+
+Note: the mainnet and testnet deployments are whitelisted, so you will not be able to do much more than call `view`
+functions on these contracts unless you've been whitelisted previously.
+
+Please do not run any security tests against the mainnet deployment. 
 
 ### Upload Prices to the `ManualPriceFeed`
 
 After deploying the contracts to your network of choice, you can upload prices to the `ManualPriceFeed` contract for
-use by any derivatives that you choose to deploy. The script defaults to publishing `ESM19` and `CBN19`
-every 15 minutes. A barchart key must be set in your environment variable as `BARCHART_API_KEY`. You can run this script using the following command:
-```
-./publishPrices.sh <network>
-```
+use by any derivatives that you choose to deploy. The script defaults to publishing `ESM19` and `CBN19` every 15
+minutes. Depending on the types of price feeds configured in your `v0/config/identifiers.json` file, you may need some
+API keys in your environment:
+- Crypto price feeds (like `BTCETH` or `ETHUSD`): no environment variables are required.
+- Futures price feeds (like `ESM19` or `CBN19`): a barchart key must be set as an environment variable called
+`BARCHART_API_KEY`. A barchart key is required whenever the key-value pair `"dataSource": "Barchart"` is present in
+`identifiers.json`.
+- Equities price feeds (like `SPY`): an AlphaVantage key must be set as an environment variable called
+`ALPHAVANTAGE_API_KEY`. An AlphaVantage key is equired whenever `"dataSource: AlphaVantageCurrency"` or
+`"dataSource: AlphaVantage"` is present in `identifiers.json`.
 
+
+You can run this script using the following command:
+```
+./publishPrices.sh --network <network>
+```
 For the script to succeed, the `build` directory must contain the `ManualPriceFeed` address for the specified network.
 
 ### Running the dApp
 
 After deploying to ganache, ropsten, or mainnet (or any combination of those), you can run the Sponsor Dapp against the
-contracts by running the following commands:
+contracts. Before running the dApp, make sure you have done the following:
+- Make sure that you have [Metamask](https://metamask.io/) installed.
+- Make sure you've provided your ETH account mnemonic to metamask.
+    - If you're using the Ganache GUI, this should be available near the top of the page in the accounts (default) tab.
+    - If you're using Ganache CLI, this should be printed when you start it.
+    - If you're running against mainnet or testnet, you should use your own mnemonic.
+- Make sure you select the correct account.
+    - If you're using Ganache, the only account that will be whitelisted will be the second account associated with
+    your mnemonic. If you only have one account in Metamask, you can use the `Create Account` button to create a
+    second. You will need to select the second account if you'd like to launch contracts in the dapp.
+- Make sure you have the correct network selected in metamask.
+    - If you're using ganache, you'll need to create a custom RPC with the following URL: `http://127.0.0.1:9545`.
+
+Once you've done the above, you can start the dapp by running the following commands from the `protocol` (top level)
+directory:
 ```
 cd sponsor-dapp
 npm install
 npm run link-contracts
 npm start
 ```
-This should automatically start the dApp in your browser.
 
-### Interacting with contracts in truffle console
+This should automatically start the dApp in your browser. If it doesn't start on its own, you can enter following URL
+into your browser: `localhost:3000`.
 
-Make sure you've done the [initial setup](#initial-setup) and either [deployed to ganache](#deploying-to-ganache) or
-[deployed to a public network](#mainnetropsten-testnet-deployment).
+### Interacting with contracts directly in the truffle console
+
+Make sure you've done the [initial setup](#initial-setup) and either [deployed to ganache](#deploying-to-ganache),
+[deployed to a public network](#mainnetropsten-testnet-deployment), or
+[loaded the UMA deployment](#load-uma-mainnet-and-testnet-deployments). If you are using a mainnet or testnet
+deployment, make sure you load a mnemonic and infura API key into your environment as shown
+[here](#mainnetropsten-testnet-deployment).
 
 You can open a truffle console (a light wrapper around a node console) by running the following command and
 substituting `your_network_name` with the name of the network you deployed to:
@@ -112,13 +145,6 @@ substituting `your_network_name` with the name of the network you deployed to:
 ```
 $(npm bin)/truffle console --network your_network_name
 ```
-
-
-To interact with the contracts you've deployed, run:
-```
-$(npm bin)/truffle console --network test
-```
-This will open a node console with all contracts loaded along with a web3 instance connected to your ganache instance.
 
 ## Security and Bug Bounty
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Before starting this example, ensure you have done the [initial setup](#initial-
 
 1. Follow [these instructions](#deploying-to-ganache) to set up and deploy to Ganache. Note: this means that you should
 be using the network `test` throughout these instructions.
-1. To configure the price feed to track BTC/ETH rather than futures contracts that require an API key, you'll need to
+2. To configure the price feed to track BTC/ETH rather than futures contracts that require an API key, you'll need to
 change the names of two files:
 ```
 mv config/identifiers.json config/identifiersProdBackup.json
 mv config/identifiersTest.json config/identifiers.json
 ```
-1. Follow [these instructions](#upload-prices-to-the-manualpricefeed) to begin uploading BTC/ETH prices to your
+3. Follow [these instructions](#upload-prices-to-the-manualpricefeed) to begin uploading BTC/ETH prices to your
 price feed.
-1. Follow [these instructions](#running-the-dapp) to begin running the dapp and launching contracts.
+4. Follow [these instructions](#running-the-dapp) to begin running the dapp and launching contracts.
 
 ### Deploying to Ganache
 
@@ -67,6 +67,11 @@ $(npm bin)/truffle migrate --reset --network mainnet_mnemonic
 If you'd like to deploy to the Ropsten testnet instead, run the following command:
 ```
 $(npm bin)/truffle migrate --reset --network ropsten_mnemonic
+```
+
+Note: these deployments do not automatically whitelist addresses. To whitelist your address, run the following command:
+```
+$(npm bin)/truffle exec test/scripts/WhitelistSponsor.js --sponsor <your_address_here> --network <network_name>
 ```
 
 ### Load UMA Mainnet and Testnet Deployments

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please use Slack for all technical questions and discussions.
 
 ### Initial Setup
 
-[Before](#initial-setup) attempting to do anything with the v0 system, please run the following commands:
+Before attempting to do anything with the v0 system, please run the following commands:
 
 1. Install nodejs and npm
 1. Run `npm install`.
@@ -20,8 +20,18 @@ Please use Slack for all technical questions and discussions.
 
 ### Motivating Example: Deploying a test BTC/ETH tracking token on a local Ganache instance
 
+Before starting this example, ensure you have done the [initial setup](#initial-setup) and are in the `v0` directory.
 
-### Deploying in Ganache
+1. Follow [these instructions](#deploying-to-ganache) to set up and deploy to ganache.
+1. To configure the price feed to track BTC/ETH rather than futures contracts that require an API key, you'll need to
+change the names of two files:
+```
+mv config/identifiers.json config/identifiersProdBackup.json
+mv config/identifiersTest.json config/identifiers.json
+```
+1. Follow [these instructions](#upload-prices-to-the-manualpricefeed) to upload begin uploading BTC/ETH prices to your price feed. Note: your network
+
+### Deploying to Ganache
 
 1. Install the [Ganache UI](https://truffleframework.com/ganache). You can also use
 [ganache-cli](https://github.com/trufflesuite/ganache-cli) if you prefer to use the command line.
@@ -30,15 +40,10 @@ Please use Slack for all technical questions and discussions.
 ```
 $(npm bin)/truffle migrate --reset --network test
 ```
-4. To interact with the contracts you've deployed, run:
-```
-$(npm bin)/truffle console --network test
-```
-This will open a node console with all contracts loaded along with a web3 instance connected to your ganache instance.
 
 5. To run the automated tests, run:
 ```
-$(npm bin)/truffle test
+$(npm bin)/truffle test --network test
 ```
 
 ### Mainnet/Ropsten Testnet Deployment
@@ -95,6 +100,25 @@ npm run link-contracts
 npm start
 ```
 This should automatically start the dApp in your browser.
+
+### Interacting with contracts in truffle console
+
+Make sure you've done the [initial setup](#initial-setup) and either [deployed to ganache](#deploying-to-ganache) or
+[deployed to a public network](#mainnetropsten-testnet-deployment).
+
+You can open a truffle console (a light wrapper around a node console) by running the following command and
+substituting `your_network_name` with the name of the network you deployed to:
+
+```
+$(npm bin)/truffle console --network your_network_name
+```
+
+
+To interact with the contracts you've deployed, run:
+```
+$(npm bin)/truffle console --network test
+```
+This will open a node console with all contracts loaded along with a web3 instance connected to your ganache instance.
 
 ## Security and Bug Bounty
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # UMA Protocol
 
-## Contact
+## [Contact](#contact)
 
 - [Slack](umaprotocol.slack.com): to join, use this
 [invite link](https://join.slack.com/t/umaprotocol/shared_invite/enQtNTk4MjQ4ODY0MDA1LWZiYjg3ODY2M2MwZGQ3MDVjZDc1ZjUwNDJkMTA5NDZlNzFlZDYxYmQxOTAwNTY1NmZlNGRjY2IxYzUzNjQ0YjI).
 Please use Slack for all technical questions and discussions.
 - [Email](mailto:hello@umaproject.org): for anything non-technical.
 
-## Deployment
+## [V0 System Deployment](#v0-system-deployment)
 
 ### Initial Setup
 
+Before attempting to do anything with the v0 system, please run the following commands:
+
 1. Install nodejs and npm
 1. Run `npm install`.
+1. Run `cd v0`. You'll need to be in the `v0` directory to run any truffle commands against the `v0` system. 
 1. Run `$(npm bin)/truffle compile` to compile the contracts.
 
-### Deployment and Testing in Ganache
+### Motivating Example: Deploying a test BTC/ETH tracking token on a local Ganache instance
+
+
+### Deploying in Ganache
 
 1. Install the [Ganache UI](https://truffleframework.com/ganache). You can also use
 [ganache-cli](https://github.com/trufflesuite/ganache-cli) if you prefer to use the command line.
@@ -35,7 +41,7 @@ This will open a node console with all contracts loaded along with a web3 instan
 $(npm bin)/truffle test
 ```
 
-### Mainnet/Testnet Deployment
+### Mainnet/Ropsten Testnet Deployment
 
 1. Load your wallet mnemonic into your environment as such:
 ```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # UMA Protocol
 
-## [Contact](#contact)
+## Contact
 
 - [Slack](umaprotocol.slack.com): to join, use this
 [invite link](https://join.slack.com/t/umaprotocol/shared_invite/enQtNTk4MjQ4ODY0MDA1LWZiYjg3ODY2M2MwZGQ3MDVjZDc1ZjUwNDJkMTA5NDZlNzFlZDYxYmQxOTAwNTY1NmZlNGRjY2IxYzUzNjQ0YjI).
 Please use Slack for all technical questions and discussions.
 - [Email](mailto:hello@umaproject.org): for anything non-technical.
 
-## [V0 System Deployment](#v0-system-deployment)
+## V0 System Deployment
 
 ### Initial Setup
 
-Before attempting to do anything with the v0 system, please run the following commands:
+[Before](#initial-setup) attempting to do anything with the v0 system, please run the following commands:
 
 1. Install nodejs and npm
 1. Run `npm install`.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ If you'd like to deploy to the Ropsten testnet instead, run the following comman
 $(npm bin)/truffle migrate --reset --network ropsten_mnemonic
 ```
 
-5. Note: these deployments do not automatically whitelist addresses. To whitelist your address, run the following command:
+5. Note: mainnet and testnet deployments do not automatically whitelist addresses. To whitelist your address, run the
+following command:
 ```
 $(npm bin)/truffle exec test/scripts/WhitelistSponsor.js --sponsor <your_address_here> --network <network_name>
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before attempting to do anything with the v0 system, please run the following co
 
 Before starting this example, ensure you have done the [initial setup](#initial-setup) and are in the `v0` directory.
 
-1. Follow [these instructions](#deploying-to-ganache) to set up and deploy to ganache. Note: this means that you should
+1. Follow [these instructions](#deploying-to-ganache) to set up and deploy to Ganache. Note: this means that you should
 be using the network `test` throughout these instructions.
 1. To configure the price feed to track BTC/ETH rather than futures contracts that require an API key, you'll need to
 change the names of two files:
@@ -38,8 +38,8 @@ price feed.
 
 1. Install the [Ganache UI](https://truffleframework.com/ganache). You can also use
 [ganache-cli](https://github.com/trufflesuite/ganache-cli) if you prefer to use the command line.
-2. Run ganache on localhost port `9545` (use the above links for instructions on how to do this).
-3. To deploy to ganache, run:
+2. Run Ganache on localhost port `9545` (use the above links for instructions on how to do this).
+3. To deploy to Ganache, run:
 ```
 $(npm bin)/truffle migrate --reset --network test
 ```
@@ -48,7 +48,7 @@ $(npm bin)/truffle migrate --reset --network test
 ```
 $(npm bin)/truffle test --network test
 ```
-5. If you want to use the dapp with your ganache deployment, make sure you plug the mnemonic that it generates into
+5. If you want to use the dapp with your Ganache deployment, make sure you plug the mnemonic that it generates into
 Metamask instead of your normal ETH account.
 
 ### Mainnet/Ropsten Testnet Deployment
@@ -105,7 +105,7 @@ For the script to succeed, the `build` directory must contain the `ManualPriceFe
 
 ### Running the dApp
 
-After deploying to ganache, ropsten, or mainnet (or any combination of those), you can run the Sponsor Dapp against the
+After deploying to Ganache, ropsten, or mainnet (or any combination of those), you can run the Sponsor Dapp against the
 contracts. Before running the dApp, make sure you have done the following:
 - Make sure that you have [Metamask](https://metamask.io/) installed.
 - Make sure you've provided your ETH account mnemonic to metamask.
@@ -117,7 +117,7 @@ contracts. Before running the dApp, make sure you have done the following:
     your mnemonic. If you only have one account in Metamask, you can use the `Create Account` button to create a
     second. You will need to select the second account if you'd like to launch contracts in the dapp.
 - Make sure you have the correct network selected in metamask.
-    - If you're using ganache, you'll need to create a custom RPC with the following URL: `http://127.0.0.1:9545`.
+    - If you're using Ganache, you'll need to create a custom RPC with the following URL: `http://127.0.0.1:9545`.
 
 Once you've done the above, you can start the dapp by running the following commands from the `protocol` (top level)
 directory:
@@ -133,7 +133,7 @@ into your browser: `localhost:3000`.
 
 ### Interacting with contracts directly in the truffle console
 
-Make sure you've done the [initial setup](#initial-setup) and either [deployed to ganache](#deploying-to-ganache),
+Make sure you've done the [initial setup](#initial-setup) and either [deployed to Ganache](#deploying-to-ganache),
 [deployed to a public network](#mainnetropsten-testnet-deployment), or
 [loaded the UMA deployment](#load-uma-mainnet-and-testnet-deployments). If you are using a mainnet or testnet
 deployment, make sure you load a mnemonic and infura API key into your environment as shown
@@ -149,7 +149,7 @@ $(npm bin)/truffle console --network your_network_name
 ## Security and Bug Bounty
 
 Please report all security vulnerabilities through our [HackerOne bug bounty page](https://hackerone.com/uma_project).
-Please run all security tests against the testnet deployment or a local ganache to preserve the integrity of the
+Please run all security tests against the testnet deployment or a local Ganache to preserve the integrity of the
 mainnet deployment.
 
 ## Developer Information and Tools

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you'd like to deploy to the Ropsten testnet instead, run the following comman
 $(npm bin)/truffle migrate --reset --network ropsten_mnemonic
 ```
 
-Note: these deployments do not automatically whitelist addresses. To whitelist your address, run the following command:
+5. Note: these deployments do not automatically whitelist addresses. To whitelist your address, run the following command:
 ```
 $(npm bin)/truffle exec test/scripts/WhitelistSponsor.js --sponsor <your_address_here> --network <network_name>
 ```

--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ substituting `your_network_name` with the name of the network you deployed to:
 $(npm bin)/truffle console --network your_network_name
 ```
 
+### Troubleshooting
+
+- Run `git diff`. If you see any changes that were unintended, remove them. If you notice any changes in`package.json`,
+you should remove them and run:
+```
+rm -rf node_modules
+npm install
+```
+
 ## Security and Bug Bounty
 
 Please report all security vulnerabilities through our [HackerOne bug bounty page](https://hackerone.com/uma_project).

--- a/sponsor-dapp/src/App.test.js
+++ b/sponsor-dapp/src/App.test.js
@@ -50,7 +50,10 @@ const addDrizzleProviderWrapper = getComponent => {
 
 it("renders Dashboard without crashing", done => {
   const getDashboard = (drizzle, drizzleState) => {
-    const params = { identifiers: [] };
+    const params = {
+      currencies: { "0x0000000000000000000000000000000000000000": "ETH" },
+      identifiers: []
+    };
     return <Dashboard drizzle={drizzle} drizzleState={drizzleState} params={params} />;
   };
 

--- a/sponsor-dapp/src/parameters.js
+++ b/sponsor-dapp/src/parameters.js
@@ -18,7 +18,9 @@ const parameters = {
       "0xA7E2f86B4E2c241Ac6D2fb7cE9dEBb37DbB05093": "TUSD"
     }
   },
-  private: {},
+  private: {
+    "0x0000000000000000000000000000000000000000": "ETH"
+  },
   identifiers: {
     ...Object.entries(identifierConfig).reduce((joinedConfig, [identifier, config]) => {
       return { ...joinedConfig, [identifier]: config.dappConfig };

--- a/sponsor-dapp/src/parameters.js
+++ b/sponsor-dapp/src/parameters.js
@@ -1,9 +1,6 @@
 import identifierConfig from "./identifiers.json";
 
 const parameters = {
-  currencies: {
-    "0x0000000000000000000000000000000000000000": "ETH"
-  },
   main: {
     currencies: {
       "0x0000000000000000000000000000000000000000": "ETH",

--- a/sponsor-dapp/src/parameters.js
+++ b/sponsor-dapp/src/parameters.js
@@ -19,7 +19,9 @@ const parameters = {
     }
   },
   private: {
-    "0x0000000000000000000000000000000000000000": "ETH"
+    currencies: {
+      "0x0000000000000000000000000000000000000000": "ETH"
+    }
   },
   identifiers: {
     ...Object.entries(identifierConfig).reduce((joinedConfig, [identifier, config]) => {

--- a/v0/config/identifiersTest.json
+++ b/v0/config/identifiersTest.json
@@ -1,15 +1,19 @@
 {
-  "SPY": {
+  "BTCETH": {
     "dappConfig": {
-      "comment": "expiry: May 15, 2019 4:15pm ET, supportedMove: 0.085 corresponds to 8.5%",
-      "expiry": "1557951300",
-      "supportedMove": "0.085"
+      "comment": "expiry: January 1st, 2020 12:00 AM UTC, supportedMove: 0.2 corresponds to 20%",
+      "expiry": "1577836800",
+      "supportedMove": "0.2"
     },
     "uploaderConfig": {
       "publishInterval": "900",
       "numerator": {
-        "dataSource": "AlphaVantage",
-        "assetName": "SPY"
+        "dataSource": "Coinbase",
+        "assetName": "BTC"
+      },
+      "denominator": {
+        "dataSource": "Coinbase",
+        "assetName": "ETH"
       }
     }
   }

--- a/v0/migrations/8_deploy_tokenized_derivative_creator.js
+++ b/v0/migrations/8_deploy_tokenized_derivative_creator.js
@@ -54,5 +54,7 @@ module.exports = async function(deployer, network, accounts) {
 
   if (!network.startsWith("mainnet") && !network.startsWith("ropsten")) {
     await sponsorWhitelist.addToWhitelist(accounts[1], { from: keys.sponsorWhitelist });
+    const ethAddress = "0x0000000000000000000000000000000000000000";
+    await marginCurrencyWhitelist.addToWhitelist(ethAddress, { from: keys.marginCurrencyWhitelist });
   }
 };


### PR DESCRIPTION
I tried to section the readme a little better, and I set up a motivating example so anyone should be able to walk through the steps to deploy their own instance of our system.

Notes:
- I added a line to the migration to automatically whitelist ETH on the test network.
- To make the ETH whitelisting work, I had to provide a mapping from 0x0 -> ETH in the private network config for the dapp.
- I changed the test identifier to be BTCETH since that's much easier to deploy than an SPY tracker.