### PR TITLE
Change value to rawValue

### DIFF
--- a/core/contracts/FixedPoint.sol
+++ b/core/contracts/FixedPoint.sol
@@ -15,7 +15,7 @@ library FixedPoint {
     uint private constant FP_SCALING_FACTOR = 10**18;
 
     struct Unsigned {
-        uint value;
+        uint rawValue;
     }
 
     /** @dev Constructs an `Unsigned` from an unscaled uint, e.g., `b=5` gets stored internally as `5**18`. */
@@ -25,37 +25,37 @@ library FixedPoint {
 
     /** @dev Whether `a` is greater than `b`. */
     function isGreaterThan(Unsigned memory a, Unsigned memory b) internal pure returns (bool) {
-        return a.value > b.value;
+        return a.rawValue > b.rawValue;
     }
 
     /** @dev Whether `a` is greater than `b`. */
     function isGreaterThan(Unsigned memory a, uint b) internal pure returns (bool) {
-        return a.value > fromUnscaledUint(b).value;
+        return a.rawValue > fromUnscaledUint(b).rawValue;
     }
 
     /** @dev Whether `a` is greater than `b`. */
     function isGreaterThan(uint a, Unsigned memory b) internal pure returns (bool) {
-        return fromUnscaledUint(a).value > b.value;
+        return fromUnscaledUint(a).rawValue > b.rawValue;
     }
 
     /** @dev Whether `a` is less than `b`. */
     function isLessThan(Unsigned memory a, Unsigned memory b) internal pure returns (bool) {
-        return a.value < b.value;
+        return a.rawValue < b.rawValue;
     }
 
     /** @dev Whether `a` is less than `b`. */
     function isLessThan(Unsigned memory a, uint b) internal pure returns (bool) {
-        return a.value < fromUnscaledUint(b).value;
+        return a.rawValue < fromUnscaledUint(b).rawValue;
     }
 
     /** @dev Whether `a` is less than `b`. */
     function isLessThan(uint a, Unsigned memory b) internal pure returns (bool) {
-        return fromUnscaledUint(a).value < b.value;
+        return fromUnscaledUint(a).rawValue < b.rawValue;
     }
 
     /** @dev Adds two `Unsigned`s, reverting on overflow. */
     function add(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
-        return Unsigned(a.value.add(b.value));
+        return Unsigned(a.rawValue.add(b.rawValue));
     }
 
     /** @dev Adds an `Unsigned` to an unscaled uint, reverting on overflow. */
@@ -65,7 +65,7 @@ library FixedPoint {
 
     /** @dev Subtracts two `Unsigned`s, reverting on underflow. */
     function sub(Unsigned memory a, Unsigned memory b) internal pure returns (Unsigned memory) {
-        return Unsigned(a.value.sub(b.value));
+        return Unsigned(a.rawValue.sub(b.rawValue));
     }
 
     /** @dev Subtracts an unscaled uint from an `Unsigned`, reverting on underflow. */
@@ -86,12 +86,12 @@ library FixedPoint {
         // 2. Results that can't be represented exactly are truncated not rounded. E.g., 1.4 * 2e-18 = 2.8e-18, which
         // would round to 3, but this computation produces the result 2.
         // No need to use SafeMath because FP_SCALING_FACTOR != 0.
-        return Unsigned(a.value.mul(b.value) / FP_SCALING_FACTOR);
+        return Unsigned(a.rawValue.mul(b.rawValue) / FP_SCALING_FACTOR);
     }
 
     /** @dev Multiplies an `Unsigned` by an unscaled uint, reverting on overflow. */
     function mul(Unsigned memory a, uint b) internal pure returns (Unsigned memory) {
-        return Unsigned(a.value.mul(b));
+        return Unsigned(a.rawValue.mul(b));
     }
 
     /** @dev Divides with truncation two `Unsigned`s, reverting on overflow or division by 0. */
@@ -101,12 +101,12 @@ library FixedPoint {
         // 10^41 is stored internally as a uint 10^59.
         // 2. Results that can't be represented exactly are truncated not rounded. E.g., 2 / 3 = 0.6 repeating, which
         // would round to 0.666666666666666667, but this computation produces the result 0.666666666666666666.
-        return Unsigned(a.value.mul(FP_SCALING_FACTOR).div(b.value));
+        return Unsigned(a.rawValue.mul(FP_SCALING_FACTOR).div(b.rawValue));
     }
 
     /** @dev Divides with truncation an `Unsigned` by an unscaled uint, reverting on division by 0. */
     function div(Unsigned memory a, uint b) internal pure returns (Unsigned memory) {
-        return Unsigned(a.value.div(b));
+        return Unsigned(a.rawValue.div(b));
     }
 
     /** @dev Divides with truncation an unscaled uint by an `Unsigned`, reverting on overflow or division by 0. */

--- a/core/contracts/TokenMigrator.sol
+++ b/core/contracts/TokenMigrator.sol
@@ -50,6 +50,6 @@ contract TokenMigrator {
         }
 
         FixedPoint.Unsigned memory newBalance = oldBalance.div(rate);
-        require(newToken.mint(tokenHolder, newBalance.value), "Mint failed");
+        require(newToken.mint(tokenHolder, newBalance.rawValue), "Mint failed");
     }
 }

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -832,7 +832,7 @@ library TokenizedDerivativeUtils {
             FixedPoint.Unsigned(_safeUintCast(pfc))
         );
         // TODO(ptare): Implement a keeper system, but for now, pay the delay fee to the Oracle.
-        uint expectedFeeAmount = regularFee.add(delayFee).value;
+        uint expectedFeeAmount = regularFee.add(delayFee).rawValue;
 
         // Ensure the fee returned can actually be paid by the short margin account.
         uint shortBalance = _safeUintCast(s.shortBalance);
@@ -890,7 +890,7 @@ library TokenizedDerivativeUtils {
         FixedPoint.Unsigned memory expectedFee = store.computeFinalFee(
             address(s.externalAddresses.marginCurrency)
         );
-        uint expectedFeeAmount = expectedFee.value;
+        uint expectedFeeAmount = expectedFee.rawValue;
         // Ensure the fee returned can actually be paid by the short margin account.
         uint shortBalanceUint = _safeUintCast(shortBalance);
         actualFeeAmount = (shortBalanceUint < expectedFeeAmount) ? shortBalanceUint : expectedFeeAmount;

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -432,7 +432,7 @@ contract Voting is Testable, MultiRole, OracleInterface {
 
         // Issue any accumulated rewards.
         if (totalRewardToIssue.isGreaterThan(0)) {
-            require(votingToken.mint(msg.sender, totalRewardToIssue.value));
+            require(votingToken.mint(msg.sender, totalRewardToIssue.rawValue));
         }
     }
 

--- a/core/contracts/test/FixedPointTest.sol
+++ b/core/contracts/test/FixedPointTest.sol
@@ -10,7 +10,7 @@ contract FixedPointTest {
     using SafeMath for uint;
 
     function wrapFromUnscaledUint(uint a) external pure returns (uint) {
-        return FixedPoint.fromUnscaledUint(a).value;
+        return FixedPoint.fromUnscaledUint(a).rawValue;
     }
 
     function wrapIsGreaterThan(uint a, uint b) external pure returns (bool) {
@@ -38,53 +38,53 @@ contract FixedPointTest {
     }
 
     function wrapAdd(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).add(FixedPoint.Unsigned(b)).value;
+        return FixedPoint.Unsigned(a).add(FixedPoint.Unsigned(b)).rawValue;
     }
 
     // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedAdd(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).add(b).value;
+        return FixedPoint.Unsigned(a).add(b).rawValue;
     }
 
     function wrapSub(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).sub(FixedPoint.Unsigned(b)).value;
+        return FixedPoint.Unsigned(a).sub(FixedPoint.Unsigned(b)).rawValue;
     }
 
     // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedSub(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).sub(b).value;
+        return FixedPoint.Unsigned(a).sub(b).rawValue;
     }
 
     // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedSubOpposite(uint a, uint b) external pure returns (uint) {
