### PR TITLE
New store tests for setting final fees, and paying fees in both Eth and ERC20 (fixes #459)

### DIFF
--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -74,5 +74,111 @@ contract("Store", function(accounts) {
     assert.equal(fee.value, web3.utils.toWei("5", "ether"));
   });
 
-  // TODO tests for fees in Ether and ERC20
+  it("Pay fees in Ether", async function() {
+     // Verify the starting balance is 0.
+     let balance = await web3.eth.getBalance(store.address);
+     assert.equal(balance.toString(), "0");
+ 
+     // Can't pay a fee of 0 ether.
+     assert(
+       await didContractThrow(
+         store.payOracleFees({ from: derivative, value: web3.utils.toWei("0", "ether") })
+       )
+     );
+ 
+     // Send 1 ether to the contract and verify balance.
+     await store.payOracleFees({ from: derivative, value: web3.utils.toWei("1", "ether") });
+     balance = await web3.eth.getBalance(store.address);
+     assert.equal(balance.toString(), web3.utils.toWei("1", "ether"));
+ 
+     // Send a further 2 ether to the contract and verify balance.
+     await store.payOracleFees({ from: derivative, value: web3.utils.toWei("2", "ether") });
+     balance = await web3.eth.getBalance(store.address);
+     assert.equal(balance.toString(), web3.utils.toWei("3", "ether"));
+ 
+     // Only the owner can withdraw.
+     assert(await didContractThrow(store.withdraw(web3.utils.toWei("0.5", "ether"), { from: derivative })));
+ 
+     // Withdraw 0.5 ether and verify the  balance.
+     await store.withdraw(web3.utils.toWei("0.5", "ether"));
+     balance = await web3.eth.getBalance(store.address);
+     assert.equal(balance.toString(), web3.utils.toWei("2.5", "ether"));
+ 
+     // Can't withdraw more than the balance.
+     assert(await didContractThrow(store.withdraw(web3.utils.toWei("10", "ether"))));
+ 
+     // Withdraw remaining balance.
+     await store.withdraw(web3.utils.toWei("2.5", "ether"));
+     balance = await web3.eth.getBalance(store.address);
+     assert.equal(balance.toString(), web3.utils.toWei("0", "ether"));
+  });
+
+  it("Pay fees in ERC20 token", async function() {
+    const firstMarginToken = await ERC20Mintable.new({ from: erc20TokenOwner });
+    const secondMarginToken = await ERC20Mintable.new({ from: erc20TokenOwner });
+
+    // Mint 100 tokens of each to the contract and verify balances.
+    await firstMarginToken.mint(derivative, web3.utils.toWei("100", "ether"), { from: erc20TokenOwner });
+    let firstTokenBalanceInStore = await firstMarginToken.balanceOf(store.address);
+    let firstTokenBalanceInDerivative = await firstMarginToken.balanceOf(derivative);
+    assert.equal(firstTokenBalanceInStore, 0);
+    assert.equal(firstTokenBalanceInDerivative, web3.utils.toWei("100", "ether"));
+
+    await secondMarginToken.mint(derivative, web3.utils.toWei("100", "ether"), { from: erc20TokenOwner });
+    let secondTokenBalanceInStore = await secondMarginToken.balanceOf(store.address);
+    let secondTokenBalanceInDerivative = await secondMarginToken.balanceOf(derivative);
+    assert.equal(secondTokenBalanceInStore, 0);
+    assert.equal(secondTokenBalanceInDerivative, web3.utils.toWei("100", "ether"));
+
+    // Pay 10 of the first margin token to the store and verify balances.
+    await firstMarginToken.approve(store.address, web3.utils.toWei("10", "ether"), { from: derivative });
+    await store.payOracleFeesErc20(firstMarginToken.address, { from: derivative });
+    firstTokenBalanceInStore = await firstMarginToken.balanceOf(store.address);
+    firstTokenBalanceInDerivative = await firstMarginToken.balanceOf(derivative);
+    assert.equal(firstTokenBalanceInStore.toString(), web3.utils.toWei("10", "ether"));
+    assert.equal(firstTokenBalanceInDerivative.toString(), web3.utils.toWei("90", "ether"));
+
+    // Pay 20 of the second margin token to the store and verify balances.
+    await secondMarginToken.approve(store.address, web3.utils.toWei("20", "ether"), { from: derivative });
+    await store.payOracleFeesErc20(secondMarginToken.address, { from: derivative });
+    secondTokenBalanceInStore = await secondMarginToken.balanceOf(store.address);
+    secondTokenBalanceInDerivative = await secondMarginToken.balanceOf(derivative);
+    assert.equal(secondTokenBalanceInStore.toString(), web3.utils.toWei("20", "ether"));
+    assert.equal(secondTokenBalanceInDerivative.toString(), web3.utils.toWei("80", "ether"));
+
+    // Withdraw 15 (out of 20) of the second margin token and verify balances.
+    await store.withdrawErc20(secondMarginToken.address, web3.utils.toWei("15", "ether"), { from: owner });
+    let secondTokenBalanceInOwner = await secondMarginToken.balanceOf(owner);
+    secondTokenBalanceInStore = await secondMarginToken.balanceOf(store.address);
+    assert.equal(secondTokenBalanceInOwner.toString(), web3.utils.toWei("15", "ether"));
+    assert.equal(secondTokenBalanceInStore.toString(), web3.utils.toWei("5", "ether"));
+
+    // Only owner can withdraw.
+    assert(
+      await didContractThrow(
+        store.withdrawErc20(secondMarginToken.address, web3.utils.toWei("5", "ether"), { from: derivative })
+      )
+    );
+
+    // Can't withdraw more than the balance.
+    assert(
+      await didContractThrow(
+        store.withdrawErc20(secondMarginToken.address, web3.utils.toWei("100", "ether"), { from: owner })
+      )
+    );
+
+    // Withdraw remaining amounts and verify balancse.
+    await store.withdrawErc20(firstMarginToken.address, web3.utils.toWei("10", "ether"), { from: owner });
+    await store.withdrawErc20(secondMarginToken.address, web3.utils.toWei("5", "ether"), { from: owner });
+
+    let firstTokenBalanceInOwner = await firstMarginToken.balanceOf(owner);
+    firstTokenBalanceInStore = await firstMarginToken.balanceOf(store.address);
+    assert.equal(firstTokenBalanceInOwner.toString(), web3.utils.toWei("10", "ether"));
+    assert.equal(firstTokenBalanceInStore.toString(), web3.utils.toWei("0", "ether"));
+
+    secondTokenBalanceInOwner = await secondMarginToken.balanceOf(owner);
+    secondTokenBalanceInStore = await secondMarginToken.balanceOf(store.address);
+    assert.equal(secondTokenBalanceInOwner.toString(), web3.utils.toWei("20", "ether"));
+    assert.equal(secondTokenBalanceInStore.toString(), web3.utils.toWei("0", "ether"));
+  });
 });

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -69,48 +69,44 @@ contract("Store", function(accounts) {
 
   it("Final fees", async function() {
     //Add final fee and confirm
-    await store.setFinalFee(tokenAddr, { value: web3.utils.toWei("5", "ether") }, { from: owner } );
+    await store.setFinalFee(tokenAddr, { value: web3.utils.toWei("5", "ether") }, { from: owner });
     let fee = await store.computeFinalFee(tokenAddr);
     assert.equal(fee.value, web3.utils.toWei("5", "ether"));
   });
 
   it("Pay fees in Ether", async function() {
-     // Verify the starting balance is 0.
-     let balance = await web3.eth.getBalance(store.address);
-     assert.equal(balance.toString(), "0");
- 
-     // Can't pay a fee of 0 ether.
-     assert(
-       await didContractThrow(
-         store.payOracleFees({ from: derivative, value: web3.utils.toWei("0", "ether") })
-       )
-     );
- 
-     // Send 1 ether to the contract and verify balance.
-     await store.payOracleFees({ from: derivative, value: web3.utils.toWei("1", "ether") });
-     balance = await web3.eth.getBalance(store.address);
-     assert.equal(balance.toString(), web3.utils.toWei("1", "ether"));
- 
-     // Send a further 2 ether to the contract and verify balance.
-     await store.payOracleFees({ from: derivative, value: web3.utils.toWei("2", "ether") });
-     balance = await web3.eth.getBalance(store.address);
-     assert.equal(balance.toString(), web3.utils.toWei("3", "ether"));
- 
-     // Only the owner can withdraw.
-     assert(await didContractThrow(store.withdraw(web3.utils.toWei("0.5", "ether"), { from: derivative })));
- 
-     // Withdraw 0.5 ether and verify the  balance.
-     await store.withdraw(web3.utils.toWei("0.5", "ether"));
-     balance = await web3.eth.getBalance(store.address);
-     assert.equal(balance.toString(), web3.utils.toWei("2.5", "ether"));
- 
-     // Can't withdraw more than the balance.
-     assert(await didContractThrow(store.withdraw(web3.utils.toWei("10", "ether"))));
- 
-     // Withdraw remaining balance.
-     await store.withdraw(web3.utils.toWei("2.5", "ether"));
-     balance = await web3.eth.getBalance(store.address);
-     assert.equal(balance.toString(), web3.utils.toWei("0", "ether"));
+    // Verify the starting balance is 0.
+    let balance = await web3.eth.getBalance(store.address);
+    assert.equal(balance.toString(), "0");
+
+    // Can't pay a fee of 0 ether.
+    assert(await didContractThrow(store.payOracleFees({ from: derivative, value: web3.utils.toWei("0", "ether") })));
+
+    // Send 1 ether to the contract and verify balance.
+    await store.payOracleFees({ from: derivative, value: web3.utils.toWei("1", "ether") });
+    balance = await web3.eth.getBalance(store.address);
+    assert.equal(balance.toString(), web3.utils.toWei("1", "ether"));
+
+    // Send a further 2 ether to the contract and verify balance.
+    await store.payOracleFees({ from: derivative, value: web3.utils.toWei("2", "ether") });
+    balance = await web3.eth.getBalance(store.address);
+    assert.equal(balance.toString(), web3.utils.toWei("3", "ether"));
+
+    // Only the owner can withdraw.
+    assert(await didContractThrow(store.withdraw(web3.utils.toWei("0.5", "ether"), { from: derivative })));
+
+    // Withdraw 0.5 ether and verify the  balance.
+    await store.withdraw(web3.utils.toWei("0.5", "ether"));
+    balance = await web3.eth.getBalance(store.address);
+    assert.equal(balance.toString(), web3.utils.toWei("2.5", "ether"));
+
+    // Can't withdraw more than the balance.
+    assert(await didContractThrow(store.withdraw(web3.utils.toWei("10", "ether"))));
+
+    // Withdraw remaining balance.
+    await store.withdraw(web3.utils.toWei("2.5", "ether"));
+    balance = await web3.eth.getBalance(store.address);
+    assert.equal(balance.toString(), web3.utils.toWei("0", "ether"));
   });
 
   it("Pay fees in ERC20 token", async function() {

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -16,6 +16,7 @@ contract("Store", function(accounts) {
   const erc20TokenOwner = accounts[2];
 
   const identifier = web3.utils.utf8ToHex("id");
+  const tokenAddr = "0x249bB6CF1751c221058749a9B571F1Fb0a621443";
 
   // TODO Add test final fee for test identifier
 
@@ -64,6 +65,13 @@ contract("Store", function(accounts) {
     assert(await didContractThrow(store.setFixedOracleFeePerSecond(highFee, { from: owner })));
 
     // TODO Check that only permitted role can change the fee
+  });
+
+  it("Final fees", async function() {
+    //Add final fee and confirm
+    await store.setFinalFee(tokenAddr, { value: web3.utils.toWei("5", "ether") }, { from: owner } );
+    let fee = await store.computeFinalFee(tokenAddr);
+    assert.equal(fee.value, web3.utils.toWei("5", "ether"));
   });
 
   // TODO tests for fees in Ether and ERC20

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -16,7 +16,7 @@ contract("Store", function(accounts) {
   const erc20TokenOwner = accounts[2];
 
   const identifier = web3.utils.utf8ToHex("id");
-  const tokenAddr = "0x249bB6CF1751c221058749a9B571F1Fb0a621443";
+  const arbitraryTokenAddr = web3.utils.randomHex(20);
 
   // TODO Add test final fee for test identifier
 
@@ -69,8 +69,8 @@ contract("Store", function(accounts) {
 
   it("Final fees", async function() {
     //Add final fee and confirm
-    await store.setFinalFee(tokenAddr, { value: web3.utils.toWei("5", "ether") }, { from: owner });
-    let fee = await store.computeFinalFee(tokenAddr);
+    await store.setFinalFee(arbitraryTokenAddr, { value: web3.utils.toWei("5", "ether") }, { from: owner });
+    const fee = await store.computeFinalFee(arbitraryTokenAddr);
     assert.equal(fee.value, web3.utils.toWei("5", "ether"));
   });
 


### PR DESCRIPTION
Added some more store tests -- the only thing left to add is some governance testing, which might be a broader issue to address.