### PR TITLE
Send one email at the end of committing or revealing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,18 @@ FROM node:11
 RUN git clone https://github.com/UMAprotocol/protocol.git
 WORKDIR protocol
 
+COPY core/scripts/Voting.js core/scripts
+COPY package.json ./
+COPY common/globalTruffleConfig.js common/
+
 # Install dependencies and compile contracts.
 RUN npm install
 RUN scripts/buildContracts.sh
+
+# Environment variables to set up email notifications.
+ENV SENDGRID_API_KEY=
+ENV NOTIFICATION_FROM_ADDRESS=
+ENV NOTIFICATION_TO_ADDRESS=
 
 # Command to run Voting system. The setup above could probably be extracted to a base Docker image, but that may require
 # modifying the directory structure more.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,6 @@ FROM node:11
 RUN git clone https://github.com/UMAprotocol/protocol.git
 WORKDIR protocol
 
-COPY core/scripts/Voting.js core/scripts
-COPY package.json ./
-COPY common/globalTruffleConfig.js common/
-
 # Install dependencies and compile contracts.
 RUN npm install
 RUN scripts/buildContracts.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Build this Docker container from `protocol` directory with:
 #   docker build -t <username>/<imagename> .
 # Execute the voting system with:
-#   docker run <username>/<imagename> --network=<network>
+#   docker run <username>/<imagename>
+#     --network=<network>
+#     --env SENDGRID_API_KEY=<key>
+#     --env NOTIFICATION_FROM_ADDRESS=<email address>
+#     --env NOTIFICATION_TO_ADDRESS=<email address>
 
 # Fix node version due to high potential for incompatibilities.
 FROM node:11

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -1,23 +1,36 @@
 const Voting = artifacts.require("Voting");
 const { VotePhasesEnum } = require("../utils/Enums");
+const sendgrid = require("@sendgrid/mail");
 
 // TODO(#492): Implement price fetching logic.
 async function fetchPrice(request) {
   return web3.utils.toWei("1.5");
 }
 
+class EmailSender {
+  async sendEmailNotification(subject, body) {
+    await sendgrid.send({
+      to: process.env.NOTIFICATION_TO_ADDRESS,
+      from: process.env.NOTIFICATION_FROM_ADDRESS,
+      subject,
+      text: body
+    });
+  }
+}
+
 // TODO(#493): Implement persistance.
 class VotingSystem {
-  constructor(voting, persistence) {
+  constructor(voting, persistence, emailSender) {
     this.voting = voting;
     this.persistence = persistence;
+    this.emailSender = emailSender;
   }
 
   async runCommit(request, roundId) {
     const persistedVote = this.persistence[{ request, roundId }];
     // If the vote has already been persisted and committed, we don't need to recommit.
     if (persistedVote) {
-      return;
+      return false;
     }
     const fetchedPrice = await fetchPrice(request);
     const salt = web3.utils.toBN(web3.utils.randomHex(32));
@@ -25,27 +38,42 @@ class VotingSystem {
     this.persistence[{ request, roundId }] = { price: fetchedPrice, salt: salt };
     const hash = web3.utils.soliditySha3(fetchedPrice, salt);
     await this.voting.commitVote(request.identifier, request.time, hash);
+    return true;
   }
 
   async runReveal(request, roundId) {
     const persistedVote = this.persistence[{ request, roundId }];
     // If no vote was persisted and committed, then we can't reveal.
-    if (persistedVote) {
-      await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt);
-      delete this.persistence[{ request, roundId }];
+    if (!persistedVote) {
+      return false;
     }
+    await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt);
+    delete this.persistence[{ request, roundId }];
+    return true;
   }
 
   async runIteration() {
     const phase = await this.voting.getVotePhase();
     const roundId = await this.voting.getCurrentRoundId();
     const pendingRequests = await this.voting.getPendingRequests();
+    const updatesMade = [];
     for (const request of pendingRequests) {
+      let didUpdate = false;
       if (phase == VotePhasesEnum.COMMIT) {
-        await this.runCommit(request, roundId);
+        didUpdate = await this.runCommit(request, roundId);
       } else {
-        await this.runReveal(request, roundId);
+        didUpdate = await this.runReveal(request, roundId);
       }
+      if (didUpdate) {
+        updatesMade.push(request);
+      }
+    }
+    if (updatesMade.length > 0) {
+      // TODO(ptare): Get email copies.
+      await this.emailSender.sendEmailNotification(
+        "Automated voting system update",
+        "Updated " + updatesMade.length + " price requests"
+      );
     }
   }
 }
@@ -53,8 +81,10 @@ class VotingSystem {
 async function runVoting() {
   try {
     console.log("Running Voting system");
+    sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
+
     const voting = await Voting.deployed();
-    const votingSystem = new VotingSystem(voting, {});
+    const votingSystem = new VotingSystem(voting, {}, new EmailSender());
     await votingSystem.runIteration();
   } catch (error) {
     console.log(error);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/storage": "^2.4.2",
+    "@sendgrid/mail": "^6.4.0",
     "bignumber.js": "^8.0.1",
     "dotenv": "^6.2.0",
     "eslint": "5.12.0",


### PR DESCRIPTION
Two follow up changes:
1. Environment variables are obviously not the best way to set API keys. Figuring out a better way is tracked in #490 
2. Does the script reveal votes over and over? If so, we might need to update EncryptedSender somehow to remember that the vote was revealed? (Not sure about this yet)

Issue #491 