### PR TITLE
Add natspec docs for most contracts

### DIFF
--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -5,14 +5,18 @@ pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
-
+/**
+ * @title A contract to track a whitelist of addresses.
+ */
 contract AddressWhitelist is Ownable {
     enum Status { None, In, Out }
     mapping(address => Status) private whitelist;
 
     address[] private whitelistIndices;
 
-    // Adds an address to the whitelist
+    /**
+     * @notice Adds an address to the whitelist.
+     */
     function addToWhitelist(address newElement) external onlyOwner {
         // Ignore if address is already included
         if (whitelist[newElement] == Status.In) {
@@ -29,7 +33,9 @@ contract AddressWhitelist is Ownable {
         emit AddedToWhitelist(newElement);
     }
 
-    // Removes an address from the whitelist.
+    /**
+     * @notice Removes an address from the whitelist.
+     */
     function removeFromWhitelist(address elementToRemove) external onlyOwner {
         if (whitelist[elementToRemove] != Status.Out) {
             whitelist[elementToRemove] = Status.Out;
@@ -37,17 +43,20 @@ contract AddressWhitelist is Ownable {
         }
     }
 
-    // Checks whether an address is on the whitelist.
+    /**
+     * @notice Checks whether an address is on the whitelist.
+     */
     function isOnWhitelist(address elementToCheck) external view returns (bool) {
         return whitelist[elementToCheck] == Status.In;
     }
 
-    // Gets all addresses that are currently included in the whitelist
-    // Note: This method skips over, but still iterates through addresses.
-    // It is possible for this call to run out of gas if a large number of
-    // addresses have been removed. To prevent this unlikely scenario, we can
-    // modify the implementation so that when addresses are removed, the last addresses
-    // in the array is moved to the empty index.
+    /**
+     * @notice Gets all addresses that are currently included in the whitelist.
+     * @dev Note: This method skips over, but still iterates through addresses. It is possible for this call to run out
+     * of gas if a large number of addresses have been removed. To reduce the likelihood of this unlikely scenario, we
+     * can modify the implementation so that when addresses are removed, the last addresses in the array is moved to
+     * the empty index.
+     */
     function getWhitelist() external view returns (address[] memory activeWhitelist) {
         // Determine size of whitelist first
         uint activeCount = 0;

--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
+
 /**
  * @title A contract to track a whitelist of addresses.
  */

--- a/core/contracts/AdministrateeInterface.sol
+++ b/core/contracts/AdministrateeInterface.sol
@@ -4,6 +4,7 @@
  */
 pragma solidity ^0.5.0;
 
+
 /**
  * @title Interface that all derivative contracts expose to the admin.
  */

--- a/core/contracts/AdministrateeInterface.sol
+++ b/core/contracts/AdministrateeInterface.sol
@@ -1,16 +1,21 @@
-/*
-  AdministrateeInterface contract.
-  The interfact that enumerates the functionality that derivative contracts expose to the admin.
-*/
+/**
+ * AdministrateeInterface contract.
+ * The interface that enumerates the functionality that derivative contracts expose to the admin.
+ */
 pragma solidity ^0.5.0;
 
-
-// The functionality that all derivative contracts expose to the admin.
+/**
+ * @title Interface that all derivative contracts expose to the admin.
+ */
 interface AdministrateeInterface {
-    // Initiates the shutdown process, in case of an emergency.
+    /**
+     * @notice Initiates the shutdown process, in case of an emergency.
+     */
     function emergencyShutdown() external;
 
-    // A core contract method called immediately before or after any financial transaction. It pays fees and moves money
-    // between margin accounts to make sure they reflect the NAV of the contract.
+    /**
+     * @notice A core contract method called independently or as a part of other financial contract transactions. It
+     * pays fees and moves money between margin accounts to make sure they reflect the NAV of the contract.
+     */
     function remargin() external;
 }

--- a/core/contracts/ExpandedIERC20.sol
+++ b/core/contracts/ExpandedIERC20.sol
@@ -1,17 +1,24 @@
-/*
-  ExpandedIERC20 contract.
-  Interface that expands IERC20 to include burning and minting tokens.
-*/
+/**
+ * ExpandedIERC20 contract.
+ * Interface that expands IERC20 to include burning and minting tokens.
+ */
 pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
-
+/**
+ * @title ERC20 interface that includes burn and mint methods.
+ */
 contract ExpandedIERC20 is IERC20 {
-    // Burns a specific amount of tokens. Burns the sender's tokens, so it is safe to leave this method permissionless.
+    /**
+     * @notice Burns a specific amount of the caller's tokens.
+     * @dev Only burns the caller's tokens, so it is safe to leave this method permissionless.
+     */
     function burn(uint value) external;
 
-    // Mints tokens and adds them to the balance of the `to` address.
-    // Note: this method should be permissioned to only allow designated parties to mint tokens.
+    /**
+     * @notice Mints tokens and adds them to the balance of the `to` address.
+     * @dev This method should be permissioned to only allow designated parties to mint tokens.
+     */
     function mint(address to, uint value) external returns (bool);
 }

--- a/core/contracts/ExpandedIERC20.sol
+++ b/core/contracts/ExpandedIERC20.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
+
 /**
  * @title ERC20 interface that includes burn and mint methods.
  */

--- a/core/contracts/LeveragedReturnCalculator.sol
+++ b/core/contracts/LeveragedReturnCalculator.sol
@@ -1,15 +1,17 @@
-/*
-  Leveraged Return Calculator.
-
-  Implements a return calculator that applies leverage to the input prices.
-*/
+/**
+ * Leveraged Return Calculator.
+ *
+ * Implements a return calculator that applies leverage to the input prices.
+ */
 pragma solidity ^0.5.0;
 
 import "./ReturnCalculatorInterface.sol";
 import "./Withdrawable.sol";
 import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 
-
+/**
+ * @title ERC20 interface that includes burn and mint methods.
+ */
 contract LeveragedReturnCalculator is ReturnCalculatorInterface, Withdrawable {
     using SignedSafeMath for int;
 

--- a/core/contracts/LeveragedReturnCalculator.sol
+++ b/core/contracts/LeveragedReturnCalculator.sol
@@ -9,8 +9,9 @@ import "./ReturnCalculatorInterface.sol";
 import "./Withdrawable.sol";
 import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 
+
 /**
- * @title ERC20 interface that includes burn and mint methods.
+ * @title Computes return values based on a fixed leverage.
  */
 contract LeveragedReturnCalculator is ReturnCalculatorInterface, Withdrawable {
     using SignedSafeMath for int;

--- a/core/contracts/ManualPriceFeed.sol
+++ b/core/contracts/ManualPriceFeed.sol
@@ -12,7 +12,9 @@ import "./Testable.sol";
 import "./Withdrawable.sol";
 
 
-// Implementation of PriceFeedInterface with the ability to push prices.
+/**
+ * @title Implementation of PriceFeedInterface with the ability to manually push prices.
+ */
 contract ManualPriceFeed is PriceFeedInterface, Withdrawable, Testable {
 
     using SafeMath for uint;
@@ -45,8 +47,10 @@ contract ManualPriceFeed is PriceFeedInterface, Withdrawable, Testable {
         createWithdrawRole(uint(Roles.Withdraw), uint(Roles.Governance), msg.sender);
     }
 
-    // Adds a new price to the series for a given identifier. The pushed publishTime must be later than the last time
-    // pushed so far.
+    /**
+     * @notice Adds a new price to the series for a given identifier.
+     * @dev The pushed publishTime must be later than the last time pushed so far.
+     */
     function pushLatestPrice(bytes32 identifier, uint publishTime, int newPrice) external
         onlyRoleHolder(uint(Roles.Writer)) {
         require(publishTime <= getCurrentTime().add(BLOCK_TIMESTAMP_TOLERANCE));
@@ -55,7 +59,9 @@ contract ManualPriceFeed is PriceFeedInterface, Withdrawable, Testable {
         emit PriceUpdated(identifier, publishTime, newPrice);
     }
 
-    // Whether this feed has ever published any prices for this identifier.
+    /**
+     * @notice Whether this feed has ever published any prices for this identifier.
+     */
     function isIdentifierSupported(bytes32 identifier) external view returns (bool isSupported) {
         isSupported = _isIdentifierSupported(identifier);
     }

--- a/core/contracts/MultiRole.sol
+++ b/core/contracts/MultiRole.sol
@@ -1,6 +1,6 @@
-/*
-  MultiRole contract.
-*/
+/**
+ * MultiRole contract.
+ */
 
 pragma solidity ^0.5.0;
 
@@ -53,7 +53,9 @@ library Shared {
     }
 }
 
-
+/**
+ * @title Base class to manage permissions for the derived class.
+ */
 contract MultiRole {
     using Exclusive for Exclusive.RoleMembership;
     using Shared for Shared.RoleMembership;
@@ -69,26 +71,42 @@ contract MultiRole {
 
     mapping(uint => Role) private roles;
 
+    /**
+     * @notice Reverts unless the caller is a member of the specified roleId.
+     */
     modifier onlyRoleHolder(uint roleId) {
         require(holdsRole(roleId, msg.sender), "Sender does not hold required role");
         _;
     }
 
+    /**
+     * @notice Reverts unless the caller is a member of the manager role for the specified roleId.
+     */
     modifier onlyRoleManager(uint roleId) {
         require(holdsRole(roles[roleId].managingRole, msg.sender), "Can only be called by a role manager");
         _;
     }
 
+    /**
+     * @notice Reverts unless the roleId represents an initialized, exclusive roleId.
+     */
     modifier onlyExclusive(uint roleId) {
         require(roles[roleId].roleType == RoleType.Exclusive, "Must be called on an initialized Exclusive role");
         _;
     }
 
+    /**
+     * @notice Reverts unless the roleId represents an initialized, shared roleId.
+     */
     modifier onlyShared(uint roleId) {
         require(roles[roleId].roleType == RoleType.Shared, "Must be called on an initialized Shared role");
         _;
     }
 
+    /**
+     * @notice Whether `memberToCheck` is a member of roleId.
+     * @dev Reverts if roleId does not correspond to an initialized role.
+     */
     function holdsRole(uint roleId, address memberToCheck) public view returns (bool) {
         Role storage role = roles[roleId];
         if (role.roleType == RoleType.Exclusive) {
@@ -99,32 +117,63 @@ contract MultiRole {
         require(false, "Invalid roleId");
     }
 
+    /**
+     * @notice Changes the exclusive role holder of `roleId` to `newMember`.
+     * @dev Reverts if the caller is not a member of the managing role for `roleId` or if `roleId` is not an
+     * initialized, exclusive role.
+     */
     function resetMember(uint roleId, address newMember) public onlyExclusive(roleId) onlyRoleManager(roleId) {
         roles[roleId].exclusiveRoleMembership.resetMember(newMember);
     }
 
+    /**
+     * @notice Gets the current holder of the exclusive role, `roleId`.
+     * @dev Reverts if `roleId` does not represent an initialized, exclusive role.
+     */
     function getMember(uint roleId) public view onlyExclusive(roleId) returns (address) {
         return roles[roleId].exclusiveRoleMembership.getMember();
     }
 
+    /**
+     * @notice Adds `newMember` to the shared role, `roleId`.
+     * @dev Reverts if `roleId` does not represent an initialized, shared role or if the caller is not a member of the
+     * managing role for `roleId`.
+     */
     function addMember(uint roleId, address newMember) public onlyShared(roleId) onlyRoleManager(roleId) {
         roles[roleId].sharedRoleMembership.addMember(newMember);
     }
 
+    /**
+     * @notice Removes `memberToRemove` from the shared role, `roleId`.
+     * @dev Reverts if `roleId` does not represent an initialized, shared role or if the caller is not a member of the
+     * managing role for `roleId`.
+     */
     function removeMember(uint roleId, address memberToRemove) public onlyShared(roleId) onlyRoleManager(roleId) {
         roles[roleId].sharedRoleMembership.removeMember(memberToRemove);
     }
 
+    /**
+     * @notice Reverts if `roleId` is not initialized.
+     */
     modifier onlyValidRole(uint roleId) {
         require(roles[roleId].roleType != RoleType.Invalid, "Attempted to use an invalid roleId");
         _;
     }
 
+    /**
+     * @notice Reverts if `roleId` is initialized.
+     */
     modifier onlyInvalidRole(uint roleId) {
         require(roles[roleId].roleType == RoleType.Invalid, "Cannot use a pre-existing role");
         _;
     }
 
+    /**
+     * @notice Internal method to initialize a shared role, `roleId`, which will be managed by `managingRoleId`.
+     * `initialMembers` will be immediately added to the role.
+     * @dev Should be called by derived contracts, usually at construction time. Will revert if the role is already
+     * initialized.
+     */
     function _createSharedRole(uint roleId, uint managingRoleId, address[] memory initialMembers)
         internal
         onlyInvalidRole(roleId)
@@ -137,6 +186,12 @@ contract MultiRole {
             "Attempted to use an invalid role to manage a shared role");
     }
 
+    /**
+     * @notice Internal method to initialize a exclusive role, `roleId`, which will be managed by `managingRoleId`.
+     * `initialMembers` will be immediately added to the role.
+     * @dev Should be called by derived contracts, usually at construction time. Will revert if the role is already
+     * initialized.
+     */
     function _createExclusiveRole(uint roleId, uint managingRoleId, address initialMember)
         internal
         onlyInvalidRole(roleId)

--- a/core/contracts/MultiRole.sol
+++ b/core/contracts/MultiRole.sol
@@ -53,6 +53,7 @@ library Shared {
     }
 }
 
+
 /**
  * @title Base class to manage permissions for the derived class.
  */

--- a/core/contracts/PriceFeedInterface.sol
+++ b/core/contracts/PriceFeedInterface.sol
@@ -3,6 +3,7 @@
  */
 pragma solidity ^0.5.0;
 
+
 /**
  * @title This interface allows contracts to query unverified prices.
  */

--- a/core/contracts/PriceFeedInterface.sol
+++ b/core/contracts/PriceFeedInterface.sol
@@ -1,19 +1,25 @@
-/*
-  PriceFeedInterface contract.
-  The interface that contracts use to query unverified price feeds.
-*/
+/**
+ * PriceFeedInterface contract.
+ */
 pragma solidity ^0.5.0;
 
-
-// This interface allows contracts to query unverified prices.
+/**
+ * @title This interface allows contracts to query unverified prices.
+ */
 interface PriceFeedInterface {
-    // Whether this PriceFeeds provides prices for the given identifier.
+    /**
+     * @notice Whether this PriceFeeds provides prices for the given identifier.
+     */
     function isIdentifierSupported(bytes32 identifier) external view returns (bool isSupported);
 
-    // Gets the latest time-price pair at which a price was published. The transaction will revert if no prices have
-    // been published for this identifier.
+    /**
+     * @notice Gets the latest time-price pair at which a price was published.
+     * @dev Will revert if no prices have been published for this identifier.
+     */
     function latestPrice(bytes32 identifier) external view returns (uint publishTime, int price);
 
-    // An event fired when a price is published.
+    /**
+     * @notice An event fired when a price is published.
+     */
     event PriceUpdated(bytes32 indexed identifier, uint indexed time, int price);
 }

--- a/core/contracts/RegistryInterface.sol
+++ b/core/contracts/RegistryInterface.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 
 /**
- * @title Interface for a registry of derivatives and derivative creators
+ * @title Interface for a registry of derivatives and derivative creators.
  */
 interface RegistryInterface {
     struct RegisteredDerivative {
@@ -18,7 +18,7 @@ interface RegistryInterface {
     function registerDerivative(address[] calldata counterparties, address derivativeAddress) external;
 
     /**
-     * @dev Returns whether the derivative has been registered with the registry (and is therefore an authorized
+     * @dev Returns whether the derivative has been registered with the registry (and is therefore an authorized.
      * participant in the UMA system).
      */
     function isDerivativeRegistered(address derivative) external view returns (bool isRegistered);

--- a/core/contracts/ReturnCalculatorInterface.sol
+++ b/core/contracts/ReturnCalculatorInterface.sol
@@ -4,6 +4,7 @@
 */
 pragma solidity ^0.5.0;
 
+
 /**
  * @title Computes the synthetic asset return based on the underlying asset's return.
  */

--- a/core/contracts/ReturnCalculatorInterface.sol
+++ b/core/contracts/ReturnCalculatorInterface.sol
@@ -4,12 +4,21 @@
 */
 pragma solidity ^0.5.0;
 
-
+/**
+ * @title Computes the synthetic asset return based on the underlying asset's return.
+ */
 interface ReturnCalculatorInterface {
-    // Computes the return between oldPrice and newPrice.
+    /**
+     * @notice Computes the synthetic asset return when the underlying asset price changes from `oldPrice` to
+     * `newPrice`.
+     * @dev This can be implemented in many different ways, but a simple one would just be levering (or multiplying)
+     * the return by some fixed integer.
+     */
     function computeReturn(int oldPrice, int newPrice) external view returns (int assetReturn);
 
-    // Gets the effective leverage for the return calculator.
-    // Note: if this parameter doesn't exist for this calculator, this method should return 1.
+    /**
+     * @notice Gets the effective leverage for the return calculator.
+     * @dev If there is no sensible leverage value for a return calculator, this method should return 1.
+     */
     function leverage() external view returns (int _leverage);
 }

--- a/core/contracts/Testable.sol
+++ b/core/contracts/Testable.sol
@@ -4,6 +4,7 @@
 
 pragma solidity ^0.5.0;
 
+
 /**
  * @title Base class that provides time overrides, but only if being run in test mode.
  */

--- a/core/contracts/Testable.sol
+++ b/core/contracts/Testable.sol
@@ -1,12 +1,12 @@
-/*
-  Testable contract.
-
-  Base class that provides time overrides, but only if being run in test mode.
-*/
+/**
+ * Testable contract.
+ */
 
 pragma solidity ^0.5.0;
 
-
+/**
+ * @title Base class that provides time overrides, but only if being run in test mode.
+ */
 contract Testable {
     // Is the contract being run on the test network. Note: this variable should be set on construction and never
     // modified.
@@ -21,15 +21,26 @@ contract Testable {
         }
     }
 
+    /**
+     * @notice Reverts if not running in test mode.
+     */
     modifier onlyIfTest {
         require(isTest);
         _;
     }
 
+    /**
+     * @notice Sets the current time.
+     * @dev Will revert if not running in test mode.
+     */
     function setCurrentTime(uint _time) external onlyIfTest {
         currentTime = _time;
     }
 
+    /**
+     * @notice Gets the current time. Will return the last time set in `setCurrentTime` if running in test mode.
+     * Otherwise, it will return the block timestamp.
+     */
     function getCurrentTime() public view returns (uint) {
         if (isTest) {
             return currentTime;

--- a/core/contracts/Withdrawable.sol
+++ b/core/contracts/Withdrawable.sol
@@ -1,28 +1,38 @@
-/*
-    Contract that allows the owner to withdraw any ETH and/or ERC20 tokens that the contract holds.
-*/
+/**
+ * Withdrawable contract.
+ */
 
 pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./MultiRole.sol";
 
-
+/**
+ * @title Base contract that allows a specific role to withdraw any ETH and/or ERC20 tokens that the contract holds.
+ */
 contract Withdrawable is MultiRole {
 
     uint private _roleId;
 
-    // Withdraws ETH from the contract.
+    /**
+     * @notice Withdraws ETH from the contract.
+     */
     function withdraw(uint amount) external onlyRoleHolder(_roleId) {
         msg.sender.transfer(amount);
     }
 
-    // Withdraws ERC20 tokens from the contract.
+    /**
+     * @notice Withdraws ERC20 tokens from the contract.
+     */
     function withdrawErc20(address erc20Address, uint amount) external onlyRoleHolder(_roleId) {
         IERC20 erc20 = IERC20(erc20Address);
         require(erc20.transfer(msg.sender, amount));
     }
 
+    /**
+     * @notice Internal method that allows derived contracts to create a role for withdrawal.
+     * @dev This method must be called by the derived class for this contract to function properly.
+     */
     function createWithdrawRole(uint roleId, uint managingRoleId, address owner) internal {
         _roleId = roleId;
         _createExclusiveRole(roleId, managingRoleId, owner);

--- a/core/contracts/Withdrawable.sol
+++ b/core/contracts/Withdrawable.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.5.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./MultiRole.sol";
 
+
 /**
  * @title Base contract that allows a specific role to withdraw any ETH and/or ERC20 tokens that the contract holds.
  */


### PR DESCRIPTION
The only contract left should be the `TokenizedDerivative`. I think that one is worthy of its own PR.