### PR TITLE
Unify Expanded ERC20 method signatures

### DIFF
--- a/core/contracts/ExpandedIERC20.sol
+++ b/core/contracts/ExpandedIERC20.sol
@@ -13,5 +13,5 @@ contract ExpandedIERC20 is IERC20 {
 
     // Mints tokens and adds them to the balance of the `to` address.
     // Note: this method should be permissioned to only allow designated parties to mint tokens.
-    function mint(address to, uint value) external;
+    function mint(address to, uint value) external returns (bool);
 }

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -761,7 +761,7 @@ library TokenizedDerivativeUtils {
 
         ExpandedIERC20 thisErc20Token = ExpandedIERC20(address(this));
 
-        thisErc20Token.mint(msg.sender, tokensToPurchase);
+        require(thisErc20Token.mint(msg.sender, tokensToPurchase), "Token minting failed");
         emit TokensCreated(s.fixedParameters.symbol, tokensToPurchase);
 
         s.nav = _computeNavForTokens(s.currentTokenState.tokenPrice, _totalSupply());

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -1241,8 +1241,9 @@ contract TokenizedDerivative is ERC20, AdministrateeInterface, ExpandedIERC20 {
     }
 
     // Only allow calls from this contract or its libraries to mint tokens.
-    function mint(address to, uint256 value) external onlyThis {
+    function mint(address to, uint256 value) external onlyThis returns (bool) {
         _mint(to, value);
+        return true;
     }
 
     // Returns the expected net asset value (NAV) of the contract using the latest available Price Feed price.

--- a/core/contracts/VotingToken.sol
+++ b/core/contracts/VotingToken.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.0;
 
 import "./MultiRole.sol";
+import "./ExpandedIERC20.sol";
 
 import "openzeppelin-solidity/contracts/drafts/ERC20Snapshot.sol";
 
@@ -9,7 +10,7 @@ import "openzeppelin-solidity/contracts/drafts/ERC20Snapshot.sol";
  * @title UMA voting token
  * @dev Supports snapshotting and allows the Oracle to mint new tokens as rewards.
  */
-contract VotingToken is ERC20Snapshot, MultiRole {
+contract VotingToken is ExpandedIERC20, ERC20Snapshot, MultiRole {
 
     enum Roles {
         // Can set the minter and burner.


### PR DESCRIPTION
This makes `VoteToken` and `TokenizedDerivative` conform to the same expanded (+mint and burn) ERC20 interface.