### PR TITLE
[WIP]

### DIFF
--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -1086,7 +1086,7 @@ contract("Voting", function(accounts) {
     const topicHash = computeTopicHash({ identifier, time }, roundId);
     const retrievedEncryptedMessage = await voting.getMessage(account1, topicHash);
 
-    const secondEncryptedMessage = web3.utils.toHex(getRandomUnsignedInt());
+    const secondEncryptedMessage = await encryptMessage(publicKey, getRandomUnsignedInt());
 
     await voting.commitAndPersistEncryptedVote(identifier, time, hash, secondEncryptedMessage);
     const secondRetrievedEncryptedMessage = await voting.getMessage(account1, topicHash);


### PR DESCRIPTION
Due to some padding behavior on `bytes` passed to Solidity, this test
can be flaky sometimes (e.g., '0x1' saved gets retrieved at '0x01') if just the hex versions of ints are passed to it.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>