### PR TITLE
Pin solc version

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -93,7 +93,7 @@ module.exports = {
   networks: networks,
   compilers: {
     solc: {
-      version: "0.5.0"
+      version: "0.5.11"
     }
   }
 };

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -93,7 +93,7 @@ module.exports = {
   networks: networks,
   compilers: {
     solc: {
-      version: "0.5.8"
+      version: "0.5.0"
     }
   }
 };

--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -1,7 +1,7 @@
 /*
   Simple Address Whitelist
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 

--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -1,7 +1,7 @@
 /*
   Simple Address Whitelist
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 

--- a/core/contracts/AdministrateeInterface.sol
+++ b/core/contracts/AdministrateeInterface.sol
@@ -2,7 +2,7 @@
  * AdministrateeInterface contract.
  * The interface that enumerates the functionality that derivative contracts expose to the admin.
  */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 /**

--- a/core/contracts/AdministrateeInterface.sol
+++ b/core/contracts/AdministrateeInterface.sol
@@ -2,7 +2,7 @@
  * AdministrateeInterface contract.
  * The interface that enumerates the functionality that derivative contracts expose to the admin.
  */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 /**

--- a/core/contracts/ContractCreator.sol
+++ b/core/contracts/ContractCreator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./Finder.sol";
 import "./Registry.sol";

--- a/core/contracts/ContractCreator.sol
+++ b/core/contracts/ContractCreator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./Finder.sol";
 import "./Registry.sol";

--- a/core/contracts/EncryptedSender.sol
+++ b/core/contracts/EncryptedSender.sol
@@ -1,7 +1,7 @@
 /*
   EncryptedSender contract for sending encrypted messages via the EVM.
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 /**

--- a/core/contracts/EncryptedSender.sol
+++ b/core/contracts/EncryptedSender.sol
@@ -1,7 +1,7 @@
 /*
   EncryptedSender contract for sending encrypted messages via the EVM.
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 /**

--- a/core/contracts/ExpandedIERC20.sol
+++ b/core/contracts/ExpandedIERC20.sol
@@ -2,7 +2,7 @@
  * ExpandedIERC20 contract.
  * Interface that expands IERC20 to include burning and minting tokens.
  */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 

--- a/core/contracts/ExpandedIERC20.sol
+++ b/core/contracts/ExpandedIERC20.sol
@@ -2,7 +2,7 @@
  * ExpandedIERC20 contract.
  * Interface that expands IERC20 to include burning and minting tokens.
  */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 

--- a/core/contracts/FinancialContractsAdmin.sol
+++ b/core/contracts/FinancialContractsAdmin.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./AdministrateeInterface.sol";
 import "./MultiRole.sol";

--- a/core/contracts/FinancialContractsAdmin.sol
+++ b/core/contracts/FinancialContractsAdmin.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./AdministrateeInterface.sol";
 import "./MultiRole.sol";

--- a/core/contracts/Finder.sol
+++ b/core/contracts/Finder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./MultiRole.sol";
 

--- a/core/contracts/Finder.sol
+++ b/core/contracts/Finder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./MultiRole.sol";
 

--- a/core/contracts/FixedPoint.sol
+++ b/core/contracts/FixedPoint.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 

--- a/core/contracts/FixedPoint.sol
+++ b/core/contracts/FixedPoint.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 

--- a/core/contracts/LeveragedReturnCalculator.sol
+++ b/core/contracts/LeveragedReturnCalculator.sol
@@ -3,7 +3,7 @@
  *
  * Implements a return calculator that applies leverage to the input prices.
  */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./ReturnCalculatorInterface.sol";
 import "./Withdrawable.sol";

--- a/core/contracts/LeveragedReturnCalculator.sol
+++ b/core/contracts/LeveragedReturnCalculator.sol
@@ -3,7 +3,7 @@
  *
  * Implements a return calculator that applies leverage to the input prices.
  */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./ReturnCalculatorInterface.sol";
 import "./Withdrawable.sol";

