### PR TITLE
Return `collateralizationRequirement` as a string

### DIFF
--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -125,7 +125,8 @@ export function useCollateralizationInformation(tokenAddress, changeInShortBalan
 
   data.collateralizationRequirement = toBN(data.derivativeStorage.fixedParameters.supportedMove)
     .add(toBN(toWei("1")))
-    .muln(100);
+    .muln(100)
+    .toString();
 
   data.currentCollateralization = "-- %";
   data.newCollateralizationAmount = "-- %";


### PR DESCRIPTION
The other fields returned by this function are strings too.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>