### PR TITLE
Whitelist margin currencies and approve identifiers during migrations

### DIFF
--- a/core/migrations/13_deploy_testnet_token.js
+++ b/core/migrations/13_deploy_testnet_token.js
@@ -1,17 +1,32 @@
 const TestnetERC20 = artifacts.require("TestnetERC20");
-const { deploy, setToExistingAddress } = require("../../common/MigrationUtils.js");
+const TokenizedDerivativeCreator = artifacts.require("TokenizedDerivativeCreator");
+const AddressWhitelist = artifacts.require("AddressWhitelist");
+const { deploy, setToExistingAddress, getKeysForNetwork } = require("../../common/MigrationUtils.js");
 const publicNetworks = require("../../common/PublicNetworks.js");
 
 module.exports = async function(deployer, network, accounts) {
-  let preAssignedAddress = null;
+  const keys = getKeysForNetwork(network, accounts);
+
+  let testnetERC20Address = null;
 
   for (const { name, daiAddress } of Object.values(publicNetworks)) {
     if (network.startsWith(name) && daiAddress) {
-      await setToExistingAddress(network, TestnetERC20, preAssignedAddress);
-      return;
+      await setToExistingAddress(network, TestnetERC20, daiAddress);
+      testnetERC20Address = daiAddress;
+      break;
     }
   }
 
-  // Deploy if the network isn't public or if there was no listed DAI address.
-  await deploy(deployer, network, TestnetERC20);
+  if (!testnetERC20Address) {
+    // Deploy if the network isn't public or if there was no listed DAI address.
+    ({
+      contract: { address: testnetERC20Address }
+    } = await deploy(deployer, network, TestnetERC20, { from: keys.deployer }));
+  }
+
+  // Add testnetERC20 to the margin currency whitelist.
+  const tokenizedDerivativeCreator = await TokenizedDerivativeCreator.deployed();
+  const marginCurrencyWhitelistAddress = await tokenizedDerivativeCreator.marginCurrencyWhitelist();
+  const marginCurrencyWhitelist = await AddressWhitelist.at(marginCurrencyWhitelistAddress);
+  await marginCurrencyWhitelist.addToWhitelist(testnetERC20Address, { from: keys.marginCurrencyWhitelist });
 };

--- a/core/migrations/14_support_identifiers.js
+++ b/core/migrations/14_support_identifiers.js
@@ -1,0 +1,14 @@
+const Voting = artifacts.require("Voting");
+const { getKeysForNetwork } = require("../../common/MigrationUtils.js");
+const identifiers = require("../config/identifiers");
+
+module.exports = async function(deployer, network, accounts) {
+  const keys = getKeysForNetwork(network, accounts);
+
+  const voting = await Voting.deployed();
+
+  for (const identifier of Object.keys(identifiers)) {
+    const identifierBytes = web3.utils.utf8ToHex(identifier);
+    await voting.addSupportedIdentifier(identifierBytes, { from: keys.deployer });
+  }
+};


### PR DESCRIPTION
This adds a new step to migrations where all the identifiers are approved.

It also adds whitelisting to the deployment step of the TestnetERC20 contract.

Fixes #647.