### PR TITLE
Add Docs Site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - restore_cache:
           key: protocol-{{ .Environment.CIRCLE_SHA1 }}
-      - run: 
+      - run:
           name: Install Pandoc
           command: wget https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-linux.tar.gz
       - run:
@@ -238,6 +238,12 @@ jobs:
     steps:
       - restore_cache:
           key: dapp-env-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Install Pandoc
+          command: wget https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-linux.tar.gz
+      - run:
+          name: Untar Pandoc
+          command: sudo tar xvzf pandoc-2.7.3-linux.tar.gz --strip-components 1 -C /usr/local
       - run:
           name: Deploy Dapp
           command: ./ci/deploy_to_staging.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           key: protocol-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Generate Docs
-          command: ./ci/docgen.sh
+          command: ./scripts/build_docs_site.sh
       - store_artifacts:
           path: docs
   slither:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,12 @@ jobs:
     steps:
       - restore_cache:
           key: protocol-{{ .Environment.CIRCLE_SHA1 }}
+      - run: 
+          name: Install Pandoc
+          command: wget https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-linux.tar.gz
+      - run:
+          name: Untar Pandoc
+          command: sudo tar xvzf pandoc-2.7.3-linux.tar.gz --strip-components 1 -C /usr/local
       - run:
           name: Generate Docs
           command: ./scripts/build_docs_site.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: Generate Docs
           command: ./scripts/build_docs_site.sh
       - store_artifacts:
-          path: docs
+          path: build/site
   slither:
     docker:
       - image: trailofbits/eth-security-toolbox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-dependency-cache-{{ checksum "package.json" }}
-            - v2-dependency-cache-
+            - v3-dependency-cache-{{ checksum "package.json" }}
+            - v3-dependency-cache-
       - run:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: v2-dependency-cache-{{ checksum "package.json" }}
+          key: v3-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - save_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out.log
 docs
 modules
 public
+ui
 .DS_Store
 
 # GAE deployment files and directories for GAE deployments.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ coverage.json
 out.log
 .GckmsOverride.js
 docs
+modules
+public
+.DS_Store
 
 # GAE deployment files and directories for GAE deployments.
 app.yaml

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ use by any derivatives that you choose to deploy. The script defaults to publish
 minutes. Depending on the types of price feeds configured in your `v0/config/identifiers.json` file, you may need some
 API keys in your environment:
 - Crypto price feeds (like `BTCETH` or `ETHUSD`): no environment variables are required.
+
 - Futures price feeds (like `ESM19` or `CBN19`): a barchart key must be set as an environment variable called
 `BARCHART_API_KEY`. A barchart key is required whenever the key-value pair `"dataSource": "Barchart"` is present in
 `identifiers.json`.
+
 - Equities price feeds (like `SPY`): an AlphaVantage key must be set as an environment variable called
 `ALPHAVANTAGE_API_KEY`. An AlphaVantage key is equired whenever `"dataSource: AlphaVantageCurrency"` or
 `"dataSource: AlphaVantage"` is present in `identifiers.json`.
@@ -161,16 +163,25 @@ For the script to succeed, the `build` directory must contain the `ManualPriceFe
 
 After deploying to Ganache, ropsten, or mainnet (or any combination of those), you can run the Sponsor Dapp against the
 contracts. Before running the dApp, make sure you have done the following:
+
 - Make sure that you have [Metamask](https://metamask.io/) installed.
+
 - Make sure you've provided your ETH account mnemonic to metamask.
+
     - If you're using the Ganache GUI, this should be available near the top of the page in the accounts (default) tab.
+
     - If you're using Ganache CLI, this should be printed when you start it.
+
     - If you're running against mainnet or testnet, you should use your own mnemonic.
+
 - Make sure you select the correct account.
+
     - If you're using Ganache, the only account that will be whitelisted will be the second account associated with
     your mnemonic. If you only have one account in Metamask, you can use the `Create Account` button to create a
     second. You will need to select the second account if you'd like to launch contracts in the dapp.
+
 - Make sure you have the correct network selected in metamask.
+
     - If you're using Ganache, you'll need to create a custom RPC with the following URL: `http://127.0.0.1:9545`.
 
 Once you've done the above, you can start the dapp by running the following commands from the `protocol` (top level)

