### PR TITLE
Add request trigger option to RequestOraclePrice

### DIFF
--- a/core/scripts/local/RequestOraclePrice.js
+++ b/core/scripts/local/RequestOraclePrice.js
@@ -83,7 +83,7 @@ const runRequestOraclePrice = async function(callback) {
 
   // Note: use ENV for port because in some cases GCP doesn't allow the user to change the docker args.
   if (process.env.PORT) {
-    // Only trigger on request if PORT is in the ENV. Otherwise, we assume the user wants it called syncrhonously.
+    // Only trigger on request if PORT is in the ENV. Otherwise, we assume the user wants it called synchronously.
     await triggerOnRequest(callRun);
   } else {
     await callRun();

--- a/core/scripts/local/RequestOraclePrice.js
+++ b/core/scripts/local/RequestOraclePrice.js
@@ -77,9 +77,9 @@ const runRequestOraclePrice = async function(callback) {
   const finder = await Finder.deployed();
 
   const callRun = async () => {
-      await run(finder, argv.identifier, argv.time);
-      callback();
-    };
+    await run(finder, argv.identifier, argv.time);
+    callback();
+  };
 
   // Note: use ENV for port because in some cases GCP doesn't allow the user to change the docker args.
   if (process.env.PORT) {

--- a/core/truffle-config.js
+++ b/core/truffle-config.js
@@ -1,4 +1,3 @@
 const globalConfig = require("../common/globalTruffleConfig.js");
 
 module.exports = globalConfig;
-

--- a/core/utils/Serving.js
+++ b/core/utils/Serving.js
@@ -1,0 +1,22 @@
+const express = require("express");
+const { decorateApp } = require("@awaitjs/express");
+const app = decorateApp(express());
+
+// Calls a function on every request.
+async function triggerOnRequest(fn) {
+  app.getAsync("/", async (req, res) => {
+    console.log("Received a request.");
+
+    await fn();
+    res.send("Done.");
+    console.log("Finished processing request.");
+  });
+
+  app.listen(process.env.PORT, () => {
+    console.log("Listening on port", port);
+  });
+}
+
+module.exports = {
+  triggerOnRequest
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prettier": "npm run prettier_vanilla -- --write",
     "prettier_check": "npm run prettier_vanilla -- --check",
-    "prettier_vanilla": "prettier '**/test/**/*.js' '**/migrations/*.js' '**/scripts/*.js' '**/utils/*.js' 'common/**/*.js' '*.js' 'sponsor-dapp/src/**/*.js' 'voter-dapp/src/**/*.js'"
+    "prettier_vanilla": "prettier 'core/**/*.js' 'common/**/*.js' '*.js' 'sponsor-dapp/src/**/*.js' 'voter-dapp/src/**/*.js'"
   },
   "author": "UMA Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "truffle-deploy-registry": "^0.5.1"
   },
   "dependencies": {
+    "@awaitjs/express": "^0.3.0",
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/storage": "^2.4.2",
     "@sendgrid/mail": "^6.4.0",
@@ -27,6 +28,7 @@
     "dotenv": "^6.2.0",
     "eslint": "5.16.0",
     "eth-crypto": "^1.3.4",
+    "express": "^4.17.1",
     "ganache-cli": "^6.4.3",
     "minimist": "^1.2.0",
     "node-fetch": "^2.3.0",


### PR DESCRIPTION
This will allow the RequestOraclePrice script to be triggered by an http request on a port. The end goal is to allow [Cloud Scheduler](https://cloud.google.com/scheduler/) to send a request over [PubSub](https://cloud.google.com/pubsub/) to trigger RequestOraclePrice running in [Cloud Run](https://cloud.google.com/run/).

Also updated prettier command to cover all of `core/` because it wasn't covering `js` in `core/scripts/local/`.