### PR TITLE
Fix flaky test

### DIFF
--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -58,7 +58,6 @@ contract("scripts/Voting.js", function(accounts) {
 
     // The vote should have been committed.
     await votingSystem.runIteration();
-
     assert.equal(persistence[persistenceKey].price, hardcodedPrice);
 
     // Move to the reveal phase.

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -2,7 +2,8 @@ const VotingScript = require("../../scripts/Voting.js");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 const Registry = artifacts.require("Registry");
-const { RegistryRolesEnum } = require("../../utils/Enums.js");
+const { RegistryRolesEnum, VotePhasesEnum } = require("../../utils/Enums.js");
+const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
 
 contract("scripts/Voting.js", function(accounts) {
   let voting;
@@ -11,19 +12,10 @@ contract("scripts/Voting.js", function(accounts) {
 
   const account1 = accounts[0];
 
-  const phaseLength = web3.utils.toBN(86400);
-
-  const moveToNextPhase = async () => {
-    const currentTime = await voting.getCurrentTime();
-    await voting.setCurrentTime(currentTime.add(phaseLength));
-  };
-
   before(async function() {
     voting = await Voting.deployed();
     votingToken = await VotingToken.deployed();
     registry = await Registry.deployed();
-
-    await moveToNextPhase();
 
     // Register "derivative" with Registry, so we can make price requests in this test.
     await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, account1);
@@ -35,6 +27,11 @@ contract("scripts/Voting.js", function(accounts) {
     await votingToken.mint(account1, web3.utils.toWei("1", "ether"));
   });
 
+  beforeEach(async function() {
+    // Each test starts at the beginning of a fresh round.
+    await moveToNextRound(voting);
+  });
+
   it("basic case", async function() {
     const identifier = web3.utils.utf8ToHex("one-voter");
     const time = "1000";
@@ -42,7 +39,9 @@ contract("scripts/Voting.js", function(accounts) {
     // Request an Oracle price.
     await voting.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
-    await moveToNextPhase();
+
+    // Move to the round in which voters will vote on the requested price.
+    await moveToNextRound(voting);
 
     const pendingRequest = (await voting.getPendingRequests())[0];
     const roundId = await voting.getCurrentRoundId();
@@ -59,14 +58,17 @@ contract("scripts/Voting.js", function(accounts) {
 
     // The vote should have been committed.
     await votingSystem.runIteration();
+
     assert.equal(persistence[persistenceKey].price, hardcodedPrice);
 
-    await moveToNextPhase();
+    // Move to the reveal phase.
+    await moveToNextPhase(voting);
+
     // This vote should have been removed from the persistence layer so we don't re-reveal.
     await votingSystem.runIteration();
     assert.isFalse({ pendingRequest, roundId } in persistence);
 
-    await moveToNextPhase();
+    await moveToNextRound(voting);
     // The previous `runIteration()` should have revealed the vote, so the price request should be resolved.
     assert.equal(await voting.getPrice(identifier, time), hardcodedPrice);
   });

--- a/core/utils/Crypto.js
+++ b/core/utils/Crypto.js
@@ -3,33 +3,33 @@ const EthCrypto = require("eth-crypto");
 // Encrypts a message using an ethereum public key. To decrypt messages that are encrypted with this method, use
 // decryptMessage().
 async function encryptMessage(publicKey, message) {
-    // substr(2) removes the web3 friendly "0x" from the public key.
-    const encryptedMessageObject = await EthCrypto.encryptWithPublicKey(publicKey.substr(2), message);
-    return "0x" + EthCrypto.cipher.stringify(encryptedMessageObject);
+  // substr(2) removes the web3 friendly "0x" from the public key.
+  const encryptedMessageObject = await EthCrypto.encryptWithPublicKey(publicKey.substr(2), message);
+  return "0x" + EthCrypto.cipher.stringify(encryptedMessageObject);
 }
 
 // Converts an ethereum public key to the corresponding address.
 function addressFromPublicKey(publicKey) {
-    // substr(2) just removes the web3 friendly "0x" from the public key.
-    return EthCrypto.publicKey.toAddress(publicKey.substr(2));
+  // substr(2) just removes the web3 friendly "0x" from the public key.
+  return EthCrypto.publicKey.toAddress(publicKey.substr(2));
 }
 
 // Recovers a public key from a private key.
 function recoverPublicKey(privateKey) {
-    // The "0x" is added to make the public key web3 friendly.
-    return "0x" + EthCrypto.publicKeyByPrivateKey(privateKey);
+  // The "0x" is added to make the public key web3 friendly.
+  return "0x" + EthCrypto.publicKeyByPrivateKey(privateKey);
 }
 
 // Decrypts a message that was encrypted using encryptMessage().
 async function decryptMessage(privKey, encryptedMessage) {
-    // substr(2) just removes the 0x at the beginning. parse() reverses the stringify() in encryptMessage().
-    const encryptedMessageObject = EthCrypto.cipher.parse(encryptedMessage.substr(2));
-    return await EthCrypto.decryptWithPrivateKey(privKey, encryptedMessageObject);
+  // substr(2) just removes the 0x at the beginning. parse() reverses the stringify() in encryptMessage().
+  const encryptedMessageObject = EthCrypto.cipher.parse(encryptedMessage.substr(2));
+  return await EthCrypto.decryptWithPrivateKey(privKey, encryptedMessageObject);
 }
 
 module.exports = {
-    encryptMessage,
-    addressFromPublicKey,
-    decryptMessage,
-    recoverPublicKey
+  encryptMessage,
+  addressFromPublicKey,
+  decryptMessage,
+  recoverPublicKey
 };

--- a/core/utils/Random.js
+++ b/core/utils/Random.js
@@ -1,19 +1,19 @@
 const web3 = require("web3");
 
-  function getRandomSignedInt() {
-    // Generate a random unsigned 256 bit int.
-    const unsignedValue = web3.utils.toBN(web3.utils.randomHex(32));
+function getRandomSignedInt() {
+  // Generate a random unsigned 256 bit int.
+  const unsignedValue = web3.utils.toBN(web3.utils.randomHex(32));
 
-    // The signed range is just the unsigned range decreased by 2^255.
-    const signedOffset = web3.utils.toBN(2).pow(web3.utils.toBN(255));
-    return unsignedValue.sub(signedOffset);
-  }
+  // The signed range is just the unsigned range decreased by 2^255.
+  const signedOffset = web3.utils.toBN(2).pow(web3.utils.toBN(255));
+  return unsignedValue.sub(signedOffset);
+}
 
-  function getRandomUnsignedInt() {
-    return web3.utils.toBN(web3.utils.randomHex(32));
-  }
+function getRandomUnsignedInt() {
+  return web3.utils.toBN(web3.utils.randomHex(32));
+}
 
 module.exports = {
-    getRandomSignedInt,
-    getRandomUnsignedInt
+  getRandomSignedInt,
+  getRandomUnsignedInt
 };

--- a/core/utils/Voting.js
+++ b/core/utils/Voting.js
@@ -1,0 +1,30 @@
+const { VotePhasesEnum } = require("./Enums.js");
+
+const secondsPerDay = web3.utils.toBN(86400);
+
+// Moves the voting contract to the first phase of the next round.
+async function moveToNextRound(voting) {
+  const phase = await voting.getVotePhase();
+  const currentTime = await voting.getCurrentTime();
+  let timeIncrement;
+  if (phase.toString() === VotePhasesEnum.COMMIT) {
+    // Commit phase, so it will take 2 days to move to the next round.
+    timeIncrement = secondsPerDay.muln(2);
+  } else {
+    // Reveal phase, so it will take 1 day to move to the next round.
+    timeIncrement = secondsPerDay;
+  }
+
+  await voting.setCurrentTime(currentTime.add(timeIncrement));
+}
+
+// Moves the voting contract to the next phase.
+async function moveToNextPhase(voting) {
+  const currentTime = await voting.getCurrentTime();
+  await voting.setCurrentTime(currentTime.add(secondsPerDay));
+}
+
+module.exports = {
+  moveToNextRound,
+  moveToNextPhase
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prettier": "npm run prettier_vanilla -- --write",
     "prettier_check": "npm run prettier_vanilla -- --check",
-    "prettier_vanilla": "prettier '**/test/**/*.js' '**/migrations/*.js' '**/scripts/*.js' 'common/**/*.js' '*.js' 'sponsor-dapp/src/**/*.js'"
+    "prettier_vanilla": "prettier '**/test/**/*.js' '**/migrations/*.js' '**/scripts/*.js' '**/utils/*.js' 'common/**/*.js' '*.js' 'sponsor-dapp/src/**/*.js'"
   },
   "author": "UMA Team",
   "license": "MIT",


### PR DESCRIPTION
Our Voting script test seems to be flaking on master. This was due to assumptions about the starting vote phase that didn't hold. I'm not exactly sure why the test's assumption about phasing didn't hold. That deserves to be investigated, but this fix should make the test robust to arbitrary phasing start states.

This fix makes that test robust to starting in any vote phase. It also does a few other things:
- Pulls out the phase/round increment utility functions used in the Voting.sol test for use in other tests.
- Adds the core/utils/ directory so it is covered by prettier (and reformats those files).