### PR TITLE
Add syntax highlighting for code blocks

### DIFF
--- a/documentation/explainers/price-feed-configuration.md
+++ b/documentation/explainers/price-feed-configuration.md
@@ -16,22 +16,22 @@ This json file contains a list of entries for each supported identifier, with tw
 2. `uploaderConfig`: configuration for UMA's price feed uploader. See the [Uploader](#uploader) section for more details.
 
 The configuration will look like:
-```
+```js
 {
     "IDENTIFIER": {
         "dappConfig": {
-            ...
+            // ...
         },
         "uploaderConfig": {
-            ...
+            // ...
         }
     },
     "IDENTIFIER2": {
         "dappConfig": {
-            ...
+            // ...
         },
         "uploaderConfig": {
-            ...
+            // ...
         }
     }
 }
@@ -41,19 +41,19 @@ To support a new identifier, follow these steps:
 1. Add an entry to `identifiers.json` with both `dappConfig` and `uploaderConfig`.
 2. Approve the identifier in the Oracle. Locally, you can run:
 
-   ```
+   ```bash
    $(npm bin)/truffle exec scripts/local/ApproveIdentifiers.js --network=test
    ```
 
 3. Push at least one price. Locally, you can manually push a price:
 
-   ```
+   ```bash
    $(npm bin)/truffle exec scripts/ManualPublishPriceFeed.js --identifier <identifier> --price <price> --time <time> --network=test
    ```
 
    Or you can run UMA's price feed uploader:
 
-   ```
+   ```bash
    $(npm bin)/truffle exec scripts/PublishPrices.js --network=test
    ```
 
@@ -65,8 +65,8 @@ The [Sponsor dApp](https://github.com/UMAprotocol/protocol/tree/master/sponsor-d
 If the identifier is supported, the dApp allows you to select it as the index for your synthetic token.
 
 An example config looks like:
-```
-"dappConfig: {
+```json
+"dappConfig": {
     "expiries": [1572552000, 1575061200, 1577826000, 0],
     "supportedMove": "0.15"
 }
@@ -88,7 +88,7 @@ UMA's price feed uploader script [PublishPrices.js](https://github.com/UMAprotoc
 references the `uploaderConfig` field. If you bring your own price feed, you can configure it your own way.
 
 An example config looks like:
-```
+```json
 "uploaderConfig": {
     "publishInterval": "900",
     "minDelay": "0",

--- a/documentation/tutorials/creating-tokens-locally.md
+++ b/documentation/tutorials/creating-tokens-locally.md
@@ -18,7 +18,7 @@ Run all commands in this section from the `core/` directory.
 
 1. Start the Ganache UI.
 1. Switch to a test identifier config:
-```
+```console
 mv core/config/identifiersTest.json core/config/identifiers.json
 ```
 1. Deploy smart contracts to the locally running Ganache instance via:

--- a/documentation/tutorials/creating-tokens-locally.md
+++ b/documentation/tutorials/creating-tokens-locally.md
@@ -18,11 +18,11 @@ Run all commands in this section from the `core/` directory.
 
 1. Start the Ganache UI.
 1. Switch to a test identifier config:
-```console
+```bash
 mv core/config/identifiersTest.json core/config/identifiers.json
 ```
 1. Deploy smart contracts to the locally running Ganache instance via:
-```
+```bash
 $(npm bin)/truffle migrate --reset --network test
 ```
 
@@ -37,14 +37,14 @@ blockchain. An example of such a script is `core/scripts/PublishPrices.js`.
 
 Locally, however, let's skip the step of setting up a data feed and manually push a price for `BTCUSD` via:
 
-```
+```bash
 $(npm bin)/truffle exec scripts/ManualPublishPriceFeed.js --identifier BTCUSD --price <price> --time <time>
 ```
 
 where `<price>` is the current price of Bitcoin in USD and `<time>` is the current UNIX timestamp in seconds.
 
 For example, if the price of Bitcoin were `$8,923` at 10/21/2019 15:40 EDT, run:
-```
+```bash
 $(npm bin)/truffle exec scripts/ManualPublishPriceFeed.js --identifier BTCUSD --price 8293 --time 1571686800
 ```
 

--- a/documentation/tutorials/prerequisites.md
+++ b/documentation/tutorials/prerequisites.md
@@ -11,7 +11,7 @@ Start in the top-level directory in this repository, `protocol/`.
 
 We should be able to compile the smart contracts from `protocol/core`:
 
-```
+```bash
 cd core
 $(npm bin)/truffle compile
 ```
@@ -25,7 +25,7 @@ If everything worked, we should see the line "> Compiled successfully using:" in
 
 If everything was setup correctly, we should be able to run automated tests from `protocol/core`:
 
-```
+```bash
 cd core
 $(npm bin)/truffle test --network test
 ```


### PR DESCRIPTION
All we need to do to get syntax highlighting and code block backgrounds is to add a language for the block in github. This causes asciidoc to label it a code block and not a literal block, which has different styling. We should start doing this going forward. Added benefit is that we get syntax highlighting for free :)