### PR TITLE
Fix "Excess Collateral" field to be short margin balance

### DIFF
--- a/sponsor-dapp-v2/src/views/ManagePositions.js
+++ b/sponsor-dapp-v2/src/views/ManagePositions.js
@@ -331,7 +331,7 @@ function ManagePositions(props) {
                           </td>
 
                           <td>
-                            <strong>{format(data.excessMargin)} DAI</strong>
+                            <strong>{format(data.shortMarginBalance)} DAI</strong>
                           </td>
 
                           <td>


### PR DESCRIPTION
This field does *not* represent excess short margin balance, it's just
the short margin balance.

Fixes #672 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>