### PR TITLE
Generate markdown representation of Solidity docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,18 @@ jobs:
       - run:
           name: Lint
           command: ./ci/lint.sh
+  docs:
+    docker:
+      - image: circleci/node:11.5.0
+    working_directory: ~/protocol
+    steps:
+      - restore_cache:
+          key: protocol-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Generate Docs
+          command: ./ci/docgen.sh
+      - store_artifacts:
+          path: docs
   slither:
     docker:
       - image: trailofbits/eth-security-toolbox
@@ -163,3 +175,6 @@ workflows:
           context: infura
           requires:
             - build
+      - docs:
+          requires:
+            - checkout_and_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ jobs:
           command: apk update && apk add make git python g++ curl ca-certificates openssl && update-ca-certificates
       - restore_cache:
           keys:
-            - v2-coverage-dependency-cache-{{ checksum "package.json" }}
-            - v2-coverage-dependency-cache-
+            - v3-coverage-dependency-cache-{{ checksum "package.json" }}
+            - v3-coverage-dependency-cache-
       - run:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: v2-coverage-dependency-cache-{{ checksum "package.json" }}
+          key: v3-coverage-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ jobs:
           command: apk update && apk add make git python g++ curl ca-certificates openssl && update-ca-certificates
       - restore_cache:
           keys:
-            - v3-coverage-dependency-cache-{{ checksum "package.json" }}
-            - v3-coverage-dependency-cache-
+            - v2-coverage-dependency-cache-{{ checksum "package.json" }}
+            - v2-coverage-dependency-cache-
       - run:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: v3-coverage-dependency-cache-{{ checksum "package.json" }}
+          key: v2-coverage-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage
 coverage.json
 out.log
 .GckmsOverride.js
+docs
 
 # GAE deployment files and directories for GAE deployments.
 app.yaml

--- a/ci/docgen.sh
+++ b/ci/docgen.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Note: because we've forked the solidity-docgen library, providing the path alias doesn't have an effect. However,
+# once external libraries are supported in v2 and we deprecate our fork, this will allow the docgen to find the
+# openzeppelin directory. See https://github.com/OpenZeppelin/solidity-docgen/issues/24 for progress on that front.
+OPEN_ZEPPELIN_DIR=$(pwd)/node_modules/openzeppelin-solidity
+SOLC_ARGS="openzeppelin-solidity=$OPEN_ZEPPELIN_DIR" \
+$(npm bin)/solidity-docgen -c ./core/contracts

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "minimist": "^1.2.0",
     "node-fetch": "^2.3.0",
     "openzeppelin-solidity": "2.3.0",
-    "solidity-docgen": "github:UMAprotocol/solidity-docgen#master",
     "truffle": "5.0.21",
     "truffle-assertions": "0.8.2",
     "truffle-contract": "4.0.19",
@@ -38,5 +37,8 @@
     "web3-core-promievent": "1.0.0-beta.37",
     "web3-eth-abi": "1.0.0-beta.37",
     "web3-utils": "1.0.0-beta.37"
+  },
+  "optionalDependencies": {
+    "solidity-docgen": "github:UMAprotocol/solidity-docgen#master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   },
   "author": "UMA Team",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UMAprotocol/protocol.git"
+  },
   "devDependencies": {
     "prettier": "^1.16.4",
     "solhint": "^1.5.0",
@@ -25,7 +29,7 @@
     "minimist": "^1.2.0",
     "node-fetch": "^2.3.0",
     "openzeppelin-solidity": "2.3.0",
-    "solidity-docgen": "^0.1.1",
+    "solidity-docgen": "github:UMAprotocol/solidity-docgen#master",
     "truffle": "5.0.21",
     "truffle-assertions": "0.8.2",
     "truffle-contract": "4.0.19",


### PR DESCRIPTION
A few notes:
- I forked the solidity-docgen package because v2 was missing the ability to import external dependencies (like openzeppelin). Once this feature is added in v2, we should move off of our fork.
- For whatever reason, reading this package directly from a repo (this happens on the unforked repo as well) causes a strange preinstall failure in some environments (the npm error messages are extremely unclear - my theory is that something is causing babel to fail). Specifically, this seems to fail in the coverage environment (ganache-cli docker image). The fix for this is to make the dependency optional so a failure doesn't cause the install the fail. This issue should be fixed once we stop using our fork.
- The markdown representation is built to be consumed by a static site generator, like docusaurus. It's not very readable in plaintext like markdown usually is.
- We don't do anything with the generated markdown yet. In a later PR, we can pass the markdown to a static site generator and publish the static site to github-pages (or some other static site hosting service).


Signed-off-by: Matthew Rice <matthewcrice32@gmail.com>