### PR TITLE
Add steps 5 and 6

### DIFF
--- a/sponsor-dapp-v2/src/components/Step6.js
+++ b/sponsor-dapp-v2/src/components/Step6.js
@@ -1,32 +1,38 @@
-import React, { Component } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import classNames from "classnames";
+import { createFormatFunction } from "common/FormattingUtils";
+import { drizzleReactHooks } from "drizzle-react";
+import { useIdentifierConfig, useEtherscanUrl } from "lib/custom-hooks";
 
-class Step6 extends Component {
-  constructor(props) {
-    super(props);
+function Step6(props) {
+  // Grab functions to retrieve/compute displayed variables.
+  const {
+    drizzle: { web3 }
+  } = drizzleReactHooks.useDrizzle();
+  const format = createFormatFunction(web3, 4);
+  const { toWei, toBN } = web3.utils;
 
-    this.state = {
-      allowedToProceed: true
-    };
-  }
+  // Grab variables to display.
+  const { identifier, contractAddress, tokensBorrowed } = props.userSelectionsRef.current;
+  const etherscanUrl = useEtherscanUrl();
+  const {
+    [identifier]: { supportedMove }
+  } = useIdentifierConfig();
+  const collatReq = format(
+    toBN(toWei(supportedMove))
+      .add(toBN(toWei("1")))
+      .muln(100)
+  );
 
-  checkProceeding = status => {
-    this.setState({
-      allowedToProceed: status
-    });
-  };
-
-  render() {
-    const { data } = this.props;
-
+  const render = () => {
     return (
       <div className="step step--tertiary">
         <div className="step__content-alt">
           <p>
-            You have successfully borrowed {this.props.tokens} synthetic tokens tracking {data.identifier}! View token
+            You have successfully borrowed {format(tokensBorrowed)} synthetic tokens tracking {identifier}! View token
             details on{" "}
-            <a href={data.tokenFacilityAddress.link} target="_blank" rel="noopener noreferrer">
+            <a href={`${etherscanUrl}address/${contractAddress}`} target="_blank" rel="noopener noreferrer">
               Etherscan.
             </a>
           </p>
@@ -36,7 +42,7 @@ class Step6 extends Component {
           </p>
 
           <p>
-            <span>Maintain token facility collateralization greater than 110% to avoid liquidation.</span>
+            <span>Maintain token facility collateralization greater than {collatReq}% to avoid liquidation.</span>
           </p>
 
           <p>
@@ -52,7 +58,7 @@ class Step6 extends Component {
             <Link
               to="/ViewPositions"
               className={classNames("btn", {
-                disabled: !this.state.allowedToProceed
+                disabled: false
               })}
             >
               View my risk
@@ -61,7 +67,9 @@ class Step6 extends Component {
         </div>
       </div>
     );
-  }
+  };
+
+  return render();
 }
 
 export default Step6;

--- a/sponsor-dapp-v2/src/views/Steps.js
+++ b/sponsor-dapp-v2/src/views/Steps.js
@@ -20,7 +20,8 @@ function Steps() {
     expiry: null,
     name: null,
     symbol: null,
-    contractAddress: null
+    contractAddress: null,
+    tokensBorrowed: null
   });
 
   const lastSteps = {
@@ -82,21 +83,11 @@ function Steps() {
     stepsNav[currentStepIndex].isActive = false;
     stepsNav[currentStepIndex].isCompleted = true;
 
-    if (currentStepIndex === 4) {
-      setTimeout(() => {
-        setState(oldState => ({
-          ...oldState,
-          activeStepIndex: nextStepIndex,
-          steps: stepsNav
-        }));
-      }, 5000);
-    } else {
-      setState(oldState => ({
-        ...oldState,
-        activeStepIndex: nextStepIndex,
-        steps: stepsNav
-      }));
-    }
+    setState(oldState => ({
+      ...oldState,
+      activeStepIndex: nextStepIndex,
+      steps: stepsNav
+    }));
   };
 
   const prevStep = event => {
@@ -185,11 +176,11 @@ function Steps() {
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 4} timeout={300} classNames="step-5" unmountOnExit>
-                <Step5 data={lastSteps} onNextStep={e => nextStep(e)} />
+                <Step5 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 5} timeout={300} classNames="step-6" unmountOnExit>
-                <Step6 data={lastSteps} tokens="10" />
+                <Step6 userSelectionsRef={userSelectionsRef} />
               </CSSTransition>
             </div>
           </div>


### PR DESCRIPTION
Step 5 allows the user to borrow tokens (effectively the same as the borrow modal) and step 6 just shows a summary and allows the user to jump to the ViewPositions page.

Note: step 5 might be able to take advantage of the `useSendTransactionOnLink` method if it were modified to allow a custom `onSuccess` function. However, I figured that since it was a relatively small amount of code and it would require a refactor that might significantly complicate/change the implementation of the hook, I would leave them separate for now.

Fixes #637.