### PR TITLE
Fix gas estimation script to exclude gas refund

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -607,6 +607,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
             // There is no snapshot ID set, so create one.
             round.snapshotId = votingToken.snapshot();
         }
+
         return round.snapshotId;
     }
 

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -6,6 +6,8 @@ const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 
+const numPriceRequests = 5;
+
 const getVoter = (accounts, id) => {
   // Offset by 2, because owner == accounts[0] and registeredDerivative == accounts[1]
   return accounts[id + 2];
@@ -44,7 +46,7 @@ async function run() {
   }
 
   const now = await voting.getCurrentTime();
-  const max = now - 50;
+  const max = now - numPriceRequests * 5;
   // Pick a random time. Probabilistically, this won't request a duplicate time from a previous run.
   let time = Math.floor(Math.random() * max);
 
@@ -52,9 +54,8 @@ async function run() {
 
   for (var i = 0; i < 5; i++) {
     console.log("Round", i);
-    // Makes 5 price requests that are resolved by 5 voters
     await cycleRound(voting, votingToken, identifier, time, accounts);
-    time += 5;
+    time += numPriceRequests;
   }
 
   for (var i = 0; i < 5; i++) {
@@ -67,24 +68,24 @@ async function run() {
 }
 
 const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
-  for (var i = 0; i < 5; i++) {
-    console.log("requestPrice", await voting.requestPrice.estimateGas(identifier, time + i, { from: accounts[1] }));
-    await voting.requestPrice(identifier, time + i, { from: accounts[1] });
+  for (var i = 0; i < numPriceRequests; i++) {
+    const result = await voting.requestPrice(identifier, time + i, { from: accounts[1] });
+    console.log("requestPrice", result.receipt.gasUsed);
   }
 
   await moveToNextRound(voting);
 
   const salts = {};
   const price = getRandomSignedInt();
-  for (var i = 0; i < 5; i++) {
+  for (var i = 0; i < numPriceRequests; i++) {
     for (var j = 0; j < 5; j++) {
       const salt = getRandomUnsignedInt();
       const hash = web3.utils.soliditySha3(price, salt);
 
       const voter = getVoter(accounts, j);
 
-      console.log("commit", await voting.commitVote.estimateGas(identifier, time + i, hash, { from: voter }));
-      await voting.commitVote(identifier, time + i, hash, { from: voter });
+      const result = await voting.commitVote(identifier, time + i, hash, { from: voter });
+      console.log("commitVote", result.receipt.gasUsed);
 
       if (salts[i] == null) {
         salts[i] = {};
@@ -95,15 +96,12 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
 
   await moveToNextPhase(voting);
 
-  for (var i = 0; i < 5; i++) {
+  for (var i = 0; i < numPriceRequests; i++) {
     for (var j = 0; j < 5; j++) {
       const voter = getVoter(accounts, j);
 
-      console.log(
-        "reveal",
-        await voting.revealVote.estimateGas(identifier, time + i, price, salts[i][j], { from: voter })
-      );
-      await voting.revealVote(identifier, time + i, price, salts[i][j], { from: voter });
+      const result = await voting.revealVote(identifier, time + i, price, salts[i][j], { from: voter });
+      console.log("revealVote", result.receipt.gasUsed);
     }
   }
 };


### PR DESCRIPTION
I preemptively blamed Ganache for `estimateGas` returning the wrong value. The actual problem was that `estimateGas` intentionally includes the gas refund. To get the actual gas used, there's a `gasUsed` field in the receipt.

I updated [this doc](https://docs.google.com/document/d/1NjI3bXG2HjunVfu9KzXNrsliOWpN1SeICREoe8Lx2DA/edit?usp=sharing), but the gas usage dropped from 6.4M -> 3.5M.