--- a/antora.yml
+++ b/antora.yml
@@ -1,0 +1,6 @@
+name: uma
+title: UMA
+version: master
+nav:
+  - modules/ROOT/nav.adoc
+  - modules/contracts/nav.adoc

--- a/ci/deploy_to_staging.sh
+++ b/ci/deploy_to_staging.sh
@@ -32,3 +32,7 @@ gsutil cp gs://staging-deployment-configuration/sponsor-v2-app.yaml sponsor-dapp
 
 # Deploy sponsor-dapp-v2
 ./scripts/deploy_dapp.sh sponsor-dapp-v2 sponsor-dapp-v2/app.yaml -q
+
+# Deploy docs
+./scripts/deploy_docs.sh documentation/gae_app.yaml -q
+

--- a/ci/docgen.sh
+++ b/ci/docgen.sh
@@ -3,6 +3,4 @@
 # Note: because we've forked the solidity-docgen library, providing the path alias doesn't have an effect. However,
 # once external libraries are supported in v2 and we deprecate our fork, this will allow the docgen to find the
 # openzeppelin directory. See https://github.com/OpenZeppelin/solidity-docgen/issues/24 for progress on that front.
-# OPEN_ZEPPELIN_DIR=$(pwd)/node_modules/openzeppelin-solidity
-# SOLC_ARGS="openzeppelin-solidity=$OPEN_ZEPPELIN_DIR" \
 $(npm bin)/solidity-docgen -i ./core/contracts -t documentation --contract-pages -x adoc -e core/contracts/test,core/contracts/echidna_tests

--- a/ci/docgen.sh
+++ b/ci/docgen.sh
@@ -3,6 +3,6 @@
 # Note: because we've forked the solidity-docgen library, providing the path alias doesn't have an effect. However,
 # once external libraries are supported in v2 and we deprecate our fork, this will allow the docgen to find the
 # openzeppelin directory. See https://github.com/OpenZeppelin/solidity-docgen/issues/24 for progress on that front.
-OPEN_ZEPPELIN_DIR=$(pwd)/node_modules/openzeppelin-solidity
-SOLC_ARGS="openzeppelin-solidity=$OPEN_ZEPPELIN_DIR" \
-$(npm bin)/solidity-docgen -c ./core/contracts
+# OPEN_ZEPPELIN_DIR=$(pwd)/node_modules/openzeppelin-solidity
+# SOLC_ARGS="openzeppelin-solidity=$OPEN_ZEPPELIN_DIR" \
+$(npm bin)/solidity-docgen -i ./core/contracts -t documentation --contract-pages -x adoc -e core/contracts/test,core/contracts/echidna_tests

--- a/core/contracts/EncryptedSender.sol
+++ b/core/contracts/EncryptedSender.sol
@@ -9,8 +9,11 @@ pragma solidity ^0.5.0;
  * @dev This contract uses topic hashes as keys and can store a single arbitrary encrypted message per topic at any
  * given time. Note: there's technically nothing that requires the topics hashed or for the messages to be encrypted.
  * This contract is built for the following specific use case:
+ *
  * - The sender and recipient know the topics ahead of time. This can either be communicated elsewhere or be implicit.
+ *
  * - Only one message per topic is stored at any given time.
+ *
  * - Only addresses that are authorized by the recipient can send messages. These authorized parties can overwrite, but
  * not delete the previous message for a particular topic.
  */

--- a/core/contracts/TokenMigrator.sol
+++ b/core/contracts/TokenMigrator.sol
@@ -35,7 +35,7 @@ contract TokenMigrator {
     }
 
     /**
-     * @notice Migrates `tokenHolder`'s old tokens to new tokens.
+     * @notice Migrates the tokenHolder's old tokens to new tokens.
      * @dev This function can only be called once per `tokenHolder`. Anyone can call this method on behalf of any other
      * token holder since there is no disadvantage to receiving the tokens earlier.
      */

