### PR TITLE
Don't estimate #tokens that can be created if no underlying price

### DIFF
--- a/sponsor-dapp/src/components/ContractInteraction.js
+++ b/sponsor-dapp/src/components/ContractInteraction.js
@@ -68,9 +68,14 @@ class ContractInteraction extends Component {
 
     const fpScalingFactor = BigNumber(web3.utils.toWei("1", "ether"));
     const newExcessMargin = BigNumber(drizzleHelper.getCache(contractAddress, "calcExcessMargin", []));
-    const newUnderlyingPrice = BigNumber(
-      drizzleHelper.getCache(contractAddress, "getUpdatedUnderlyingPrice", []).underlyingPrice
-    );
+    const updatedPriceCache = drizzleHelper.getCache(contractAddress, "getUpdatedUnderlyingPrice", []);
+    if (!updatedPriceCache) {
+      // If the updated price isn't available, we can't estimate the number of tokens that can be created. One case
+      // in which a valid contract gets into this state is when the contract will expire on a remargin but no Oracle
+      // price is available yet.
+      return "";
+    }
+    const newUnderlyingPrice = BigNumber(updatedPriceCache.underlyingPrice);
 
     // Computation in Solidity will round differently, so results may slightly differ. Since this value is rounded to
     // 4 decimal places anyway, the difference in precision shouldn't matter.


### PR DESCRIPTION
Effectively, the helper text is disabled.

This situation happens when a contract will expire on remargin (so the
price feed price is ignored), but an Oracle price is not yet available.

There could be other situations as well.

Issue #417 