### PR TITLE
Workaround for non reverting view methods bug

### DIFF
--- a/sponsor-dapp-v2/src/components/Step5.js
+++ b/sponsor-dapp-v2/src/components/Step5.js
@@ -2,7 +2,12 @@ import React, { useEffect } from "react";
 
 import classNames from "classnames";
 import { withAddedContract } from "lib/contracts";
-import { useTextInput, useCollateralizationInformation, useMaxTokensThatCanBeCreated } from "lib/custom-hooks";
+import {
+  useTextInput,
+  useCollateralizationInformation,
+  useMaxTokensThatCanBeCreated,
+  revertWrapper
+} from "lib/custom-hooks";
 import { drizzleReactHooks } from "drizzle-react";
 import TokenizedDerivative from "contracts/TokenizedDerivative.json";
 import { createFormatFunction } from "common/FormattingUtils";
@@ -54,7 +59,7 @@ function Step5(props) {
 
   // Get data to display.
   const { collateralizationRequirement } = useCollateralizationInformation(contractAddress, "");
-  const currentPrice = useCacheCall(contractAddress, "getUpdatedUnderlyingPrice");
+  const currentPrice = revertWrapper(useCacheCall(contractAddress, "getUpdatedUnderlyingPrice"));
 
   const { ready, maxTokens } = useMaxTokensThatCanBeCreated(contractAddress, dai);
 

--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -31,6 +31,8 @@ export function revertWrapper(result) {
       }
     }
   }
