### PR TITLE
Add blockchain persistence to the Voting script

### DIFF
--- a/common/gckms/ManagedSecretProvider.js
+++ b/common/gckms/ManagedSecretProvider.js
@@ -106,7 +106,7 @@ class ManagedSecretProvider {
 
         // Make the internal wallets directly available to users.
         this.wallets = this.wrappedProvider.wallets;
-        
+
         return this.wrappedProvider;
       },
       reason => {

--- a/common/gckms/ManagedSecretProvider.js
+++ b/common/gckms/ManagedSecretProvider.js
@@ -103,6 +103,10 @@ class ManagedSecretProvider {
         }
 
         this.wrappedProvider = new HDWalletProvider(keys, ...this.remainingArgs);
+
+        // Make the internal wallets directly available to users.
+        this.wallets = this.wrappedProvider.wallets;
+        
         return this.wrappedProvider;
       },
       reason => {

--- a/core/contracts/EncryptedSender.sol
+++ b/core/contracts/EncryptedSender.sol
@@ -68,8 +68,16 @@ contract EncryptedSender {
      */
     function sendMessage(address recipient_, bytes32 topicHash, bytes memory message) public {
         Recipient storage recipient = recipients[recipient_];
-        require(recipient.authorizedSenders[msg.sender], "Not authorized to send to this recipient");
+        require(isAuthorizedSender(msg.sender, recipient_), "Not authorized to send to this recipient");
         recipient.messages[topicHash] = message;
+    }
+
+    /**
+     * @notice Returns true if the `sender` is authorized to send to the `recipient`.
+     */
+    function isAuthorizedSender(address sender, address recipient) public view returns (bool) {
+        // Note: the recipient is always authorized to send messages to themselves.
+        return recipients[recipient].authorizedSenders[sender] || recipient == sender;
     }
 
     /**
@@ -77,7 +85,7 @@ contract EncryptedSender {
      */
     function setPublicKey(bytes memory publicKey) public {
         // Verify that the uploaded public key matches the sender.
-        require(_publicKeyToAddress(publicKey) == msg.sender);
+        require(_publicKeyToAddress(publicKey) == msg.sender, "Public key does not match the sender");
 
         // Set the public key if it passed verification.
         recipients[msg.sender].publicKey = publicKey;

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -1,38 +1,81 @@
 const Voting = artifacts.require("Voting");
+const EncryptedSender = artifacts.require("EncryptedSender");
 const { VotePhasesEnum } = require("../utils/Enums");
+const { decryptMessage, encryptMessage } = require("../utils/Crypto");
+
 
 // TODO(#492): Implement price fetching logic.
 async function fetchPrice(request) {
   return web3.utils.toWei("1.5");
 }
 
-// TODO(#493): Implement persistance.
 class VotingSystem {
-  constructor(voting, persistence) {
+  constructor(voting, encryptedSender, account) {
     this.voting = voting;
-    this.persistence = persistence;
+    this.encryptedSender = encryptedSender;
+    this.account = account;
+  }
+
+  async readVote(request, roundId) {
+    const encryptedCommit = await this.encryptedSender.getMessage(this.account, this.computeTopicHash(request, roundId));
+
+    if (!encryptedCommit) {
+      // Nothing has been published for this topic.
+      return null;
+    }
+
+    const { privKey } = this.getAccountKeys();
+    const decryptedMessage = await decryptMessage(privKey, encryptedCommit);
+    return JSON.parse(decryptedMessage);
+  }
+
+  async writeVote(request, roundId, vote) {
+    // TODO: if we want to authorize other accounts to send messages to the automated voting system, we should check
+    // and authorize them here.
+
+    // Get the account's public key from the encryptedSender.
+    let pubKey = await this.encryptedSender.getPublicKey(this.account);
+
+    if (!pubKey) {
+      // If the public key isn't published, pull it from the local wallet.
+      pubKey = this.getAccountKeys().pubKey;
+
+      // Publish the public key so dApps or scripts that are authorized can write without direct access to this
+      // account's private key.
+      await this.encryptedSender.setPublicKey(pubKey, { from: this.account });
+    }
+
+    // Encrypt the vote using the public key.
+    const encryptedMessage = await encryptMessage(pubKey, JSON.stringify(vote));
+
+    // Upload the encrypted commit.
+    const topicHash = this.computeTopicHash(request, roundId);
+    await this.encryptedSender.sendMessage(this.account, topicHash, encryptedMessage, { from: this.account });
   }
 
   async runCommit(request, roundId) {
-    const persistedVote = this.persistence[{ request, roundId }];
+    const persistedVote = await this.readVote(request, roundId);
     // If the vote has already been persisted and committed, we don't need to recommit.
+    // TODO: we may want to add a feature in the future where we ensure that the persisted vote matches the commit, and
+    // if it does not, we commit the persisted vote.
     if (persistedVote) {
       return;
     }
     const fetchedPrice = await fetchPrice(request);
     const salt = web3.utils.toBN(web3.utils.randomHex(32));
 
-    this.persistence[{ request, roundId }] = { price: fetchedPrice, salt: salt };
     const hash = web3.utils.soliditySha3(fetchedPrice, salt);
-    await this.voting.commitVote(request.identifier, request.time, hash);
+    await this.voting.commitVote(request.identifier, request.time, hash, { from: this.account });
+
+    // Persist the vote only after the commit hash has been sent to the Voting contract.
+    await this.writeVote(request, roundId, { price: fetchedPrice.toString(), salt: salt.toString() });
   }
 
   async runReveal(request, roundId) {
-    const persistedVote = this.persistence[{ request, roundId }];
+    const persistedVote = await this.readVote(request, roundId);
     // If no vote was persisted and committed, then we can't reveal.
     if (persistedVote) {
-      await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt);
-      delete this.persistence[{ request, roundId }];
+      await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt, { from: this.account });
     }
   }
 
@@ -48,13 +91,31 @@ class VotingSystem {
       }
     }
   }
+
+  computeTopicHash(request, roundId) {
+    return web3.utils.soliditySha3(request.identifier, request.time, roundId);
+  }
+
+  getAccountKeys() {
+    // Note: this assumes that current provider has a .wallets field that is keyed by wallet address.
+    // Each wallet in the wallets field is assumed to have ._privKey and ._pubKey fields that store buffers holding the
+    // keys.
+    const wallet = web3.currentProvider.wallets[this.account];
+    return {
+      privKey: wallet._privKey.toString('hex'),
+      // Note: the "0x" addition is because public keys are expected to be passed in a web3 friendly format.
+      pubKey: "0x" + wallet._pubKey.toString('hex')
+    };
+  }
 }
 
 async function runVoting() {
   try {
     console.log("Running Voting system");
     const voting = await Voting.deployed();
-    const votingSystem = new VotingSystem(voting, {});
+    const encryptedSender = await EncryptedSender.deployed();
+    const account = (await web3.eth.getAccounts())[0];
+    const votingSystem = new VotingSystem(voting, encryptedSender, account);
     await votingSystem.runIteration();
   } catch (error) {
     console.log(error);

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -3,7 +3,6 @@ const EncryptedSender = artifacts.require("EncryptedSender");
 const { VotePhasesEnum } = require("../utils/Enums");
 const { decryptMessage, encryptMessage } = require("../utils/Crypto");
 
-
 // TODO(#492): Implement price fetching logic.
 async function fetchPrice(request) {
   return web3.utils.toWei("1.5");
@@ -17,7 +16,10 @@ class VotingSystem {
   }
 
   async readVote(request, roundId) {
-    const encryptedCommit = await this.encryptedSender.getMessage(this.account, this.computeTopicHash(request, roundId));
+    const encryptedCommit = await this.encryptedSender.getMessage(
+      this.account,
+      this.computeTopicHash(request, roundId)
+    );
 
     if (!encryptedCommit) {
       // Nothing has been published for this topic.
@@ -75,7 +77,9 @@ class VotingSystem {
     const persistedVote = await this.readVote(request, roundId);
     // If no vote was persisted and committed, then we can't reveal.
     if (persistedVote) {
-      await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt, { from: this.account });
+      await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt, {
+        from: this.account
+      });
     }
   }
 
@@ -102,9 +106,9 @@ class VotingSystem {
     // keys.
     const wallet = web3.currentProvider.wallets[this.account];
     return {
-      privKey: wallet._privKey.toString('hex'),
+      privKey: wallet._privKey.toString("hex"),
       // Note: the "0x" addition is because public keys are expected to be passed in a web3 friendly format.
-      pubKey: "0x" + wallet._pubKey.toString('hex')
+      pubKey: "0x" + wallet._pubKey.toString("hex")
     };
   }
 }

--- a/core/test/EncryptedSender.js
+++ b/core/test/EncryptedSender.js
@@ -1,6 +1,12 @@
 const { didContractThrow } = require("../../common/SolidityTestUtils.js");
 const { getRandomSignedInt, getRandomUnsignedInt } = require("../utils/Random.js");
-const { decryptMessage, encryptMessage, addressFromPublicKey, recoverPublicKey, createVisibleAccount } = require("../utils/Crypto.js");
+const {
+  decryptMessage,
+  encryptMessage,
+  addressFromPublicKey,
+  recoverPublicKey,
+  createVisibleAccount
+} = require("../utils/Crypto.js");
 const EthCrypto = require("eth-crypto");
 
 const EncryptedSender = artifacts.require("EncryptedSender");
@@ -18,7 +24,7 @@ contract("EncryptedSender", function(accounts) {
   before(async function() {
     encryptedSender = await EncryptedSender.deployed();
 
-    ({ pubKey: receiverPubKey, privKey: receiverPrivKey, address: receiverAccount } = await createVisibleAccount(web3)); 
+    ({ pubKey: receiverPubKey, privKey: receiverPrivKey, address: receiverAccount } = await createVisibleAccount(web3));
 
     // Fund the new account
     await web3.eth.sendTransaction({ from: accounts[9], to: receiverAccount, value: web3.utils.toWei("5", "ether") });

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -2,20 +2,42 @@ const VotingScript = require("../../scripts/Voting.js");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 const Registry = artifacts.require("Registry");
+const EncryptedSender = artifacts.require("EncryptedSender");
 const { RegistryRolesEnum, VotePhasesEnum } = require("../../utils/Enums.js");
 const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
+const { createVisibleAccount } = require("../../utils/Crypto");
 
 contract("scripts/Voting.js", function(accounts) {
   let voting;
   let votingToken;
   let registry;
+  let encryptedSender;
 
   const account1 = accounts[0];
+  let voter;
+  let privKey;
 
   before(async function() {
     voting = await Voting.deployed();
     votingToken = await VotingToken.deployed();
     registry = await Registry.deployed();
+    encryptedSender = await EncryptedSender.deployed();
+
+    // Load the keys and add them to the wallets object on the provider.
+    let pubKey;
+    ({ address: voter, privKey, pubKey } = await createVisibleAccount(web3));
+    if (!web3.currentProvider.wallets) {
+        // If no wallets object has been created, create one.
+        web3.currentProvider.wallets = {};
+    }
+    // Format the private and public keys for the wallet.
+    web3.currentProvider.wallets[voter] = {
+        _privKey: Buffer.from(privKey.substr(2), "hex"),
+        _pubKey: Buffer.from(pubKey.substr(2), "hex")
+    };
+
+    // Fund the voter account.
+    await web3.eth.sendTransaction({ from: accounts[9], to: voter, value: web3.utils.toWei("5", "ether") });
 
     // Register "derivative" with Registry, so we can make price requests in this test.
     await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, account1);
@@ -24,7 +46,7 @@ contract("scripts/Voting.js", function(accounts) {
     // Give account1 all of the tokens.
     const minterRole = 1;
     await votingToken.addMember(minterRole, account1);
-    await votingToken.mint(account1, web3.utils.toWei("1", "ether"));
+    await votingToken.mint(voter, web3.utils.toWei("1", "ether"));
   });
 
   beforeEach(async function() {
@@ -43,32 +65,64 @@ contract("scripts/Voting.js", function(accounts) {
     // Move to the round in which voters will vote on the requested price.
     await moveToNextRound(voting);
 
-    const pendingRequest = (await voting.getPendingRequests())[0];
-    const roundId = await voting.getCurrentRoundId();
-    // Both the persistence and the actual price fetching haven't been implemented yet, so for the purpose of this
-    // test case, we use these same hardcoded values.
-    const persistenceKey = { pendingRequest, roundId };
-    const hardcodedPrice = web3.utils.toWei("1.5");
-
     // Sanity check.
     assert.isFalse(await voting.hasPrice(identifier, time));
-
-    const persistence = {};
-    const votingSystem = new VotingScript.VotingSystem(voting, persistence);
+    let votingSystem = new VotingScript.VotingSystem(voting, encryptedSender, voter);
 
     // The vote should have been committed.
     await votingSystem.runIteration();
-    assert.equal(persistence[persistenceKey].price, hardcodedPrice);
 
     // Move to the reveal phase.
     await moveToNextPhase(voting);
 
+    // Replace the voting system object with a new one so the class can't persist the commit.
+    votingSystem = new VotingScript.VotingSystem(voting, encryptedSender, voter);
+
     // This vote should have been removed from the persistence layer so we don't re-reveal.
     await votingSystem.runIteration();
-    assert.isFalse({ pendingRequest, roundId } in persistence);
 
     await moveToNextRound(voting);
     // The previous `runIteration()` should have revealed the vote, so the price request should be resolved.
+    const hardcodedPrice = web3.utils.toWei("1.5");
     assert.equal(await voting.getPrice(identifier, time), hardcodedPrice);
+  });
+
+  it("simultaneous and overlapping votes", async function() {
+    const identifier1 = web3.utils.utf8ToHex("overlapping1");
+    const time1 = "1000";
+    const identifier2 = web3.utils.utf8ToHex("overlapping2");
+    const time2 = "1000";
+
+    // Add both identifiers.
+    await voting.addSupportedIdentifier(identifier1);
+    await voting.addSupportedIdentifier(identifier2);
+
+    // Send three overlapping requests such that each parameter overlaps with one other request.
+    await voting.requestPrice(identifier1, time1);
+    await voting.requestPrice(identifier1, time2);
+    await voting.requestPrice(identifier2, time2);
+
+    // Move to the round in which voters will vote on the requested prices.
+    await moveToNextRound(voting);
+    let votingSystem = new VotingScript.VotingSystem(voting, encryptedSender, voter);
+
+    // The votes should have been committed.
+    await votingSystem.runIteration();
+
+    // Move to the reveal phase.
+    await moveToNextPhase(voting);
+
+    // Replace the voting system object with a new one so the class can't persist the commits.
+    votingSystem = new VotingScript.VotingSystem(voting, encryptedSender, voter);
+
+    // This vote should have been removed from the persistence layer so we don't re-reveal.
+    await votingSystem.runIteration();
+
+    await moveToNextRound(voting);
+    // The previous `runIteration()` should have revealed the vote, so the price request should be resolved.
+    const hardcodedPrice = web3.utils.toWei("1.5");
+    assert.equal(await voting.getPrice(identifier1, time1), hardcodedPrice);
+    assert.equal(await voting.getPrice(identifier1, time2), hardcodedPrice);
+    assert.equal(await voting.getPrice(identifier2, time2), hardcodedPrice);
   });
 });

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -27,13 +27,13 @@ contract("scripts/Voting.js", function(accounts) {
     let pubKey;
     ({ address: voter, privKey, pubKey } = await createVisibleAccount(web3));
     if (!web3.currentProvider.wallets) {
-        // If no wallets object has been created, create one.
-        web3.currentProvider.wallets = {};
+      // If no wallets object has been created, create one.
+      web3.currentProvider.wallets = {};
     }
     // Format the private and public keys for the wallet.
     web3.currentProvider.wallets[voter] = {
-        _privKey: Buffer.from(privKey.substr(2), "hex"),
-        _pubKey: Buffer.from(pubKey.substr(2), "hex")
+      _privKey: Buffer.from(privKey.substr(2), "hex"),
+      _pubKey: Buffer.from(pubKey.substr(2), "hex")
     };
 
     // Fund the voter account.

--- a/core/utils/Crypto.js
+++ b/core/utils/Crypto.js
@@ -27,9 +27,29 @@ async function decryptMessage(privKey, encryptedMessage) {
   return await EthCrypto.decryptWithPrivateKey(privKey, encryptedMessageObject);
 }
 
+// Adds an account to web3 and returns all account "secrets" to the caller. 
+// Note: This is primarily of use when attempting to use a node that comes preloaded with unlocked accounts. Since
+// there is no way for the user to access the private keys of these accounts over the node JSON-RPC api, the user must
+// manually generate an account and add it for the private key to be accessible.
+async function createVisibleAccount(web3) {
+  const newAccount = web3.eth.accounts.create();
+  const password = "password";
+  await web3.eth.personal.importRawKey(newAccount.privateKey, password);
+  if(!(await web3.eth.personal.unlockAccount(newAccount.address, password, 3600))) {
+    throw "Account could not be unlocked";
+  }
+
+  return {
+    privKey: newAccount.privateKey,
+    pubKey: recoverPublicKey(newAccount.privateKey),
+    address: newAccount.address
+  }
+}
+
 module.exports = {
   encryptMessage,
   addressFromPublicKey,
   decryptMessage,
-  recoverPublicKey
+  recoverPublicKey,
+  createVisibleAccount
 };

--- a/core/utils/Crypto.js
+++ b/core/utils/Crypto.js
@@ -27,7 +27,7 @@ async function decryptMessage(privKey, encryptedMessage) {
   return await EthCrypto.decryptWithPrivateKey(privKey, encryptedMessageObject);
 }
 
-// Adds an account to web3 and returns all account "secrets" to the caller. 
+// Adds an account to web3 and returns all account "secrets" to the caller.
 // Note: This is primarily of use when attempting to use a node that comes preloaded with unlocked accounts. Since
 // there is no way for the user to access the private keys of these accounts over the node JSON-RPC api, the user must
 // manually generate an account and add it for the private key to be accessible.
@@ -35,7 +35,7 @@ async function createVisibleAccount(web3) {
   const newAccount = web3.eth.accounts.create();
   const password = "password";
   await web3.eth.personal.importRawKey(newAccount.privateKey, password);
-  if(!(await web3.eth.personal.unlockAccount(newAccount.address, password, 3600))) {
+  if (!(await web3.eth.personal.unlockAccount(newAccount.address, password, 3600))) {
     throw "Account could not be unlocked";
   }
 
@@ -43,7 +43,7 @@ async function createVisibleAccount(web3) {
     privKey: newAccount.privateKey,
     pubKey: recoverPublicKey(newAccount.privateKey),
     address: newAccount.address
-  }
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
This PR uses the `EncryptedSender` contract to add blockchain persistence to the voting script. 

There are a few assumptions baked into this implementation:
- Everyone who wants to persist votes must have access to the account that owns the voting tokens.
- Persistence always happens *after* the commit transaction is confirmed. 

These assumptions are not expected to be permanent, so there are a few scattered TODOs to make these assumptions more flexible (other accounts persisting votes that are expected to be committed by the script, for instance), but we probably want to discuss a particular direction before moving in any particular direction.

Note: this implementation also assumes that the private keys being used are always accessible via a `wallets` object on the provider. This is true of the `HDWalletProvider`, and I added it to our wrapped provider. For Ganache, some hackery was necessary similar to what was needed for the `EncryptedSender` tests. This will not hold for hardware wallets and I doubt that they have a flexible decryption mechanism, so it will probably be the case that hardware wallets are incompatible with this persistence mechanism - we can discuss more on this point.

Fixes #493.