### PR TITLE
Update text input regex to allow decimals

### DIFF
--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -63,7 +63,7 @@ export function useTextInput() {
   const [amount, setAmount] = useState("");
   const handleChangeAmount = event => {
     // Regular expression that matches a decimal, e.g., `2.5`.
-    if (/^(\d+\.?\d*)$/.test(event.target.value)) {
+    if (event.target.value === "" || /^(\d+\.?\d*)$/.test(event.target.value)) {
       setAmount(event.target.value);
     }
   };

--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -62,8 +62,8 @@ export function useFaucetUrls() {
 export function useTextInput() {
   const [amount, setAmount] = useState("");
   const handleChangeAmount = event => {
-    // Check if regex number matches
-    if (/^(\s*|\d+)$/.test(event.target.value)) {
+    // Regular expression that matches a decimal, e.g., `2.5`.
+    if (/^(\d+\.?\d*)$/.test(event.target.value)) {
       setAmount(event.target.value);
     }
   };


### PR DESCRIPTION
Note that this regex isn't perfect. It'll allow some corner cases like "2." and disallow some cases like ".2" (but "0.2" will work).

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>