### PR TITLE
Tweak formatting and visual spacing in header component

### DIFF
--- a/voter-dapp/src/Header.js
+++ b/voter-dapp/src/Header.js
@@ -2,7 +2,8 @@ import React from "react";
 import { drizzleReactHooks } from "drizzle-react";
 import logo from "./logo.png";
 import Grid from "@material-ui/core/Grid";
-import { formatDate } from "./common/FormattingUtils.js";
+import { formatWei, formatWithMaxDecimals } from "./common/FormattingUtils.js";
+import BigNumber from "bignumber.js";
 
 // MaterialUI has a number of options for styling which seem to be
 // made more complicated by the React Hooks setup. When attempting to
@@ -11,6 +12,7 @@ import { formatDate } from "./common/FormattingUtils.js";
 
 export default function Header() {
   const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
+  const { web3 } = drizzle;
   const account = drizzleReactHooks.useDrizzleState(drizzleState => ({
     account: drizzleState.accounts[0]
   })).account;
@@ -20,10 +22,23 @@ export default function Header() {
   let tokenBalance;
 
   if (balance && supply) {
+    const formattedBalance = formatWithMaxDecimals(formatWei(balance, web3), 2, false);
+    const formattedSupply = formatWithMaxDecimals(formatWei(supply, web3), 2, false);
+    const formattedPercentage =
+      supply.toString() === "0"
+        ? "0"
+        : formatWithMaxDecimals(
+            BigNumber(balance)
+              .div(BigNumber(supply))
+              .times(BigNumber(100))
+              .toString(),
+            4,
+            false
+          );
     tokenBalance = (
       <div>
         {" "}
-        {balance} tokens of {supply} supply is {!(balance / supply) ? 0 : (balance / supply) * 100}%{" "}
+        Your Token Balance: {formattedBalance}/{formattedSupply} ({formattedPercentage}%){" "}
       </div>
     );
   } else {
@@ -33,9 +48,25 @@ export default function Header() {
   if (!logo) {
     return <div>Logo goes here</div>;
   }
+
+  const textAlign = {
+    paddingRight: "10px",
+    paddingBottom: "3px"
+  };
+
+  const dateTimeOptions = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    hour12: false,
+    minute: "numeric"
+  };
+
   return (
     <div>
-      <Grid container direction="row" alignItems="center">
+      <Grid container direction="row" alignItems="center" justify="space-between">
         <Grid item>
           <img src={logo} alt="Logo" style={{ padding: 15 }} height="30" />
         </Grid>
@@ -44,9 +75,15 @@ export default function Header() {
         </Grid>
         <Grid item>
           <ul>
-            <div>User Addr = {account} </div>
-            <div> {tokenBalance} </div>
-            <div> Current time: {formatDate(Date.now(), drizzle.web3)} </div>
+            <div align="right" style={textAlign}>
+              Your Address: {account}
+            </div>
+            <div align="right" style={textAlign}>
+              {tokenBalance}
+            </div>
+            <div align="right" style={textAlign}>
+              Current Time: {new Date().toLocaleDateString(undefined, dateTimeOptions)}
+            </div>
           </ul>
         </Grid>
       </Grid>

--- a/voter-dapp/src/Header.js
+++ b/voter-dapp/src/Header.js
@@ -49,7 +49,7 @@ export default function Header() {
     return <div>Logo goes here</div>;
   }
 
-  const textAlign = {
+  const textStyle = {
     paddingRight: "10px",
     paddingBottom: "3px"
   };
@@ -75,13 +75,13 @@ export default function Header() {
         </Grid>
         <Grid item>
           <ul>
-            <div align="right" style={textAlign}>
+            <div align="right" style={textStyle}>
               Your Address: {account}
             </div>
-            <div align="right" style={textAlign}>
+            <div align="right" style={textStyle}>
               {tokenBalance}
             </div>
-            <div align="right" style={textAlign}>
+            <div align="right" style={textStyle}>
               Current Time: {new Date().toLocaleDateString(undefined, dateTimeOptions)}
             </div>
           </ul>


### PR DESCRIPTION
This attempts to make the header conform to the visual spec in figma a bit closer:
- Right aligns the rightmost informational text.
- Converts the token numbers to their decimal form and limits their precision to 2 decimal places.
- Limits the precision of the percentage to 4 decimal places.
- Makes the time formatting conform to the figma spec (more closely, at least :) ).