### PR TITLE
Add MockOracle that implements OracleInterface

### DIFF
--- a/core/contracts/OracleInterface.sol
+++ b/core/contracts/OracleInterface.sol
@@ -20,6 +20,11 @@ interface OracleInterface {
     function isIdentifierSupported(bytes32 identifier) external view returns (bool);
 
     /**
+     * @notice Whether the price for `identifier` and `time` is available.
+     */
+    function hasPrice(bytes32 identifier, uint time) external view returns (bool);
+
+    /**
      * @notice Gets the price for `identifier` and `time` if it has already been requested and resolved.
      * @dev If the price is not available, the method reverts.
      */

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -179,6 +179,11 @@ contract Voting is Testable, MultiRole, OracleInterface {
         return supportedIdentifiers[identifier];
     }
 
+    function hasPrice(bytes32 identifier, uint time) external view returns (bool) {
+        // TODO(ptare): Price resolution isn't implemented yet.
+        return true;
+    }
+
     function getPrice(bytes32 identifier, uint time) external view returns (int price) {
         PriceResolution storage priceResolution = _getPriceResolution(identifier, time);
         uint resolutionVotingRound = priceResolution.lastVotingRound;

--- a/core/contracts/test/MockOracle.sol
+++ b/core/contracts/test/MockOracle.sol
@@ -1,24 +1,13 @@
-/*
-  CentralizedOracle implementation.
-
-  Implementation of OracleInterface that allows the owner to provide verified prices.
-*/
 pragma solidity ^0.5.0;
 
 pragma experimental ABIEncoderV2;
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./AdminInterface.sol";
-import "./OracleInterface.sol";
-import "./RegistryInterface.sol";
-import "../../common/contracts/Testable.sol";
-import "./Withdrawable.sol";
+import "../OracleInterface.sol";
+import "../Testable.sol";
 
 
-// Implements an oracle that allows the owner to push prices for queries that have been made.
-contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
-    using SafeMath for uint;
+// A mock oracle used for testing.
+contract MockOracle is OracleInterface, Testable {
 
     // This contract doesn't implement the voting routine, and naively indicates that all requested prices will be
     // available in a week.
@@ -56,17 +45,11 @@ contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
     mapping(bytes32 => mapping(uint => QueryIndex)) private queryIndices;
     QueryPoint[] private requestedPrices;
 
-    // Registry to verify that a derivative is approved to use the Oracle.
-    RegistryInterface private registry;
-
-    constructor(address _registry, bool _isTest) public Testable(_isTest) {
-        registry = RegistryInterface(_registry);
+    constructor() public Testable(true) {
     }
 
     // Enqueues a request (if a request isn't already present) for the given (identifier, time) pair.
     function requestPrice(bytes32 identifier, uint time) external returns (uint expectedTime) {
-        // Ensure that the caller has been registered with the Oracle before processing the request.
-        require(registry.isDerivativeRegistered(msg.sender));
         require(supportedIdentifiers[identifier]);
         Price storage lookup = verifiedPrices[identifier][time];
         if (lookup.isAvailable) {
@@ -74,20 +57,18 @@ contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
             return 0;
         } else if (queryIndices[identifier][time].isValid) {
             // We already have a pending query, don't need to do anything.
-            return getCurrentTime().add(SECONDS_IN_WEEK);
+            return getCurrentTime() + SECONDS_IN_WEEK;
         } else {
             // New query, enqueue it for review.
             queryIndices[identifier][time] = QueryIndex(true, requestedPrices.length);
             requestedPrices.push(QueryPoint(identifier, time));
-            emit VerifiedPriceRequested(identifier, time);
-            return getCurrentTime().add(SECONDS_IN_WEEK);
+            return getCurrentTime() + SECONDS_IN_WEEK;
         }
     }
 
     // Pushes the verified price for a requested query.
-    function pushPrice(bytes32 identifier, uint time, int price) external onlyOwner {
+    function pushPrice(bytes32 identifier, uint time, int price) external {
         verifiedPrices[identifier][time] = Price(true, price, getCurrentTime());
-        emit VerifiedPriceAvailable(identifier, time, price);
 
         QueryIndex storage queryIndex = queryIndices[identifier][time];
         require(queryIndex.isValid, "Can't push prices that haven't been requested");
@@ -95,39 +76,24 @@ contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
         // the contents of the last index (unless it is the last index).
         uint indexToReplace = queryIndex.index;
         delete queryIndices[identifier][time];
-        uint lastIndex = requestedPrices.length.sub(1);
+        uint lastIndex = requestedPrices.length - 1;
         if (lastIndex != indexToReplace) {
             QueryPoint storage queryToCopy = requestedPrices[lastIndex];
             queryIndices[queryToCopy.identifier][queryToCopy.time].index = indexToReplace;
             requestedPrices[indexToReplace] = queryToCopy;
         }
-        requestedPrices.length = requestedPrices.length.sub(1);
+        requestedPrices.length = requestedPrices.length - 1;
     }
 
     // Adds the provided identifier as a supported identifier.
-    function addSupportedIdentifier(bytes32 identifier) external onlyOwner {
+    function addSupportedIdentifier(bytes32 identifier) external {
         if (!supportedIdentifiers[identifier]) {
             supportedIdentifiers[identifier] = true;
-            emit AddSupportedIdentifier(identifier);
         }
-    }
-
-    // Calls emergencyShutdown() on the provided derivative.
-    function callEmergencyShutdown(address derivative) external onlyOwner {
-        AdminInterface admin = AdminInterface(derivative);
-        admin.emergencyShutdown();
-    }
-
-    // Calls remargin() on the provided derivative.
-    function callRemargin(address derivative) external onlyOwner {
-        AdminInterface admin = AdminInterface(derivative);
-        admin.remargin();
     }
 
     // Checks whether a price has been resolved.
     function hasPrice(bytes32 identifier, uint time) external view returns (bool hasPriceAvailable) {
-        // Ensure that the caller has been registered with the Oracle before processing the request.
-        require(registry.isDerivativeRegistered(msg.sender));
         require(supportedIdentifiers[identifier]);
         Price storage lookup = verifiedPrices[identifier][time];
         return lookup.isAvailable;
@@ -135,8 +101,6 @@ contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
 
     // Gets a price that has already been resolved.
     function getPrice(bytes32 identifier, uint time) external view returns (int price) {
-        // Ensure that the caller has been registered with the Oracle before processing the request.
-        require(registry.isDerivativeRegistered(msg.sender));
         require(supportedIdentifiers[identifier]);
         Price storage lookup = verifiedPrices[identifier][time];
         require(lookup.isAvailable);
@@ -144,7 +108,7 @@ contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
     }
 
     // Gets the queries that still need verified prices.
-    function getPendingQueries() external view onlyOwner returns (QueryPoint[] memory queryPoints) {
+    function getPendingQueries() external view returns (QueryPoint[] memory queryPoints) {
         return requestedPrices;
     }
 
@@ -152,6 +116,4 @@ contract CentralizedOracle is OracleInterface, Withdrawable, Testable {
     function isIdentifierSupported(bytes32 identifier) external view returns (bool isSupported) {
         return supportedIdentifiers[identifier];
     }
-
-    event AddSupportedIdentifier(bytes32 indexed identifier);
 }


### PR DESCRIPTION
This is so that tests for other contracts that interact with the Oracle
don't have to deal with the phasing, voting, etc.

Also needed to add another method `hasPrice` to `OracleInterface`.

Issue #453 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>