### PR TITLE
Redeploy TokenizedDerivativeCreator

### DIFF
--- a/core/migrations/11_deploy_tokenized_derivative_creator.js
+++ b/core/migrations/11_deploy_tokenized_derivative_creator.js
@@ -45,7 +45,5 @@ module.exports = async function(deployer, network, accounts) {
   await returnCalculatorWhitelist.addToWhitelist(returnCalculator.address, { from: keys.returnCalculatorWhitelist });
 
   // For any test networks, automatically add ETH as an allowed margin currency.
-  if (!isPublicNetwork(network)) {
-    await marginCurrencyWhitelist.addToWhitelist(ethAddress, { from: keys.marginCurrencyWhitelist });
-  }
+  await marginCurrencyWhitelist.addToWhitelist(ethAddress, { from: keys.marginCurrencyWhitelist });
 };

--- a/core/networks/4.json
+++ b/core/networks/4.json
@@ -33,11 +33,15 @@
   },
   {
     "contractName": "LeveragedReturnCalculator",
+    "address": "0xEcf1b08D18229533164162f6F4A6DFe2cffDfd0a"
+  },
+  {
+    "contractName": "LeveragedReturnCalculator",
     "address": "0x87DaFfC54F7872b441CcD047f15A51555a907515"
   },
   {
     "contractName": "TokenizedDerivativeUtils",
-    "address": "0x544ED595564e4Cda489a426bD98899A86A89fba7"
+    "address": "0x4F21D841Bd73A2eD8749C8e72A71Ddc5b337B664"
   },
   {
     "contractName": "AddressWhitelist",
@@ -49,7 +53,7 @@
   },
   {
     "contractName": "TokenizedDerivativeCreator",
-    "address": "0xB5E894106c5BdD1198E0eaCc8D59c9166F83AD30"
+    "address": "0x8bB95ab35e64F1F36A6AF04A38F4B3Ca4fF768B0"
   },
   {
     "contractName": "TestnetERC20",


### PR DESCRIPTION
This PR modifies our deployment and deployed addresses in a few ways:
- Redeploys the updated TokenizedDerivativeCreator.
- Adds a new LeveragedReturnCalculator that has leverage of 2. The default will still be one, but the other is included in the networks file just to help us keep track of the address.
- Removes the `if` in migrations around adding ETH as a margin currency so it's enabled for all networks.