### PR TITLE
Re-add registry to store

### DIFF
--- a/sponsor-dapp-v2/src/drizzleOptions.js
+++ b/sponsor-dapp-v2/src/drizzleOptions.js
@@ -1,7 +1,8 @@
 import Finder from "contracts/Finder.json";
+import Registry from "contracts/Registry.json";
 
 const options = {
-  contracts: [Finder],
+  contracts: [Registry, Finder],
   polls: {
     accounts: 3500,
     blocks: 3000


### PR DESCRIPTION
A previous PR broke parts of the dApp that were depending on the Registry contract to query existing TokenizedDerivatives.