### PR TITLE
Add https redirect to GAE config

### DIFF
--- a/sponsor-dapp-v2/sample_gae_app.yaml
+++ b/sponsor-dapp-v2/sample_gae_app.yaml
@@ -5,6 +5,10 @@ handlers:
 - url: /[^.]*$
   static_files: build/index.html
   upload: build/index.html
+  secure: always
+  redirect_http_response_code: 301
 - url: /
   static_dir: build
+  secure: always
+  redirect_http_response_code: 301
 service: your-gae-service-name


### PR DESCRIPTION
This tells the browser to always redirect to the https version of the site.