### PR TITLE
Remove strange Custom Indices

### DIFF
--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -176,7 +176,7 @@
     "dappConfig": {
       "comment": "expiries: Sept 30, 2019 4:00PM EST, Oct 31st, 2019 4:00PM EST, Nov 29th, 2019 4:00PM EST, Dec 31st, 2019 4:00PM EST, Perpetual; supportedMove: 0.1 corresponds to 10%",
       "expiries": [1569873600, 1572552000, 1575061200, 1577826000, 0],
-      "supportedMove": "0.1"
+      "supportedMove": "0.2"
     },
     "uploaderConfig": {
       "publishInterval": "900",

--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -138,21 +138,6 @@
       }
     }
   },
-  "Custom Index": {
-    "dappConfig": {
-      "comment": "expiries: Sept 30, 2019 4:00PM EST, Oct 31st, 2019 4:00PM EST, Nov 29th, 2019 4:00PM EST, Dec 31st, 2019 4:00PM EST, Perpetual; supportedMove: 0.1 corresponds to 10%",
-      "expiries": [1569873600, 1572552000, 1575061200, 1577826000, 0],
-      "supportedMove": "0.1"
-    },
-    "uploaderConfig": {
-      "publishInterval": "900",
-      "minDelay": "0",
-      "numerator": {
-        "dataSource": "Constant",
-        "assetName": "100"
-      }
-    }
-  },
   "USD/ETH": {
     "dappConfig": {
       "comment": "expiries: Sept 30, 2019 4:00PM EST, Oct 31st, 2019 4:00PM EST, Nov 29th, 2019 4:00PM EST, Dec 31st, 2019 4:00PM EST, Perpetual; supportedMove: 0.2 corresponds to 20%",
@@ -187,18 +172,18 @@
       }
     }
   },
-  "Custom Index (84.3)": {
+  "Custom Index (100)": {
     "dappConfig": {
-      "comment": "expiries: Sept 30, 2019 4:00PM EST, Oct 31st, 2019 4:00PM EST, Nov 29th, 2019 4:00PM EST, Dec 31st, 2019 4:00PM EST, Perpetual; supportedMove: 0.2 corresponds to 20%",
+      "comment": "expiries: Sept 30, 2019 4:00PM EST, Oct 31st, 2019 4:00PM EST, Nov 29th, 2019 4:00PM EST, Dec 31st, 2019 4:00PM EST, Perpetual; supportedMove: 0.1 corresponds to 10%",
       "expiries": [1569873600, 1572552000, 1575061200, 1577826000, 0],
-      "supportedMove": "0.2"
+      "supportedMove": "0.1"
     },
     "uploaderConfig": {
       "publishInterval": "900",
       "minDelay": "0",
       "numerator": {
         "dataSource": "Constant",
-        "assetName": "84.3"
+        "assetName": "100"
       }
     }
   }

--- a/core/scripts/local/ApproveIdentifiers.js
+++ b/core/scripts/local/ApproveIdentifiers.js
@@ -1,0 +1,26 @@
+const Voting = artifacts.require("Voting");
+const identifiers = require("../../config/identifiers");
+
+const approveIdentifiers = async function(callback) {
+  try {
+    const deployer = (await web3.eth.getAccounts())[0];
+
+    const voting = await Voting.deployed();
+
+    for (const identifier of Object.keys(identifiers)) {
+      const identifierBytes = web3.utils.utf8ToHex(identifier);
+      if (!(await voting.isIdentifierSupported(identifierBytes))) {
+        await voting.addSupportedIdentifier(identifierBytes, { from: deployer });
+        console.log(`Approved new identifier: ${identifier}`);
+      } else {
+        console.log(`${identifier} is already approved.`);
+      }
+    }
+  } catch (e) {
+    console.log(`ERROR: ${e}`);
+  }
+
+  callback();
+};
+
+module.exports = approveIdentifiers;


### PR DESCRIPTION
This PR will remove some existing identifiers, which will pull them from the dapp. However, those who have already built on these identifiers will see their contracts never expire. I don't think this is that big of a deal at this stage since it's only for a select few identifiers.

Note: this also adds a script to approve any identifiers that are listed in the config but unapproved.