### PR TITLE
Add data to View Positions page

### DIFF
--- a/sponsor-dapp-v2/package.json
+++ b/sponsor-dapp-v2/package.json
@@ -8,7 +8,7 @@
     "moment": "^2.24.0",
     "node-sass": "^4.12.0",
     "drizzle": "github:UMAprotocol/drizzle#1.4.0-fix2",
-    "drizzle-react": "^1.3.0",
+    "drizzle-react": "github:UMAprotocol/drizzle-react#develop",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.0",

--- a/sponsor-dapp-v2/src/components/Position.js
+++ b/sponsor-dapp-v2/src/components/Position.js
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import Tooltip from "components/common/Tooltip";
 
 function Position(props) {
-  const { position } = props;
+  const { position, index, totalLength } = props;
 
   return (
     <div className="position">
@@ -23,7 +23,9 @@ function Position(props) {
           <li>Liquidation price: {position.liquidationPrice}</li>
         </ul>
 
-        <span className="status">1 of 2</span>
+        <span className="status">
+          {index + 1} of {totalLength}
+        </span>
       </div>
 
       <div className="position__body">

--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -1,0 +1,59 @@
+import { drizzleReactHooks } from "drizzle-react";
+
+export function useNumRegisteredContracts() {
+  const { useCacheCall } = drizzleReactHooks.useDrizzle();
+  const account = drizzleReactHooks.useDrizzleState(drizzleState => {
+    return drizzleState.accounts[0];
+  });
+
+  const registeredContracts = useCacheCall("Registry", "getRegisteredDerivatives", account);
+
+  if (account && registeredContracts) {
+    return registeredContracts.length;
+  }
+
+  return undefined;
+}
+
+export function useEtherscanUrl() {
+  const networkId = drizzleReactHooks.useDrizzleState(drizzleState => {
+    return drizzleState.web3.networkId;
+  });
+
+  switch (networkId.toString()) {
+    case "1":
+      return "https://etherscan.io/";
+    case "3":
+      return "https://ropsten.etherscan.io/";
+    case "42":
+      return "https://kovan.etherscan.io/";
+    default:
+      // Default to mainnet, even though it won't work for ganache runs.
+      return "https://etherscan.io/";
+  }
+}
+
+export function useFaucetUrls() {
+  const networkId = drizzleReactHooks.useDrizzleState(drizzleState => {
+    return drizzleState.web3.networkId;
+  });
+
+  switch (networkId.toString()) {
+    case "1":
+      return {};
+    case "3":
+      return {
+        eth: "https://faucet.metamask.io/",
+        // TODO(mrice32): put a real DAI faucet link here.
+        dai: "https://faucet.metamask.io/"
+      };
+    case "42":
+      return {
+        eth: "https://faucet.kovan.network/",
+        // TODO(mrice32): put a real DAI faucet link here.
+        dai: "https://faucet.kovan.network/"
+      };
+    default:
+      return {};
+  }
+}

--- a/sponsor-dapp-v2/src/views/Landing.js
+++ b/sponsor-dapp-v2/src/views/Landing.js
@@ -1,13 +1,24 @@
-import React, { Component } from "react";
-import { Link } from "react-router-dom";
+import React from "react";
+import { Link, Redirect } from "react-router-dom";
+import { useNumRegisteredContracts } from "lib/custom-hooks";
 
 import IconSvgComponent from "components/common/IconSvgComponent";
 
 import Header from "components/common/Header";
 import Footer from "components/common/Footer";
 
-class Landing extends Component {
-  render() {
+function Landing() {
+  const numContracts = useNumRegisteredContracts();
+
+  function render() {
+    if (numContracts === undefined) {
+      return null;
+    }
+
+    if (numContracts !== 0) {
+      return <Redirect to="/ViewPositions" />;
+    }
+
     return (
       <div className="wrapper">
         <Header />
@@ -85,6 +96,7 @@ class Landing extends Component {
       </div>
     );
   }
+  return render();
 }
 
 export default Landing;

--- a/sponsor-dapp-v2/src/views/Start.js
+++ b/sponsor-dapp-v2/src/views/Start.js
@@ -1,15 +1,21 @@
-import React, { Component } from "react";
+import React from "react";
 import { connect } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
+import { useNumRegisteredContracts, useFaucetUrls } from "lib/custom-hooks";
 
 import Header from "components/common/Header";
 
-class StartScreen extends Component {
-  render() {
-    const { landingPositions } = this.props;
+function StartScreen() {
+  const numContracts = useNumRegisteredContracts();
+  const faucetUrls = useFaucetUrls();
 
-    if (!landingPositions) {
+  function render() {
+    if (numContracts === undefined) {
       return null;
+    }
+
+    if (numContracts !== 0) {
+      return <Redirect to="/ViewPositions" />;
     }
 
     return (
@@ -25,23 +31,27 @@ class StartScreen extends Component {
                 </Link>
 
                 <div className="section__actions-inner">
-                  <a
-                    href={landingPositions.testnetEthFaucet.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn--grey btn--size1"
-                  >
-                    Testnet ETH faucet
-                  </a>
+                  {faucetUrls.eth ? (
+                    <a
+                      href={faucetUrls.eth}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn btn--grey btn--size1"
+                    >
+                      Testnet ETH faucet
+                    </a>
+                  ) : null}
 
-                  <a
-                    href={landingPositions.testnetDaiFaucet.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn--grey btn--size1"
-                  >
-                    Testnet DAI faucet
-                  </a>
+                  {faucetUrls.dai ? (
+                    <a
+                      href={faucetUrls.dai}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn btn--grey btn--size1"
+                    >
+                      Testnet DAI faucet
+                    </a>
+                  ) : null}
                 </div>
               </div>
 
@@ -66,6 +76,8 @@ class StartScreen extends Component {
       </div>
     );
   }
+
+  return render();
 }
 
 export default connect(

--- a/sponsor-dapp-v2/src/views/ViewPositions.js
+++ b/sponsor-dapp-v2/src/views/ViewPositions.js
@@ -1,16 +1,150 @@
-import React, { Component } from "react";
+import React from "react";
 import { connect } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
+import { drizzleReactHooks } from "drizzle-react";
+import TokenizedDerivative from "contracts/TokenizedDerivative.json";
+import { formatWei, formatWithMaxDecimals } from "common/FormattingUtils";
+import { useEtherscanUrl, useFaucetUrls } from "lib/custom-hooks";
 
 import Header from "components/common/Header";
 import Position from "components/Position";
 
-class ViewPositions extends Component {
-  render() {
-    const { landingPositions } = this.props;
+const BigNumber = require("bignumber.js");
 
-    if (!landingPositions) {
+function usePositionList() {
+  const { drizzle, useCacheCallPromise } = drizzleReactHooks.useDrizzle();
+  const { web3 } = drizzle;
+  const account = drizzleReactHooks.useDrizzleStatePromise((drizzleState, resolvePromise) => {
+    if (drizzleState.accounts[0]) {
+      resolvePromise(drizzleState.accounts[0]);
+    }
+  });
+
+  const registeredContracts = useCacheCallPromise("Registry", "getRegisteredDerivatives", account);
+
+  const finishedAddingContracts = drizzleReactHooks.useDrizzleStatePromise(
+    (drizzleState, resolvePromise, registeredContractsResolved) => {
+      let finished = true;
+
+      for (const registeredContract of registeredContractsResolved) {
+        const contractAddress = registeredContract.derivativeAddress;
+        if (!drizzleState.contracts[contractAddress]) {
+          finished = false;
+          drizzle.addContract({
+            contractName: contractAddress,
+            web3Contract: new drizzle.web3.eth.Contract(TokenizedDerivative.abi, contractAddress)
+          });
+        }
+      }
+
+      if (finished) {
+        resolvePromise(true);
+      }
+    },
+    [registeredContracts]
+  );
+
+  const etherscanUrl = useEtherscanUrl();
+
+  const positions = useCacheCallPromise(
+    "NotApplicable",
+    (
+      contractCall,
+      resolvePromise,
+      registeredContractsResolved,
+      accountResolved,
+      etherscanPrefix,
+      finishedAddingContracts
+    ) => {
+      let finished = true;
+
+      const call = (contractName, methodName, ...args) => {
+        const callResult = contractCall(contractName, methodName, ...args);
+        if (callResult === undefined) {
+          finished = false;
+        }
+        return callResult;
+      };
+
+      // Added a strange number as the fallback so it's obvious if this number ever makes it to the user.
+      const formatTokenAmounts = valInWei =>
+        valInWei ? formatWithMaxDecimals(formatWei(valInWei, web3), 4, false) : "-999999999";
+
+      const positions = registeredContractsResolved.map(registeredContract => {
+        const contractAddress = registeredContract.derivativeAddress;
+        const name = call(contractAddress, "name");
+        const totalSupply = formatTokenAmounts(call(contractAddress, "totalSupply"));
+        const yourSupply = formatTokenAmounts(call(contractAddress, "balanceOf", accountResolved));
+        const netPosition = BigNumber(yourSupply)
+          .minus(BigNumber(totalSupply))
+          .toString();
+        return {
+          address: {
+            display: contractAddress,
+            link: `${etherscanPrefix}/address/${contractAddress}`
+          },
+          tokenName: name,
+          // TODO(mrice32): compute real liquidation price rather than hardcoding.
+          liquidationPrice: "$14,000",
+          exposures: [
+            {
+              type: "tokenFacility",
+              items: {
+                // TODO(mrice32): not sure if this is just the name of the token or the leverage + underlying.
+                direction: `Short ${name}`,
+                totalExposure: totalSupply,
+                yourExposure: totalSupply
+              }
+            },
+            {
+              type: "tokens",
+              items: {
+                direction: `Long ${name}`,
+                totalExposure: totalSupply,
+                yourExposure: yourSupply
+              }
+            },
+            {
+              type: "netExposure",
+              items: {
+                direction: "Flat Risk",
+                totalExposure: "",
+                yourExposure: netPosition
+              }
+            }
+          ]
+        };
+      });
+
+      if (finished) {
+        resolvePromise(positions);
+      }
+    },
+    registeredContracts,
+    account,
+    etherscanUrl,
+    finishedAddingContracts
+  );
+
+  drizzleReactHooks.useRerenderOnResolution(positions);
+
+  return positions.isResolved ? positions.resolvedValue : undefined;
+}
+
+function ViewPositions() {
+  const positions = usePositionList();
+  const faucetUrls = useFaucetUrls();
+
+  function render() {
+    // TODO(mrice32): should we have some sort of loading screen to show while data is being pulled?
+    if (positions === undefined) {
       return null;
+    }
+
+    // TODO(mrice32): potentially merge Start and ViewPositions pages to simplify.
+    // Always redirect to the start screen if there are no positions.
+    if (positions.length === 0) {
+      return <Redirect to="/Start" />;
     }
 
     return (
@@ -26,23 +160,27 @@ class ViewPositions extends Component {
                 </Link>
 
                 <div className="section__actions-inner">
-                  <a
-                    href={landingPositions.testnetEthFaucet.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn--grey btn--size1"
-                  >
-                    Testnet ETH faucet
-                  </a>
+                  {faucetUrls.eth ? (
+                    <a
+                      href={faucetUrls.eth}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn btn--grey btn--size1"
+                    >
+                      Testnet ETH faucet
+                    </a>
+                  ) : null}
 
-                  <a
-                    href={landingPositions.testnetDaiFaucet.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn--grey btn--size1"
-                  >
-                    Testnet DAI faucet
-                  </a>
+                  {faucetUrls.dai ? (
+                    <a
+                      href={faucetUrls.dai}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn btn--grey btn--size1"
+                    >
+                      Testnet DAI faucet
+                    </a>
+                  ) : null}
                 </div>
               </div>
 
@@ -50,8 +188,15 @@ class ViewPositions extends Component {
                 <h2>Current risk exposure</h2>
 
                 <div className="positions">
-                  {landingPositions.positions.map((position, pIdx) => {
-                    return <Position key={`position-${pIdx}`} position={position} />;
+                  {positions.map((position, pIdx, positionsArr) => {
+                    return (
+                      <Position
+                        key={`position-${pIdx}`}
+                        position={position}
+                        index={pIdx}
+                        totalLength={positionsArr.length}
+                      />
+                    );
                   })}
                 </div>
               </div>
@@ -75,6 +220,8 @@ class ViewPositions extends Component {
       </div>
     );
   }
+
+  return render();
 }
 
 export default connect(


### PR DESCRIPTION
A few notes:
- This moves us to using a forked version of drizzle react that includes a promise-based `useCacheCall` and `useDrizzleState`.
- I kept the render functions (as we did in a previous PR) to make the diff easier to read. Will remove these in a future PR.
- I left the `liquidationPrice` hardcoded - we agreed that we would write that logic in a future PR as it's needed in a few places.
- I added real links to the ETH faucets for ropsten and kovan, but we still need to determine where to link for the DAI faucets.
- For mainnet and ganache, since there are no faucets, I added logic to omit the faucet buttons from the render.
- I'm not sure what labels and units we wanted to use for the table on the View Positions page, so I used the token names and the quantities of tokens since that was the simplest to compute - my guess is that these will likely change.

Fixes #607.