--- a/core/contracts/ManualPriceFeed.sol
+++ b/core/contracts/ManualPriceFeed.sol
@@ -3,7 +3,7 @@
 
  Implementation of PriceFeedInterface that allows manually updating prices.
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/core/contracts/ManualPriceFeed.sol
+++ b/core/contracts/ManualPriceFeed.sol
@@ -3,7 +3,7 @@
 
  Implementation of PriceFeedInterface that allows manually updating prices.
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/core/contracts/Migrations.sol
+++ b/core/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 contract Migrations {

--- a/core/contracts/Migrations.sol
+++ b/core/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 contract Migrations {

--- a/core/contracts/MultiRole.sol
+++ b/core/contracts/MultiRole.sol
@@ -2,7 +2,7 @@
  * MultiRole contract.
  */
 
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 library Exclusive {

--- a/core/contracts/MultiRole.sol
+++ b/core/contracts/MultiRole.sol
@@ -2,7 +2,7 @@
  * MultiRole contract.
  */
 
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 library Exclusive {

--- a/core/contracts/OracleInterface.sol
+++ b/core/contracts/OracleInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 /**

--- a/core/contracts/OracleInterface.sol
+++ b/core/contracts/OracleInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 /**

--- a/core/contracts/PriceFeedInterface.sol
+++ b/core/contracts/PriceFeedInterface.sol
@@ -1,7 +1,7 @@
 /**
  * PriceFeedInterface contract.
  */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 /**

--- a/core/contracts/PriceFeedInterface.sol
+++ b/core/contracts/PriceFeedInterface.sol
@@ -1,7 +1,7 @@
 /**
  * PriceFeedInterface contract.
  */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 /**

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./MultiRole.sol";
 import "./RegistryInterface.sol";

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./MultiRole.sol";
 import "./RegistryInterface.sol";

--- a/core/contracts/RegistryInterface.sol
+++ b/core/contracts/RegistryInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/RegistryInterface.sol
+++ b/core/contracts/RegistryInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/ResultComputation.sol
+++ b/core/contracts/ResultComputation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./FixedPoint.sol";
 

--- a/core/contracts/ResultComputation.sol
+++ b/core/contracts/ResultComputation.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./FixedPoint.sol";
 

--- a/core/contracts/ReturnCalculatorInterface.sol
+++ b/core/contracts/ReturnCalculatorInterface.sol
@@ -2,7 +2,7 @@
   ReturnCalculator Interface
   The interface that contracts use to compute different modified return structures.
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 /**

--- a/core/contracts/ReturnCalculatorInterface.sol
+++ b/core/contracts/ReturnCalculatorInterface.sol
@@ -2,7 +2,7 @@
   ReturnCalculator Interface
   The interface that contracts use to compute different modified return structures.
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 /**

--- a/core/contracts/Store.sol
+++ b/core/contracts/Store.sol
@@ -3,7 +3,7 @@
  
   An implementation of StoreInterface with a fee per second and withdraw functions for the owner.
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/core/contracts/Store.sol
+++ b/core/contracts/Store.sol
@@ -3,7 +3,7 @@
  
   An implementation of StoreInterface with a fee per second and withdraw functions for the owner.
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/core/contracts/StoreInterface.sol
+++ b/core/contracts/StoreInterface.sol
@@ -2,7 +2,7 @@
   StoreInterface contract.
   An interface that allows derivative contracts to pay oracle fees.
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";

--- a/core/contracts/StoreInterface.sol
+++ b/core/contracts/StoreInterface.sol
@@ -2,7 +2,7 @@
   StoreInterface contract.
   An interface that allows derivative contracts to pay oracle fees.
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";

--- a/core/contracts/Testable.sol
+++ b/core/contracts/Testable.sol
@@ -2,7 +2,7 @@
  * Testable contract.
  */
 
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 
 /**

--- a/core/contracts/Testable.sol
+++ b/core/contracts/Testable.sol
@@ -2,7 +2,7 @@
  * Testable contract.
  */
 
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 
 /**

--- a/core/contracts/TestnetERC20.sol
+++ b/core/contracts/TestnetERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 

--- a/core/contracts/TestnetERC20.sol
+++ b/core/contracts/TestnetERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 

--- a/core/contracts/TokenMigrator.sol
+++ b/core/contracts/TokenMigrator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/TokenMigrator.sol
+++ b/core/contracts/TokenMigrator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -3,7 +3,7 @@
 
   Implements a simplified version of tokenized Product/ETH Products.
 */
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -3,7 +3,7 @@
 
   Implements a simplified version of tokenized Product/ETH Products.
 */
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/VoteTiming.sol
+++ b/core/contracts/VoteTiming.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 

--- a/core/contracts/VoteTiming.sol
+++ b/core/contracts/VoteTiming.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/VotingInterface.sol
+++ b/core/contracts/VotingInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/VotingInterface.sol
+++ b/core/contracts/VotingInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 pragma experimental ABIEncoderV2;
 

--- a/core/contracts/VotingToken.sol
+++ b/core/contracts/VotingToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "./MultiRole.sol";
 import "./ExpandedIERC20.sol";

--- a/core/contracts/VotingToken.sol
+++ b/core/contracts/VotingToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "./MultiRole.sol";
 import "./ExpandedIERC20.sol";

--- a/core/contracts/Withdrawable.sol
+++ b/core/contracts/Withdrawable.sol
@@ -2,7 +2,7 @@
  * Withdrawable contract.
  */
 
-pragma solidity 0.5.0;
+pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./MultiRole.sol";

--- a/core/contracts/Withdrawable.sol
+++ b/core/contracts/Withdrawable.sol
@@ -2,7 +2,7 @@
  * Withdrawable contract.
  */
 
-pragma solidity ^0.5.0;
+pragma solidity 0.5.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./MultiRole.sol";


### PR DESCRIPTION
It's a best practice to pin the compiler version of Solidity code that isn't used in libraries. This helps ensure compilation determinism and mitigates the risk of future compilations being vulnerable to bugs in future compiler versions.