### PR TITLE
Remove outdated config options in Voting.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,8 @@ workflows:
   build_and_test:
     jobs:
       - checkout_and_install
-      - coverage
+      - coverage:
+          context: api_keys
       - slither
       - echidna
       - build:

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -12,12 +12,6 @@ const moment = require("moment");
 const argv = require("minimist")(process.argv.slice(), { string: ["network"] });
 
 const SUPPORTED_IDENTIFIERS = {
-  BTCUSD: {
-    numerator: {
-      dataSource: "CryptoCompare",
-      identifiers: { first: "BTC", second: "USD" }
-    }
-  },
   "BTC/USD": {
     numerator: {
       dataSource: "Manual"
@@ -96,12 +90,7 @@ const SUPPORTED_IDENTIFIERS = {
   },
   "USD/ETH": {
     numerator: {
-      dataSource: "Constant",
-      value: "1"
-    },
-    denominator: {
-      dataSource: "IntrinioCrypto",
-      symbol: "ethusd"
+      dataSource: "Manual"
     }
   },
   "Custom Index (1)": {

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -173,8 +173,8 @@ function fetchConstantPrice(request, config) {
 
 function getIntrinioTimeArguments(time) {
   const requestMoment = moment.unix(time);
-  const requestDate = requestMoment.format("YYYY-MM-DD");
-  const requestTime = requestMoment.format("HH:mm:ss");
+  const requestDate = requestMoment.utc().format("YYYY-MM-DD");
+  const requestTime = requestMoment.utc().format("HH:mm:ss");
 
   // If we don't specify a `start_time` or `start_date`, Intrinio APIs return data in reverse chronological order, up to
   // `end_time`.

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -165,9 +165,9 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(await voting.getPrice(identifier2, time2), hardcodedPrice);
   });
 
-  it("CryptoCompare price", async function() {
-    const identifier = web3.utils.utf8ToHex("BTCUSD");
-    const time = "1560762000";
+  it.only("Intrinio price", async function() {
+    const identifier = web3.utils.utf8ToHex("TSLA");
+    const time = "1573513368";
 
     // Request an Oracle price.
     await voting.addSupportedIdentifier(identifier);
@@ -196,7 +196,7 @@ contract("scripts/Voting.js", function(accounts) {
 
     await moveToNextRound(voting);
     // The previous `runIteration()` should have revealed the vote, so the price request should be resolved.
-    assert.equal((await voting.getPrice(identifier, time)).toString(), web3.utils.toWei("9155.05"));
+    assert.equal((await voting.getPrice(identifier, time)).toString(), web3.utils.toWei("346.84"));
   });
 
   it("Notification on crash", async function() {

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -165,7 +165,7 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(await voting.getPrice(identifier2, time2), hardcodedPrice);
   });
 
-  it.only("Intrinio price", async function() {
+  it("Intrinio price", async function() {
     const identifier = web3.utils.utf8ToHex("TSLA");
     const time = "1573513368";
 

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -165,7 +165,7 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(await voting.getPrice(identifier2, time2), hardcodedPrice);
   });
 
-  it("Intrinio price", async function() {
+  it.only("Intrinio price", async function() {
     const identifier = web3.utils.utf8ToHex("TSLA");
     const time = "1573513368";
 
@@ -196,7 +196,7 @@ contract("scripts/Voting.js", function(accounts) {
 
     await moveToNextRound(voting);
     // The previous `runIteration()` should have revealed the vote, so the price request should be resolved.
-    assert.equal((await voting.getPrice(identifier, time)).toString(), web3.utils.toWei("346.84"));
+    assert.equal((await voting.getPrice(identifier, time)).toString(), web3.utils.toWei("345.07"));
   });
 
   it("Notification on crash", async function() {


### PR DESCRIPTION
Note: while changing the config and modifying the broken test, I noticed a bug in how we query intrinio. The `moment` library outputs it's format in local time unless you force it to produce utc. So, the query was sending different times based on where the local machine was (circleci was failing because their machines are in a different time zone). I double checked that intrinio expects these times in UTC.