### PR TITLE
Restructure Steps 1-3

### DIFF
--- a/sponsor-dapp-v2/src/components/Step1.js
+++ b/sponsor-dapp-v2/src/components/Step1.js
@@ -1,34 +1,42 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 
 import classNames from "classnames";
+import web3 from "web3";
 
 import Dropdown from "components/common/Dropdown";
+import { useEnabledIdentifierConfig } from "lib/custom-hooks";
 
-class Step1 extends Component {
-  constructor(props) {
-    super(props);
+function Step1(props) {
+  const [state, setState] = useState({
+    allowedToProceed: false
+  });
 
-    this.state = {
-      allowedToProceed: false
-    };
+  const identifierConfig = useEnabledIdentifierConfig();
 
-    this.dropdown = React.createRef();
-  }
-
-  checkProceeding = (status, selectedIdentifier) => {
-    this.props.chosenIdentifierRef.current = selectedIdentifier;
-    this.setState({
+  const checkProceeding = (status, selectedIdentifier) => {
+    props.userSelectionsRef.current.identifier = selectedIdentifier;
+    setState({
       allowedToProceed: status
     });
   };
 
-  render() {
-    const { identifierConfig } = this.props;
+  const render = () => {
+    if (!identifierConfig) {
+      return null;
+    }
+
+    const { toBN, toWei, fromWei } = web3.utils;
 
     const dropdownData = Object.keys(identifierConfig).map(identifier => {
+      // Use BN rather than JS number to avoid precision issues.
+      const collatReq = fromWei(
+        toBN(toWei(identifierConfig[identifier].supportedMove))
+          .add(toBN(toWei("1")))
+          .muln(100)
+      );
       return {
         key: identifier,
-        value: `${identifier} (${identifierConfig[identifier].collateralRequirement})`
+        value: `${identifier} (${collatReq}%)`
       };
     });
 
@@ -53,20 +61,19 @@ class Step1 extends Component {
         <div className="step__aside">
           <div className="step__entry">
             <Dropdown
-              ref={this.dropdown}
               placeholder="Select synthetic asset"
               list={dropdownData}
-              onChange={this.checkProceeding}
-              initialKeySelection={this.props.chosenIdentifierRef.current}
+              onChange={checkProceeding}
+              initialKeySelection={props.userSelectionsRef.current.identifier}
             />
           </div>
 
           <div className="step__actions">
             <a
               href="test"
-              onClick={this.props.onNextStep}
+              onClick={props.onNextStep}
               className={classNames("btn", {
-                disabled: !this.state.allowedToProceed
+                disabled: !state.allowedToProceed
               })}
             >
               Next
@@ -75,7 +82,9 @@ class Step1 extends Component {
         </div>
       </div>
     );
-  }
+  };
+
+  return render();
 }
 
 export default Step1;

--- a/sponsor-dapp-v2/src/components/Step2.js
+++ b/sponsor-dapp-v2/src/components/Step2.js
@@ -1,32 +1,35 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 
 import moment from "moment";
 import classNames from "classnames";
 
 import Dropdown from "components/common/Dropdown";
+import { useIdentifierConfig } from "lib/custom-hooks";
 
-class Step2 extends Component {
-  constructor(props) {
-    super(props);
+function Step2(props) {
+  const [state, setState] = useState({
+    allowedToProceed: false
+  });
 
-    this.state = {
-      allowedToProceed: false
-    };
-
-    this.dropdown = React.createRef();
-  }
-
-  checkProceeding = (status, selectedExpiry) => {
-    this.props.chosenExpiryRef.current = selectedExpiry;
-    this.setState({
+  const checkProceeding = (status, selectedExpiry) => {
+    props.userSelectionsRef.current.expiry = selectedExpiry;
+    setState({
       allowedToProceed: status
     });
   };
 
-  render() {
-    const { identifierConfig, chosenIdentifier } = this.props;
+  const identifierConfig = useIdentifierConfig();
 
-    const timeline = identifierConfig[chosenIdentifier].expiries.map(expiry => {
+  const render = () => {
+    if (!identifierConfig) {
+      return null;
+    }
+
+    const {
+      userSelectionsRef: { current: selection }
+    } = props;
+
+    const timeline = identifierConfig[selection.identifier].expiries.map(expiry => {
       return {
         key: expiry,
         value: moment.unix(expiry).format("MMMM DD, YYYY LTS")
@@ -48,24 +51,23 @@ class Step2 extends Component {
         <div className="step__aside">
           <div className="step__entry">
             <Dropdown
-              ref={this.dropdown}
               placeholder="Select settlement date"
               list={timeline}
-              onChange={this.checkProceeding}
-              initialKeySelection={this.props.chosenExpiryRef.current}
+              onChange={checkProceeding}
+              initialKeySelection={selection.expiry}
             />
           </div>
 
           <div className="step__actions">
-            <a href="test" className="btn btn--alt" onClick={this.props.onPrevStep}>
+            <a href="test" className="btn btn--alt" onClick={props.onPrevStep}>
               Back
             </a>
 
             <a
               href="test"
-              onClick={this.props.onNextStep}
+              onClick={props.onNextStep}
               className={classNames("btn", {
-                disabled: !this.state.allowedToProceed
+                disabled: !state.allowedToProceed
               })}
             >
               Next
@@ -74,7 +76,9 @@ class Step2 extends Component {
         </div>
       </div>
     );
-  }
+  };
+
+  return render();
 }
 
 export default Step2;

--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 
 import classNames from "classnames";
+import moment from "moment";
 
 import IconSvgComponent from "components/common/IconSvgComponent";
 
@@ -8,13 +9,33 @@ class Step3 extends Component {
   constructor(props) {
     super(props);
 
+    const { name, symbol } = this.getContractNameAndSymbol();
+
     this.state = {
       allowedToProceed: true,
       isLoading: false,
-      contractName: this.props.contractName,
+      contractName: name,
       editingContractName: false,
-      tokenSymbol: this.props.tokenSymbol,
+      tokenSymbol: symbol,
       editingTokenSymbol: false
+    };
+  }
+
+  getContractNameAndSymbol() {
+    // The date is supposed to look like Sep19 in the token name.
+    const date = moment.unix(this.props.expiry).format("MMMDD");
+
+    // TODO(mrice32): figure out how this hash is supposed to be generated.
+    const hash = "0x1234";
+
+    // Strip the "/" character from the string, so it appears as BTCUSD rather than BTC/USD.
+    const asset = this.props.asset.replace("/", "");
+
+    const assetShort = asset.substr(0, 3);
+
+    return {
+      name: `${asset}_${date}_${hash}`,
+      symbol: `${assetShort}${hash}`
     };
   }
 
@@ -84,15 +105,16 @@ class Step3 extends Component {
           <div className="step__entry">
             <ul className="list-selections">
               <li>
-                Assets: <span>{this.props.assets}</span>
+                Asset: <span>{this.props.asset}</span>
               </li>
 
               <li>
-                Collateralization requirement: <span>{this.props.requirement}</span>
+                Collateralization requirement:{" "}
+                <span>{Math.round((Number(this.props.requirement) + 1) * 10000) / 100}%</span>
               </li>
 
               <li>
-                Expiry: <span>{this.props.expiry}</span>
+                Expiry: <span>{moment.unix(this.props.expiry).format("MMMM DD, YYYY LTS")}</span>
               </li>
 
               <li>

--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -1,97 +1,120 @@
-import React, { Component } from "react";
+import React, { useState, useRef } from "react";
 
 import classNames from "classnames";
 import moment from "moment";
+import web3 from "web3";
 
 import IconSvgComponent from "components/common/IconSvgComponent";
+import { useIdentifierConfig } from "lib/custom-hooks";
 
-class Step3 extends Component {
-  constructor(props) {
-    super(props);
+function getContractNameAndSymbol(selections) {
+  // The date is supposed to look like Sep19 in the token name.
+  const date = moment.unix(selections.expiry).format("MMMDD");
 
-    const { name, symbol } = this.getContractNameAndSymbol();
+  // TODO(mrice32): nice to have - predict the first 4 digits of the deployed contract hash.
+  const hash = web3.utils.randomHex(2);
 
-    this.state = {
-      allowedToProceed: true,
-      isLoading: false,
-      contractName: name,
-      editingContractName: false,
-      tokenSymbol: symbol,
-      editingTokenSymbol: false
-    };
-  }
+  // Strip the "/" character from the string, so it appears as BTCUSD rather than BTC/USD.
+  const asset = selections.identifier.replace("/", "");
 
-  getContractNameAndSymbol() {
-    // The date is supposed to look like Sep19 in the token name.
-    const date = moment.unix(this.props.expiry).format("MMMDD");
+  const assetShort = asset.substr(0, 3);
 
-    // TODO(mrice32): figure out how this hash is supposed to be generated.
-    const hash = "0x1234";
-
-    // Strip the "/" character from the string, so it appears as BTCUSD rather than BTC/USD.
-    const asset = this.props.asset.replace("/", "");
-
-    const assetShort = asset.substr(0, 3);
-
-    return {
-      name: `${asset}_${date}_${hash}`,
-      symbol: `${assetShort}${hash}`
-    };
-  }
-
-  checkProceeding = status => {
-    this.setState({
-      allowedToProceed: status
-    });
+  // If either of these have been edited previously, use the previous value.
+  return {
+    name: selections.name ? selections.name : `${asset}_${date}_${hash}`,
+    symbol: selections.symbol ? selections.symbol : `${assetShort}${hash}`
   };
+}
 
-  handleClick(event) {
+function Step3(props) {
+  const {
+    userSelectionsRef: { current: selections }
+  } = props;
+
+  const { name, symbol } = getContractNameAndSymbol(selections);
+
+  const identifierConfig = useIdentifierConfig();
+
+  const [state, setState] = useState({
+    allowedToProceed: true,
+    isLoading: false,
+    contractName: name,
+    editingContractName: false,
+    tokenSymbol: symbol,
+    editingTokenSymbol: false
+  });
+
+  const contractNameTextRef = useRef(null);
+  const contractSymbolTextRef = useRef(null);
+
+  const handleClick = event => {
     event.preventDefault();
     event.persist();
 
-    this.setState(
-      {
-        isLoading: true
-      },
-      () => this.props.onNextStep(event)
-    );
-  }
+    setState(oldState => ({
+      ...oldState,
+      isLoading: true
+    }));
 
-  editContractName = () => {
-    this.setState({
-      editingContractName: true
-    });
+    props.onNextStep(event);
   };
 
-  saveContractName = event => {
+  const editContractName = () => {
+    setState(oldState => ({
+      ...oldState,
+      editingContractName: true
+    }));
+  };
+
+  const saveContractName = event => {
     event.preventDefault();
 
-    let val = this.refs.contractNameText.value;
+    let val = contractNameTextRef.current.value;
 
-    this.setState({
+    // Only persist the name at a higher level if it was changed.
+    if (val !== state.contractName) {
+      props.userSelectionsRef.current.name = val;
+    }
+
+    setState(oldState => ({
+      ...oldState,
       contractName: val,
       editingContractName: false
-    });
+    }));
   };
 
-  editTokenSymbol = () => {
-    this.setState({
+  const editTokenSymbol = () => {
+    setState(oldState => ({
+      ...oldState,
       editingTokenSymbol: true
-    });
+    }));
   };
 
-  saveTokenSymbol = event => {
+  const saveTokenSymbol = event => {
     event.preventDefault();
 
-    let val = this.refs.tokenSymbolText.value;
+    let val = contractSymbolTextRef.current.value;
 
-    this.setState({
+    // Only persist the symbol at a higher level if it was changed.
+    if (val !== state.tokenSymbol) {
+      props.userSelectionsRef.current.symbol = val;
+    }
+
+    setState(oldState => ({
+      ...oldState,
       tokenSymbol: val,
       editingTokenSymbol: false
-    });
+    }));
   };
 
-  render() {
+  const render = () => {
+    const { toBN, toWei, fromWei } = web3.utils;
+    // Use BN rather than JS number to avoid precision issues.
+    const collatReq = fromWei(
+      toBN(toWei(identifierConfig[selections.identifier].supportedMove))
+        .add(toBN(toWei("1")))
+        .muln(100)
+    );
     return (
       <div className="step step--tertiary">
         <div className="step__content">
@@ -105,38 +128,37 @@ class Step3 extends Component {
           <div className="step__entry">
             <ul className="list-selections">
               <li>
-                Asset: <span>{this.props.asset}</span>
+                Asset: <span>{selections.identifier}</span>
               </li>
 
               <li>
-                Collateralization requirement:{" "}
-                <span>{Math.round((Number(this.props.requirement) + 1) * 10000) / 100}%</span>
+                Collateralization requirement: <span>{collatReq}%</span>
               </li>
 
               <li>
-                Expiry: <span>{moment.unix(this.props.expiry).format("MMMM DD, YYYY LTS")}</span>
+                Expiry: <span>{moment.unix(selections.expiry).format("MMMM DD, YYYY LTS")}</span>
               </li>
 
               <li>
                 Contract name:
-                {!this.state.editingContractName && (
+                {!state.editingContractName && (
                   <span className="text">
-                    {this.state.contractName}
+                    {state.contractName}
 
-                    <button type="button" className="btn-edit" onClick={this.editContractName}>
+                    <button type="button" className="btn-edit" onClick={editContractName}>
                       <IconSvgComponent iconPath="svg/ico-edit.svg" additionalClass="ico-edit" />
                     </button>
                   </span>
                 )}
-                {this.state.editingContractName && (
+                {state.editingContractName && (
                   <div className="form-edit">
-                    <form action="#" method="post" onSubmit={e => this.saveContractName(e)}>
+                    <form action="#" method="post" onSubmit={e => saveContractName(e)}>
                       <div className="form__controls">
                         <input
                           type="text"
                           className="field"
-                          ref="contractNameText"
-                          defaultValue={this.state.contractName}
+                          ref={contractNameTextRef}
+                          defaultValue={state.contractName}
                         />
                       </div>
 
@@ -152,24 +174,24 @@ class Step3 extends Component {
 
               <li>
                 Token symbol:
-                {!this.state.editingTokenSymbol && (
+                {!state.editingTokenSymbol && (
                   <span className="text">
-                    {this.state.tokenSymbol}
+                    {state.tokenSymbol}
 
-                    <button type="button" className="btn-edit" onClick={this.editTokenSymbol}>
+                    <button type="button" className="btn-edit" onClick={editTokenSymbol}>
                       <IconSvgComponent iconPath="svg/ico-edit.svg" additionalClass="ico-edit" />
                     </button>
                   </span>
                 )}
-                {this.state.editingTokenSymbol && (
+                {state.editingTokenSymbol && (
                   <div className="form-edit">
-                    <form action="#" method="post" onSubmit={e => this.saveTokenSymbol(e)}>
+                    <form action="#" method="post" onSubmit={e => saveTokenSymbol(e)}>
                       <div className="form__controls">
                         <input
                           type="text"
                           className="field"
-                          ref="tokenSymbolText"
-                          defaultValue={this.state.tokenSymbol}
+                          ref={contractSymbolTextRef}
+                          defaultValue={state.tokenSymbol}
                         />
                       </div>
 
@@ -186,16 +208,16 @@ class Step3 extends Component {
           </div>
 
           <div className="step__actions">
-            <a href="test" className="btn btn--alt" onClick={this.props.onPrevStep}>
+            <a href="test" className="btn btn--alt" onClick={props.onPrevStep}>
               Back
             </a>
 
             <a
               href="test"
-              onClick={e => this.handleClick(e)}
+              onClick={e => handleClick(e)}
               className={classNames("btn has-loading", {
-                disabled: !this.state.allowedToProceed,
-                "is-loading": this.state.isLoading
+                disabled: !state.allowedToProceed,
+                "is-loading": state.isLoading
               })}
             >
               <span>Create Contract</span>
@@ -208,7 +230,8 @@ class Step3 extends Component {
         </div>
       </div>
     );
-  }
+  };
+  return render();
 }
 
 export default Step3;

--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -72,6 +72,8 @@ function Step3(props) {
     let val = contractNameTextRef.current.value;
 
     // Only persist the name at a higher level if it was changed.
+    // Note: the reason we do this is so that a new name is always generated when this page is mounted unless the user
+    // saved a change to this field at some point in the past.
     if (val !== state.contractName) {
       props.userSelectionsRef.current.name = val;
     }
@@ -96,6 +98,8 @@ function Step3(props) {
     let val = contractSymbolTextRef.current.value;
 
     // Only persist the symbol at a higher level if it was changed.
+    // Note: the reason we do this is so that a new symbol is always generated when this page is mounted unless the
+    // user saved a change to this field at some point in the past.
     if (val !== state.tokenSymbol) {
       props.userSelectionsRef.current.symbol = val;
     }

--- a/sponsor-dapp-v2/src/views/Steps.js
+++ b/sponsor-dapp-v2/src/views/Steps.js
@@ -248,11 +248,12 @@ function Steps() {
 
               <CSSTransition in={state.activeStepIndex === 2} timeout={200} classNames="step-3" unmountOnExit>
                 <Step3
-                  assets="BTC/USD"
-                  requirement="110%"
-                  expiry="September 16, 2019 16:00:00 GMT"
-                  contractName="BTCUSD_Sep19_0x1234"
-                  tokenSymbol="BTC0x1234"
+                  asset={chosenIdentifierRef.current}
+                  requirement={
+                    identifierConfig[chosenIdentifierRef.current] &&
+                    identifierConfig[chosenIdentifierRef.current].supportedMove
+                  }
+                  expiry={chosenExpiryRef.current}
                   onNextStep={e => nextStep(e)}
                   onPrevStep={e => prevStep(e)}
                 />


### PR DESCRIPTION
This PR adds the visuals/persistence to step 3 without adding the contract creation. It also restructures Steps 1-3 so that the drizzle calls are done at the lower level components and the higher level component is only for multi-stage persistence and handling transitions between steps.

As a part of this change, I moved the hooks that were previously in `Steps.js` to the `custom-hooks.js` file.