+
+  return result;
 }
 
 export function useNumRegisteredContracts() {

--- a/sponsor-dapp-v2/src/views/Borrow.js
+++ b/sponsor-dapp-v2/src/views/Borrow.js
@@ -14,7 +14,8 @@ import {
   useSendTransactionOnLink,
   useCollateralizationInformation,
   useMaxTokensThatCanBeCreated,
-  useLiquidationPrice
+  useLiquidationPrice,
+  revertWrapper
 } from "lib/custom-hooks";
 import { createFormatFunction } from "common/FormattingUtils";
 
@@ -33,7 +34,7 @@ function Borrow(props) {
 
   const data = useCollateralizationInformation(tokenAddress, "");
   const liquidationPrice = useLiquidationPrice(tokenAddress);
-  data.updatedUnderlyingPrice = useCacheCall(tokenAddress, "getUpdatedUnderlyingPrice");
+  data.updatedUnderlyingPrice = revertWrapper(useCacheCall(tokenAddress, "getUpdatedUnderlyingPrice"));
   const derivativeStorage = useCacheCall(tokenAddress, "derivativeStorage");
   const { ready, maxTokens } = useMaxTokensThatCanBeCreated(tokenAddress, marginAmount);
   if (!data.ready || !data.updatedUnderlyingPrice || !derivativeStorage || !ready) {

--- a/sponsor-dapp-v2/src/views/ManagePositions.js
+++ b/sponsor-dapp-v2/src/views/ManagePositions.js
@@ -10,7 +10,7 @@ import Tooltip from "components/common/Tooltip";
 import { withAddedContract } from "lib/contracts";
 import TokenizedDerivative from "contracts/TokenizedDerivative.json";
 import { createFormatFunction } from "common/FormattingUtils";
-import { useEtherscanUrl } from "lib/custom-hooks";
+import { useEtherscanUrl, revertWrapper } from "lib/custom-hooks";
 import { ContractStateEnum } from "common/TokenizedDerivativeUtils";
 
 function getStateDescription(derivativeStorage) {
@@ -67,12 +67,12 @@ function useFinancialContractData(tokenAddress) {
   data.derivativeStorage = useCacheCall(tokenAddress, "derivativeStorage");
   data.name = useCacheCall(tokenAddress, "name");
   data.symbol = useCacheCall(tokenAddress, "symbol");
-  data.nav = useCacheCall(tokenAddress, "calcNAV");
-  data.tokenValue = useCacheCall(tokenAddress, "calcTokenValue");
-  data.shortMarginBalance = useCacheCall(tokenAddress, "calcShortMarginBalance");
-  data.excessMargin = useCacheCall(tokenAddress, "calcExcessMargin");
+  data.nav = revertWrapper(useCacheCall(tokenAddress, "calcNAV"));
+  data.tokenValue = revertWrapper(useCacheCall(tokenAddress, "calcTokenValue"));
+  data.shortMarginBalance = revertWrapper(useCacheCall(tokenAddress, "calcShortMarginBalance"));
+  data.excessMargin = revertWrapper(useCacheCall(tokenAddress, "calcExcessMargin"));
 
-  const updatedUnderlyingPrice = useCacheCall(tokenAddress, "getUpdatedUnderlyingPrice");
+  const updatedUnderlyingPrice = revertWrapper(useCacheCall(tokenAddress, "getUpdatedUnderlyingPrice"));
 
   // If the blockchain value === null, this means that the call reverted, so we just make its children null (to prevent access errors down the line).
   data.updatedUnderlyingPrice =

--- a/sponsor-dapp-v2/src/views/Repay.js
+++ b/sponsor-dapp-v2/src/views/Repay.js
@@ -14,7 +14,8 @@ import {
   useTextInput,
   useSendTransactionOnLink,
   useCollateralizationInformation,
-  useTokenPreapproval
+  useTokenPreapproval,
+  revertWrapper
 } from "lib/custom-hooks";
 import { createFormatFunction } from "common/FormattingUtils";
 
@@ -34,8 +35,8 @@ function Repay(props) {
   const handleRedeemClick = useSendTransactionOnLink({ send, status }, [amount], props.history);
 
   const data = useCollateralizationInformation(tokenAddress, "");
-  data.updatedUnderlyingPrice = useCacheCall(tokenAddress, "getUpdatedUnderlyingPrice");
-  data.tokenValue = useCacheCall(tokenAddress, "calcTokenValue");
+  data.updatedUnderlyingPrice = revertWrapper(useCacheCall(tokenAddress, "getUpdatedUnderlyingPrice"));
+  data.tokenValue = revertWrapper(useCacheCall(tokenAddress, "calcTokenValue"));
   data.tokenBalance = useCacheCall(tokenAddress, "balanceOf", account);
 
   const { ready: approvalDataReady, approveTokensHandler, isApproved, isLoadingApproval } = useTokenPreapproval(

--- a/sponsor-dapp-v2/src/views/ViewPositions.js
+++ b/sponsor-dapp-v2/src/views/ViewPositions.js
@@ -3,7 +3,13 @@ import { Link, Redirect } from "react-router-dom";
 import { drizzleReactHooks } from "drizzle-react";
 import TokenizedDerivative from "contracts/TokenizedDerivative.json";
 import { formatWei, formatWithMaxDecimals } from "common/FormattingUtils";
-import { useEtherscanUrl, useEthFaucetUrl, useDaiFaucetRequest, computeLiquidationPrice } from "lib/custom-hooks";
+import {
+  useEtherscanUrl,
+  useEthFaucetUrl,
+  useDaiFaucetRequest,
+  computeLiquidationPrice,
+  revertWrapper
+} from "lib/custom-hooks";
 import { createFormatFunction } from "common/FormattingUtils";
 import { useSendGaPageview } from "lib/google-analytics";
 
@@ -84,9 +90,9 @@ function usePositionList() {
           .toString();
 
         // These are needed to compute the liquidation price.
-        const nav = call(contractAddress, "calcNAV");
-        const excessMargin = call(contractAddress, "calcExcessMargin");
-        const underlyingPriceTime = call(contractAddress, "getUpdatedUnderlyingPrice");
+        const nav = revertWrapper(call(contractAddress, "calcNAV"));
+        const excessMargin = revertWrapper(call(contractAddress, "calcExcessMargin"));
+        const underlyingPriceTime = revertWrapper(call(contractAddress, "getUpdatedUnderlyingPrice"));
         const liquidationPrice = computeLiquidationPrice(web3, nav, excessMargin, underlyingPriceTime);
         const derivativeStorage = call(contractAddress, "derivativeStorage");
 


### PR DESCRIPTION
The strange liquidation price was due to a bug in how public networks + web3 deal with reverting view methods. See https://forum.openzeppelin.com/t/require-in-view-pure-functions-dont-revert-on-public-networks/1211 for more on this issue. This PR adds a workaround to allow the dApp to continue to work correctly.

Fixes #717 