### PR TITLE
[WIP] Remove node_modules cache for Slither and Echidna

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ jobs:
     working_directory: ~/protocol
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v3-sec-toolbox-deps-{{ checksum "package.json" }}
-            - v3-sec-toolbox-deps-
       - run:
           name: Change user
           command: sudo su ethsec
@@ -76,10 +72,6 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm install --quiet
-      - save_cache:
-          key: v3-sec-toolbox-deps-{{ checksum "package.json" }}
-          paths:
-            - node_modules
       - run:
           name: Slither
           command: ./ci/run_slither.sh
@@ -136,10 +128,6 @@ jobs:
     working_directory: ~/protocol	
     steps:
       - checkout	
-      - restore_cache:
-          keys:
-            - v3-sec-toolbox-deps-{{ checksum "package.json" }}
-            - v3-sec-toolbox-deps-
       - run:
           name: Change user
           command: sudo su ethsec
@@ -149,10 +137,6 @@ jobs:
       - run:
           name: Install Dependencies
           command: npm install --quiet
-      - save_cache:
-          key: v3-sec-toolbox-deps-{{ checksum "package.json" }}
-          paths:
-            - node_modules
       - run:
           name: Run Echidna Tests
           command: ./ci/run_echidna_tests.sh


### PR DESCRIPTION
On other PRs (ex: #719), these tests always fail with:
"""
npm ERR! code EISGIT
npm ERR! path /home/ethsec/protocol/node_modules/websocket
npm ERR! git /home/ethsec/protocol/node_modules/websocket: Appears to be a git repo or submodule.
npm ERR! git     /home/ethsec/protocol/node_modules/websocket
npm ERR! git Refusing to remove it. Update manually,
npm ERR! git or move it out of the way first.
"""

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>