### PR TITLE
Minor PriceRequest script refinements

### DIFF
--- a/core/scripts/local/RequestOraclePrice.js
+++ b/core/scripts/local/RequestOraclePrice.js
@@ -46,7 +46,7 @@ async function run(deployedFinder, identifier, timeString) {
     let timeInSeconds = parseInt(timeString);
     if (timeInSeconds === 0) {
       // If time input is 0, use current time (less 2 minutes to ensure we don't jump in front of the block timestamp).
-      timeInSeconds = Math.floor((new Date()).getTime() / 10e2) - 120;
+      timeInSeconds = Math.floor(new Date().getTime() / 10e2) - 120;
       console.log(`User provided timestamp of 0, using current timestamp less 2 minutes: ${timeInSeconds}`);
     }
 

--- a/core/utils/Serving.js
+++ b/core/utils/Serving.js
@@ -4,11 +4,12 @@ const app = decorateApp(express());
 
 // Calls a function on every request.
 async function triggerOnRequest(fn) {
-  app.getAsync("/", async (req, res) => {
+  // GCP PubSub pushes come as POSTs.
+  app.postAsync("/", async (req, res) => {
     console.log("Received a request.");
 
     await fn();
-    res.send("Done.");
+    res.status(200).send("Done.");
     console.log("Finished processing request.");
   });
 


### PR DESCRIPTION
There are a few distinct changes made in this PR:
- A time input of 0 instructs the script to use the *time of request*. This allows the same server to make multiple, distinct requests. This is needed to get the cron job to continually make new requests rather than re-requesting the same price.
- The server responds to HTTP POSTs. This is needed because GCP PubSub pushes with posts rather than gets.
- The callback is never called in the server case to allow the server to run indefinitely rather than shutting down immediately after the first request.