### PR TITLE
Store the revealHash rather than the reveal price

### DIFF
--- a/core/contracts/ResultComputation.sol
+++ b/core/contracts/ResultComputation.sol
@@ -59,11 +59,11 @@ library ResultComputation {
     }
 
     /**
-     * @dev Checks whether a `votePrice` is considered correct. Should only be called after a vote is resolved, i.e.,
+     * @dev Checks whether a `voteHash` is considered correct. Should only be called after a vote is resolved, i.e.,
      * via `getResolvedPrice`.
      */
-    function wasVoteCorrect(Data storage data, int votePrice) internal view returns (bool) {
-        return votePrice == data.currentMode;
+    function wasVoteCorrect(Data storage data, bytes32 voteHash) internal view returns (bool) {
+        return voteHash == keccak256(abi.encode(data.currentMode));
     }
 
     /**

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -588,6 +588,9 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
                 // Zero out the price request to reduce gas costs.
                 delete lastActiveVotingRound.priceRequestIds[i];
+
+                // Delete the result computation since it's no longer needed.
+                delete voteInstance.resultComputation;
             }
         }
 

--- a/core/contracts/test/ResultComputationTest.sol
+++ b/core/contracts/test/ResultComputationTest.sol
@@ -20,8 +20,8 @@ contract ResultComputationTest {
         return data.getResolvedPrice(FixedPoint.Unsigned(minVoteThreshold));
     }
 
-    function wrapWasVoteCorrect(int votePrice) external view returns (bool) {
-        return data.wasVoteCorrect(votePrice);
+    function wrapWasVoteCorrect(bytes32 revealHash) external view returns (bool) {
+        return data.wasVoteCorrect(revealHash);
     }
 
     function wrapGetTotalCorrectlyVotedTokens() external view returns (uint) {

--- a/core/test/ResultComputation.js
+++ b/core/test/ResultComputation.js
@@ -17,8 +17,8 @@ contract("ResultComputation", function(accounts) {
     let resolved = await resultComputation.wrapGetResolvedPrice(minVoteThreshold);
     assert.isTrue(resolved.isResolved);
     assert.equal(resolved.price, priceOne);
-    assert.isTrue(await resultComputation.wrapWasVoteCorrect(priceOne));
-    assert.isFalse(await resultComputation.wrapWasVoteCorrect(priceTwo));
+    assert.isTrue(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceOne)));
+    assert.isFalse(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceTwo)));
     assert.equal(await resultComputation.wrapGetTotalCorrectlyVotedTokens(), web3.utils.toWei("5"));
 
     await resultComputation.wrapAddVote(priceTwo, web3.utils.toWei("4"));
@@ -26,8 +26,8 @@ contract("ResultComputation", function(accounts) {
     resolved = await resultComputation.wrapGetResolvedPrice(minVoteThreshold);
     assert.isTrue(resolved.isResolved);
     assert.equal(resolved.price, priceOne);
-    assert.isTrue(await resultComputation.wrapWasVoteCorrect(priceOne));
-    assert.isFalse(await resultComputation.wrapWasVoteCorrect(priceTwo));
+    assert.isTrue(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceOne)));
+    assert.isFalse(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceTwo)));
     assert.equal(await resultComputation.wrapGetTotalCorrectlyVotedTokens(), web3.utils.toWei("5"));
 
     await resultComputation.wrapAddVote(priceThree, web3.utils.toWei("4"));
@@ -47,8 +47,8 @@ contract("ResultComputation", function(accounts) {
     resolved = await resultComputation.wrapGetResolvedPrice(minVoteThreshold);
     assert.isTrue(resolved.isResolved);
     assert.equal(resolved.price, priceTwo);
-    assert.isFalse(await resultComputation.wrapWasVoteCorrect(priceOne));
-    assert.isTrue(await resultComputation.wrapWasVoteCorrect(priceTwo));
+    assert.isFalse(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceOne)));
+    assert.isTrue(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceTwo)));
     assert.equal((await resultComputation.wrapGetTotalCorrectlyVotedTokens()).toString(), web3.utils.toWei("9.1"));
   });
 
@@ -98,8 +98,8 @@ contract("ResultComputation", function(accounts) {
     resolved = await resultComputation.wrapGetResolvedPrice(minVotes);
     assert.isTrue(resolved.isResolved);
     assert.equal(resolved.price, priceOne);
-    assert.isTrue(await resultComputation.wrapWasVoteCorrect(priceOne));
-    assert.isFalse(await resultComputation.wrapWasVoteCorrect(priceTwo));
+    assert.isTrue(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceOne)));
+    assert.isFalse(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(priceTwo)));
     assert.equal((await resultComputation.wrapGetTotalCorrectlyVotedTokens()).toString(), web3.utils.toWei("10"));
   });
 });

--- a/core/test/ResultComputation.js
+++ b/core/test/ResultComputation.js
@@ -68,8 +68,8 @@ contract("ResultComputation", function(accounts) {
     resolved = await resultComputation.wrapGetResolvedPrice(minVoteThreshold);
     assert.isTrue(resolved.isResolved);
     assert.equal(resolved.price, zeroPrice);
-    assert.isTrue(await resultComputation.wrapWasVoteCorrect(zeroPrice));
-    assert.isFalse(await resultComputation.wrapWasVoteCorrect(web3.utils.toWei("1")));
+    assert.isTrue(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(zeroPrice)));
+    assert.isFalse(await resultComputation.wrapWasVoteCorrect(web3.utils.soliditySha3(web3.utils.toWei("1"))));
     assert.equal((await resultComputation.wrapGetTotalCorrectlyVotedTokens()).toString(), web3.utils.toWei("5"));
   });
 


### PR DESCRIPTION
The basic premise of this PR is that if we store the hash of the reveal rather than the exact price that was revealed, we don't need to store a boolean to denote whether the voter revealed. This is because there is no known price that will generate a `0x0` hash, so the default will never be misinterpreted as a valid vote for some price - it will always fail the comparison.

A few notes:
- This approach as written will only work for voting systems where there is only one "correct" vote per vote instance since the result hash must be directly compared to the voter's hash. This will likely not work for a median-style system where ranges of values are considered acceptable.
- This also includes a small optimization so that we delete the old `ResultComputation` struct when a vote is rolled over.

I'm not completely sold on this optimization, so please comment as to whether you think the gas savings are worth the additional code complexity/ambiguity and/or there are better ways to achieve the same savings.