### PR TITLE
Use crypto identifiers for contract creation

### DIFF
--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -10,7 +10,7 @@
       "minDelay": "0",
       "numerator": {
         "dataSource": "Coinbase",
-        "assetName": "BTC"
+        "assetName": "BTC-USD"
       }
     }
   },
@@ -25,7 +25,7 @@
       "minDelay": "0",
       "numerator": {
         "dataSource": "Coinbase",
-        "assetName": "ETH"
+        "assetName": "ETH-USD"
       }
     }
   }

--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -1,31 +1,31 @@
 {
-  "ESM19": {
+  "BTCUSD": {
     "dappConfig": {
-      "comment": "expiry: May 15, 2019 4:15pm ET, supportedMove: 0.085 corresponds to 8.5%",
-      "expiry": "1557951300",
-      "supportedMove": "0.085"
+      "comment": "expiry: January 1st, 2020 12:00 AM UTC, supportedMove: 0.2 corresponds to 20%",
+      "expiry": "1577836800",
+      "supportedMove": "0.2"
     },
     "uploaderConfig": {
       "publishInterval": "900",
-      "minDelay": "600",
+      "minDelay": "0",
       "numerator": {
-        "dataSource": "Barchart",
-        "assetName": "ESM19"
+        "dataSource": "Coinbase",
+        "assetName": "BTC"
       }
     }
   },
-  "CBN19": {
+  "ETHUSD": {
     "dappConfig": {
-      "comment": "expiry: May 15, 2019 7:30pm BST, supportedMove: 0.1 corresponds to 10%",
-      "expiry": "1557945000",
-      "supportedMove": "0.1"
+      "comment": "expiry: January 1st, 2020 12:00 AM UTC, supportedMove: 0.2 corresponds to 20%",
+      "expiry": "1577836800",
+      "supportedMove": "0.2"
     },
     "uploaderConfig": {
       "publishInterval": "900",
-      "minDelay": "600",
+      "minDelay": "0",
       "numerator": {
-        "dataSource": "Barchart",
-        "assetName": "CBN19"
+        "dataSource": "Coinbase",
+        "assetName": "ETH"
       }
     }
   }


### PR DESCRIPTION
We should use these crypto identifiers with expiries at the end of the year for any future dApp deployments since the futures we were using are expired.