### PR TITLE
Add test to verify the price feed script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
           requires:
             - checkout_and_install
       - test:
-          context: infura
+          context: api_keys
           requires:
             - build
       - docs:

--- a/core/scripts/PublishPrices.js
+++ b/core/scripts/PublishPrices.js
@@ -327,6 +327,7 @@ function getPriceFeeds() {
   });
 }
 
+// Prints any errors and returns true if there were no errors, false otherwise.
 async function runExport() {
   // Wrap all the functionality in a try/catch, so that this function never throws.
   const errors = [];
@@ -354,8 +355,10 @@ async function runExport() {
   }
   if (errors.length) {
     console.log("FAILURE:", errors);
+    return false;
   } else {
     console.log("SUCCESS");
+    return true;
   }
 }
 
@@ -364,4 +367,5 @@ run = async function(callback) {
   callback();
 };
 run.verifyFeedConfig = verifyFeedConfig;
+run.runExport = runExport;
 module.exports = run;

--- a/core/test/scripts/PublishPrices.js
+++ b/core/test/scripts/PublishPrices.js
@@ -50,4 +50,18 @@ contract("scripts/PublishPrices.js", function(accounts) {
       PublishPrices.verifyFeedConfig({ ...validConfig, denominator: { ...validConfig.denominator, assetName: null } })
     );
   });
+
+  it("TestRun", async function() {
+    const alphaVantageKey = process.env.ALPHAVANTAGE_API_KEY;
+    const barchartStandardKey = process.env.BARCHART_API_KEY;
+    const barchartEquitiesKey = process.env.BARCHART_EQUITIES_API_KEY;
+    const cmcKey = process.env.CMC_PRO_API_KEY;
+
+    if (cmcKey && barchartStandardKey && barchartEquitiesKey && alphaVantageKey) {
+      console.log("All API keys are defined in the environment. Running runExport().");
+      assert.isTrue(await PublishPrices.runExport());
+    } else {
+      console.log("Not running runExport() because all required API keys are not defined in the environment.");
+    }
+  });
 });


### PR DESCRIPTION
This just adds a new test case that does a run through the runExport() function and verifies that it returns no errors.

This is useful since we seem to be changing the identifiers often - we should have an automated test to verify those changes work.

Note: I have added a new context to CI that has all of our API keys. The test ensures all are present before running, so those without permission to access those keys will get a free pass on this test. Going to look into adding an *approval* step for access to the api_key context in circleci so that those who aren't part of our organization will see this test run as well.

Fixes #694 