-        return a.sub(FixedPoint.Unsigned(b)).value;
+        return a.sub(FixedPoint.Unsigned(b)).rawValue;
     }
 
     function wrapMul(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).mul(FixedPoint.Unsigned(b)).value;
+        return FixedPoint.Unsigned(a).mul(FixedPoint.Unsigned(b)).rawValue;
     }
 
     // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedMul(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).mul(b).value;
+        return FixedPoint.Unsigned(a).mul(b).rawValue;
     }
 
     function wrapDiv(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).div(FixedPoint.Unsigned(b)).value;
+        return FixedPoint.Unsigned(a).div(FixedPoint.Unsigned(b)).rawValue;
     }
 
     // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedDiv(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).div(b).value;
+        return FixedPoint.Unsigned(a).div(b).rawValue;
     }
 
     // The second uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapMixedDivOpposite(uint a, uint b) external pure returns (uint) {
-        return a.div(FixedPoint.Unsigned(b)).value;
+        return a.div(FixedPoint.Unsigned(b)).rawValue;
     }
 
     // The first uint is interpreted with a scaling factor and is converted to an `Unsigned` directly.
     function wrapPow(uint a, uint b) external pure returns (uint) {
-        return FixedPoint.Unsigned(a).pow(b).value;
+        return FixedPoint.Unsigned(a).pow(b).rawValue;
     }
 }

