### PR TITLE
Remove price feed from finder

### DIFF
--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -30,6 +30,7 @@ library TokenizedDerivativeParams {
     struct ConstructorParams {
         address sponsor;
         address finderAddress;
+        address priceFeedAddress;
         uint defaultPenalty; // Percentage of margin requirement * 10^18
         uint supportedMove; // Expected percentage move in the underlying price that the long is protected against.
         bytes32 product;
@@ -125,6 +126,7 @@ library TDS {
         address sponsor;
         address apDelegate;
         Finder finder;
+        PriceFeedInterface priceFeed;
         ReturnCalculatorInterface returnCalculator;
         IERC20 marginCurrency;
     }
@@ -489,7 +491,7 @@ library TokenizedDerivativeUtils {
         require(params.startingTokenPrice <= UINT_FP_SCALING_FACTOR.mul(10**9));
 
         // TODO(mrice32): we should have an ideal start time rather than blindly polling.
-        (uint latestTime, int latestUnderlyingPrice) = PriceFeedInterface(_getPriceFeedAddress(s)).latestPrice(
+        (uint latestTime, int latestUnderlyingPrice) = s.externalAddresses.priceFeed.latestPrice(
             s.fixedParameters.product);
 
         // If nonzero, take the user input as the starting price.
@@ -526,11 +528,6 @@ library TokenizedDerivativeUtils {
     function _getStoreAddress(TDS.Storage storage s) internal view returns (address) {
         bytes32 storeInterface = "Store";
         return s.externalAddresses.finder.getImplementationAddress(storeInterface);
-    }
-
-    function _getPriceFeedAddress(TDS.Storage storage s) internal view returns (address) {
-        bytes32 priceFeedInterface = "PriceFeed";
-        return s.externalAddresses.finder.getImplementationAddress(priceFeedInterface);
     }
 
     function _getAdminAddress(TDS.Storage storage s) internal view returns (address) {
@@ -647,11 +644,12 @@ library TokenizedDerivativeUtils {
 
         s.externalAddresses.returnCalculator = ReturnCalculatorInterface(params.returnCalculator);
         s.externalAddresses.finder = Finder(params.finderAddress);
+        s.externalAddresses.priceFeed = PriceFeedInterface(params.priceFeedAddress);
 
         // Verify that the price feed and Oracle support the given s.fixedParameters.product.
         OracleInterface oracle = OracleInterface(_getOracleAddress(s));
         require(oracle.isIdentifierSupported(params.product));
-        require(PriceFeedInterface(_getPriceFeedAddress(s)).isIdentifierSupported(params.product));
+        require(s.externalAddresses.priceFeed.isIdentifierSupported(params.product));
 
         s.externalAddresses.sponsor = params.sponsor;
     }
@@ -898,8 +896,7 @@ library TokenizedDerivativeUtils {
     }
 
     function _getLatestPrice(TDS.Storage storage s) internal view returns (uint latestTime, int latestUnderlyingPrice) {
-        (latestTime, latestUnderlyingPrice) = PriceFeedInterface(
-            _getPriceFeedAddress(s)).latestPrice(s.fixedParameters.product);
+        (latestTime, latestUnderlyingPrice) = s.externalAddresses.priceFeed.latestPrice(s.fixedParameters.product);
         require(latestTime != 0);
     }
 
@@ -1361,6 +1358,7 @@ contract TokenizedDerivative is ERC20, AdministrateeInterface, ExpandedIERC20 {
  */
 contract TokenizedDerivativeCreator is ContractCreator, Testable {
     struct Params {
+        address priceFeedAddress;
         uint defaultPenalty; // Percentage of mergin requirement * 10^18
         uint supportedMove; // Expected percentage move in the underlying that the long is protected against.
         bytes32 product;
@@ -1424,6 +1422,7 @@ contract TokenizedDerivativeCreator is ContractCreator, Testable {
         require(marginCurrencyWhitelist.isOnWhitelist(params.marginCurrency));
         constructorParams.marginCurrency = params.marginCurrency;
 
+        constructorParams.priceFeedAddress = params.priceFeedAddress;
         constructorParams.defaultPenalty = params.defaultPenalty;
         constructorParams.supportedMove = params.supportedMove;
         constructorParams.product = params.product;

--- a/core/contracts/TokenizedDerivativeCreator.sol
+++ b/core/contracts/TokenizedDerivativeCreator.sol
@@ -13,6 +13,7 @@ import "./Testable.sol";
  */
 contract TokenizedDerivativeCreator is ContractCreator, Testable {
     struct Params {
+        address priceFeedAddress;
         uint defaultPenalty; // Percentage of mergin requirement * 10^18
         uint supportedMove; // Expected percentage move in the underlying that the long is protected against.
         bytes32 product;
@@ -76,6 +77,7 @@ contract TokenizedDerivativeCreator is ContractCreator, Testable {
         require(marginCurrencyWhitelist.isOnWhitelist(params.marginCurrency));
         constructorParams.marginCurrency = params.marginCurrency;
 
+        constructorParams.priceFeedAddress = params.priceFeedAddress;
         constructorParams.defaultPenalty = params.defaultPenalty;
         constructorParams.supportedMove = params.supportedMove;
         constructorParams.product = params.product;

--- a/core/migrations/6_deploy_price_feed.js
+++ b/core/migrations/6_deploy_price_feed.js
@@ -1,4 +1,3 @@
-const Finder = artifacts.require("Finder");
 const ManualPriceFeed = artifacts.require("ManualPriceFeed");
 const { getKeysForNetwork, enableControllableTiming, deploy, addToTdr } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
@@ -9,10 +8,5 @@ module.exports = async function(deployer, network, accounts) {
 
   const { contract: manualPriceFeed } = await deploy(deployer, network, ManualPriceFeed, controllableTiming, {
     from: keys.priceFeed
-  });
-
-  const finder = await Finder.deployed();
-  await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.PriceFeed), manualPriceFeed.address, {
-    from: keys.deployer
   });
 };

--- a/core/scripts/ManualPublishPriceFeed.js
+++ b/core/scripts/ManualPublishPriceFeed.js
@@ -1,7 +1,6 @@
 const argv = require("minimist")(process.argv.slice(), { string: ["identifier", "price", "time"] });
 const { interfaceName } = require("../utils/Constants.js");
 
-const Finder = artifacts.require("Finder");
 const ManualPriceFeed = artifacts.require("ManualPriceFeed");
 
 async function run(account, identifier, priceAsString, time) {
@@ -9,11 +8,7 @@ async function run(account, identifier, priceAsString, time) {
     const identifierBytes = web3.utils.hexToBytes(web3.utils.utf8ToHex(identifier));
     const price = web3.utils.toWei(priceAsString);
 
-    const deployedFinder = await Finder.deployed();
-    const priceFeed = await ManualPriceFeed.at(
-      await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.PriceFeed))
-    );
-
+    const priceFeed = await ManualPriceFeed.deployed();
     await priceFeed.pushLatestPrice(identifierBytes, time, price, { from: account });
     console.log(`Published price for ${identifier} @ ${time}: ${priceAsString}`);
   } catch (e) {

--- a/core/scripts/local/InitializeSystem.js
+++ b/core/scripts/local/InitializeSystem.js
@@ -78,6 +78,7 @@ const initializeSystem = async function(callback) {
 
     const defaultConstructorParams = {
       sponsor: sponsor,
+      priceFeedAddress: deployedManualPriceFeed.address,
       defaultPenalty: web3.utils.toWei("0.5", "ether"),
       supportedMove: web3.utils.toWei("0.1", "ether"),
       product: identifierBytes,

--- a/core/scripts/local/InitializeSystem.js
+++ b/core/scripts/local/InitializeSystem.js
@@ -32,9 +32,7 @@ const initializeSystem = async function(callback) {
     const deployedVoting = await Voting.at(
       await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle))
     );
-    const deployedManualPriceFeed = await ManualPriceFeed.at(
-      await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.PriceFeed))
-    );
+    const deployedManualPriceFeed = await ManualPriceFeed.deployed();
 
     const tokenizedDerivativeCreator = await TokenizedDerivativeCreator.deployed();
     const noLeverageCalculator = await LeveragedReturnCalculator.deployed();
@@ -77,7 +75,6 @@ const initializeSystem = async function(callback) {
     const identifierBytes = web3.utils.hexToBytes(web3.utils.utf8ToHex(identifier));
 
     const defaultConstructorParams = {
-      sponsor: sponsor,
       priceFeedAddress: deployedManualPriceFeed.address,
       defaultPenalty: web3.utils.toWei("0.5", "ether"),
       supportedMove: web3.utils.toWei("0.1", "ether"),

--- a/core/test/TokenizedDerivative.js
+++ b/core/test/TokenizedDerivative.js
@@ -2636,6 +2636,8 @@ contract("TokenizedDerivative", function(accounts) {
           tokenizedDerivativeCreator.createTokenizedDerivative(defaultConstructorParams, { from: sponsor })
         )
       );
+      // Reset the price feed for remaining assertions.
+      await pushPrice(web3.utils.toWei("1", "ether"));
 
       // Invalid returnType.
       const invalidReturnTypeParams = { ...defaultConstructorParams, returnType: "2" };

--- a/core/test/TokenizedDerivative.js
+++ b/core/test/TokenizedDerivative.js
@@ -159,7 +159,7 @@ contract("TokenizedDerivative", function(accounts) {
       const startTime = (await deployedManualPriceFeed.latestPrice(identifierBytes))[0];
 
       let defaultConstructorParams = {
-        sponsor: sponsor,
+        priceFeedAddress: deployedManualPriceFeed.address,
         defaultPenalty: web3.utils.toWei("0.5", "ether"),
         supportedMove: web3.utils.toWei("0.1", "ether"),
         product: identifierBytes,
@@ -2488,7 +2488,7 @@ contract("TokenizedDerivative", function(accounts) {
 
     it(annotateTitle("Constructor assertions"), async function() {
       const defaultConstructorParams = {
-        sponsor: sponsor,
+        priceFeedAddress: deployedManualPriceFeed.address,
         defaultPenalty: web3.utils.toWei("0.5", "ether"),
         supportedMove: web3.utils.toWei("0.1", "ether"),
         product: identifierBytes,
@@ -2504,6 +2504,8 @@ contract("TokenizedDerivative", function(accounts) {
         name: "1x coin",
         symbol: web3.utils.utf8ToHex("BTCETH")
       };
+
+      await pushPrice(web3.utils.toWei("1", "ether"));
 
       // Verify that the defaults work.
       await tokenizedDerivativeCreator.createTokenizedDerivative(defaultConstructorParams, { from: sponsor });

--- a/core/test/scripts/EmergencyShutdown.js
+++ b/core/test/scripts/EmergencyShutdown.js
@@ -51,6 +51,7 @@ contract("scripts/EmergencyShutdown.js", function(accounts) {
     // Create derivative
     const params = {
       sponsor: sponsor,
+      priceFeedAddress: priceFeed.address,
       defaultPenalty: web3.utils.toWei("0.5", "ether"),
       supportedMove: web3.utils.toWei("0.1", "ether"),
       product: identifierBytes,

--- a/core/utils/Constants.js
+++ b/core/utils/Constants.js
@@ -2,7 +2,6 @@
 const interfaceName = {
   FinancialContractsAdmin: "FinancialContractsAdmin",
   Oracle: "Oracle",
-  PriceFeed: "PriceFeed",
   Registry: "Registry",
   Store: "Store"
 };

--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -61,6 +61,7 @@ function useCreateContract(userSelectionsRef, identifierConfig, onNextStep, stat
     const withdrawLimit = "1000000000000000000000000000000000000";
 
     rawSend({
+      priceFeedAddress: drizzle.contracts.ManualPriceFeed.address,
       defaultPenalty: toWei("1"),
       supportedMove: toWei(identifierConfig[identifier].supportedMove),
       product: utf8ToHex(identifier),

--- a/sponsor-dapp-v2/src/views/ManagePositions.js
+++ b/sponsor-dapp-v2/src/views/ManagePositions.js
@@ -86,8 +86,6 @@ function useFinancialContractData(tokenAddress) {
   }
   data.ready = true;
 
-  data.priceFeedAddress = data.derivativeStorage.externalAddresses.priceFeedAddress;
-
   // Format financial contract data for display.
   const { toBN, toChecksumAddress } = web3.utils;
   data.isTokenSponsor =
@@ -131,7 +129,7 @@ function useFinancialContractData(tokenAddress) {
     { type: "address", title: "Sponsor", address: { display: data.derivativeStorage.externalAddresses.sponsor } },
     { type: "timestamp", title: "Created", timestamp: data.derivativeStorage.fixedParameters.creationTime },
     { type: "timestamp", title: "Expiry", timestamp: data.derivativeStorage.endTime },
-    { type: "address", title: "Price feed", address: { display: data.priceFeedAddress } },
+    { type: "address", title: "Price feed", address: { display: data.derivativeStorage.externalAddresses.priceFeed } },
     {
       type: "namedAddress",
       title: "Denomination",

--- a/sponsor-dapp-v2/src/views/ManagePositions.js
+++ b/sponsor-dapp-v2/src/views/ManagePositions.js
@@ -81,12 +81,13 @@ function useFinancialContractData(tokenAddress) {
   data.totalSupply = useCacheCall(tokenAddress, "totalSupply");
   data.tokenBalance = useCacheCall(tokenAddress, "balanceOf", account);
 
-  data.priceFeedAddress = useCacheCall("Finder", "getImplementationAddress", web3.utils.utf8ToHex("PriceFeed"));
 
   if (!Object.values(data).every(val => val !== undefined)) {
     return { ready: false };
   }
   data.ready = true;
+
+  data.priceFeedAddress = derivativeStorage.externalAddresses.priceFeedAddress;
 
   // Format financial contract data for display.
   const { toBN, toChecksumAddress } = web3.utils;

--- a/sponsor-dapp-v2/src/views/ManagePositions.js
+++ b/sponsor-dapp-v2/src/views/ManagePositions.js
@@ -81,13 +81,12 @@ function useFinancialContractData(tokenAddress) {
   data.totalSupply = useCacheCall(tokenAddress, "totalSupply");
   data.tokenBalance = useCacheCall(tokenAddress, "balanceOf", account);
 
-
   if (!Object.values(data).every(val => val !== undefined)) {
     return { ready: false };
   }
   data.ready = true;
 
-  data.priceFeedAddress = derivativeStorage.externalAddresses.priceFeedAddress;
+  data.priceFeedAddress = data.derivativeStorage.externalAddresses.priceFeedAddress;
 
   // Format financial contract data for display.
   const { toBN, toChecksumAddress } = web3.utils;


### PR DESCRIPTION
Sponsors can now use their own price feed contract when creating a new
TokenizedDerivative. The sponsor dApp doesn't support this feature, but
the sponsor can use the CLI.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>