### PR TITLE
Convert Testable into a pure contract

### DIFF
--- a/core/contracts/Testable.sol
+++ b/core/contracts/Testable.sol
@@ -6,8 +6,8 @@
 
 pragma solidity ^0.5.0;
 
-contract Testable {
 
+contract Testable {
     // Is the contract being run on the test network. Note: this variable should be set on construction and never
     // modified.
     bool public isTest;

--- a/core/contracts/Testable.sol
+++ b/core/contracts/Testable.sol
@@ -6,10 +6,7 @@
 
 pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-
-
-contract Testable is Ownable {
+contract Testable {
 
     // Is the contract being run on the test network. Note: this variable should be set on construction and never
     // modified.
@@ -29,7 +26,7 @@ contract Testable is Ownable {
         _;
     }
 
-    function setCurrentTime(uint _time) external onlyOwner onlyIfTest {
+    function setCurrentTime(uint _time) external onlyIfTest {
         currentTime = _time;
     }
 

--- a/core/contracts/test/TestableTest.sol
+++ b/core/contracts/test/TestableTest.sol
@@ -5,7 +5,6 @@ import "../Testable.sol";
 
 // TestableTest is derived from the abstract contract Testable for testing purposes.
 contract TestableTest is Testable {
-    constructor(bool _isTest) public Testable(_isTest) {
-        return;
-    }
+    // solhint-disable-next-line no-empty-blocks
+    constructor(bool _isTest) public Testable(_isTest) {}
 }

--- a/core/contracts/test/TestableTest.sol
+++ b/core/contracts/test/TestableTest.sol
@@ -2,7 +2,10 @@ pragma solidity ^0.5.0;
 
 import "../Testable.sol";
 
+
 // TestableTest is derived from the abstract contract Testable for testing purposes.
 contract TestableTest is Testable {
-    constructor(bool _isTest) public Testable(_isTest) {}
+    constructor(bool _isTest) public Testable(_isTest) {
+        return;
+    }
 }

--- a/core/contracts/test/TestableTest.sol
+++ b/core/contracts/test/TestableTest.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.0;
+
+import "../Testable.sol";
+
+// TestableTest is derived from the abstract contract Testable for testing purposes.
+contract TestableTest is Testable {
+    constructor(bool _isTest) public Testable(_isTest) {}
+}

--- a/core/test/Testable.js
+++ b/core/test/Testable.js
@@ -1,0 +1,24 @@
+const { didContractThrow } = require("../../common/SolidityTestUtils.js");
+
+const TestableTest = artifacts.require("TestableTest");
+
+contract("Testable", function() {
+  it("isTest on", async function() {
+    const testable = await TestableTest.new(true);
+
+    await testable.setCurrentTime(0);
+    assert.equal(await testable.getCurrentTime(), 0);
+  });
+
+  it("isTest off", async function() {
+    const testable = await TestableTest.new(false);
+
+    // Assert that the latest block's timestamp equals the testable contract's current time.
+    const timestamp = (await web3.eth.getBlock("latest")).timestamp.toString();
+    const currentTime = (await testable.getCurrentTime()).toString();
+    assert.equal(timestamp, currentTime);
+
+    // Assert that setCurrentTime fails
+    assert(await didContractThrow(testable.setCurrentTime(0)));
+  });
+});


### PR DESCRIPTION
Following @ptare 's suggestion, `Testable` is now a standalone contract without any ownership restrictions.