### PR TITLE
Add sample app.yaml with routing fix

### DIFF
--- a/sponsor-dapp-v2/sample_gae_app.yaml
+++ b/sponsor-dapp-v2/sample_gae_app.yaml
@@ -1,0 +1,10 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+handlers:
+- url: /[^.]*$
+  static_files: build/index.html
+  upload: build/index.html
+- url: /
+  static_dir: build
+service: your-gae-service-name


### PR DESCRIPTION
This adds a sample app.yaml to the repository that seems to fix #646 (as far as I can tell). It basically matches everything *without* a `.` and sends it to `index.html`. Otherwise, it attempts to find the file in the build directory. I assume this rule should generally hold for our application and other react applications since when referencing specific files, they generally have an extension, but normal user-facing url paths don't have an extension.

I've done a test deployment of this and it seems to work. Images are loading and when fresh loading a url like `/ManagePositions/0x0f680cF767D63F6468b28D299Efce4429C45fb89`, the dApp works as one would expect.

I've replaced the config in our CI deployment with this one as well. Please let me know if you see any flaws with this approach.

Fixes #646.