### PR TITLE
Support batch commit/reveal in the Voting script

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -230,7 +230,6 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
                     commits[i].hash,
                     commits[i].encryptedVote);
             }
-
         }
     }
 

--- a/core/migrations/13_deploy_encrypted_sender.js
+++ b/core/migrations/13_deploy_encrypted_sender.js
@@ -1,9 +1,0 @@
-const EncryptedSender = artifacts.require("EncryptedSender");
-const { getKeysForNetwork, deploy, addToTdr } = require("../../common/MigrationUtils.js");
-
-module.exports = async function(deployer, network, accounts) {
-  const keys = getKeysForNetwork(network, accounts);
-
-  // Deploy EncryptedSender.
-  await deploy(deployer, network, EncryptedSender, { from: keys.deployer });
-};

--- a/core/networks/42.json
+++ b/core/networks/42.json
@@ -54,10 +54,6 @@
   {
     "contractName": "TokenizedDerivativeCreator",
     "address": "0xdc7298045665c72351D9cD3756DcC53d0e208A0d"
-  },
-  {
-    "contractName": "EncryptedSender",
-    "address": "0xf8a95aABc4Beb81C9AA388E85fcef16283C1F565"
   }
 ]
 

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -1,5 +1,4 @@
 const Voting = artifacts.require("Voting");
-const EncryptedSender = artifacts.require("EncryptedSender");
 const { VotePhasesEnum } = require("../../common/Enums");
 const { decryptMessage, encryptMessage, deriveKeyPairFromSignature } = require("../../common/Crypto");
 const { computeTopicHash, getKeyGenMessage } = require("../utils/EncryptionHelper");
