### PR TITLE
Fix resolved requests table

### DIFF
--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -68,7 +68,7 @@ function ResolvedRequests() {
   });
 
   return (
-    <div className={classes.root} >
+    <div className={classes.root}>
       <Typography variant="h6" component="h6">
         Resolved Requests
       </Typography>
@@ -106,8 +106,7 @@ function ResolvedRequests() {
           })}
         </TableBody>
       </Table>
-      <Button onClick={clickShowAll} variant="contained"
-          color="primary">
+      <Button onClick={clickShowAll} variant="contained" color="primary">
         Show {showAllResolvedRequests ? "only recently" : "all"} resolved requests
       </Button>
     </div>

--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { drizzleReactHooks } from "drizzle-react";
+import Button from "@material-ui/core/Button";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -67,11 +68,11 @@ function ResolvedRequests() {
   });
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} >
       <Typography variant="h6" component="h6">
         Resolved Requests
       </Typography>
-      <Table>
+      <Table style={{ marginBottom: "10px" }}>
         <TableHead className={classes.tableHeader}>
           <TableRow>
             <TableCell className={classes.tableHeaderCell}>Price Feed</TableCell>
@@ -105,9 +106,10 @@ function ResolvedRequests() {
           })}
         </TableBody>
       </Table>
-      <a href="#" onClick={clickShowAll}>
+      <Button onClick={clickShowAll} variant="contained"
+          color="primary">
         Show {showAllResolvedRequests ? "only recently" : "all"} resolved requests
-      </a>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
This modifies the resolved requests table in two ways:
- Fixes the event queries so they pick up past resolved requests (we forgot to add the `fromBlock` key).
- Adds a "Show all" button at the bottom to optionally toggle showing all past requests instead of just the ones from the last round id. We may want to limit this to some arbitrary number of rounds (like 100) in the future, but for now, it seems to be relatively snappy with 30 or 40.