### PR TITLE
Filter out past expiries

### DIFF
--- a/sponsor-dapp-v2/src/components/Step2.js
+++ b/sponsor-dapp-v2/src/components/Step2.js
@@ -28,12 +28,18 @@ function Step2(props) {
     userSelectionsRef: { current: selection }
   } = props;
 
-  const timeline = identifierConfig[selection.identifier].expiries.map(expiry => {
-    return {
-      key: expiry,
-      value: expiry ? moment.unix(expiry).format("MMMM DD, YYYY LTS") : "Perpetual"
-    };
-  });
+  const currentTime = new Date().getTime() / 1000;
+  const timeline = identifierConfig[selection.identifier].expiries
+    .filter(expiry => {
+      // Remove any expiries that have already passed.
+      return !expiry || expiry > currentTime;
+    })
+    .map(expiry => {
+      return {
+        key: expiry,
+        value: expiry ? moment.unix(expiry).format("MMMM DD, YYYY LTS") : "Perpetual"
+      };
+    });
 
   return (
     <>


### PR DESCRIPTION
This just uses the local timestamp of the machine to filter out any old expiries.

Fixes #695.