### PR TITLE
Fix icons not loading by properly loading assets from public folder

### DIFF
--- a/sponsor-dapp-v2/src/components/common/IconSvgComponent.js
+++ b/sponsor-dapp-v2/src/components/common/IconSvgComponent.js
@@ -13,7 +13,7 @@ const IconSvgComponent = ({ iconPath, additionalClass }) => {
     classAddition = "";
   }
 
-  return <ReactSVG src={iconPath} className={`svg-icon ${classAddition}`} />;
+  return <ReactSVG src={process.env.PUBLIC_URL.concat('/', iconPath)} className={`svg-icon ${classAddition}`} />;
 };
 
 export default IconSvgComponent;

--- a/sponsor-dapp-v2/src/components/common/IconSvgComponent.js
+++ b/sponsor-dapp-v2/src/components/common/IconSvgComponent.js
@@ -13,7 +13,7 @@ const IconSvgComponent = ({ iconPath, additionalClass }) => {
     classAddition = "";
   }
 
-  return <ReactSVG src={process.env.PUBLIC_URL.concat('/', iconPath)} className={`svg-icon ${classAddition}`} />;
+  return <ReactSVG src={process.env.PUBLIC_URL.concat("/", iconPath)} className={`svg-icon ${classAddition}`} />;
 };
 
 export default IconSvgComponent;


### PR DESCRIPTION
The icons are stored as files in `public/svg`, and we need to explicitly
prefix paths relative to `public` with `process.env.PUBLIC_URL`.

Fixes #628.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>