### PR TITLE
Add commit/reveal details in email

### DIFF
--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -163,13 +163,16 @@ class VotingSystem {
 
     // Always call `batchCommit`, even if there's only one commitment. Difference in gas cost is negligible.
     // TODO (#562): Handle case where tx exceeds gas limit.
-    const { receipt } = await this.voting.batchCommit(commitments.map(commitment => {
-      // This filters out the parts of the commitment that we don't need to send to solidity.
-      // Note: this isn't strictly necessary since web3 will only encode variables that share names with properties in
-      // the solidity struct.
-      const { price, salt, ...rest } = commitment;
-      return rest;
-    }), { from: this.account });
+    const { receipt } = await this.voting.batchCommit(
+      commitments.map(commitment => {
+        // This filters out the parts of the commitment that we don't need to send to solidity.
+        // Note: this isn't strictly necessary since web3 will only encode variables that share names with properties in
+        // the solidity struct.
+        const { price, salt, ...rest } = commitment;
+        return rest;
+      }),
+      { from: this.account }
+    );
 
     // Add the batch transaction hash to each commitment.
     commitments.forEach(commitment => {


### PR DESCRIPTION
Note: I'm not exactly sure if testing the email body makes sense. These sorts of tests often end up being "change detectors" (they basically just hardcode the expected output and fail whenever anything changes). Please let me know if you have an idea for a good way to test this.

I worked with @rcai1 to come up with an email template that made sense. Here's a sample (note the link doesn't match up with the txn hash - I was running on ganache, so I fudged that part :)):

**The AVS has revealed 3 price requests on-chain.**

__Price request 1__:
Price feed: BTCUSD
Request time: Thu, 18 Jul 2019 13:36:51 GMT (Unix timestamp: 1563457011)
Value revealed: 9770.62
*Salt: 91688650169801159701281221741261196733890428798947866347522299367376684217265
**Transaction: [0xd340004ece359d8a9855dc52f467d2a793072c66ad992737bbeaef3b6a947c56](https://kovan.etherscan.io/tx/0x8dda4fbbdb4bf0562df4f356d21e0394a9d9181a224ee5ddbe2f518d38c9beb6)

__Price request 2__:
Price feed: BTCUSD
Request time: Thu, 18 Jul 2019 13:36:52 GMT (Unix timestamp: 1563457012)
Value revealed: 9770.62
*Salt: 68271185660584596395767087371886778907374230676660493139369978777627952275077
**Transaction: [0xd340004ece359d8a9855dc52f467d2a793072c66ad992737bbeaef3b6a947c56](https://kovan.etherscan.io/tx/0x8dda4fbbdb4bf0562df4f356d21e0394a9d9181a224ee5ddbe2f518d38c9beb6)

__Price request 3__:
Price feed: BTCUSD
Request time: Thu, 18 Jul 2019 13:36:53 GMT (Unix timestamp: 1563457013)
Value revealed: 9770.62
*Salt: 7067091320910934696153090441913192178547149178414251388400041537016379835173
**Transaction: [0xd340004ece359d8a9855dc52f467d2a793072c66ad992737bbeaef3b6a947c56](https://kovan.etherscan.io/tx/0x8dda4fbbdb4bf0562df4f356d21e0394a9d9181a224ee5ddbe2f518d38c9beb6)


*If you want to manually reveal your vote, you will need the salt. This should be done rarely, if ever.
**The AVS attempts to batch commits and reveals to save gas, so it is common to see the same transaction hash for multiple commits/reveals.