### PR TITLE
Change all event names to be different from function names

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -6,7 +6,6 @@
         "max-line-length": ["error", 120],
         "compiler-fixed": false,
         "max-states-count": false,
-        "no-simple-event-func-name": false,
         "function-max-lines": false
     }
 }

--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -26,14 +26,14 @@ contract AddressWhitelist is Ownable {
 
         whitelist[newElement] = Status.In;
 
-        emit AddToWhitelist(newElement);
+        emit AddedToWhitelist(newElement);
     }
 
     // Removes an address from the whitelist.
     function removeFromWhitelist(address elementToRemove) external onlyOwner {
         if (whitelist[elementToRemove] != Status.Out) {
             whitelist[elementToRemove] = Status.Out;
-            emit RemoveFromWhitelist(elementToRemove);
+            emit RemovedFromWhitelist(elementToRemove);
         }
     }
 
@@ -69,6 +69,6 @@ contract AddressWhitelist is Ownable {
         }
     }
 
-    event AddToWhitelist(address indexed addedAddress);
-    event RemoveFromWhitelist(address indexed removedAddress);
+    event AddedToWhitelist(address indexed addedAddress);
+    event RemovedFromWhitelist(address indexed removedAddress);
 }

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -84,7 +84,7 @@ contract Registry is RegistryInterface, MultiRole {
         }
 
         address[] memory partiesForEvent = parties;
-        emit RegisterDerivative(derivativeAddress, partiesForEvent);
+        emit NewDerivativeRegistered(derivativeAddress, partiesForEvent);
     }
 
     function isDerivativeRegistered(address derivative) external view returns (bool isRegistered) {
@@ -133,5 +133,5 @@ contract Registry is RegistryInterface, MultiRole {
         _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Writer), new address[](0));
     }
 
-    event RegisterDerivative(address indexed derivativeAddress, address[] parties);
+    event NewDerivativeRegistered(address indexed derivativeAddress, address[] parties);
 }

--- a/core/contracts/Store.sol
+++ b/core/contracts/Store.sol
@@ -93,7 +93,7 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
         // Oracle fees at or over 100% don't make sense.
         require(newOracleFee.isLessThan(1));
         fixedOracleFeePerSecond = newOracleFee;
-        emit SetFixedOracleFeePerSecond(newOracleFee);
+        emit NewFixedOracleFeePerSecond(newOracleFee);
     }
     
     /**
@@ -117,6 +117,6 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
     }
 
-    event SetFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
+    event NewFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
 
 }

--- a/core/test/AddressWhitelist.js
+++ b/core/test/AddressWhitelist.js
@@ -36,7 +36,7 @@ contract("AddressWhitelist", function(accounts) {
     // Owner can add to the whitelist.
     const result = await addressWhitelist.addToWhitelist(contractToAdd, { from: owner });
 
-    truffleAssert.eventEmitted(result, "AddToWhitelist", ev => {
+    truffleAssert.eventEmitted(result, "AddedToWhitelist", ev => {
       return web3.utils.toChecksumAddress(ev.addedAddress) === web3.utils.toChecksumAddress(contractToAdd);
     });
 
@@ -58,7 +58,7 @@ contract("AddressWhitelist", function(accounts) {
     // Remove contractToRemove
     let result = await addressWhitelist.removeFromWhitelist(contractToRemove, { from: owner });
 
-    truffleAssert.eventEmitted(result, "RemoveFromWhitelist", ev => {
+    truffleAssert.eventEmitted(result, "RemovedFromWhitelist", ev => {
       return web3.utils.toChecksumAddress(ev.removedAddress) === web3.utils.toChecksumAddress(contractToRemove);
     });
 
@@ -68,7 +68,7 @@ contract("AddressWhitelist", function(accounts) {
 
     // Double remove from whitelist. Shouldn't error, but shouldn't generate an event.
     result = await addressWhitelist.removeFromWhitelist(contractToRemove, { from: owner });
-    truffleAssert.eventNotEmitted(result, "RemoveFromWhitelist");
+    truffleAssert.eventNotEmitted(result, "RemovedFromWhitelist");
   });
 
   it("Add to whitelist twice", async function() {
@@ -77,7 +77,7 @@ contract("AddressWhitelist", function(accounts) {
     await addressWhitelist.addToWhitelist(contractToAdd, { from: owner });
     const result = await addressWhitelist.addToWhitelist(contractToAdd, { from: owner });
 
-    truffleAssert.eventNotEmitted(result, "AddToWhitelist");
+    truffleAssert.eventNotEmitted(result, "AddedToWhitelist");
 
     assert.isTrue(await addressWhitelist.isOnWhitelist(contractToAdd));
   });

--- a/core/test/Registry.js
+++ b/core/test/Registry.js
@@ -61,8 +61,8 @@ contract("Registry", function(accounts) {
     result = await registry.registerDerivative(parties, arbitraryContract, { from: creator1 });
     assert.isTrue(await registry.isDerivativeRegistered(arbitraryContract));
 
-    // Make sure a RegisterDerivative event is emitted.
-    truffleAssert.eventEmitted(result, "RegisterDerivative", ev => {
+    // Make sure a NewDerivativeRegistered event is emitted.
+    truffleAssert.eventEmitted(result, "NewDerivativeRegistered", ev => {
       return web3.utils.toChecksumAddress(ev.derivativeAddress) === web3.utils.toChecksumAddress(arbitraryContract);
     });
 


### PR DESCRIPTION
Can add back a lint check.

Fixes issue #389.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>