### PR TITLE
Use `formatWei` rather than `fromWei` to fix issue in optimized mode

### DIFF
--- a/sponsor-dapp-v2/src/components/Step1.js
+++ b/sponsor-dapp-v2/src/components/Step1.js
@@ -5,6 +5,7 @@ import web3 from "web3";
 
 import Dropdown from "components/common/Dropdown";
 import { useEnabledIdentifierConfig } from "lib/custom-hooks";
+import { formatWei } from "common/FormattingUtils.js";
 
 function Step1(props) {
   const [state, setState] = useState({
@@ -25,14 +26,15 @@ function Step1(props) {
       return null;
     }
 
-    const { toBN, toWei, fromWei } = web3.utils;
+    const { toBN, toWei } = web3.utils;
 
     const dropdownData = Object.keys(identifierConfig).map(identifier => {
       // Use BN rather than JS number to avoid precision issues.
-      const collatReq = fromWei(
+      const collatReq = formatWei(
         toBN(toWei(identifierConfig[identifier].supportedMove))
           .add(toBN(toWei("1")))
-          .muln(100)
+          .muln(100),
+        web3
       );
       return {
         key: identifier,

--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -7,6 +7,7 @@ import web3 from "web3";
 import IconSvgComponent from "components/common/IconSvgComponent";
 import { useIdentifierConfig, useDaiAddress } from "lib/custom-hooks";
 import { drizzleReactHooks } from "drizzle-react";
+import { formatWei } from "common/FormattingUtils.js";
 
 function getContractNameAndSymbol(selections) {
   // The date is supposed to look like Sep19 in the token name.
@@ -167,12 +168,13 @@ function Step3(props) {
       return <div />;
     }
 
-    const { toBN, toWei, fromWei } = web3.utils;
+    const { toBN, toWei } = web3.utils;
     // Use BN rather than JS number to avoid precision issues.
-    const collatReq = fromWei(
+    const collatReq = formatWei(
       toBN(toWei(identifierConfig[selections.identifier].supportedMove))
         .add(toBN(toWei("1")))
-        .muln(100)
+        .muln(100),
+      web3
     );
 
     return (


### PR DESCRIPTION
The function `fromWei` can't accept `BN` instances in optimized mode.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>