### PR TITLE
Set `baseUrl` from jsconfig.json file

### DIFF
--- a/sponsor-dapp-v2/jsconfig.json
+++ b/sponsor-dapp-v2/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}


### PR DESCRIPTION
This setting allows imports such as `import routes from "lib/routes";`
rather than `import routes from "../../lib/routes";`. The code in
sponsor-dapp-v2 relies on imports relative to `src`.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>