### PR TITLE
Add table showing active (i.e., pending) requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,10 @@ jobs:
     steps:
       - restore_cache:
           key: protocol-completed-build-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Deploy Contracts
+          working_directory: ~/protocol/core
+          command: $(npm bin)/truffle migrate --reset --network test
       - restore_cache:
           keys: 
             - v2-voter-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}
@@ -177,6 +181,10 @@ jobs:
           key: v2-voter-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}
           paths:
             - voter-dapp/node_modules
+      - run:
+          name: Link Contracts
+          working_directory: ~/protocol/voter-dapp
+          command: npm run link-contracts
       - save_cache:
           key: voter-dapp-env-{{ .Environment.CIRCLE_SHA1 }}
           paths:

--- a/voter-dapp/package.json
+++ b/voter-dapp/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "drizzle": "^1.4.0",
+    "drizzle-react": "^1.3.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"

--- a/voter-dapp/package.json
+++ b/voter-dapp/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "drizzle": "^1.4.0",
+    "@material-ui/core": "^3.9.2",
+    "@material-ui/icons": "^3.0.2",
+    "drizzle": "github:UMAprotocol/drizzle#1.4.0-fix2",
     "drizzle-react": "^1.3.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -13,7 +15,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "link-contracts": "ln -sfn ../../core/build/contracts src/contracts"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { drizzleReactHooks } from "drizzle-react";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+
+// TODO: Share this utility function with sponsor-dapp. React disallows imports outside of src/, so we'll need to find
+// some clever workaround.
+function formatDate(timestampInSeconds, web3) {
+  return new Date(
+    parseInt(
+      web3.utils
+        .toBN(timestampInSeconds)
+        .muln(1000)
+        .toString(),
+      10
+    )
+  ).toString();
+}
+
+function ActiveRequests() {
+  const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
+  drizzleReactHooks.useDrizzleState(drizzleState => {
+    return {
+      voting: drizzleState.voting
+    };
+  });
+  const pendingRequests = useCacheCall("Voting", "getPendingRequests");
+  if (!pendingRequests) {
+    return <div>Looking up requests</div>;
+  }
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Price Feed</TableCell>
+          <TableCell>Timestamp</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {pendingRequests.map((pendingRequest, index) => {
+          return (
+            <TableRow key={index}>
+              <TableCell>{drizzle.web3.utils.hexToUtf8(pendingRequest.identifier)}</TableCell>
+              <TableCell>{formatDate(pendingRequest.time, drizzle.web3)}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export default ActiveRequests;

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -22,11 +22,6 @@ function formatDate(timestampInSeconds, web3) {
 
 function ActiveRequests() {
   const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
-  drizzleReactHooks.useDrizzleState(drizzleState => {
-    return {
-      voting: drizzleState.voting
-    };
-  });
   const pendingRequests = useCacheCall("Voting", "getPendingRequests");
   if (!pendingRequests) {
     return <div>Looking up requests</div>;

--- a/voter-dapp/src/App.js
+++ b/voter-dapp/src/App.js
@@ -1,8 +1,23 @@
 import React from "react";
+import { drizzleReactHooks } from "drizzle-react";
 import "./App.css";
+import ActiveRequests from "./ActiveRequests.js";
 
 function App() {
-  return <div className="App">Voter dApp</div>;
+  const drizzleState = drizzleReactHooks.useDrizzleState(drizzleState => {
+    return {
+      initialized: drizzleState.drizzleStatus.initialized
+    };
+  });
+  if (!drizzleState.initialized) {
+    return <div>Loading</div>;
+  } else {
+    return (
+      <div>
+        Voter dApp <ActiveRequests />
+      </div>
+    );
+  }
 }
 
 export default App;

--- a/voter-dapp/src/App.test.js
+++ b/voter-dapp/src/App.test.js
@@ -1,9 +1,24 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
+import { Drizzle, generateStore } from "drizzle";
+import { drizzleReactHooks } from "drizzle-react";
+import drizzleOptions from "./drizzleOptions";
+
+const getNewDrizzleInstance = () => {
+  // Add a custom fallback provider for testing.
+  const options = { ...drizzleOptions, web3: { fallback: { url: "ws://127.0.0.1:9545" } } };
+  const drizzleStore = generateStore(options);
+  return new Drizzle(options, drizzleStore);
+};
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(
+    <drizzleReactHooks.DrizzleProvider drizzle={getNewDrizzleInstance()}>
+      <App />
+    </drizzleReactHooks.DrizzleProvider>,
+    div
+  );
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/voter-dapp/src/drizzleOptions.js
+++ b/voter-dapp/src/drizzleOptions.js
@@ -1,0 +1,7 @@
+import Voting from "./contracts/Voting.json";
+
+const options = {
+  contracts: [Voting]
+};
+
+export default options;

--- a/voter-dapp/src/index.js
+++ b/voter-dapp/src/index.js
@@ -1,10 +1,22 @@
 import React from "react";
+import { Drizzle, generateStore } from "drizzle";
+import { drizzleReactHooks } from "drizzle-react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
+import drizzleOptions from "./drizzleOptions";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+// Setup drizzle.
+const drizzleStore = generateStore(drizzleOptions);
+const drizzle = new Drizzle(drizzleOptions, drizzleStore);
+
+ReactDOM.render(
+  <drizzleReactHooks.DrizzleProvider drizzle={drizzle}>
+    <App />
+  </drizzleReactHooks.DrizzleProvider>,
+  document.getElementById("root")
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
This PR integrates the voter-dapp with Drizzle. We still have to use our
fork of Drizzle because the version of web3 Drizzle uses doesn't support
structs as return values (e.g., from `getPendingRequests`).

Follow up PRs will add other required columns, i.e., what vote the user has committed.

Issue #532 