### PR TITLE
Update identifiersTest.json

### DIFF
--- a/v0/config/identifiersTest.json
+++ b/v0/config/identifiersTest.json
@@ -9,11 +9,11 @@
       "publishInterval": "900",
       "numerator": {
         "dataSource": "Coinbase",
-        "assetName": "BTC"
+        "assetName": "BTC-USD"
       },
       "denominator": {
         "dataSource": "Coinbase",
-        "assetName": "ETH"
+        "assetName": "ETH-USD"
       }
     }
   }


### PR DESCRIPTION
Should retrieve properly prices from Coinbase API:

Publishing price feed for [BTCETH], with config [{"identifier":"BTCETH","priceFeedAddress":"0xB6Ef49A111Dee1cdF8473e10d398c9ddE881e616","publishInterval":"900","numerator":{"dataSource":"Coinbase","assetName":"BTC-USD"},"denominator":{"dataSource":"Coinbase","assetName":"ETH-USD"}}]
IdentifierBytes [0x425443455448] is currently unsupported, so publishing a new price
Querying Coinbase with [https://api.coinbase.com/v2/prices/BTC-USD/spot]
Coinbase response [{"data":{"base":"BTC","currency":"USD","amount":"7965.44"}}]
Retrieved price [7965.44] from Coinbase for asset [BTC-USD]
Querying Coinbase with [https://api.coinbase.com/v2/prices/ETH-USD/spot]
Coinbase response [{"data":{"base":"ETH","currency":"USD","amount":"256.215"}}]
Retrieved price [256.215] from Coinbase for asset [ETH-USD]
Dividing numerator [7965440000000000000000] / denominator [256215000000000000000] = exchange rate (in Wei) [31000000000000000000]
Publishing identifierBytes [0x425443455448] publishTime [1558278267] exchangeRate (in Wei) [31000000000000000000]
Done publishing for one feed.


Returns the following with the previous file:

Publishing price feed for [BTCETH], with config [{"identifier":"BTCETH","priceFeedAddress":"0xB6Ef49A111Dee1cdF8473e10d398c9ddE881e616","publishInterval":"900","numerator":{"dataSource":"Coinbase","assetName":"BTC"},"denominator":{"dataSource":"Coinbase","assetName":"ETH"}}]
IdentifierBytes [0x425443455448] is currently unsupported, so publishing a new price
Querying Coinbase with [https://api.coinbase.com/v2/prices/BTC/spot]
Coinbase response [{"errors":[{"id":"not_found","message":"Invalid currency"}]}]
TypeError: Cannot read property 'amount' of {redacted}
Done publishing for all feeds
Using network 'test'.