### PR TITLE
Add rinkeby and create a general public networks config

### DIFF
--- a/common/MigrationUtils.js
+++ b/common/MigrationUtils.js
@@ -23,9 +23,7 @@ function enableControllableTiming(network) {
 
 function shouldCommitDeployment(network) {
   // ci is included here just for testing the process of saving deployments.
-  return (
-    network === "ci" || isPublicNetwork(network)
-  );
+  return network === "ci" || isPublicNetwork(network);
 }
 
 function isEmptyObject(obj) {

--- a/common/MigrationUtils.js
+++ b/common/MigrationUtils.js
@@ -22,8 +22,9 @@ function enableControllableTiming(network) {
 }
 
 function shouldCommitDeployment(network) {
+  // ci is included here just for testing the process of saving deployments.
   return (
-    network === "ci" || isPublicNetwork(network) // Just for testing the process of saving deployments. // Any public network.
+    network === "ci" || isPublicNetwork(network)
   );
 }
 

--- a/common/MigrationUtils.js
+++ b/common/MigrationUtils.js
@@ -23,8 +23,7 @@ function enableControllableTiming(network) {
 
 function shouldCommitDeployment(network) {
   return (
-    network === "ci" || // Just for testing the process of saving deployments.
-    isPublicNetwork(network) // Any public network.
+    network === "ci" || isPublicNetwork(network) // Just for testing the process of saving deployments. // Any public network.
   );
 }
 

--- a/common/PublicNetworks.js
+++ b/common/PublicNetworks.js
@@ -1,0 +1,22 @@
+module.exports = {
+    1: {
+        name: "mainnet",
+        ethFaucet: null,
+        etherscan: "https://etherscan.io/",
+    },
+    3: {
+        name: "ropsten",
+        ethFaucet: "https://faucet.metamask.io/",
+        etherscan: "https://ropsten.etherscan.io/"
+    },
+    4: {
+        name: "rinkeby",
+        ethFaucet: "https://faucet.rinkeby.io/",
+        etherscan: "https://rinkeby.etherscan.io/"
+    },
+    42: {
+        name: "kovan",
+        ethFaucet: "https://faucet.kovan.network/",
+        etherscan: "https://kovan.etherscan.io/"
+    }
+};

--- a/common/PublicNetworks.js
+++ b/common/PublicNetworks.js
@@ -1,22 +1,22 @@
 module.exports = {
-    1: {
-        name: "mainnet",
-        ethFaucet: null,
-        etherscan: "https://etherscan.io/",
-    },
-    3: {
-        name: "ropsten",
-        ethFaucet: "https://faucet.metamask.io/",
-        etherscan: "https://ropsten.etherscan.io/"
-    },
-    4: {
-        name: "rinkeby",
-        ethFaucet: "https://faucet.rinkeby.io/",
-        etherscan: "https://rinkeby.etherscan.io/"
-    },
-    42: {
-        name: "kovan",
-        ethFaucet: "https://faucet.kovan.network/",
-        etherscan: "https://kovan.etherscan.io/"
-    }
+  1: {
+    name: "mainnet",
+    ethFaucet: null,
+    etherscan: "https://etherscan.io/"
+  },
+  3: {
+    name: "ropsten",
+    ethFaucet: "https://faucet.metamask.io/",
+    etherscan: "https://ropsten.etherscan.io/"
+  },
+  4: {
+    name: "rinkeby",
+    ethFaucet: "https://faucet.rinkeby.io/",
+    etherscan: "https://rinkeby.etherscan.io/"
+  },
+  42: {
+    name: "kovan",
+    ethFaucet: "https://faucet.kovan.network/",
+    etherscan: "https://kovan.etherscan.io/"
+  }
 };

--- a/common/gckms/GckmsConfig.js
+++ b/common/gckms/GckmsConfig.js
@@ -29,7 +29,7 @@ function getDefaultStaticConfig() {
   //   locationId: Google Cloud location, e.g., 'global'.
   //   ciphertextBucket: ID of a Google Cloud storage bucket.
   //   ciphertextFilename: Name of a file within `ciphertextBucket`.
-  
+
   const defaultConfig = {
     private: {
       deployer: {},
@@ -51,7 +51,7 @@ function getDefaultStaticConfig() {
     }
   };
 
-   // Add a blank network config for all public networks so they don't fail to process but will fail if selected.
+  // Add a blank network config for all public networks so they don't fail to process but will fail if selected.
   const blankNetworkConfig = {
     deployer: {},
     registry: {},
@@ -70,11 +70,11 @@ function getDefaultStaticConfig() {
 }
 
 function getNetworkName() {
-    if (argv.network in publicNetworkNames) {
-      return argv.network;
-    }
+  if (argv.network in publicNetworkNames) {
+    return argv.network;
+  }
 
-    return "private";
+  return "private";
 }
 
 // Compose the exact config for this network.

--- a/common/gckms/GckmsConfig.js
+++ b/common/gckms/GckmsConfig.js
@@ -4,6 +4,9 @@
 const argv = require("minimist")(process.argv.slice());
 const fs = require("fs");
 
+// Grab the name property from each to get a list of the names of the public networks.
+const publicNetworkNames = Object.values(require("./PublicNetworks.js")).map(elt => elt.name);
+
 // Import the .GckmsOverride.js file if it exists.
 // Note: this file is expected to be present in the same directory as this script.
 let overrideFname = ".GckmsOverride.js";
@@ -26,25 +29,8 @@ function getDefaultStaticConfig() {
   //   locationId: Google Cloud location, e.g., 'global'.
   //   ciphertextBucket: ID of a Google Cloud storage bucket.
   //   ciphertextFilename: Name of a file within `ciphertextBucket`.
-  return {
-    main: {
-      deployer: {},
-      registry: {},
-      store: {},
-      priceFeed: {},
-      sponsorWhitelist: {},
-      returnCalculatorWhitelist: {},
-      marginCurrencyWhitelist: {}
-    },
-    ropsten: {
-      deployer: {},
-      registry: {},
-      store: {},
-      priceFeed: {},
-      sponsorWhitelist: {},
-      returnCalculatorWhitelist: {},
-      marginCurrencyWhitelist: {}
-    },
+  
+  const defaultConfig = {
     private: {
       deployer: {},
       registry: {},
@@ -53,6 +39,7 @@ function getDefaultStaticConfig() {
       sponsorWhitelist: {},
       returnCalculatorWhitelist: {},
       marginCurrencyWhitelist: {},
+      // This is an example to show you what a typical config for a gcloud-stored config might look like.
       example: {
         projectId: "project-name",
         locationId: "asia-east2",
@@ -63,17 +50,31 @@ function getDefaultStaticConfig() {
       }
     }
   };
+
+   // Add a blank network config for all public networks so they don't fail to process but will fail if selected.
+  const blankNetworkConfig = {
+    deployer: {},
+    registry: {},
+    store: {},
+    priceFeed: {},
+    sponsorWhitelist: {},
+    returnCalculatorWhitelist: {},
+    marginCurrencyWhitelist: {}
+  };
+
+  for (name of publicNetworkNames) {
+    defaultConfig[name] = blankNetworkConfig;
+  }
+
+  return defaultConfig;
 }
 
 function getNetworkName() {
-  switch (argv.network) {
-    case "mainnet":
-      return "main";
-    case "ropsten":
-      return "ropsten";
-    default:
-      return "private";
-  }
+    if (argv.network in publicNetworkNames) {
+      return argv.network;
+    }
+
+    return "private";
 }
 
 // Compose the exact config for this network.

--- a/common/gckms/GckmsConfig.js
+++ b/common/gckms/GckmsConfig.js
@@ -5,7 +5,7 @@ const argv = require("minimist")(process.argv.slice());
 const fs = require("fs");
 
 // Grab the name property from each to get a list of the names of the public networks.
-const publicNetworkNames = Object.values(require("./PublicNetworks.js")).map(elt => elt.name);
+const publicNetworkNames = Object.values(require("../PublicNetworks.js")).map(elt => elt.name);
 
 // Import the .GckmsOverride.js file if it exists.
 // Note: this file is expected to be present in the same directory as this script.

--- a/common/gckms/GckmsConfig.js
+++ b/common/gckms/GckmsConfig.js
@@ -70,7 +70,7 @@ function getDefaultStaticConfig() {
 }
 
 function getNetworkName() {
-  if (argv.network in publicNetworkNames) {
+  if (publicNetworkNames.some(name => argv.network === name)) {
     return argv.network;
   }
 

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -73,7 +73,7 @@ function addLocalNetwork(networks, name, customOptions) {
 let networks = {};
 
 // Public networks that need both a mnemonic and GCS ManagedSecretProvider network.
-for (const [name, id] of Object.entries(publicNetworks)) {
+for (const [id, { name }] of Object.entries(publicNetworks)) {
   addPublicNetwork(networks, name, id);
 }
 

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -1,6 +1,7 @@
 const HDWalletProvider = require("truffle-hdwallet-provider");
 const GckmsConfig = require("./gckms/GckmsConfig.js");
 const ManagedSecretProvider = require("./gckms/ManagedSecretProvider.js");
+const publicNetworks = require("./PublicNetworks.js");
 require("dotenv").config();
 
 // Fallback to a public mnemonic to prevent exceptions
@@ -72,9 +73,9 @@ function addLocalNetwork(networks, name, customOptions) {
 let networks = {};
 
 // Public networks that need both a mnemonic and GCS ManagedSecretProvider network.
-addPublicNetwork(networks, "kovan", 42);
-addPublicNetwork(networks, "ropsten", 3);
-addPublicNetwork(networks, "mainnet", 1);
+for (const [name, id] of Object.entries(publicNetworks)) {
+  addPublicNetwork(networks, name, id);
+}
 
 // CI requires a specific port and network ID because of peculiarities of the environment.
 addLocalNetwork(networks, "ci", { port: 8545, network_id: 1234 });

--- a/core/migrations/11_deploy_tokenized_derivative_creator.js
+++ b/core/migrations/11_deploy_tokenized_derivative_creator.js
@@ -3,7 +3,13 @@ const TokenizedDerivativeCreator = artifacts.require("TokenizedDerivativeCreator
 const TokenizedDerivativeUtils = artifacts.require("TokenizedDerivativeUtils");
 const LeveragedReturnCalculator = artifacts.require("LeveragedReturnCalculator");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
-const { getKeysForNetwork, deploy, enableControllableTiming, addToTdr, isPublicNetwork } = require("../../common/MigrationUtils.js");
+const {
+  getKeysForNetwork,
+  deploy,
+  enableControllableTiming,
+  addToTdr,
+  isPublicNetwork
+} = require("../../common/MigrationUtils.js");
 
 const ethAddress = "0x0000000000000000000000000000000000000000";
 

--- a/core/migrations/11_deploy_tokenized_derivative_creator.js
+++ b/core/migrations/11_deploy_tokenized_derivative_creator.js
@@ -3,7 +3,7 @@ const TokenizedDerivativeCreator = artifacts.require("TokenizedDerivativeCreator
 const TokenizedDerivativeUtils = artifacts.require("TokenizedDerivativeUtils");
 const LeveragedReturnCalculator = artifacts.require("LeveragedReturnCalculator");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
-const { getKeysForNetwork, deploy, enableControllableTiming, addToTdr } = require("../../common/MigrationUtils.js");
+const { getKeysForNetwork, deploy, enableControllableTiming, addToTdr, isPublicNetwork } = require("../../common/MigrationUtils.js");
 
 const ethAddress = "0x0000000000000000000000000000000000000000";
 
@@ -38,7 +38,8 @@ module.exports = async function(deployer, network, accounts) {
   const returnCalculator = await LeveragedReturnCalculator.deployed();
   await returnCalculatorWhitelist.addToWhitelist(returnCalculator.address, { from: keys.returnCalculatorWhitelist });
 
-  if (!network.startsWith("mainnet") && !network.startsWith("ropsten")) {
+  // For any test networks, automatically add ETH as an allowed margin currency.
+  if (!isPublicNetwork(network)) {
     await marginCurrencyWhitelist.addToWhitelist(ethAddress, { from: keys.marginCurrencyWhitelist });
   }
 };

--- a/core/migrations/13_deploy_testnet_token.js
+++ b/core/migrations/13_deploy_testnet_token.js
@@ -1,27 +1,17 @@
 const TestnetERC20 = artifacts.require("TestnetERC20");
 const { deploy, setToExistingAddress } = require("../../common/MigrationUtils.js");
+const publicNetworks = require("../../common/PublicNetworks.js");
 
 module.exports = async function(deployer, network, accounts) {
   let preAssignedAddress = null;
-  if (network.startsWith("mainnet")) {
-    // Regular DAI address - the allocateTo method will fail if called on this contract, so it's only here to allow
-    // Drizzle to load it without breaking.
-    preAssignedAddress = "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359";
-  } else if (network.startsWith("ropsten")) {
-    // Compound's fake DAI address on ropsten.
-    preAssignedAddress = "0xB5E5D0F8C0cbA267CD3D7035d6AdC8eBA7Df7Cdd";
-  } else if (network.startsWith("kovan")) {
-    // Compound's fake DAI address on kovan.
-    preAssignedAddress = "0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99";
-  } else if (network.startsWith("rinkeby")) {
-    // Compound's fake DAI address on rinkeby.
-    preAssignedAddress = "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa";
-  }
 
-  if (preAssignedAddress) {
-    await setToExistingAddress(network, TestnetERC20, preAssignedAddress);
-  } else {
-    // Deploy if there is no listed address to create a fake DAI token.
-    await deploy(deployer, network, TestnetERC20);
+  for (const { name, daiAddress } of Object.values(publicNetworks)) {
+    if (network.startsWith(name) && daiAddress) {
+      await setToExistingAddress(network, TestnetERC20, preAssignedAddress);
+      return;
+    }
   }
+    
+  // Deploy if the network isn't public or if there was no listed DAI address.
+  await deploy(deployer, network, TestnetERC20);
 };

--- a/core/migrations/13_deploy_testnet_token.js
+++ b/core/migrations/13_deploy_testnet_token.js
@@ -11,7 +11,7 @@ module.exports = async function(deployer, network, accounts) {
       return;
     }
   }
-    
+
   // Deploy if the network isn't public or if there was no listed DAI address.
   await deploy(deployer, network, TestnetERC20);
 };

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -91,7 +91,7 @@ function getTxnLink(txnHash) {
     const url = `${networkConfig.etherscan}tx/${txnHash}`;
     return `<a href="${url}">${txnHash}</a>`;
   }
-  
+
   // If there is no etherscan link, just return the plaintext txnHash.
   return txnHash;
 }

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -2,6 +2,7 @@ const Voting = artifacts.require("Voting");
 const { VotePhasesEnum } = require("../../common/Enums");
 const { decryptMessage, encryptMessage, deriveKeyPairFromSignatureTruffle } = require("../../common/Crypto");
 const { computeTopicHash, getKeyGenMessage } = require("../../common/EncryptionHelper");
+const publicNetworks = require("../../common/PublicNetworks");
 const sendgrid = require("@sendgrid/mail");
 const fetch = require("node-fetch");
 require("dotenv").config();
@@ -84,29 +85,14 @@ async function fetchPrice(request) {
 // Returns an html link to the transaction.
 // If the network is not recognized/not public, just returns the txn hash in plaintext.
 function getTxnLink(txnHash) {
-  let url;
-
-  switch (Voting.network_id) {
-    case "1":
-      // Mainnet
-      url = `https://etherscan.io/tx/${txnHash}`;
-      break;
-    case "3":
-      // Ropsten
-      url = `https://ropsten.etherscan.io/tx/${txnHash}`;
-      break;
-    case "42":
-      // Kovan
-      url = `https://kovan.etherscan.io/tx/${txnHash}`;
-      break;
-  }
-
-  // If there is a valid URL, add a link HTML tag.
-  if (url) {
+  const networkConfig = publicNetworks[Voting.network_id];
+  if (networkConfig && networkConfig.etherscan) {
+    // If there is an etherscan link, add it to the txn hash element.
+    const url = `${networkConfig.etherscan}tx/${txnHash}`;
     return `<a href="${url}">${txnHash}</a>`;
   }
-
-  // If there is no etherscan link, just return the txn hash in plain text.
+  
+  // If there is no etherscan link, just return the plaintext txnHash.
   return txnHash;
 }
 

--- a/scripts/deploy_dapp.sh
+++ b/scripts/deploy_dapp.sh
@@ -30,7 +30,7 @@ shift
 # Move to the v0 directory for contract compilation.
 cd $PROTOCOL_DIR/core
 
-# Compile contracts, load deployed addresses for mainnet and ropsten.
+# Compile contracts, load deployed addresses for mainnet and testnets.
 echo "Compiling contracts."
 $(npm bin)/truffle compile
 

--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { drizzleReactHooks } from "drizzle-react";
+import publicNetworks from "common/PublicNetworks";
 
 export function useNumRegisteredContracts() {
   const { useCacheCall } = drizzleReactHooks.useDrizzle();
@@ -21,17 +22,14 @@ export function useEtherscanUrl() {
     return drizzleState.web3.networkId;
   });
 
-  switch (networkId.toString()) {
-    case "1":
-      return "https://etherscan.io/";
-    case "3":
-      return "https://ropsten.etherscan.io/";
-    case "42":
-      return "https://kovan.etherscan.io/";
-    default:
-      // Default to mainnet, even though it won't work for ganache runs.
-      return "https://etherscan.io/";
+  const networkConfig = publicNetworks[networkId];
+
+  if (networkConfig && networkConfig.etherscan) {
+    return networkConfig.etherscan;
   }
+
+  // Default to mainnet, even though it won't work for ganache runs.
+  return "https://etherscan.io/";
 }
 
 export function useFaucetUrls() {
@@ -39,24 +37,19 @@ export function useFaucetUrls() {
     return drizzleState.web3.networkId;
   });
 
-  switch (networkId.toString()) {
-    case "1":
-      return {};
-    case "3":
-      return {
-        eth: "https://faucet.metamask.io/",
-        // TODO(mrice32): put a real DAI faucet link here.
-        dai: "https://faucet.metamask.io/"
-      };
-    case "42":
-      return {
-        eth: "https://faucet.kovan.network/",
-        // TODO(mrice32): put a real DAI faucet link here.
-        dai: "https://faucet.kovan.network/"
-      };
-    default:
-      return {};
+  const networkConfig = publicNetworks[networkId];
+
+  // The only networks that are both public and have an eth faucet should be testnets.
+  if (networkConfig && networkConfig.ethFaucet) {
+    return {
+      eth: networkConfig.ethFaucet,
+      // TODO(mrice32): put a real DAI faucet link here.
+      dai: networkConfig.ethFaucet
+    };
   }
+
+  // Mainnet and private networks will default to this case.
+  return {};
 }
 
 export function useTextInput() {


### PR DESCRIPTION
The goal of this PR is to make it as easy as possible to add a new public network.

This is accomplished by making everything in the repo pull the list of public networks and any unique properties about each network from a single, central config.

To add a new network in the future, one should just have to edit a single config file.

This PR also adds the rinkeby testnet.