### PR TITLE
Prevent dApp from crashing after expiry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,8 +171,8 @@ jobs:
           command: $(npm bin)/truffle migrate --reset --network test
       - restore_cache:
           keys: 
-            - v2-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
-            - v2-dapp-dep-cache-
+            - v3-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
+            - v3-dapp-dep-cache-
       - run:
           name: Install Voter dApp Dependencies
           working_directory: ~/protocol/voter-dapp
@@ -182,7 +182,7 @@ jobs:
           working_directory: ~/protocol/sponsor-dapp-v2
           command: npm install
       - save_cache:
-          key: v2-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
+          key: v3-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
           paths:
             - voter-dapp/node_modules
             - sponsor-dapp-v2/node_modules

--- a/sponsor-dapp-v2/src/components/common/ExpandBox.js
+++ b/sponsor-dapp-v2/src/components/common/ExpandBox.js
@@ -21,7 +21,9 @@ class ExpandBox extends Component {
     });
 
     const convertTimestamp = timestamp => {
-      if (timestamp === UINT_MAX) {
+      if (timestamp == null) {
+        return "--";
+      } else if (timestamp === UINT_MAX) {
         return "None";
       } else {
         return moment.unix(timestamp).format("YYYY-MM-DD, HH:MM:SS");


### PR DESCRIPTION
This PR just prevents the dapp from crashing in the event of expiry. There are many fields that will be filled with `--` in that case, but I think that's appropriate as a first step.

Note: this PR required an update to the our forked version of drizzle-react, so I changed the name of a dependency cache in our ci configuration to wipe it clean.

Fixes #681.