--- a/core/contracts/test/ResultComputationTest.sol
+++ b/core/contracts/test/ResultComputationTest.sol
@@ -25,7 +25,7 @@ contract ResultComputationTest {
     }
 
     function wrapGetTotalCorrectlyVotedTokens() external view returns (uint) {
-        return data.getTotalCorrectlyVotedTokens().value;
+        return data.getTotalCorrectlyVotedTokens().rawValue;
     }
 }
 

--- a/core/migrations/4_deploy_voting.js
+++ b/core/migrations/4_deploy_voting.js
@@ -14,10 +14,10 @@ module.exports = async function(deployer, network, accounts) {
   const controllableTiming = enableControllableTiming(network);
 
   // Set the GAT percentage to 5%
-  const gatPercentage = { value: web3.utils.toWei("0.05", "ether") };
+  const gatPercentage = { rawValue: web3.utils.toWei("0.05", "ether") };
 
   // Set the inflation rate.
-  const inflationRate = { value: web3.utils.toWei("0.05", "ether") };
+  const inflationRate = { rawValue: web3.utils.toWei("0.05", "ether") };
 
   // Get the previously deployed VotingToken and Finder.
   const votingToken = await VotingToken.deployed();

--- a/core/migrations/8_deploy_store.js
+++ b/core/migrations/8_deploy_store.js
@@ -19,5 +19,5 @@ module.exports = async function(deployer, network, accounts) {
   const annualFee = web3.utils.toWei("0.005");
   const secondsPerYear = 31536000;
   const feePerSecond = web3.utils.toBN(annualFee).divn(secondsPerYear);
-  await store.setFixedOracleFeePerSecond({ value: feePerSecond.toString() }, { from: keys.store });
+  await store.setFixedOracleFeePerSecond({ rawValue: feePerSecond.toString() }, { from: keys.store });
 };

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -22,7 +22,7 @@ async function run() {
   const owner = accounts[0];
   const registeredDerivative = accounts[1];
 
-  await voting.setInflationRate({ value: web3.utils.toWei("0.01", "ether") });
+  await voting.setInflationRate({ rawValue: web3.utils.toWei("0.01", "ether") });
   await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, owner);
 
   if (!(await registry.isDerivativeRegistered(registeredDerivative))) {

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -26,10 +26,10 @@ contract("Store", function(accounts) {
 
   it("Compute fees basic check", async function() {
     // Set fee to 10%
-    let newFee = { value: web3.utils.toWei("0.1", "ether") };
+    let newFee = { rawValue: web3.utils.toWei("0.1", "ether") };
     await store.setFixedOracleFeePerSecond(newFee, { from: owner });
 
-    let pfc = { value: web3.utils.toWei("2", "ether") };
+    let pfc = { rawValue: web3.utils.toWei("2", "ether") };
 
     // Wait one second, then check fees are correct
     let fees = await store.computeRegularFee(100, 101, pfc, {});
@@ -43,10 +43,10 @@ contract("Store", function(accounts) {
 
   it("Compute fees at 20%", async function() {
     // Change fee to 20%
-    let newFee = { value: web3.utils.toWei("0.2", "ether") };
+    let newFee = { rawValue: web3.utils.toWei("0.2", "ether") };
     await store.setFixedOracleFeePerSecond(newFee, { from: owner });
 
-    let pfc = { value: web3.utils.toWei("2", "ether") };
+    let pfc = { rawValue: web3.utils.toWei("2", "ether") };
 
     // Run time tests again
     let fees = await store.computeRegularFee(100, 101, pfc, {});
@@ -61,7 +61,7 @@ contract("Store", function(accounts) {
     assert(await didContractThrow(store.computeRegularFee(2, 1, 10)));
 
     // Disallow setting fees higher than 100%.
-    let highFee = { value: web3.utils.toWei("1", "ether") };
+    let highFee = { rawValue: web3.utils.toWei("1", "ether") };
     assert(await didContractThrow(store.setFixedOracleFeePerSecond(highFee, { from: owner })));
 
     // TODO Check that only permitted role can change the fee
@@ -69,7 +69,7 @@ contract("Store", function(accounts) {
 
   it("Final fees", async function() {
     //Add final fee and confirm
-    await store.setFinalFee(arbitraryTokenAddr, { value: web3.utils.toWei("5", "ether") }, { from: owner });
+    await store.setFinalFee(arbitraryTokenAddr, { rawValue: web3.utils.toWei("5", "ether") }, { from: owner });
     const fee = await store.computeFinalFee(arbitraryTokenAddr);
     assert.equal(fee.value, web3.utils.toWei("5", "ether"));
   });

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -71,7 +71,7 @@ contract("Store", function(accounts) {
     //Add final fee and confirm
     await store.setFinalFee(arbitraryTokenAddr, { rawValue: web3.utils.toWei("5", "ether") }, { from: owner });
     const fee = await store.computeFinalFee(arbitraryTokenAddr);
-    assert.equal(fee.value, web3.utils.toWei("5", "ether"));
+    assert.equal(fee.rawValue, web3.utils.toWei("5", "ether"));
   });
 
   it("Pay fees in Ether", async function() {

--- a/core/test/TokenMigrator.js
+++ b/core/test/TokenMigrator.js
@@ -24,7 +24,7 @@ contract("TokenMigrator", function(accounts) {
   });
 
   const createMigrator = async rate => {
-    const migrator = await TokenMigrator.new({ value: rate }, oldToken.address, newToken.address);
+    const migrator = await TokenMigrator.new({ rawValue: rate }, oldToken.address, newToken.address);
     await newToken.addMember(minterRoleEnumValue, migrator.address, { from: owner });
     return migrator;
   };

--- a/core/test/TokenizedDerivative.js
+++ b/core/test/TokenizedDerivative.js
@@ -127,11 +127,11 @@ contract("TokenizedDerivative", function(accounts) {
   };
 
   const setNewFixedOracleFee = async feePerSecond => {
-    await deployedStore.setFixedOracleFeePerSecond({ value: feePerSecond.toString() });
+    await deployedStore.setFixedOracleFeePerSecond({ rawValue: feePerSecond.toString() });
   };
 
   const setNewWeeklyDelayFee = async weeklyDelayFee => {
-    await deployedStore.setWeeklyDelayFee({ value: weeklyDelayFee.toString() });
+    await deployedStore.setWeeklyDelayFee({ rawValue: weeklyDelayFee.toString() });
   };
 
   const getRandomIntBetween = (min, max) => {
@@ -256,7 +256,7 @@ contract("TokenizedDerivative", function(accounts) {
 
     const setOracleFinalFee = async finalFee => {
       const marginCurrencyAddress = (await derivativeContract.derivativeStorage()).externalAddresses.marginCurrency;
-      await deployedStore.setFinalFee(marginCurrencyAddress, { value: finalFee.toString() });
+      await deployedStore.setFinalFee(marginCurrencyAddress, { rawValue: finalFee.toString() });
     };
 
     const annotateTitle = title => {

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -20,7 +20,7 @@ contract("Voting", function(accounts) {
   const unregisteredDerivative = accounts[5];
 
   const setNewInflationRate = async inflationRate => {
-    await voting.setInflationRate({ value: inflationRate.toString() });
+    await voting.setInflationRate({ rawValue: inflationRate.toString() });
   };
 
   before(async function() {


### PR DESCRIPTION
This changes the name of the internal variable `value` in the `FixedPoint.Unsigned` struct to `rawValue`.

Reasoning: the transaction options object that is optionally passed as the last argument in a truffle transaction call has a field called `value` to denote the amount of ether sent. If we were to pass a `FixedPoint.Unsigned` value as the last argument in a transaction call, it would look very similar to truffle and to a reader. I think it makes sense to change it to preempt any problems that may arise due to this conflict.