### PR TITLE
Lift wrapper div outside of Step components to fix transitions

### DIFF
--- a/sponsor-dapp-v2/src/components/Step1.js
+++ b/sponsor-dapp-v2/src/components/Step1.js
@@ -42,7 +42,7 @@ function Step1(props) {
   });
 
   return (
-    <div className="step step--primary">
+    <>
       <div className="step__content">
         <p>
           Choose an asset
@@ -81,7 +81,7 @@ function Step1(props) {
           </a>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/sponsor-dapp-v2/src/components/Step2.js
+++ b/sponsor-dapp-v2/src/components/Step2.js
@@ -36,7 +36,7 @@ function Step2(props) {
   });
 
   return (
-    <div className="step step--secondary">
+    <>
       <div className="step__content">
         <p>
           Choose token expiry
@@ -73,7 +73,7 @@ function Step2(props) {
           </a>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -177,7 +177,7 @@ function Step3(props) {
   );
 
   return (
-    <div className="step step--tertiary">
+    <>
       <div className="step__content">
         <p>
           Launch token facility
@@ -289,7 +289,7 @@ function Step3(props) {
           </a>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/sponsor-dapp-v2/src/components/Step4.js
+++ b/sponsor-dapp-v2/src/components/Step4.js
@@ -41,7 +41,7 @@ function Step4(props) {
   }
 
   return (
-    <div className="step">
+    <>
       <div className="step__content">
         <p>
           Your token facility was successfully created.
@@ -77,7 +77,7 @@ function Step4(props) {
           </a>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/sponsor-dapp-v2/src/components/Step5.js
+++ b/sponsor-dapp-v2/src/components/Step5.js
@@ -76,7 +76,7 @@ function Step5(props) {
   const allowedToProceed = dai !== "" && tokens !== "";
 
   return (
-    <div className="step step-5-enter-done">
+    <>
       <div className="form-borrow">
         <form action="#" method="post">
           <div className="form__body">
@@ -178,7 +178,7 @@ function Step5(props) {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/sponsor-dapp-v2/src/components/Step6.js
+++ b/sponsor-dapp-v2/src/components/Step6.js
@@ -26,7 +26,7 @@ function Step6(props) {
   );
 
   return (
-    <div className="step step--tertiary">
+    <>
       <div className="step__content-alt">
         <p>
           You have successfully borrowed {format(tokensBorrowed)} synthetic tokens tracking {identifier}! View token
@@ -63,7 +63,7 @@ function Step6(props) {
           </Link>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/sponsor-dapp-v2/src/views/Steps.js
+++ b/sponsor-dapp-v2/src/views/Steps.js
@@ -152,35 +152,47 @@ function Steps() {
 
             <div className="steps__body">
               <CSSTransition in={state.activeStepIndex === 0} timeout={300} classNames="step-1" unmountOnExit>
-                <Step1 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
+                <div className="step step--primary">
+                  <Step1 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
+                </div>
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 1} timeout={300} classNames="step-2" unmountOnExit>
-                <Step2
-                  userSelectionsRef={userSelectionsRef}
-                  onNextStep={e => nextStep(e)}
-                  onPrevStep={e => prevStep(e)}
-                />
+                <div className="step step--secondary">
+                  <Step2
+                    userSelectionsRef={userSelectionsRef}
+                    onNextStep={e => nextStep(e)}
+                    onPrevStep={e => prevStep(e)}
+                  />
+                </div>
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 2} timeout={200} classNames="step-3" unmountOnExit>
-                <Step3
-                  userSelectionsRef={userSelectionsRef}
-                  onNextStep={e => nextStep(e)}
-                  onPrevStep={e => prevStep(e)}
-                />
+                <div className="step step--tertiary">
+                  <Step3
+                    userSelectionsRef={userSelectionsRef}
+                    onNextStep={e => nextStep(e)}
+                    onPrevStep={e => prevStep(e)}
+                  />
+                </div>
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 3} timeout={200} classNames="step-4" unmountOnExit>
-                <Step4 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
+                <div className="step">
+                  <Step4 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
+                </div>
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 4} timeout={300} classNames="step-5" unmountOnExit>
-                <Step5 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
+                <div className="step">
+                  <Step5 userSelectionsRef={userSelectionsRef} onNextStep={e => nextStep(e)} />
+                </div>
               </CSSTransition>
 
               <CSSTransition in={state.activeStepIndex === 5} timeout={300} classNames="step-6" unmountOnExit>
-                <Step6 userSelectionsRef={userSelectionsRef} />
+                <div className="step step--tertiary">
+                  <Step6 userSelectionsRef={userSelectionsRef} />
+                </div>
               </CSSTransition>
             </div>
           </div>


### PR DESCRIPTION
In some cases, if the `div` element returned by `components/StepN.js`
changes entirely, then the the outer `CSSTransition` doesn't work and
results in the CSS class overrides `step-N-enter-done` never getting
applied to the div that has the CSS class `step`. This results in all of
the content having opacity 0 and being invisible.

One way to address this issue is to make sure that the direct child of
`CSSTransition` is always the same wrapper div.

Fixes #638 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>