### PR TITLE
Add Finder contract to migration

### DIFF
--- a/v1/migrations/5_deploy_finder.js
+++ b/v1/migrations/5_deploy_finder.js
@@ -1,0 +1,9 @@
+const Finder = artifacts.require("Finder");
+const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+
+module.exports = async function(deployer, network, accounts) {
+  const keys = getKeysForNetwork(network, accounts);
+
+  const finder = await deployAndGet(deployer, Finder, { from: keys.deployer });
+  await addToTdr(finder, network);
+};

--- a/v1/migrations/5_deploy_finder.js
+++ b/v1/migrations/5_deploy_finder.js
@@ -1,9 +1,16 @@
 const Finder = artifacts.require("Finder");
+const Registry = artifacts.require("Registry");
 const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
   const finder = await deployAndGet(deployer, Finder, { from: keys.deployer });
   await addToTdr(finder, network);
+
+  const registry = await Registry.deployed();
+  await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.Registry), registry.address, {
+    from: keys.deployer
+  });
 };

--- a/v1/scripts/CheckDeploymentValidity.js
+++ b/v1/scripts/CheckDeploymentValidity.js
@@ -1,5 +1,7 @@
+const Finder = artifacts.require("Finder");
 const Migrations = artifacts.require("Migrations");
 const Registry = artifacts.require("Registry");
+const { interfaceName } = require("../utils/Constants.js");
 
 const checkDeploymentValidity = async function(callback) {
   try {
@@ -13,6 +15,15 @@ const checkDeploymentValidity = async function(callback) {
     // Registry
     const registry = await Registry.deployed();
     await registry.getAllRegisteredDerivatives();
+
+    // Finder
+    const finder = await Finder.deployed();
+    const registryImplementationAddress = await finder.getImplementationAddress(
+      web3.utils.utf8ToHex(interfaceName.Registry)
+    );
+    if (registryInterfaceAddress != registry.address) {
+      throw "Incorrect implementation address for Registry";
+    }
 
     console.log("Deployment looks good!");
   } catch (e) {

--- a/v1/scripts/CheckDeploymentValidity.js
+++ b/v1/scripts/CheckDeploymentValidity.js
@@ -21,7 +21,7 @@ const checkDeploymentValidity = async function(callback) {
     const registryImplementationAddress = await finder.getImplementationAddress(
       web3.utils.utf8ToHex(interfaceName.Registry)
     );
-    if (registryInterfaceAddress != registry.address) {
+    if (registryImplementationAddress != registry.address) {
       throw "Incorrect implementation address for Registry";
     }
 

--- a/v1/test/Finder.js
+++ b/v1/test/Finder.js
@@ -13,7 +13,7 @@ contract("Finder", function(accounts) {
   const RolesEnumWriter = "1";
 
   it("General methods", async function() {
-    const finder = await Finder.new({ from: owner });
+    const finder = await Finder.deployed();
     await finder.resetMember(RolesEnumWriter, writer, { from: owner });
 
     const interfaceName1 = web3.utils.hexToBytes(web3.utils.utf8ToHex("interface1"));

--- a/v1/utils/Constants.js
+++ b/v1/utils/Constants.js
@@ -1,0 +1,8 @@
+// The interface names that Finder.sol uses to refer to interfaces in the UMA system.
+const interfaceName = {
+  Registry: "Registry"
+};
+
+module.exports = {
+  interfaceName
+};


### PR DESCRIPTION
The only implementation it can currently find is the Registry. We should add the store, etc.

Fixes #390 

Tested by running:
```
$ $(npm bin)/truffle migrate --reset --network=test
```
and then:
```
$ $(npm bin)/truffle exec scripts/CheckDeploymentValidity.js  --network=test
Using network 'test'.

Deployment looks good!
```