### PR TITLE
Rewrite withdraw view with real data

### DIFF
--- a/sponsor-dapp-v2/src/lib/routes.js
+++ b/sponsor-dapp-v2/src/lib/routes.js
@@ -14,7 +14,7 @@ const routes = [
   { path: "/Steps", component: Steps, exact: false },
   { path: "/ViewPositions", component: ViewPositions, exact: false },
   { path: "/ManagePositions/:tokenAddress", component: ManagePositions, exact: false },
-  { path: "/Withdraw", component: Withdraw, exact: false },
+  { path: "/Withdraw/:tokenAddress", component: Withdraw, exact: false },
   { path: "/Deposit", component: Deposit, exact: false },
   { path: "/Borrow", component: Borrow, exact: false },
   { path: "/Repay", component: Repay, exact: false }

--- a/sponsor-dapp-v2/src/views/ManagePositions.js
+++ b/sponsor-dapp-v2/src/views/ManagePositions.js
@@ -86,12 +86,14 @@ function useFinancialContractData(tokenAddress) {
     denominator.isZero()
       ? "0"
       : toBN(numerator)
-          .div(denominator)
-          .muln(100);
+          .muln(100)
+          .div(denominator);
 
   const totalSupplyBn = toBN(data.totalSupply);
   data.tokenOwnershipPercentage = computeSafePercentage(data.tokenBalance, totalSupplyBn);
-  data.tokenOwnershipValue = totalSupplyBn.mul(toBN(data.tokenValue)).div(scalingFactor);
+  data.tokenOwnershipValue = toBN(data.tokenBalance)
+    .mul(toBN(data.tokenValue))
+    .div(scalingFactor);
   const navBn = toBN(data.nav);
   const shortMarginBalanceBn = toBN(data.shortMarginBalance);
   data.totalHoldings = navBn.add(shortMarginBalanceBn);
@@ -130,7 +132,8 @@ function ManagePositions(props) {
     drizzle: { web3 }
   } = drizzleReactHooks.useDrizzle();
 
-  const data = useFinancialContractData(props.match.params.tokenAddress);
+  const { tokenAddress } = props.match.params;
+  const data = useFinancialContractData(tokenAddress);
   if (!data.ready) {
     return <div>Loading data</div>;
   }
@@ -246,12 +249,14 @@ function ManagePositions(props) {
 
                           <td>
                             <strong>
-                              {format(data.totalHoldings)} DAI ({data.collateralizationRatio}%)
+                              {format(data.totalHoldings)} DAI ({data.collateralizationRatio.toString()}%)
                             </strong>
                           </td>
 
                           <td>
-                            <strong>(min. {data.minCollateralizationPercentage}% needed to avoid liquidation)</strong>
+                            <strong>
+                              (min. {data.minCollateralizationPercentage.toString()}% needed to avoid liquidation)
+                            </strong>
                           </td>
                         </tr>
 
@@ -296,7 +301,7 @@ function ManagePositions(props) {
                   </div>
 
                   <div className="detail-box__actions">
-                    <Link to="/Withdraw" className="btn">
+                    <Link to={"/Withdraw/" + tokenAddress} className="btn">
                       <span>Withdraw collateral</span>
                     </Link>
 
@@ -346,7 +351,7 @@ function ManagePositions(props) {
 
                           <td>
                             <strong>
-                              {format(data.tokenBalance)} ({data.tokenOwnershipPercentage}%)
+                              {format(data.tokenBalance)} ({data.tokenOwnershipPercentage.toString()}%)
                             </strong>
                           </td>
 


### PR DESCRIPTION
Far from the ideal implementation. Because the original Withdraw component wasn't parameterized based on any incoming data, I pretty much had to scrap and rewrite it.

Some of this code could definitely be broken up/reused, but I want to write the Deposit component first, to get a better handle on the shared vs. unique logic.

Fix some percentage related bugs in ManagePositions.
Also fix a bug in ManagePositions where token value was calculated based
on the total supply, not the user's balance.

Issue #604.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>