@@ -91,78 +90,94 @@ class EmailSender {
 }
 
 class VotingSystem {
-  constructor(voting, encryptedSender, account, emailSender) {
+  constructor(voting, account, emailSender) {
     this.voting = voting;
-    this.encryptedSender = encryptedSender;
     this.account = account;
     this.emailSender = emailSender;
   }
 
-  async readVote(request, roundId) {
-    const encryptedCommit = await this.encryptedSender.getMessage(this.account, computeTopicHash(request, roundId));
+  async getMessage(request, roundId) {
+    const topicHash = computeTopicHash(request, roundId);
+    return await this.voting.getMessage(this.account, topicHash, { from: this.account });
+  }
 
-    if (!encryptedCommit) {
-      // Nothing has been published for this topic.
+  async constructCommitment(request, roundId) {
+    const fetchedPrice = await fetchPrice(request);
+    const salt = web3.utils.toBN(web3.utils.randomHex(32));
+    const hash = web3.utils.soliditySha3(fetchedPrice, salt);
+
+    const vote = { price: fetchedPrice, salt };
+    const { publicKey } = await deriveKeyPairFromSignature(web3, getKeyGenMessage(roundId), this.account);
+    const encryptedVote = await encryptMessage(publicKey, JSON.stringify(vote));
+
+    return {
+      identifier: request.identifier,
+      time: request.time,
+      hash,
+      encryptedVote
+    };
+  }
+
+  async runBatchCommit(requests, roundId) {
+    const commitments = [];
+
+    for (let i = 0; i < requests.length; i++) {
+      // Skip commits if a message already exists for this request.
+      // This does not check the existence of an actual commit.
+      if (await this.getMessage(requests[i], roundId)) {
+        continue;
+      }
+
+      commitments.push(await this.constructCommitment(requests[i], roundId));
+    }
+
+    // Always call `batchCommit`, even if there's only one commitment. Difference in gas cost is negligible.
+    await this.voting.batchCommit(commitments, { from: this.account });
+
+    return commitments.length;
+  }
+
+  async constructReveal(request, roundId) {
+    const encryptedCommit = await this.getMessage(request, roundId);
+
+    let vote;
+
+    // Catch messages that are indecipherable and handle by skipping over the request.
+    try {
+      const { privateKey } = await deriveKeyPairFromSignature(web3, getKeyGenMessage(roundId), this.account);
+      vote = JSON.parse(await decryptMessage(privateKey, encryptedCommit));
+    } catch (e) {
+      console.error("Failed to decrypt message:", encryptedCommit, "\n", e);
       return null;
     }
 
-    // Generate the one-time keypair for this round.
-    const { privateKey } = await deriveKeyPairFromSignature(web3, getKeyGenMessage(roundId), this.account);
-
-    // Decrypt message.
-    const decryptedMessage = await decryptMessage(privateKey, encryptedCommit);
-    return JSON.parse(decryptedMessage);
+    return {
+      identifier: request.identifier,
+      time: request.time,
+      price: vote.price.toString(),
+      salt: web3.utils.hexToNumberString(vote.salt)
+    };
   }
 
-  async writeVote(request, roundId, vote) {
-    // TODO: if we want to authorize other accounts to send messages to the automated voting system, we should check
-    // and authorize them here.
+  async runBatchReveal(requests, roundId) {
+    const reveals = [];
 
-    // Generate the one-time keypair for this round.
-    const { publicKey } = await deriveKeyPairFromSignature(web3, getKeyGenMessage(roundId), this.account);
+    let reveal;
+    for (let i = 0; i < requests.length; i++) {
+      const encryptedCommit = await this.getMessage(requests[i], roundId);
+      if (!encryptedCommit) {
+        continue;
+      }
 
-    // Encrypt the vote using the public key.
-    const encryptedMessage = await encryptMessage(publicKey, JSON.stringify(vote));
-
-    // Upload the encrypted commit.
-    const topicHash = computeTopicHash(request, roundId);
-    await this.encryptedSender.sendMessage(this.account, topicHash, encryptedMessage, { from: this.account });
-  }
-
-  async runCommit(request, roundId) {
-    const persistedVote = await this.readVote(request, roundId);
-    // If the vote has already been persisted and committed, we don't need to recommit.
-    // TODO: we may want to add a feature in the future where we ensure that the persisted vote matches the commit, and
-    // if it does not, we commit the persisted vote.
-    if (persistedVote) {
-      return false;
+      reveal = await this.constructReveal(requests[i], roundId);
+      if (reveal) {
+        reveals.push(reveal);
+      }
     }
-    const fetchedPrice = await fetchPrice(request);
-    const salt = web3.utils.toBN(web3.utils.randomHex(32));
 
-    const hash = web3.utils.soliditySha3(fetchedPrice, salt);
-    await this.voting.commitVote(request.identifier, request.time, hash, { from: this.account });
-
-    // Persist the vote only after the commit hash has been sent to the Voting contract.
-    await this.writeVote(request, roundId, { price: fetchedPrice.toString(), salt: salt.toString() });
-    return true;
-  }
-
-  async runReveal(request, roundId) {
-    const persistedVote = await this.readVote(request, roundId);
-    // If no vote was persisted and committed, then we can't reveal.
-    if (!persistedVote) {
-      return false;
-    }
-    const hasRevealedVote = await this.voting.hasRevealedVote(request.identifier, request.time, { from: this.account });
-    // If we've already revealed, no need to re-reveal.
-    if (hasRevealedVote) {
-      return false;
-    }
-    await this.voting.revealVote(request.identifier, request.time, persistedVote.price, persistedVote.salt, {
-      from: this.account
-    });
-    return true;
+    // Always call `batchReveal`, even if there's only one reveal.
+    await this.voting.batchReveal(reveals, { from: this.account });
+    return reveals.length;
   }
 
   async runIteration() {
@@ -170,25 +185,22 @@ class VotingSystem {
     const phase = await this.voting.getVotePhase();
     const roundId = await this.voting.getCurrentRoundId();
     const pendingRequests = await this.voting.getPendingRequests();
-    const updatesMade = [];
-    for (const request of pendingRequests) {
-      let didUpdate = false;
-      if (phase == VotePhasesEnum.COMMIT) {
-        didUpdate = await this.runCommit(request, roundId);
-      } else {
-        didUpdate = await this.runReveal(request, roundId);
-      }
-      if (didUpdate) {
-        updatesMade.push(request);
-      }
+
+    let numUpdates = 0;
+    if (phase == VotePhasesEnum.COMMIT) {
+      numUpdates = await this.runBatchCommit(pendingRequests, roundId);
+    } else {
+      numUpdates = await this.runBatchReveal(pendingRequests, roundId);
     }
-    if (updatesMade.length > 0) {
-      // TODO(ptare): Get email copies.
+
+    if (numUpdates > 0) {
+      // TODO(ptare): Add granular email notifications.
       await this.emailSender.sendEmailNotification(
         "Automated voting system update",
-        "Updated " + updatesMade.length + " price requests"
+        "Updated " + numUpdates + " price requests"
       );
     }
+
     console.log("Finished voting iteration");
   }
 }
@@ -198,9 +210,8 @@ async function runVoting() {
     console.log("Running Voting system");
     sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
     const voting = await Voting.deployed();
-    const encryptedSender = await EncryptedSender.deployed();
     const account = (await web3.eth.getAccounts())[0];
-    const votingSystem = new VotingSystem(voting, encryptedSender, account, new EmailSender());
+    const votingSystem = new VotingSystem(voting, account, new EmailSender());
     await votingSystem.runIteration();
   } catch (error) {
     console.log(error);
@@ -211,5 +222,6 @@ run = async function(callback) {
   await runVoting();
   callback();
 };
+
 run.VotingSystem = VotingSystem;
 module.exports = run;

--- a/core/test/EncryptedSender.js
+++ b/core/test/EncryptedSender.js
@@ -16,7 +16,7 @@ contract("EncryptedSender", function(accounts) {
   const receiverAccount = accounts[1];
 
   before(async function() {
-    encryptedSender = await EncryptedSender.deployed();
+    encryptedSender = await EncryptedSender.new();
   });
 
   it("Encrypt Decrypt", async function() {


### PR DESCRIPTION
 - Removes references to `EncryptedSender` as a standalone contract
 - Voting script now uses `batchCommit` and `batchReveal`