### PR TITLE
Derive Key Pair from signature

### DIFF
--- a/common/gckms/ManagedSecretProvider.js
+++ b/common/gckms/ManagedSecretProvider.js
@@ -104,9 +104,6 @@ class ManagedSecretProvider {
 
         this.wrappedProvider = new HDWalletProvider(keys, ...this.remainingArgs);
 
-        // Make the internal wallets directly available to users.
-        this.wallets = this.wrappedProvider.wallets;
-
         return this.wrappedProvider;
       },
       reason => {

--- a/core/contracts/EncryptedSender.sol
+++ b/core/contracts/EncryptedSender.sol
@@ -24,7 +24,6 @@ contract EncryptedSender {
         bytes message;
     }
 
-
     struct Recipient {
         // This maps from a hash to the data for this topic.
         // Note: the hash is a hash of the "subject" or "topic" of the message.

--- a/core/contracts/EncryptedSender.sol
+++ b/core/contracts/EncryptedSender.sol
@@ -15,16 +15,23 @@ pragma solidity ^0.5.0;
  * not delete the previous message for a particular topic.
  */
 contract EncryptedSender {
+    struct TopicData {
+        // An (optional) public key used to encrypt messages for this topic. This is only necessary if the sender will
+        // not have access to the public key offchain.
+        bytes publicKey;
+
+        // The encrypted message.
+        bytes message;
+    }
+
+
     struct Recipient {
-        // This maps from a hash to an encrypted message.
+        // This maps from a hash to the data for this topic.
         // Note: the hash is a hash of the "subject" or "topic" of the message.
-        mapping(bytes32 => bytes) messages;
+        mapping(bytes32 => TopicData) topics;
 
         // This contains the set of all authorized senders for this recipient.
         mapping(address => bool) authorizedSenders;
-
-        // A public key for the recipient that can be used to send messages to the recipient.
-        bytes publicKey;
     }
 
     mapping(address => Recipient) private recipients;
@@ -49,15 +56,17 @@ contract EncryptedSender {
      * function in core/utils/Crypto.js. 
      */
     function getMessage(address recipient, bytes32 topicHash) external view returns (bytes memory) {
-        return recipients[recipient].messages[topicHash];
+        return recipients[recipient].topics[topicHash].message;
     }
 
     /**
-     * @notice Gets the stored public key for `recipient`. Return value will be 0 length if no public key has been set.
-     * @dev Senders will need this public key to encrypt messages that only the `recipient` can read.
+     * @notice Gets the stored public key for a particular `recipient` and `topicHash`. Return value will be 0 length
+     * if no public key has been set.
+     * @dev Senders may need this public key to encrypt messages that only the `recipient` can read. If the public key
+     * is communicated offchain, this field may be left empty.
      */
-    function getPublicKey(address recipient) external view returns (bytes memory) {
-        return recipients[recipient].publicKey;
+    function getPublicKey(address recipient, bytes32 topicHash) external view returns (bytes memory) {
+        return recipients[recipient].topics[topicHash].publicKey;
     }
 
     /**
@@ -69,7 +78,18 @@ contract EncryptedSender {
     function sendMessage(address recipient_, bytes32 topicHash, bytes memory message) public {
         Recipient storage recipient = recipients[recipient_];
         require(isAuthorizedSender(msg.sender, recipient_), "Not authorized to send to this recipient");
-        recipient.messages[topicHash] = message;
+        recipient.topics[topicHash].message = message;
+    }
+
+    /**
+     * @notice Sets the public key for this caller and topicHash.
+     * @dev Note: setting the public key is optional - if the publicKey is communicated or can be derived offchain by
+     * the sender, there is no need to set it here. Because there are no specific requirements for the publicKey, there
+     * is also no verification of its validity other than its length.
+     */
+    function setPublicKey(bytes memory publicKey, bytes32 topicHash) public {
+        require(publicKey.length == 64, "Public key is the wrong length");
+        recipients[msg.sender].topics[topicHash].publicKey = publicKey;
     }
 
     /**
@@ -78,25 +98,5 @@ contract EncryptedSender {
     function isAuthorizedSender(address sender, address recipient) public view returns (bool) {
         // Note: the recipient is always authorized to send messages to themselves.
         return recipients[recipient].authorizedSenders[sender] || recipient == sender;
-    }
-
-    /**
-     * @notice Sets the caller's public key.
-     */
-    function setPublicKey(bytes memory publicKey) public {
-        // Verify that the uploaded public key matches the sender.
-        require(_publicKeyToAddress(publicKey) == msg.sender, "Public key does not match the sender");
-
-        // Set the public key if it passed verification.
-        recipients[msg.sender].publicKey = publicKey;
-    }
-
-    /**
-     * @notice Converts the public key to an address.
-     * @dev Conversion fails if the public key is not 64 bytes.
-     */
-    function _publicKeyToAddress(bytes memory publicKey) private pure returns (address) {
-        require(publicKey.length == 64, "Public key is the wrong length");
-        return address(uint256(keccak256(publicKey)));
     }
 }

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -96,7 +96,7 @@ class VotingSystem {
     // and authorize them here.
 
     // Generate the one-time keypair for this round.
-    const { publicKey } = await deriveKeyPairFromSignature(web3, this.getKeyGenMessage(roundId), this.account); 
+    const { publicKey } = await deriveKeyPairFromSignature(web3, this.getKeyGenMessage(roundId), this.account);
 
     // Encrypt the vote using the public key.
     const encryptedMessage = await encryptMessage(publicKey, JSON.stringify(vote));

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -1,7 +1,7 @@
 const Voting = artifacts.require("Voting");
 const EncryptedSender = artifacts.require("EncryptedSender");
 const { VotePhasesEnum } = require("../utils/Enums");
-const { decryptMessage, encryptMessage } = require("../utils/Crypto");
+const { decryptMessage, encryptMessage, deriveKeyPairFromSignature } = require("../utils/Crypto");
 const sendgrid = require("@sendgrid/mail");
 
 const fetch = require("node-fetch");
@@ -83,8 +83,11 @@ class VotingSystem {
       return null;
     }
 
-    const { privKey } = this.getAccountKeys();
-    const decryptedMessage = await decryptMessage(privKey, encryptedCommit);
+    // Generate the one-time keypair for this round.
+    const { privateKey } = await deriveKeyPairFromSignature(web3, this.getKeyGenMessage(roundId), this.account);
+
+    // Decrypt message.
+    const decryptedMessage = await decryptMessage(privateKey, encryptedCommit);
     return JSON.parse(decryptedMessage);
   }
 
@@ -92,20 +95,11 @@ class VotingSystem {
     // TODO: if we want to authorize other accounts to send messages to the automated voting system, we should check
     // and authorize them here.
 
-    // Get the account's public key from the encryptedSender.
-    let pubKey = await this.encryptedSender.getPublicKey(this.account);
-
-    if (!pubKey) {
-      // If the public key isn't published, pull it from the local wallet.
-      pubKey = this.getAccountKeys().pubKey;
-
-      // Publish the public key so dApps or scripts that are authorized can write without direct access to this
-      // account's private key.
-      await this.encryptedSender.setPublicKey(pubKey, { from: this.account });
-    }
+    // Generate the one-time keypair for this round.
+    const { publicKey } = await deriveKeyPairFromSignature(web3, this.getKeyGenMessage(roundId), this.account); 
 
     // Encrypt the vote using the public key.
-    const encryptedMessage = await encryptMessage(pubKey, JSON.stringify(vote));
+    const encryptedMessage = await encryptMessage(publicKey, JSON.stringify(vote));
 
     // Upload the encrypted commit.
     const topicHash = this.computeTopicHash(request, roundId);
@@ -177,16 +171,9 @@ class VotingSystem {
     return web3.utils.soliditySha3(request.identifier, request.time, roundId);
   }
 
-  getAccountKeys() {
-    // Note: this assumes that current provider has a .wallets field that is keyed by wallet address.
-    // Each wallet in the wallets field is assumed to have ._privKey and ._pubKey fields that store buffers holding the
-    // keys.
-    const wallet = web3.currentProvider.wallets[this.account];
-    return {
-      privKey: wallet._privKey.toString("hex"),
-      // Note: the "0x" addition is because public keys are expected to be passed in a web3 friendly format.
-      pubKey: "0x" + wallet._pubKey.toString("hex")
-    };
+  getKeyGenMessage(roundId) {
+    // TODO: discuss dApp tradeoffs for changing this to a per-topic hash keypair.
+    return `UMA Protocol one time key for round: ${roundId.toString()}`;
   }
 }
 

--- a/core/test/EncryptedSender.js
+++ b/core/test/EncryptedSender.js
@@ -5,7 +5,7 @@ const {
   encryptMessage,
   addressFromPublicKey,
   recoverPublicKey,
-  createVisibleAccount
+  deriveKeyPairFromSignature
 } = require("../utils/Crypto.js");
 const EthCrypto = require("eth-crypto");
 
@@ -13,27 +13,17 @@ const EncryptedSender = artifacts.require("EncryptedSender");
 
 contract("EncryptedSender", function(accounts) {
   const senderAccount = accounts[0];
-
-  // The receiving account is created in before().
-  let receiverAccount;
-  let receiverPrivKey;
-  let receiverPubKey;
-
-  let encryptedSender;
+  const receiverAccount = accounts[1];
 
   before(async function() {
     encryptedSender = await EncryptedSender.deployed();
-
-    ({ pubKey: receiverPubKey, privKey: receiverPrivKey, address: receiverAccount } = await createVisibleAccount(web3));
-
-    // Fund the new account
-    await web3.eth.sendTransaction({ from: accounts[9], to: receiverAccount, value: web3.utils.toWei("5", "ether") });
   });
 
   it("Encrypt Decrypt", async function() {
     const message = web3.utils.randomHex(100);
-    const encryptedMessage = await encryptMessage(receiverPubKey, message);
-    assert.equal(await decryptMessage(receiverPrivKey, encryptedMessage), message);
+    const { publicKey, privateKey } = await deriveKeyPairFromSignature(web3, "Some message to sign", receiverAccount);
+    const encryptedMessage = await encryptMessage(publicKey, message);
+    assert.equal(await decryptMessage(privateKey, encryptedMessage), message);
   });
 
   it("Auth", async function() {
@@ -67,23 +57,20 @@ contract("EncryptedSender", function(accounts) {
     );
   });
 
-  it("Key validation", async function() {
-    // Verify that the address can be correctly recovered offchain.
-    assert.equal(addressFromPublicKey(receiverPubKey), receiverAccount);
-
-    // If the valid key is sent by the wrong address, the call should fail.
-    assert(await didContractThrow(encryptedSender.setPublicKey(receiverPubKey, { from: senderAccount })));
-
-    // Valid key should succeed.
-    await encryptedSender.setPublicKey(receiverPubKey, { from: receiverAccount });
-  });
-
   it("Send a message", async function() {
-    // // Set the public key for the receiver.
-    await encryptedSender.setPublicKey(receiverPubKey, { from: receiverAccount });
+    // Hash topic for lookup.
+    const identifier = web3.utils.utf8ToHex("identifier");
+    const time = "1000";
+    const topicHash = web3.utils.soliditySha3(identifier, time);
+
+    // Derive the keypair for this topic hash.
+    const { publicKey, privateKey } = await deriveKeyPairFromSignature(web3, "Signed message for topic hash: " + topicHash, receiverAccount);
+
+    // Set the public key for the receiver.
+    await encryptedSender.setPublicKey(publicKey, topicHash, { from: receiverAccount });
 
     // Verify the correct public key can be retrieved.
-    assert.equal(await encryptedSender.getPublicKey(receiverAccount), receiverPubKey);
+    assert.equal(await encryptedSender.getPublicKey(receiverAccount, topicHash), publicKey);
 
     // Prepare message to send.
     const salt = getRandomUnsignedInt().toString();
@@ -91,12 +78,7 @@ contract("EncryptedSender", function(accounts) {
     const message = salt + "," + price;
 
     // Encrypt the message.
-    const encryptedMessage = await encryptMessage(receiverPubKey, message);
-
-    // Hash topic for lookup.
-    const identifier = web3.utils.utf8ToHex("identifier");
-    const time = "1000";
-    const topicHash = web3.utils.soliditySha3(identifier, time);
+    const encryptedMessage = await encryptMessage(publicKey, message);
 
     // Authorize senderAccount to send messages to receiverAccount via the EncryptedSender.
     await encryptedSender.addAuthorizedSender(senderAccount, { from: receiverAccount });
@@ -104,7 +86,7 @@ contract("EncryptedSender", function(accounts) {
 
     // Pull down the encrypted message and decrypt it.
     const pulledMessage = await encryptedSender.getMessage(receiverAccount, topicHash);
-    const decryptedMessage = await decryptMessage(receiverPrivKey, pulledMessage);
+    const decryptedMessage = await decryptMessage(privateKey, pulledMessage);
 
     // decryptedMessage should match the plaintext message from above.
     assert.equal(decryptedMessage, message);

--- a/core/test/EncryptedSender.js
+++ b/core/test/EncryptedSender.js
@@ -64,7 +64,11 @@ contract("EncryptedSender", function(accounts) {
     const topicHash = web3.utils.soliditySha3(identifier, time);
 
     // Derive the keypair for this topic hash.
-    const { publicKey, privateKey } = await deriveKeyPairFromSignature(web3, "Signed message for topic hash: " + topicHash, receiverAccount);
+    const { publicKey, privateKey } = await deriveKeyPairFromSignature(
+      web3,
+      "Signed message for topic hash: " + topicHash,
+      receiverAccount
+    );
 
     // Set the public key for the receiver.
     await encryptedSender.setPublicKey(publicKey, topicHash, { from: receiverAccount });

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -24,30 +24,13 @@ contract("scripts/Voting.js", function(accounts) {
   let encryptedSender;
 
   const account1 = accounts[0];
-  let voter;
-  let privKey;
+  const voter = accounts[1];
 
   before(async function() {
     voting = await Voting.deployed();
     votingToken = await VotingToken.deployed();
     registry = await Registry.deployed();
     encryptedSender = await EncryptedSender.deployed();
-
-    // Load the keys and add them to the wallets object on the provider.
-    let pubKey;
-    ({ address: voter, privKey, pubKey } = await createVisibleAccount(web3));
-    if (!web3.currentProvider.wallets) {
-      // If no wallets object has been created, create one.
-      web3.currentProvider.wallets = {};
-    }
-    // Format the private and public keys for the wallet.
-    web3.currentProvider.wallets[voter] = {
-      _privKey: Buffer.from(privKey.substr(2), "hex"),
-      _pubKey: Buffer.from(pubKey.substr(2), "hex")
-    };
-
-    // Fund the voter account.
-    await web3.eth.sendTransaction({ from: accounts[9], to: voter, value: web3.utils.toWei("5", "ether") });
 
     // Register "derivative" with Registry, so we can make price requests in this test.
     await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, account1);


### PR DESCRIPTION
This PR changes the encryption scheme for on-chain (salt, price) persistence in `EncryptedSender` due to limitations in metamask - instead of encrypting and decrypting (salt, price) messages with the user's ethereum address key pair, this moves to deriving a "one-time key pair" from a signature. This signature is generated by the user's ethereum account. Since all wallets that are integrated with web3 can generate signatures, this allows the dApp and the automated voting system to get access to the keypair without receiving the user's keys in plaintext (which is prohibited in metamask for obvious reasons).

It's currently implemented such that a unique message is signed for each round of voting, so the generated key-pair is only used for a single round.