### PR TITLE
Update price feed pushing to match desired API calls

### DIFF
--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -9,7 +9,7 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "Barchart",
+        "dataSource": "BarchartCrypto",
         "assetName": "^BTCUSD"
       }
     }
@@ -24,7 +24,7 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "Barchart",
+        "dataSource": "BarchartCrypto",
         "assetName": "^ETHUSD"
       }
     }


### PR DESCRIPTION
Several changes:
1. Change spacing to separate each feed into its own stanza
2. Print an overall "SUCCESS" or "FAILURE" message
3. Use `serverTimestamp` rather than `tradeTimestamp`
4. Use `getCrypto` API call for crypto quotes from Barchart

More context on #3:
The field `tradeTimestamp` returns values with an incorrect timezone
offset (at least during Daylight Savings Time).

Issue #656 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>