### PR TITLE
Change `hasRevealed` to only apply to the current round

### DIFF
--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -770,9 +770,9 @@ contract("Voting", function(accounts) {
     assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account2 }));
     assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account3 }));
 
-    // Can still check once in the next round, even if this behavior is useless to the voter.
+    // Once in the next round, no voter is considered to have revealed.
     await moveToNextRound(voting);
-    assert.isTrue(await voting.hasRevealedVote(identifier, time, { from: account1 }));
+    assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account1 }));
     assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account2 }));
     assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account3 }));
   });


### PR DESCRIPTION
For example, if a price request fails to resolve, then it automatically
becomes pending in the next round. Then, suppose the next commit phase
goes by with no activity. The voter dapp will then try to pull
the `hasRevealed` status, which should show `Cannot be revealed`. The
voter dapp relies on the `hasRevealed` call to return `false`.

Issue #532.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>