### PR TITLE
Fix bugs in prod/testnet migrations

### DIFF
--- a/common/MigrationUtils.js
+++ b/common/MigrationUtils.js
@@ -23,7 +23,8 @@ function shouldCommitDeployment(network) {
   return (
     network === "ci" || // Just for testing the process of saving deployments.
     network.startsWith("ropsten") ||
-    network.startsWith("mainnet")
+    network.startsWith("mainnet") ||
+    network.startsWith("kovan")
   );
 }
 
@@ -101,7 +102,7 @@ async function deploy(deployer, network, contractType, ...args) {
 
 // Maps key ordering to key names.
 function getKeysForNetwork(network, accounts) {
-  if (network === "ropsten" || network === "mainnet") {
+  if (network === "ropsten" || network === "mainnet" || network === "kovan") {
     return {
       deployer: accounts[0],
       registry: accounts[1],

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -30,7 +30,7 @@ function addPublicNetwork(networks, name, networkId) {
     ...options,
     provider: new ManagedSecretProvider(
       GckmsConfig,
-      `https://kovan.infura.io/v3/${infuraApiKey}`,
+      `https://${name}.infura.io/v3/${infuraApiKey}`,
       0,
       GckmsConfig.length
     )
@@ -39,7 +39,7 @@ function addPublicNetwork(networks, name, networkId) {
   // Mnemonic network.
   networks[name + "_mnemonic"] = {
     ...options,
-    provider: new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/${infuraApiKey}`, 0, 2)
+    provider: new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2)
   };
 }
 

--- a/core/migrations/7_deploy_financial_contracts_admin.js
+++ b/core/migrations/7_deploy_financial_contracts_admin.js
@@ -11,7 +11,7 @@ module.exports = async function(deployer, network, accounts) {
   });
 
   const remarginRole = "1"; // Corresponds to FinancialContractsAdmin.Roles.Remargin.
-  await financialContractsAdmin.addMember(remarginRole, keys.deployer);
+  await financialContractsAdmin.addMember(remarginRole, keys.deployer, { from: keys.deployer });
 
   const finder = await Finder.deployed();
   await finder.changeImplementationAddress(


### PR DESCRIPTION
There were a few mistakenly hardcoded URLs and outdated network checks in our truffle config and migration utility file. Once these were fixed, I was able to successfully run a full migration against Kovan.