### PR TITLE
Allow parts of previous migrations to be preserved

### DIFF
--- a/core/migrations/10_deploy_tokenized_derivative_utils.js
+++ b/core/migrations/10_deploy_tokenized_derivative_utils.js
@@ -1,9 +1,8 @@
 const TokenizedDerivativeUtils = artifacts.require("TokenizedDerivativeUtils");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const tokenizedDerivativeUtils = await deployAndGet(deployer, TokenizedDerivativeUtils, { from: keys.deployer });
-  await addToTdr(tokenizedDerivativeUtils, network);
+  const tokenizedDerivativeUtils = await deploy(deployer, network, TokenizedDerivativeUtils, { from: keys.deployer });
 };

--- a/core/migrations/11_deploy_tokenized_derivative_creator.js
+++ b/core/migrations/11_deploy_tokenized_derivative_creator.js
@@ -12,13 +12,13 @@ module.exports = async function(deployer, network, accounts) {
   const controllableTiming = enableControllableTiming(network);
 
   // Deploy whitelists.
-  const { contract: sponsorWhitelist, didDeploy: deployedSponsorWhitelist } = await deploy(
+  const { contract: sponsorWhitelist } = await deploy(
     deployer,
     network,
     AddressWhitelist,
     { from: keys.sponsorWhitelist }
   );
-  const { contract: returnCalculatorWhitelist, didDeploy: deployedReturnCalculatorWhitelist } = await deploy(
+  const { contract: returnCalculatorWhitelist } = await deploy(
     deployer,
     network,
     AddressWhitelist,
@@ -26,7 +26,7 @@ module.exports = async function(deployer, network, accounts) {
       from: keys.returnCalculatorWhitelist
     }
   );
-  const { contract: marginCurrencyWhitelist, didDeploy: deployedMarginCurrencyWhitelist } = await deploy(
+  const { contract: marginCurrencyWhitelist } = await deploy(
     deployer,
     network,
     AddressWhitelist,

--- a/core/migrations/11_deploy_tokenized_derivative_creator.js
+++ b/core/migrations/11_deploy_tokenized_derivative_creator.js
@@ -12,28 +12,15 @@ module.exports = async function(deployer, network, accounts) {
   const controllableTiming = enableControllableTiming(network);
 
   // Deploy whitelists.
-  const { contract: sponsorWhitelist } = await deploy(
-    deployer,
-    network,
-    AddressWhitelist,
-    { from: keys.sponsorWhitelist }
-  );
-  const { contract: returnCalculatorWhitelist } = await deploy(
-    deployer,
-    network,
-    AddressWhitelist,
-    {
-      from: keys.returnCalculatorWhitelist
-    }
-  );
-  const { contract: marginCurrencyWhitelist } = await deploy(
-    deployer,
-    network,
-    AddressWhitelist,
-    {
-      from: keys.marginCurrencyWhitelist
-    }
-  );
+  const { contract: sponsorWhitelist } = await deploy(deployer, network, AddressWhitelist, {
+    from: keys.sponsorWhitelist
+  });
+  const { contract: returnCalculatorWhitelist } = await deploy(deployer, network, AddressWhitelist, {
+    from: keys.returnCalculatorWhitelist
+  });
+  const { contract: marginCurrencyWhitelist } = await deploy(deployer, network, AddressWhitelist, {
+    from: keys.marginCurrencyWhitelist
+  });
 
   const finder = await Finder.deployed();
 

--- a/core/migrations/13_deploy_encrypted_sender.js
+++ b/core/migrations/13_deploy_encrypted_sender.js
@@ -1,10 +1,9 @@
 const EncryptedSender = artifacts.require("EncryptedSender");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
   // Deploy EncryptedSender.
-  const encryptedSender = await deployAndGet(deployer, EncryptedSender, { from: keys.deployer });
-  await addToTdr(encryptedSender, network);
+  await deploy(deployer, network, EncryptedSender, { from: keys.deployer });
 };

--- a/core/migrations/1_initial_migration.js
+++ b/core/migrations/1_initial_migration.js
@@ -1,8 +1,7 @@
 const Migrations = artifacts.require("./Migrations.sol");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
-  const migrations = await deployAndGet(deployer, Migrations, { from: keys.deployer });
-  await addToTdr(migrations, network);
+  await deploy(deployer, network, Migrations, { from: keys.deployer });
 };

--- a/core/migrations/2_deploy_finder.js
+++ b/core/migrations/2_deploy_finder.js
@@ -4,12 +4,11 @@ const ManualPriceFeed = artifacts.require("ManualPriceFeed");
 const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
 const Store = artifacts.require("Store");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const finder = await deployAndGet(deployer, Finder, { from: keys.deployer });
-  await addToTdr(finder, network);
+  await deploy(deployer, network, Finder, { from: keys.deployer });
 };

--- a/core/migrations/3_deploy_voting_token.js
+++ b/core/migrations/3_deploy_voting_token.js
@@ -1,10 +1,9 @@
 const VotingToken = artifacts.require("VotingToken");
 const Voting = artifacts.require("Voting");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const votingToken = await deployAndGet(deployer, VotingToken, { from: keys.deployer });
-  await addToTdr(votingToken, network);
+  await deploy(deployer, network, VotingToken, { from: keys.deployer });
 };

--- a/core/migrations/4_deploy_voting.js
+++ b/core/migrations/4_deploy_voting.js
@@ -1,12 +1,7 @@
 const Finder = artifacts.require("Finder");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
-const {
-  getKeysForNetwork,
-  deployAndGet,
-  addToTdr,
-  enableControllableTiming
-} = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr, enableControllableTiming } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
@@ -26,8 +21,9 @@ module.exports = async function(deployer, network, accounts) {
   // Set phase length to one day.
   const secondsPerDay = "86400";
 
-  const voting = await deployAndGet(
+  const { contract: voting } = await deploy(
     deployer,
+    network,
     Voting,
     secondsPerDay,
     gatPercentage,
@@ -37,7 +33,6 @@ module.exports = async function(deployer, network, accounts) {
     controllableTiming,
     { from: keys.deployer }
   );
-  await addToTdr(voting, network);
 
   await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle), voting.address, {
     from: keys.deployer

--- a/core/migrations/5_deploy_registry.js
+++ b/core/migrations/5_deploy_registry.js
@@ -1,13 +1,12 @@
 const Finder = artifacts.require("Finder");
 const Registry = artifacts.require("Registry");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const registry = await deployAndGet(deployer, Registry, { from: keys.deployer });
-  await addToTdr(registry, network);
+  const { contract: registry } = await deploy(deployer, network, Registry, { from: keys.deployer });
 
   const finder = await Finder.deployed();
   await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.Registry), registry.address, {

--- a/core/migrations/6_deploy_price_feed.js
+++ b/core/migrations/6_deploy_price_feed.js
@@ -1,19 +1,15 @@
 const Finder = artifacts.require("Finder");
 const ManualPriceFeed = artifacts.require("ManualPriceFeed");
-const {
-  getKeysForNetwork,
-  enableControllableTiming,
-  deployAndGet,
-  addToTdr
-} = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, enableControllableTiming, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const controllableTiming = enableControllableTiming(network);
   const keys = getKeysForNetwork(network, accounts);
 
-  const manualPriceFeed = await deployAndGet(deployer, ManualPriceFeed, controllableTiming, { from: keys.priceFeed });
-  await addToTdr(manualPriceFeed, network);
+  const { contract: manualPriceFeed } = await deploy(deployer, network, ManualPriceFeed, controllableTiming, {
+    from: keys.priceFeed
+  });
 
   const finder = await Finder.deployed();
   await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.PriceFeed), manualPriceFeed.address, {

--- a/core/migrations/7_deploy_financial_contracts_admin.js
+++ b/core/migrations/7_deploy_financial_contracts_admin.js
@@ -1,13 +1,14 @@
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 const Finder = artifacts.require("Finder");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const financialContractsAdmin = await deployAndGet(deployer, FinancialContractsAdmin, { from: keys.deployer });
-  await addToTdr(financialContractsAdmin, network);
+  const { contract: financialContractsAdmin } = await deploy(deployer, network, FinancialContractsAdmin, {
+    from: keys.deployer
+  });
 
   const remarginRole = "1"; // Corresponds to FinancialContractsAdmin.Roles.Remargin.
   await financialContractsAdmin.addMember(remarginRole, keys.deployer);

--- a/core/migrations/8_deploy_store.js
+++ b/core/migrations/8_deploy_store.js
@@ -1,23 +1,25 @@
 const Finder = artifacts.require("Finder");
 const Store = artifacts.require("Store");
 
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const store = await deployAndGet(deployer, Store, { from: keys.store });
-  await addToTdr(store, network);
+  const { contract: store, didDeploy } = await deploy(deployer, network, Store, { from: keys.store });
 
   const finder = await Finder.deployed();
   await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.Store), store.address, {
     from: keys.deployer
   });
 
-  // Set oracle fees to 0.5% per year.
-  const annualFee = web3.utils.toWei("0.005");
-  const secondsPerYear = 31536000;
-  const feePerSecond = web3.utils.toBN(annualFee).divn(secondsPerYear);
-  await store.setFixedOracleFeePerSecond({ value: feePerSecond.toString() }, { from: keys.store });
+  // Only update the fees if this contract was newly deployed during this migration.
+  if (didDeploy) {
+    // Set oracle fees to 0.5% per year.
+    const annualFee = web3.utils.toWei("0.005");
+    const secondsPerYear = 31536000;
+    const feePerSecond = web3.utils.toBN(annualFee).divn(secondsPerYear);
+    await store.setFixedOracleFeePerSecond({ value: feePerSecond.toString() }, { from: keys.store });
+  }
 };

--- a/core/migrations/9_deploy_return_calculator.js
+++ b/core/migrations/9_deploy_return_calculator.js
@@ -1,9 +1,8 @@
 const LeveragedReturnCalculator = artifacts.require("LeveragedReturnCalculator");
-const { getKeysForNetwork, deployAndGet, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const leveragedReturnCalculator = await deployAndGet(deployer, LeveragedReturnCalculator, 1, { from: keys.deployer });
-  await addToTdr(leveragedReturnCalculator, network);
+  await deploy(deployer, network, LeveragedReturnCalculator, 1, { from: keys.deployer });
 };


### PR DESCRIPTION
This PR adds command line options to allow certain portions of the system to be preserved in a call to `truffle migrate --reset`. The migration has been broken down into three components:
- The `Finder` contract.
- The `VoteToken` contract.
- Everything else. We may wish to break this down further at a later point, but until we have a use case in mind, it seemed easiest to keep the rest of the contracts bunched together.

I'm looking for feedback on these choices - I'm not sure they make sense from a usability perspective, so lmk what you think.

Issue #513.