### PR TITLE
Add Kovan Testnet to Truffle config

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -65,7 +65,7 @@ addPublicNetwork(networks, "mainnet", 1);
 // CI requires a specific port and network ID because of peculiarities of the environment.
 addLocalNetwork(networks, "ci", { port: 8545, network_id: 1234 });
 
-// Develop and test networks are exactly the same and both use the default parameters.
+// Develop and test networks are exactly the same and both use the default local parameters.
 addLocalNetwork(networks, "develop");
 addLocalNetwork(networks, "test");
 

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -12,8 +12,8 @@ const mnemonic = process.env.MNEMONIC
 const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "9317010b1b6343558b7eff9d25934f38";
 
 // Default options
-const gasPx = 20000000000;
-const gas = 6720000;
+const gasPx = 20000000000; // 20 gwei
+const gas = 6720000; // Conservative estimate of the block gas limit.
 
 // Adds a public network.
 // Note: All public networks can be accessed using keys from GCS using the ManagedSecretProvider or using a mnemonic in the

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -25,7 +25,7 @@ function addPublicNetwork(networks, name, networkId) {
     gasPrice: gasPx
   };
 
-  // Set GCS ManagedSecretProvider network.
+  // GCS ManagedSecretProvider network.
   networks[name] = {
     ...options,
     provider: new ManagedSecretProvider(GckmsConfig, `https://kovan.infura.io/v3/${infuraApiKey}`, 0, GckmsConfig.length)

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -11,70 +11,71 @@ const mnemonic = process.env.MNEMONIC
 // Fallback to a backup non-prod API key.
 const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "9317010b1b6343558b7eff9d25934f38";
 
+// Default options
+const gasPx = 20000000000;
+const gas = 6720000;
+
+// Adds a public network.
+// Note: All public networks can be accessed using keys from GCS using the ManagedSecretProvider or using a mnemonic in the
+// shell environment.
+function addPublicNetwork(networks, name, networkId) {
+  const options = {
+    network_id: networkId,
+    gas: gas,
+    gasPrice: gasPx
+  };
+
+  // Set GCS ManagedSecretProvider network.
+  networks[name] = {
+    ...options,
+    provider: new ManagedSecretProvider(GckmsConfig, `https://kovan.infura.io/v3/${infuraApiKey}`, 0, GckmsConfig.length)
+  };
+
+  // Mnemonic network.
+  networks[name + "_mnemonic"] = {
+    ...options,
+    provider: new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${infuraApiKey}`, 0, 2)
+  };
+};
+
+// Adds a local network.
+// Note: local networks generally have more varied parameters, so the user can override any network option by passing
+// a customOptions object.
+function addLocalNetwork(networks, name, customOptions) {
+  const defaultOptions = {
+    host: "127.0.0.1",
+    network_id: "*",
+    port: 9545,
+    gas: gas
+  }
+
+  networks[name] = {
+    ...defaultOptions,
+    ...customOptions
+  }
+};
+
+let networks = {};
+
+// Public networks that need both a mnemonic and GCS ManagedSecretProvider network.
+addPublicNetwork(networks, "kovan", 42);
+addPublicNetwork(networks, "ropsten", 3);
+addPublicNetwork(networks, "mainnet", 1);
+
+// CI requires a specific port and network ID because of peculiarities of the environment.
+addLocalNetwork(networks, "ci", { port: 8545, network_id: 1234 });
+
+// Develop and test networks are exactly the same and both use the default parameters.
+addLocalNetwork(networks, "develop");
+addLocalNetwork(networks, "test");
+
+// Coverage requires specific parameters to allow very high cost transactions.
+addLocalNetwork(networks, "coverage", { port: 8545, gas: 0xfffffffffff, gasPrice: 0x01 });
+
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // for more about customizing your Truffle configuration!
-  networks: {
-    ci: {
-      host: "127.0.0.1",
-      port: 8545,
-      network_id: 1234,
-      gas: 6720000
-    },
-    coverage: {
-      host: "127.0.0.1",
-      network_id: "*",
-      port: 8545,
-      gas: 0xfffffffffff,
-      gasPrice: 0x01
-    },
-    develop: {
-      host: "127.0.0.1",
-      port: 9545,
-      network_id: "*",
-      gas: 6720000
-    },
-    test: {
-      host: "127.0.0.1",
-      port: 9545,
-      network_id: "*",
-      gas: 6720000
-    },
-    ropsten_mnemonic: {
-      provider: new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${infuraApiKey}`, 0, 2),
-      network_id: 3,
-      gas: 6720000,
-      gasPrice: 20000000000
-    },
-    ropsten: {
-      provider: new ManagedSecretProvider(
-        GckmsConfig,
-        `https://ropsten.infura.io/v3/${infuraApiKey}`,
-        0,
-        GckmsConfig.length
-      ),
-      network_id: 3,
-      gas: 6720000,
-      gasPrice: 20000000000
-    },
-    mainnet_mnemonic: {
-      provider: new HDWalletProvider(mnemonic, `https://mainnet.infura.io/v3/${infuraApiKey}`, 0, 2),
-      network_id: 1,
-      gas: 6720000,
-      gasPrice: 20000000000
-    },
-    mainnet: {
-      provider: new ManagedSecretProvider(
-        GckmsConfig,
-        `https://mainnet.infura.io/v3/${infuraApiKey}`,
-        0,
-        GckmsConfig.length
-      ),
-      network_id: 1,
-      gas: 6720000,
-      gasPrice: 20000000000
-    }
-  },
+  networks: networks,
   compilers: {
     solc: {
       version: "0.5.8"

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -28,7 +28,12 @@ function addPublicNetwork(networks, name, networkId) {
   // GCS ManagedSecretProvider network.
   networks[name] = {
     ...options,
-    provider: new ManagedSecretProvider(GckmsConfig, `https://kovan.infura.io/v3/${infuraApiKey}`, 0, GckmsConfig.length)
+    provider: new ManagedSecretProvider(
+      GckmsConfig,
+      `https://kovan.infura.io/v3/${infuraApiKey}`,
+      0,
+      GckmsConfig.length
+    )
   };
 
   // Mnemonic network.
@@ -36,7 +41,7 @@ function addPublicNetwork(networks, name, networkId) {
     ...options,
     provider: new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${infuraApiKey}`, 0, 2)
   };
-};
+}
 
 // Adds a local network.
 // Note: local networks generally have more varied parameters, so the user can override any network option by passing
@@ -47,13 +52,13 @@ function addLocalNetwork(networks, name, customOptions) {
     network_id: "*",
     port: 9545,
     gas: gas
-  }
+  };
 
   networks[name] = {
     ...defaultOptions,
     ...customOptions
-  }
-};
+  };
+}
 
 let networks = {};
 


### PR DESCRIPTION
This adds the kovan testnet to the truffle config. Because the truffle config was repetitive and confusing, I wanted to simplify the construction of the `networks` portion of the config so that it was clear what options were unique and what options were unchanged between networks.