### PR TITLE
Add proposal for events

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -636,4 +636,16 @@ contract Voting is Testable, MultiRole, OracleInterface {
         // Multiply the total supply at the snapshot by the gatPercentage to get the GAT in number of tokens.
         return snapshottedSupply.mul(gatPercentage);
     }
+
+    event CommitPhaseStarted(uint roundId);
+    event RevealPhaseStarted(uint roundId);
+
+    event VoteCommitted(address voter, bytes32 identifier, uint time, uint roundId);
+    event VoteRevealed(address voter, bytes32 identifier, uint time, uint roundId, int price, uint numTokens);
+    event RewardsRetrieved(address voter, uint rewardsRoundId, uint numTokens);
+
+    event PriceRequestAdded(bytes32 identifier, uint time, uint votingRoundId);
+    event PriceRequestRolledOver(bytes32 identifier, uint time, uint newRoundId);
+    event PriceResolved(bytes32 identifier, uint time, uint resolutionRoundId, int price);
+
 }

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -648,9 +648,6 @@ contract Voting is Testable, MultiRole, OracleInterface {
         return snapshottedSupply.mul(gatPercentage);
     }
 
-    event CommitPhaseStarted(uint indexed roundId);
-    event RevealPhaseStarted(uint indexed roundId);
-
     event VoteCommitted(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time);
     event VoteRevealed(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time, int price, uint numTokens);
     event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -649,7 +649,14 @@ contract Voting is Testable, MultiRole, OracleInterface {
     }
 
     event VoteCommitted(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time);
-    event VoteRevealed(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time, int price, uint numTokens);
+    event VoteRevealed(
+        address indexed voter,
+        uint indexed roundId,
+        bytes32 indexed identifier,
+        uint time,
+        int price,
+        uint numTokens
+    );
     event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);
 
     event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -649,6 +649,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
     }
 
     event VoteCommitted(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time);
+
     event VoteRevealed(
         address indexed voter,
         uint indexed roundId,
@@ -657,10 +658,13 @@ contract Voting is Testable, MultiRole, OracleInterface {
         int price,
         uint numTokens
     );
+
     event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);
 
     event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
+
     event PriceRequestRolledOver(uint indexed newRoundId, bytes32 indexed identifier, uint time);
+
     event PriceResolved(uint indexed resolutionRoundId, bytes32 indexed identifier, uint time, int price);
 
     event SupportedIdentifierAdded(bytes32 indexed identifier);

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -178,6 +178,8 @@ contract Voting is Testable, MultiRole, OracleInterface {
             retrieveRewards();
             votersLastRound[msg.sender] = currentRoundId;
         }
+
+        emit VoteCommitted(msg.sender, currentRoundId, identifier, time);
     }
 
     /**
@@ -216,6 +218,8 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
         // Add vote to the results.
         voteInstance.resultComputation.addVote(price, balance);
+
+        emit VoteRevealed(msg.sender, roundId, identifier, time, price, balance.value);
     }
 
     function requestPrice(bytes32 identifier, uint time)
@@ -266,6 +270,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
         // Add price request to the next round.
         rounds[nextRoundId].priceRequestIds.push(priceRequestId);
+        emit PriceRequestAdded(nextRoundId, identifier, time);
 
         // Estimate the end of next round and return the time.
         return voteTiming.computeEstimatedRoundEndTime(nextRoundId);
@@ -277,6 +282,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
     function addSupportedIdentifier(bytes32 identifier) external onlyRoleHolder(uint(Roles.Writer)) {
         if (!supportedIdentifiers[identifier]) {
             supportedIdentifiers[identifier] = true;
+            emit SupportedIdentifierAdded(identifier);
         }
     }
 
@@ -433,6 +439,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
         // Issue any accumulated rewards.
         if (totalRewardToIssue.isGreaterThan(0)) {
             require(votingToken.mint(msg.sender, totalRewardToIssue.value));
+            emit RewardsRetrieved(msg.sender, roundId, totalRewardToIssue.value);
         }
     }
 
@@ -587,7 +594,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
             VoteInstance storage voteInstance = priceRequest.voteInstances[lastActiveVotingRoundId];
 
-            (bool isResolved,) = voteInstance.resultComputation.getResolvedPrice(
+            (bool isResolved, int price) = voteInstance.resultComputation.getResolvedPrice(
                 _computeGat(lastActiveVotingRoundId));
 
             if (!isResolved) {
@@ -602,6 +609,10 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
                 // Delete the result computation since it's no longer needed.
                 delete voteInstance.resultComputation;
+
+                emit PriceRequestRolledOver(nextVotingRoundId, priceRequest.identifier, priceRequest.time);
+            } else {
+                emit PriceResolved(priceRequest.lastVotingRound, priceRequest.identifier, priceRequest.time, price);
             }
         }
 
@@ -637,16 +648,16 @@ contract Voting is Testable, MultiRole, OracleInterface {
         return snapshottedSupply.mul(gatPercentage);
     }
 
-    event CommitPhaseStarted(uint roundId);
-    event RevealPhaseStarted(uint roundId);
+    event CommitPhaseStarted(uint indexed roundId);
+    event RevealPhaseStarted(uint indexed roundId);
 
-    event VoteCommitted(address voter, bytes32 identifier, uint time, uint roundId);
-    event VoteRevealed(address voter, bytes32 identifier, uint time, uint roundId, int price, uint numTokens);
-    event RewardsRetrieved(address voter, uint rewardsRoundId, uint numTokens);
+    event VoteCommitted(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time);
+    event VoteRevealed(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time, int price, uint numTokens);
+    event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);
 
-    event PriceRequestAdded(bytes32 identifier, uint time, uint votingRoundId);
-    event PriceRequestRolledOver(bytes32 identifier, uint time, uint newRoundId);
-    event PriceResolved(bytes32 identifier, uint time, uint resolutionRoundId, int price);
+    event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
+    event PriceRequestRolledOver(uint indexed newRoundId, bytes32 indexed identifier, uint time);
+    event PriceResolved(uint indexed resolutionRoundId, bytes32 indexed identifier, uint time, int price);
 
-    event SupportedIdentifierAdded(bytes32 identifier);
+    event SupportedIdentifierAdded(bytes32 indexed identifier);
 }

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -648,4 +648,5 @@ contract Voting is Testable, MultiRole, OracleInterface {
     event PriceRequestRolledOver(bytes32 identifier, uint time, uint newRoundId);
     event PriceResolved(bytes32 identifier, uint time, uint resolutionRoundId, int price);
 
+    event SupportedIdentifierAdded(bytes32 identifier);
 }

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -937,7 +937,7 @@ contract("Voting", function(accounts) {
     await moveToNextRound(voting);
     currentRoundId = await voting.getCurrentRoundId();
 
-      // Repeated price requests don't trigger events.
+    // Repeated price requests don't trigger events.
     result = await voting.requestPrice(identifier, time, { from: registeredDerivative });
     truffleAssert.eventNotEmitted(result, "PriceRequestAdded");
 


### PR DESCRIPTION
Add events for the sequence a price request goes through.

Compared to earlier versions of this PR, I removed events for `RevealPhaseStarted` and `CommitPhaseStarted`. They may not be as useful because the phases start/stop based on time, not when the first commit or reveal happens.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>