### PR TITLE
Reduce polling interval on `publishPrices.sh` to 10 minutes

### DIFF
--- a/core/scripts/publishPrices.sh
+++ b/core/scripts/publishPrices.sh
@@ -3,4 +3,4 @@
 # Example: ./scripts/publishPrices.sh --network mainnet --keys priceFeed
 # Note: this script must be run from the core/ directory (not core/scripts/).
 
-while sleep 60; do $(npm bin)/truffle exec ./scripts/PublishPrices.js "$@" >>out.log 2>&1; done
+while sleep 600; do $(npm bin)/truffle exec ./scripts/PublishPrices.js "$@" >>out.log 2>&1; done


### PR DESCRIPTION
This polling interval should keep us below our market data query limits.

Issue #656 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>