### PR TITLE
Remove resolvedPrice

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -264,7 +264,6 @@ contract Voting is Testable, MultiRole, OracleInterface {
         priceRequests[priceRequestId] = PriceRequest({
             identifier: identifier,
             time: time,
-            resolvedPrice: 0,
             lastVotingRound: nextRoundId
         });
 
@@ -467,7 +466,8 @@ contract Voting is Testable, MultiRole, OracleInterface {
                 return (false, 0, "Price was never requested");
             }
 
-            VoteInstance storage voteInstance = priceResolution.votes[resolutionVotingRound];
+            // Grab the resolution voting round to compute the resolved price.
+            VoteInstance storage voteInstance = priceRequest.voteInstances[resolutionVotingRound];
             (, int pastResolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
                 _computeGat(resolutionVotingRound));
 
@@ -576,7 +576,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
             VoteInstance storage voteInstance = priceRequest.voteInstances[lastActiveVotingRoundId];
 
-            (bool isResolved, int resolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
+            (bool isResolved,) = voteInstance.resultComputation.getResolvedPrice(
                 _computeGat(lastActiveVotingRoundId));
 
             if (!isResolved) {

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -448,11 +448,11 @@ contract Voting is Testable, MultiRole, OracleInterface {
             }
 
             VoteInstance storage voteInstance = priceResolution.votes[resolutionVotingRound];
-            (, int resolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
+            (, int pastResolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
                 _computeGat(resolutionVotingRound));
 
             // Price has been resolved.
-            return (true, resolvedPrice, "");
+            return (true, pastResolvedPrice, "");
         } else {
             // Price has not yet been resolved.
 


### PR DESCRIPTION
This PR removes `resolvedPrice` to reduce gas costs since it's not too expensive to recompute the modal outcome each time it's requested (which should usually be once).