--- a/documentation/contract.hbs
+++ b/documentation/contract.hbs
@@ -1,0 +1,89 @@
+{{~#*inline "typed-variable-array"~}}
+{{#each .}}[.var-type\]#{{typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
+{{~/inline~}}
+
+{{#each linkable}}
+:{{name}}: pass:normal[xref:#{{anchor}}[`{{name}}`]]
+{{/each}}
+
+= {{name}}
+
+{{natspec.devdoc}}
+
+{{#if modifiers}}
+[.contract-index]
+.Modifiers
+--
+{{#each inheritedItems}}
+{{#unless @first}}
+[.contract-subindex-inherited]
+.{{contract.name}}
+{{/unless}}
+{{#each modifiers}}
+* xref:#{{anchor}}[`{{name}}({{args.names}})`]
+{{/each}}
+
+{{/each}}
+--
+{{/if}}
+
+{{#if functions}}
+[.contract-index]
+.Functions
+--
+{{#each inheritedItems}}
+{{#unless @first}}
+[.contract-subindex-inherited]
+.{{contract.name}}
+{{/unless}}
+{{#each functions}}
+* xref:#{{anchor}}[`{{name}}({{args.names}})`]
+{{/each}}
+
+{{/each}}
+--
+{{/if}}
+
+{{#if events}}
+[.contract-index]
+.Events
+--
+{{#each inheritedItems}}
+{{#unless @first}}
+[.contract-subindex-inherited]
+.{{contract.name}}
+{{/unless}}
+{{#each events}}
+* xref:#{{anchor}}[`{{name}}({{args.names}})`]
+{{/each}}
+
+{{/each}}
+--
+{{/if}}
+
+{{#each modifiers}}
+[.contract-item]
+[[{{anchor}}]]
+==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#modifier#
+
+{{natspec.devdoc}}
+
+{{/each}}
+
+{{#each functions}}
+[.contract-item]
+[[{{anchor}}]]
+==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]` [.item-kind]#{{visibility}}#
+
+{{natspec.devdoc}}
+
+{{/each}}
+
+{{#each events}}
+[.contract-item]
+[[{{anchor}}]]
+==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#event#
+
+{{natspec.devdoc}}
+
+{{/each}}

--- a/documentation/contract.hbs
+++ b/documentation/contract.hbs
@@ -1,5 +1,5 @@
 {{~#*inline "typed-variable-array"~}}
-{{#each .}}[.var-type\]#{{typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
+{{#each .}}[.var-type\]#{{ecb typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
 {{~/inline~}}
 
 {{#each linkable}}
@@ -7,6 +7,10 @@
 {{/each}}
 
 = {{name}}
+
+{{#if natspec.title}}
+**{{natspec.title}}**
+{{/if}}
 
 {{natspec.devdoc}}
 
@@ -66,6 +70,8 @@
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#modifier#
 
+{{natspec.userdoc}}
+
 {{natspec.devdoc}}
 
 {{/each}}
@@ -75,6 +81,8 @@
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]` [.item-kind]#{{visibility}}#
 
+{{natspec.userdoc}}
+
 {{natspec.devdoc}}
 
 {{/each}}
@@ -83,6 +91,8 @@
 [.contract-item]
 [[{{anchor}}]]
 ==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#event#
+
+{{natspec.userdoc}}
 
 {{natspec.devdoc}}
 

--- a/documentation/gae_app.yaml
+++ b/documentation/gae_app.yaml
@@ -1,0 +1,14 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+handlers:
+- url: /[^.]*$
+  static_files: www/index.html
+  upload: www/index.html
+  secure: always
+  redirect_http_response_code: 301
+- url: /
+  static_dir: www
+  secure: always
+  redirect_http_response_code: 301
+service: docs

--- a/documentation/intro.md
+++ b/documentation/intro.md
@@ -1,0 +1,4 @@
+= Intro
+
+TBD
+

--- a/documentation/prelude.hbs
+++ b/documentation/prelude.hbs
@@ -1,0 +1,3 @@
+{{#links}}
+:{{slug target.fullName}}: pass:normal[xref:{{path}}#{{target.anchor}}[`{{target.fullName}}`]]
+{{/links}}

--- a/documentation/tutorials/sample_tutorial.md
+++ b/documentation/tutorials/sample_tutorial.md
@@ -1,0 +1,4 @@
+= Sample Tutorial
+
+TBD
+

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "truffle-deploy-registry": "^0.5.1"
   },
   "dependencies": {
+    "@antora/cli": "^2.1.2",
+    "@antora/site-generator-default": "^2.1.2",
     "@awaitjs/express": "^0.3.0",
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/storage": "^2.4.2",
@@ -30,13 +32,15 @@
     "eth-crypto": "^1.3.4",
     "express": "^4.17.1",
     "ganache-cli": "^6.4.3",
+    "gitbook-cli": "^2.3.2",
     "gmail-send": "^1.2.14",
+    "lodash.startcase": "^4.4.0",
     "minimist": "^1.2.0",
     "moment": "^2.24.0",
     "node-fetch": "^2.3.0",
     "openzeppelin-solidity": "2.3.0",
     "secp256k1": "^3.7.1",
-    "solidity-docgen": "^0.1.1",
+    "solidity-docgen": "github:UMAprotocol/solidity-docgen#fork",
     "truffle": "5.0.21",
     "truffle-assertions": "0.8.2",
     "truffle-contract": "4.0.19",
@@ -45,8 +49,5 @@
     "web3-core-promievent": "1.0.0-beta.37",
     "web3-eth-abi": "1.0.0-beta.37",
     "web3-utils": "1.0.0-beta.37"
-  },
-  "optionalDependencies": {
-    "solidity-docgen": "github:UMAprotocol/solidity-docgen#master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "node-fetch": "^2.3.0",
     "openzeppelin-solidity": "2.3.0",
     "secp256k1": "^3.7.1",
-    "solidity-docgen": "github:UMAprotocol/solidity-docgen#fork",
     "truffle": "5.0.21",
     "truffle-assertions": "0.8.2",
     "truffle-contract": "4.0.19",
@@ -49,5 +48,8 @@
     "web3-core-promievent": "1.0.0-beta.37",
     "web3-eth-abi": "1.0.0-beta.37",
     "web3-utils": "1.0.0-beta.37"
+  },
+  "optionalDependencies": {
+    "solidity-docgen": "github:UMAprotocol/solidity-docgen#fork"
   }
 }

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,17 @@
+site:
+  title: UMA Docs
+  url: https://docs.umaproject.org
+  keys:
+    google_analytics: 'UA-130599982-5'
+  start_page: uma::index.adoc
+content:
+  sources:
+    - url: .
+      branches: HEAD
+# ui:
+#   bundle:
+#     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
+#     snapshot: true
+ui:
+  bundle:
+    url: ./documentation/ui/build/uma-docs-ui.zip

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,10 +8,6 @@ content:
   sources:
     - url: .
       branches: HEAD
-# ui:
-#   bundle:
-#     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
-#     snapshot: true
 ui:
   bundle:
     url: ./documentation/ui/build/uma-docs-ui.zip

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+START_DIR=$(pwd)
+
+rm -rf $START_DIR/build/site
+rm -rf $START_DIR/modules
+rm -rf $START_DIR/documentation/ui
+
+git clone https://github.com/UMAprotocol/docs_ui.git $START_DIR/documentation/ui
+cd $START_DIR/documentation/ui
+git checkout master
+git pull
+npm install
+npm run bundle
+
+cd $START_DIR
+mkdir -p $START_DIR/modules/ROOT/pages
+mkdir -p $START_DIR/modules/contracts/pages
+
+$START_DIR/ci/docgen.sh
+cp $START_DIR/docs/*.adoc $START_DIR/modules/contracts/pages/
+node $START_DIR/scripts/gen-nav.js $START_DIR/modules/contracts/pages Contracts > $START_DIR/modules/contracts/nav.adoc
+
+shopt -s nullglob
+for FNAME in $START_DIR/documentation/tutorials/*.md
+do
+    BNAME=$(basename "$FNAME" .md)
+    pandoc --atx-headers --verbose --wrap=none --toc --reference-links -f gfm -s -o $START_DIR/modules/ROOT/pages/$BNAME.adoc -t asciidoc $FNAME
+done
+
+node $START_DIR/scripts/gen-nav.js $START_DIR/modules/ROOT/pages Tutorials > $START_DIR/modules/ROOT/nav.adoc
+
+pandoc --atx-headers --verbose --wrap=none --toc --reference-links -f gfm -s -o $START_DIR/modules/ROOT/pages/index.adoc -t asciidoc $START_DIR/documentation/intro.md
+$(npm bin)/antora playbook.yml
+

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -27,6 +27,7 @@ npm install
 
 # Prepare for gcloud deploy.
 echo "Moving files."
+rm -rf build/docs
 mkdir -p build/docs
 cp -R build/site build/docs/www
 cp $APP_YAML_PATH build/docs/

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+# Usage:
+# ./scripts/deploy_dapp.sh <your_file.yaml> <additional_args_for_gcloud_app_deploy>
+
+# Note: you must have the gcloud CLI tool installed and authenticated before using this script.
+# Note: you must also have pandoc installed before running.
+
+# Get the absolute path of a file.
+# Credit: https://stackoverflow.com/a/21188136
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+# Grab the absolute path for the provided file.
+APP_YAML_PATH=$(get_abs_filename $1)
+
+# Shift the arguments to provide to gcloud app deploy.
+shift
+
+# Build the docs site.
+echo "Building docs site locally."
+npm install
+./scripts/build_docs_site.sh
+
+# Prepare for gcloud deploy.
+echo "Moving files."
+mkdir -p build/docs
+cp -R build/site build/docs/www
+cp $APP_YAML_PATH build/docs/
+cd build/docs
+
+# Deploy.
+echo "Deploying."
+gcloud app deploy gae_app.yaml "$@"
+

--- a/scripts/gen-nav.js
+++ b/scripts/gen-nav.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const proc = require('child_process');
+const startCase = require('lodash.startcase');
+
+const baseDir = process.argv[2];
+const sectionName = process.argv[3];
+
+const files = proc.execFileSync(
+  'find', [baseDir, '-type', 'f'], { encoding: 'utf8' }
+).split('\n').filter(s => s !== '');
+
+console.log("." + sectionName);
+
+for (const file of files) {
+  const doc = file.replace(baseDir, '');
+  const title = path.parse(file).name;
+  console.log(`* xref:${doc}[${startCase(title)}]`);
+}


### PR DESCRIPTION
This PR adds a full autogenerated documentation static site modeled after docs.openzeppelin.com. It depends on two forks of open zeppelin work:

- https://github.com/UMAprotocol/docs_ui, which is a new repo because open zeppelin did not isolate their UI components from the rest of their documentation website. Loosely based on https://github.com/OpenZeppelin/docs.openzeppelin.com. However, I made quite a few changes to make the UI more UMA-y :).
- https://github.com/UMAprotocol/solidity-docgen/tree/fork, which is a fork of open zeppelin's repo by the same name. We've been forking this repository for a while, but I made more significant changes to make this work better for our needs. Two changes of note: I fixed a bug where array types don't display correctly (opened an issue about this on their repo) and I made overriding functions/events/modifiers append the base class documentation (this is important for cases where we only document the interface and not the derived class).

Multi contract files, like TokenizedDerivative.sol, still don't work. To get this to work, we'll need to split that file apart. Since this is a pretty easy change on our end, I figure it's easier to do this than making modifications in the library to handle multi-contract files.

In summary, this PR:
- Adds a `documentation/` folder where most documentation-related files are housed. Miscellaneous files were added there to interact with antora, handlebars, and the two external repos.
- Adds a script to build the documentation site.
- Adds a GAE config and a script to deploy the documentation site to GAE.
- Adds the docs site deployment to the `deploy_to_staging` stage in ci.

To preview the site, go to the artifacts tab under a successfully run docs ci job. 

Fixes #376.