### PR TITLE
moving off barchart

### DIFF
--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -9,8 +9,8 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "BarchartCrypto",
-        "assetName": "^BTCUSD"
+        "dataSource": "AlphaVantageCurrency",
+        "assetName": "BTC"
       }
     }
   },
@@ -24,8 +24,8 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "BarchartCrypto",
-        "assetName": "^ETHUSD"
+        "dataSource": "AlphaVantageCurrency",
+        "assetName": "ETH"
       }
     }
   },
@@ -58,8 +58,12 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "Barchart",
-        "assetName": "SP*1"
+        "dataSource": "AlphaVantage",
+        "assetName": "SPY"
+      },
+      "denominator": {
+        "dataSource": "Constant",
+        "assetName": "0.1"
       }
     }
   },
@@ -73,7 +77,7 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "BarchartEquities",
+        "dataSource": "AlphaVantage",
         "assetName": "TSLA"
       }
     }
@@ -88,8 +92,12 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "Barchart",
-        "assetName": "GC*1"
+        "dataSource": "AlphaVantage",
+        "assetName": "GLD"
+      },
+      "denominator": {
+        "dataSource": "Constant",
+        "assetName": "0.1"
       }
     }
   },
@@ -103,8 +111,8 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "Barchart",
-        "assetName": "CL*1"
+        "dataSource": "AlphaVantage",
+        "assetName": "OILB"
       }
     }
   },
@@ -118,8 +126,8 @@
       "publishInterval": "900",
       "minDelay": "600",
       "numerator": {
-        "dataSource": "Barchart",
-        "assetName": "^CNYUSD"
+        "dataSource": "AlphaVantageCurrency",
+        "assetName": "CNY"
       }
     }
   },
@@ -152,8 +160,8 @@
         "assetName": "1"
       },
       "denominator": {
-        "dataSource": "BarchartCrypto",
-        "assetName": "^ETHUSD"
+        "dataSource": "AlphaVantageCurrency",
+        "assetName": "ETH"
       }
     }
   },


### PR DESCRIPTION
@mrice32 @ptare if you agree, let's make the switch to barchart. I did check the alphavantage API for all these tickers (they exist and work), but I have not tested or run this locally.

With this update, we are no longer using any futures (just ETF and currencies). For gold we're using GLD/10; for SP500 we're using SPY/10; for oil we're using OILB. 

IMO these prices are all close enough for testnet. 