### PR TITLE
Reorganize the way price requests are tracked

### DIFF
--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -1,9 +1,12 @@
 pragma solidity ^0.5.0;
 
+pragma experimental ABIEncoderV2;
+
 import "./Finder.sol";
 import "./MultiRole.sol";
 import "./Withdrawable.sol";
 import "./Voting.sol";
+import "./VotingInterface.sol";
 
 
 /**
@@ -49,8 +52,11 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     /**
      * @notice Forwards a reward retrieval to Voting.
      */
-    function retrieveRewards() external onlyRoleHolder(uint(Roles.Voter)) {
-        _getVotingAddress().retrieveRewards();
+    function retrieveRewards(uint roundId, VotingInterface.PendingRequest[] memory toRetrieve)
+        public
+        onlyRoleHolder(uint(Roles.Voter))
+    {
+        _getVotingAddress().retrieveRewards(roundId, toRetrieve);
     }
 
     function _getVotingAddress() private view returns (Voting) {

--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -30,7 +30,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     Finder private finder;
 
     constructor(address finderAddress) public {
-        initializeOnce();
+        initializeOnce(finderAddress);
     }
 
     /**

--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -23,16 +23,14 @@ contract DesignatedVoting is MultiRole, Withdrawable {
         Voter
     }
 
+    bool private initialized;
+
     // Reference to the UMA Finder contract, allowing Voting upgrades to be performed without requiring any calls to
     // this contract.
     Finder private finder;
 
     constructor(address finderAddress) public {
-        _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
-        _createExclusiveRole(uint(Roles.Voter), uint(Roles.Owner), msg.sender);
-        setWithdrawRole(uint(Roles.Owner));
-
-        finder = Finder(finderAddress);
+        initializeOnce();
     }
 
     /**
@@ -57,6 +55,21 @@ contract DesignatedVoting is MultiRole, Withdrawable {
         onlyRoleHolder(uint(Roles.Voter))
     {
         _getVotingAddress().retrieveRewards(roundId, toRetrieve);
+    }
+
+    /*
+     * @notice Do not call this function externally.
+     * @dev Only called from the constructor, and only extracted to a separate method to make the coverage tool work.
+     * Will revert if called again.
+     */
+    function initializeOnce(address finderAddress) public {
+        require(!initialized, "Only the constructor should call this method");
+        initialized = true;
+        _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
+        _createExclusiveRole(uint(Roles.Voter), uint(Roles.Owner), msg.sender);
+        setWithdrawRole(uint(Roles.Owner));
+
+        finder = Finder(finderAddress);
     }
 
     function _getVotingAddress() private view returns (Voting) {

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -580,7 +580,8 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
             return isResolved ? RequestStatus.Resolved : RequestStatus.Active;
         } else if (priceRequest.lastVotingRound == currentRoundId) {
             return RequestStatus.Active;
-        } else if (priceRequest.lastVotingRound > currentRoundId) {
+        } else {
+            // Means than priceRequest.lastVotingRound > currentRoundId
             return RequestStatus.Future;
         }
     }

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -39,6 +39,11 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         // If in the past, this was the voting round where this price was resolved. If current or the upcoming round,
         // this is the voting round where this price will be voted on, but not necessarily resolved.
         uint lastVotingRound;
+
+        // These two variables are needed to track when this price request first gets resolved, so we can emit an
+        // appropriate event. Other approaches are definitely possible here instead.
+        bool isResolved;
+        uint index;
     }
 
     struct VoteInstance {
@@ -85,9 +90,6 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
     }
 
     struct Round {
-        // The list of price requests that were/are being voted on this round.
-        bytes32[] priceRequestIds;
-
         // Voting token snapshot ID for this round. If this is 0, no snapshot has been taken.
         uint snapshotId;
 
@@ -100,6 +102,10 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
 
     // Maps price request IDs to the PriceRequest struct.
     mapping(bytes32 => PriceRequest) private priceRequests;
+
+    // Price request ids for price requests that haven't yet been marked as resolved. These requests may be for future
+    // rounds.
+    bytes32[] private pendingPriceRequests;
 
     VoteTiming.Data private voteTiming;
 
@@ -118,9 +124,6 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
 
     // Reference to the voting token.
     VotingToken private votingToken;
-
-    // Voter address -> last round that they voted in.
-    mapping(address => uint) private votersLastRound;
 
     // Reference to the Finder.
     Finder private finder;
@@ -170,34 +173,35 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         onlyRegisteredDerivative()
         returns (uint expectedTime)
     {
-        // TODO: we may want to allow future price requests and/or add a delay so that the price has enough time to be
-        // widely distributed and agreed upon before the vote.
         uint blockTime = getCurrentTime();
-        require(time < blockTime);
+        require(time < blockTime, "Price request must be for a time in the past");
         require(supportedIdentifiers[identifier], "Price request for unsupported identifier");
 
         // Must ensure the round is updated here so the requested price will be voted on in the next commit cycle.
-        // It's preferred to offload this cost to voters, but since the logic currently requires the rollover to be
-        // done when adding new requests, it must be here.
-        // TODO: look into how to elminate this call or require it only for a subset of the if cases below.
-        // TODO: this may be an expensive operation - may make sense to have a public updateRound() method to handle
-        // extreme cases.
         _updateRound(blockTime);
-
-        uint currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
 
         bytes32 priceRequestId = _encodePriceRequest(identifier, time);
         PriceRequest storage priceRequest = priceRequests[priceRequestId];
         uint priceResolutionRound = priceRequest.lastVotingRound;
 
-        // Price is already slated to be resolved.
-        if (priceResolutionRound >= currentRoundId) {
-            return voteTiming.computeEstimatedRoundEndTime(priceResolutionRound);
+        VoteInstance storage voteInstance = priceRequest.voteInstances[priceResolutionRound];
+        (bool isResolved, ) = voteInstance.resultComputation.getResolvedPrice(
+            _computeGat(priceResolutionRound));
+
+        // Price has been resolved.
+        if (isResolved) {
+            return 0;
         }
 
-        // Price has been resolved
-        if (priceResolutionRound != 0) {
-            return 0;
+        uint currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
+        // Being voted on this round!
+        if (priceResolutionRound != 0 && priceResolutionRound <= currentRoundId) {
+            return voteTiming.computeEstimatedRoundEndTime(currentRoundId);
+        }
+
+        // Price is already slated to be resolved in some future round.
+        if (priceResolutionRound > currentRoundId) {
+            return voteTiming.computeEstimatedRoundEndTime(priceResolutionRound);
         }
 
         // Price has never been requested.
@@ -208,11 +212,11 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         priceRequests[priceRequestId] = PriceRequest({
             identifier: identifier,
             time: time,
-            lastVotingRound: nextRoundId
+            lastVotingRound: nextRoundId,
+            isResolved: false,
+            index: pendingPriceRequests.length
         });
-
-        // Add price request to the next round.
-        rounds[nextRoundId].priceRequestIds.push(priceRequestId);
+        pendingPriceRequests.push(priceRequestId);
         emit PriceRequestAdded(nextRoundId, identifier, time);
 
         // Estimate the end of next round and return the time.
@@ -267,32 +271,25 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
 
     function getPendingRequests() external view returns (PendingRequest[] memory pendingRequests) {
         uint blockTime = getCurrentTime();
+        uint currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
 
-        // Grab the pending price requests that were already slated for this round.
-        bytes32[] storage preexistingPriceRequests = rounds[
-            voteTiming.computeCurrentRoundId(blockTime)].priceRequestIds;
-        uint numPreexistingPriceRequests = preexistingPriceRequests.length;
+        // Solidity memory arrays aren't resizable (and reading storage is expensive). Hence this hackery to filter
+        // `pendingPriceRequests` only to those requests that `isActive()`.
+        PendingRequest[] memory unresolved = new PendingRequest[](pendingPriceRequests.length);
+        uint numUnresolved = 0;
 
-        // Get the rollover price requests.
-        (bytes32[] memory rolloverPriceRequests, uint numRolloverPriceRequests) = _getRolloverPriceRequests(
-            blockTime);
-
-        // Allocate the array to return.
-        pendingRequests = new PendingRequest[](numPreexistingPriceRequests + numRolloverPriceRequests);
-
-        // Add preexisting price requests to the array.
-        for (uint i = 0; i < numPreexistingPriceRequests; i++) {
-            PriceRequest storage priceRequest = priceRequests[preexistingPriceRequests[i]];
-            pendingRequests[i] = PendingRequest({ identifier: priceRequest.identifier, time: priceRequest.time });
+        for (uint i = 0; i < pendingPriceRequests.length; i++) {
+            PriceRequest storage priceRequest = priceRequests[pendingPriceRequests[i]];
+            if (_isActive(priceRequest, currentRoundId)) {
+                unresolved[numUnresolved] = PendingRequest(
+                    { identifier: priceRequest.identifier, time: priceRequest.time });
+                numUnresolved++;
+            }
         }
 
-        // Add rollover price requests to the array.
-        for (uint i = 0; i < numRolloverPriceRequests; i++) {
-            PriceRequest storage priceRequest = priceRequests[rolloverPriceRequests[i]];
-            pendingRequests[i + numPreexistingPriceRequests] = PendingRequest({
-                identifier: priceRequest.identifier,
-                time: priceRequest.time
-            });
+        pendingRequests = new PendingRequest[](numUnresolved);
+        for (uint i = 0; i < numUnresolved; i++) {
+            pendingRequests[i] = unresolved[i];
         }
     }
 
@@ -338,18 +335,13 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         uint currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
 
         PriceRequest storage priceRequest = _getPriceRequest(identifier, time);
+        require(_isActive(priceRequest, currentRoundId), "haha");
 
-        // This price request must be slated for this round.
-        require(priceRequest.lastVotingRound == currentRoundId,
-            "This (time, identifier) pair is not being voted on this round");
-
+        if (priceRequest.lastVotingRound < currentRoundId) {
+            priceRequest.lastVotingRound = currentRoundId;
+        }
         VoteInstance storage voteInstance = priceRequest.voteInstances[currentRoundId];
         voteInstance.voteSubmissions[msg.sender].commit = hash;
-
-        if (votersLastRound[msg.sender] != currentRoundId) {
-            retrieveRewards();
-            votersLastRound[msg.sender] = currentRoundId;
-        }
 
         emit VoteCommitted(msg.sender, currentRoundId, identifier, time);
     }
@@ -386,7 +378,7 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         // Add vote to the results.
         voteInstance.resultComputation.addVote(price, balance);
 
-        // Remove the stored message for this price request, if it exsts.
+        // Remove the stored message for this price request, if it exists.
         bytes32 topicHash = keccak256(abi.encode(identifier, time, roundId));
         removeMessage(msg.sender, topicHash);
 
@@ -414,30 +406,12 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         inflationRate = _inflationRate;
     }
 
-    function retrieveRewards() public {
+    function retrieveRewards(uint roundId, PendingRequest[] memory toRetrieve) public {
         uint blockTime = getCurrentTime();
-        uint roundId = votersLastRound[msg.sender];
-
-        if (roundId == voteTiming.computeCurrentRoundId(blockTime)) {
-            // If the last round the voter participated in is the current round, rewards cannot be dispatched until the
-            // round is over.
-            return;
-        }
-
-        // Round must be updated (if possible) for the voter to retrieve rewards.
-        // Note: this could be done only when the voter is trying to retrieve a reward for the most recently completed
-        // round, but it makes the logic a bit simpler to just do it in all cases.
         _updateRound(blockTime);
 
         Round storage round = rounds[roundId];
         uint snapshotId = round.snapshotId;
-
-        // If no snapshot has been created for this round, there are no rewards to dispatch.
-        if (snapshotId == 0) {
-            return;
-        }
-
-        // Get the voter's snapshotted balance.
         FixedPoint.Unsigned memory snapshotBalance = FixedPoint.Unsigned(
             votingToken.balanceOfAt(msg.sender, snapshotId));
 
@@ -448,21 +422,16 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         // Keep track of the voter's accumulated token reward.
         FixedPoint.Unsigned memory totalRewardToIssue = FixedPoint.Unsigned(0);
 
-        // Loop over all price requests in the round to check for rewards.
-        bytes32[] storage priceRequestIds = round.priceRequestIds;
-        for (uint i = 0; i < priceRequestIds.length; i++) {
-            PriceRequest storage priceRequest = priceRequests[priceRequestIds[i]];
-            VoteInstance storage voteInstance = priceRequest.voteInstances[roundId];
+        for (uint i = 0; i < toRetrieve.length; i++) {
+            PriceRequest storage priceRequest = _getPriceRequest(toRetrieve[i].identifier, toRetrieve[i].time);
+            VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
             VoteSubmission storage voteSubmission = voteInstance.voteSubmissions[msg.sender];
 
-            // Note: wasVoteCorrect effectively checks three conditions:
-            // 1. That the voter revealed their vote. If they did not, the hash will be 0x0 and there is no known input
-            //    to generate that hash output, so the whatever the resultComputation compares it to will be false.
-            // 2. That the vote was resolved. If the vote was not resolved, priceRequestIds[i] is 0x0, which means that
-            //    voteHash will be 0x0 (since that priceId was never used). As seen in 1, a 0x0 voteHash will always
-            //    produce a false output.
-            // 3. That the reveal was correct. If the reveal was incorrect, resultComputation should detect a hash
-            //    mismatch and return false.
+            require(priceRequest.lastVotingRound == roundId, "Only retrieve rewards for votes resolved in same round");
+
+            // TODO(ptare): Decide where we want to handle resolving price requests.
+            _resolvePriceRequest(priceRequest, voteInstance);
+
             if (voteInstance.resultComputation.wasVoteCorrect(voteSubmission.revealHash)) {
                 // The price was successfully resolved during the voter's last voting round, the voter revealed and was
                 // correct, so they are elgible for a reward.
@@ -517,86 +486,44 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         returns (bool _hasPrice, int price, string memory err)
     {
         PriceRequest storage priceRequest = _getPriceRequest(identifier, time);
-        uint resolutionVotingRound = priceRequest.lastVotingRound;
-        uint lastActiveVotingRound = voteTiming.getLastUpdatedRoundId();
+        if (priceRequest.lastVotingRound == 0) {
+            return (false, 0, "Price was never requested");
+        }
+        
+        uint currentRoundId = voteTiming.computeCurrentRoundId(getCurrentTime());
+        if (priceRequest.lastVotingRound == currentRoundId) {
+            return (false, 0, "The current voting round has not ended");
+        }
+        if (priceRequest.lastVotingRound > currentRoundId) {
+            return (false, 0, "Price will be voted on in the future");
+        }
+        VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
 
-        if (resolutionVotingRound < lastActiveVotingRound) {
-            // Price must have been requested in the past.
-            if (resolutionVotingRound == 0) {
-                return (false, 0, "Price was never requested");
-            }
-
-            // Grab the resolution voting round to compute the resolved price.
-            VoteInstance storage voteInstance = priceRequest.voteInstances[resolutionVotingRound];
-            (, int pastResolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
-                _computeGat(resolutionVotingRound));
-
-            // Price has been resolved.
-            return (true, pastResolvedPrice, "");
+        (bool isResolved, int resolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
+            _computeGat(priceRequest.lastVotingRound));
+        if (!isResolved) {
+            return (false, 0, "Price was not resolved this voting round. It will require another round of voting");
         } else {
-            // Price has not yet been resolved.
-
-            // Price must have been voted on this round for an immediate resolution to be attempted.
-            if (resolutionVotingRound != lastActiveVotingRound) {
-                return (false, 0, "Request has not yet been voted on");
-            }
-
-            // If the current voting round has not ended, we cannot immediately resolve the vote.
-            if (voteTiming.computeCurrentRoundId(getCurrentTime()) == lastActiveVotingRound) {
-                return (false, 0, "The current voting round has not ended");
-            }
-
-            // Attempt to resolve the vote immediately since the round has ended.
-            VoteInstance storage voteInstance = priceRequest.voteInstances[resolutionVotingRound];
-
-            (bool isResolved, int resolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
-                _computeGat(resolutionVotingRound));
-            if (!isResolved) {
-                return (false, 0, "Price was not resolved this voting round. It will require another round of voting");
-            }
-
             return (true, resolvedPrice, "");
         }
     }
 
-    /**
-     * @dev Gets a list of price requests that need to be rolled over from the last round. If a rollover doesn't need
-     * to happen immediately, the array will be empty. The array may be longer than the number of populated elements,
-     * so numRolloverPriceRequests gives the true number of elements.
-     */
-    function _getRolloverPriceRequests(uint blockTime)
-        private
-        view
-        returns (bytes32[] memory rolloverPriceRequests, uint numRolloverPriceRequests)
-    {
-        // Return nothing if it is not yet time to roll votes over.
-        if (!voteTiming.shouldUpdateRoundId(blockTime)) {
-            return (new bytes32[](0), 0);
+    function _isActive(PriceRequest storage priceRequest, uint currentRoundId) private view returns (bool) {
+        // Price request is for a future round -> definitely inactive.
+        if (priceRequest.lastVotingRound > currentRoundId) {
+            return false;
         }
 
-        uint roundId = voteTiming.getLastUpdatedRoundId();
-        bytes32[] storage allPriceRequests = rounds[roundId].priceRequestIds;
-        uint numPriceRequests = allPriceRequests.length;
-
-        // Allocate enough space for all of the price requests to be rolled over and just track the length
-        // separately.
-        rolloverPriceRequests = new bytes32[](numPriceRequests);
-        numRolloverPriceRequests = 0;
-
-        // Note: the code here is very similar to that in _updateRound(). The reason I decided not use this method
-        // there is that there is some complexity in this method wrt creating potentially large in-memory arrays that's
-        // unnecessary when changing storage. To preserve the gas-efficiency of _updateRound(), I didn't want to
-        // include that same complexity there.
-        for (uint i = 0; i < numPriceRequests; i++) {
-            bytes32 priceRequestId = allPriceRequests[i];
-            PriceRequest storage priceRequest = priceRequests[priceRequestId];
-            VoteInstance storage voteInstance = priceRequest.voteInstances[roundId];
-
-            (bool isResolved,) = voteInstance.resultComputation.getResolvedPrice(_computeGat(roundId));
-            if (!isResolved) {
-                rolloverPriceRequests[numRolloverPriceRequests++] = priceRequestId;
-            }
+        // Price request is for current round -> definitely active.
+        if (priceRequest.lastVotingRound == currentRoundId) {
+            return true;
         }
+
+        // Price request is for a previous round -> active only if it hasn't been resolved.
+        VoteInstance storage lastVoteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
+        (bool isResolved, ) = lastVoteInstance.resultComputation.getResolvedPrice(
+            _computeGat(priceRequest.lastVotingRound));
+        return !isResolved;
     }
 
     function _getPriceRequest(bytes32 identifier, uint time) private view returns (PriceRequest storage) {
@@ -607,64 +534,6 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         return keccak256(abi.encode(identifier, time));
     }
 
-    /**
-     * @notice Updates the round if necessary. After this method is run voteTiming.getLastUpdatedRoundId() and
-     * and voteTiming.computeCurrentRoundId(blockTime) should return the same value.
-     * @dev The method loops through all price requests for the last voting round and rolls them over to the next round
-     * if required.
-     */
-    function _updateRound(uint blockTime) private {
-        if (!voteTiming.shouldUpdateRoundId(blockTime)) {
-            return;
-        }
-
-        // Only do the rollover if the next round has started.
-        uint lastActiveVotingRoundId = voteTiming.getLastUpdatedRoundId();
-        Round storage lastActiveVotingRound = rounds[lastActiveVotingRoundId];
-
-        uint nextVotingRoundId = voteTiming.computeCurrentRoundId(blockTime);
-
-        for (uint i = 0; i < lastActiveVotingRound.priceRequestIds.length; i++) {
-            bytes32 priceRequestId = lastActiveVotingRound.priceRequestIds[i];
-            PriceRequest storage priceRequest = priceRequests[priceRequestId];
-
-            // TODO: we should probably take this assert out before we move to production to keep the voting
-            // contract from locking in the case of a bug. This would be an assert, but asserts don't allow
-            // messages.
-            require(priceRequest.lastVotingRound == lastActiveVotingRoundId,
-                "Found price request that was incorrectly placed in a round");
-
-            VoteInstance storage voteInstance = priceRequest.voteInstances[lastActiveVotingRoundId];
-
-            (bool isResolved, int price) = voteInstance.resultComputation.getResolvedPrice(
-                _computeGat(lastActiveVotingRoundId));
-
-            if (!isResolved) {
-                // If the vote cannot be resolved, push the request into the current round.
-                rounds[nextVotingRoundId].priceRequestIds.push(priceRequestId);
-
-                // Set the price resolution round number to the provided round.
-                priceRequest.lastVotingRound = nextVotingRoundId;
-
-                // Zero out the price request to reduce gas costs.
-                delete lastActiveVotingRound.priceRequestIds[i];
-
-                // Delete the result computation since it's no longer needed.
-                delete voteInstance.resultComputation;
-
-                emit PriceRequestRolledOver(nextVotingRoundId, priceRequest.identifier, priceRequest.time);
-            } else {
-                emit PriceResolved(priceRequest.lastVotingRound, priceRequest.identifier, priceRequest.time, price);
-            }
-        }
-
-        // Set the round inflation rate to the current global inflation rate.
-        rounds[nextVotingRoundId].inflationRate = inflationRate;
-
-        // Update the stored round to the current one.
-        voteTiming.updateRoundId(blockTime);
-    }
-
     function _getOrCreateSnapshotId(uint roundId) private returns (uint) {
         Round storage round = rounds[roundId];
         if (round.snapshotId == 0) {
@@ -673,6 +542,39 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         }
 
         return round.snapshotId;
+    }
+
+    function _resolvePriceRequest(PriceRequest storage priceRequest, VoteInstance storage voteInstance) private {
+        if (priceRequest.isResolved) {
+            return;
+        }
+        (bool isResolved, int resolvedPrice) = voteInstance.resultComputation.getResolvedPrice(
+            _computeGat(priceRequest.lastVotingRound));
+        require(isResolved, "Can't claim reward for unresolved price request");
+
+        emit PriceResolved(priceRequest.lastVotingRound, priceRequest.identifier, priceRequest.time, resolvedPrice);
+        priceRequest.isResolved = isResolved;
+
+        // Delete the resolved price request from pendingPriceRequests.
+        uint lastIndex = pendingPriceRequests.length - 1;
+        PriceRequest storage lastPriceRequest = priceRequests[pendingPriceRequests[lastIndex]];
+        lastPriceRequest.index = priceRequest.index;
+        pendingPriceRequests[priceRequest.index] = pendingPriceRequests[lastIndex];
+        delete pendingPriceRequests[lastIndex];
+        priceRequest.index = 0;
+    }
+
+    function _updateRound(uint blockTime) private {
+        if (!voteTiming.shouldUpdateRoundId(blockTime)) {
+            return;
+        }
+        uint nextVotingRoundId = voteTiming.computeCurrentRoundId(blockTime);
+
+        // Set the round inflation rate to the current global inflation rate.
+        rounds[nextVotingRoundId].inflationRate = inflationRate;
+
+        // Update the stored round to the current one.
+        voteTiming.updateRoundId(blockTime);
     }
 
     function _computeGat(uint roundId) private view returns (FixedPoint.Unsigned memory) {
@@ -705,9 +607,9 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
 
     event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
 
-    event PriceRequestRolledOver(uint indexed newRoundId, bytes32 indexed identifier, uint time);
-
     event PriceResolved(uint indexed resolutionRoundId, bytes32 indexed identifier, uint time, int price);
 
     event SupportedIdentifierAdded(bytes32 indexed identifier);
+
+    event Log(uint a, uint b);
 }

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -406,7 +406,7 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         uint blockTime = getCurrentTime();
         _updateRound(blockTime);
         uint currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
-        require(roundId < currentRoundId, "Can only retrieve rewards for completed rounds");
+        require(roundId < currentRoundId);
 
         Round storage round = rounds[roundId];
         uint snapshotId = round.snapshotId;

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -406,7 +406,7 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
         uint blockTime = getCurrentTime();
         _updateRound(blockTime);
         uint currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
-        require(roundId < currentRoundId);
+        require(roundId < currentRoundId, "Can only retrieve rewards for completed rounds");
 
         Round storage round = rounds[roundId];
         uint snapshotId = round.snapshotId;
@@ -427,7 +427,6 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
 
             require(priceRequest.lastVotingRound == roundId, "Only retrieve rewards for votes resolved in same round");
 
-            // TODO(ptare): Decide where we want to handle resolving price requests.
             _resolvePriceRequest(priceRequest, voteInstance);
 
             if (voteInstance.resultComputation.wasVoteCorrect(voteSubmission.revealHash)) {

--- a/core/contracts/VotingInterface.sol
+++ b/core/contracts/VotingInterface.sol
@@ -46,5 +46,5 @@ contract VotingInterface {
     /**
      * @notice Retrieves any rewards the voter is owed.
      */
-    function retrieveRewards() public;
+    function retrieveRewards(uint roundId, PendingRequest[] memory) public;
 }

--- a/core/test/DesignatedVoting.js
+++ b/core/test/DesignatedVoting.js
@@ -110,13 +110,18 @@ contract("DesignatedVoting", function(accounts) {
     assert(await didContractThrow(designatedVoting.revealVote(identifier, time, price, salt, { from: umaAdmin })));
 
     // Check the resolved price.
+    const roundId = await voting.getCurrentRoundId();
     await moveToNextRound(voting);
     assert.equal((await voting.getPrice(identifier, time, { from: registeredDerivative })).toString(), price);
 
     // Retrieve rewards and check that rewards accrued to the `designatedVoting` contract.
-    await designatedVoting.retrieveRewards({ from: voter });
-    assert(await didContractThrow(designatedVoting.retrieveRewards({ from: tokenOwner })));
-    assert(await didContractThrow(designatedVoting.retrieveRewards({ from: umaAdmin })));
+    await designatedVoting.retrieveRewards(roundId, [{ identifier, time }], { from: voter });
+    assert(
+      await didContractThrow(designatedVoting.retrieveRewards(roundId, [{ identifier, time }], { from: tokenOwner }))
+    );
+    assert(
+      await didContractThrow(designatedVoting.retrieveRewards(roundId, [{ identifier, time }], { from: umaAdmin }))
+    );
 
     // Expected inflation = token balance * inflation rate = 1 * 0.5
     const expectedInflation = web3.utils.toWei("0.5");

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -821,13 +821,16 @@ contract("Voting", function(accounts) {
     await voting.revealVote(identifier, time1, winningPrice, salt2, { from: account2 });
     await voting.revealVote(identifier, time1, winningPrice, salt3, { from: account3 });
 
+    const roundId = await voting.getCurrentRoundId();
+
     // Move to the next round to begin retrieving rewards.
     await moveToNextRound(voting);
 
-    await voting.retrieveRewards({ from: account1 });
-    await voting.retrieveRewards({ from: account2 });
-    await voting.retrieveRewards({ from: account3 });
-    await voting.retrieveRewards({ from: account4 });
+    const req = [{ identifier: identifier, time: time1 }];
+    await voting.retrieveRewards(roundId, req, { from: account1 });
+    await voting.retrieveRewards(roundId, req, { from: account2 });
+    await voting.retrieveRewards(roundId, req, { from: account3 });
+    await voting.retrieveRewards(roundId, req, { from: account4 });
 
     // account1 is not rewarded because account1 was wrong.
     assert.equal((await votingToken.balanceOf(account1)).toString(), initialAccount1Balance.toString());
@@ -848,63 +851,6 @@ contract("Voting", function(accounts) {
 
     // Reset the inflation rate to 0%.
     await setNewInflationRate("0");
-  });
-
-  it("Reward on commit", async function() {
-    // Set the inflation rate to 100% (for ease of computation).
-    await setNewInflationRate(web3.utils.toWei("1", "ether"));
-
-    const identifier = web3.utils.utf8ToHex("reward-on-commit");
-    const time1 = "1000";
-
-    // Cache balances for later comparison.
-    const initialAccount1Balance = await votingToken.balanceOf(account1);
-    const initialTotalSupply = await votingToken.totalSupply();
-
-    // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
-
-    // Request a price and move to the next round where that will be voted on.
-    await voting.requestPrice(identifier, time1, { from: registeredDerivative });
-    await moveToNextRound(voting);
-
-    // Commit.
-    const price1 = getRandomSignedInt();
-    const salt1 = getRandomUnsignedInt();
-    const hash1 = web3.utils.soliditySha3(price1, salt1);
-    await voting.commitVote(identifier, time1, hash1, { from: account1 });
-
-    // Reveal.
-    await moveToNextPhase(voting);
-    await voting.revealVote(identifier, time1, price1, salt1, { from: account1 });
-
-    // Request new price to commit to next round.
-    const time2 = "1001";
-    await voting.requestPrice(identifier, time2, { from: registeredDerivative });
-    await moveToNextRound(voting);
-
-    // Commit, which should send the reward.
-    const price2 = getRandomSignedInt();
-    const salt2 = getRandomUnsignedInt();
-    const hash2 = web3.utils.soliditySha3(price2, salt2);
-    await voting.commitVote(identifier, time2, hash2, { from: account1 });
-
-    // Check balance after reward.
-    assert.equal(
-      (await votingToken.balanceOf(account1)).toString(),
-      initialAccount1Balance.add(initialTotalSupply).toString()
-    );
-
-    // A call to retrieval should not change the balance since the reward has already been retrieved.
-    await voting.retrieveRewards({ from: account1 });
-    assert.equal(
-      (await votingToken.balanceOf(account1)).toString(),
-      initialAccount1Balance.add(initialTotalSupply).toString()
-    );
-
-    // Clean up vote.
-    await moveToNextPhase(voting);
-    await voting.revealVote(identifier, time2, price2, salt2, { from: account1 });
   });
 
   it("Events", async function() {
@@ -975,24 +921,17 @@ contract("Voting", function(accounts) {
     await moveToNextRound(voting);
     currentRoundId = await voting.getCurrentRoundId();
     // Since none of the whales voted, the price couldn't be resolved.
-    result = await voting.retrieveRewards({ from: account4 });
-    truffleAssert.eventEmitted(result, "PriceRequestRolledOver", ev => {
-      return (
-        ev.newRoundId.toString() == currentRoundId.toString() &&
-        web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier) &&
-        ev.time == time
-      );
-    });
 
     // Now the whale votes and the vote resolves.
     await voting.commitVote(identifier, time, hash, { from: account1 });
     await moveToNextPhase(voting);
     await voting.revealVote(identifier, time, price, salt, { from: account1 });
     const initialTotalSupply = await votingToken.totalSupply();
+    const roundId = await voting.getCurrentRoundId();
     await moveToNextRound(voting);
 
     // When the round updates, the price request should be resolved.
-    result = await voting.retrieveRewards({ from: account1 });
+    result = await voting.retrieveRewards(roundId, [{ identifier, time }], { from: account1 });
     truffleAssert.eventEmitted(result, "PriceResolved", ev => {
       return (
         ev.resolutionRoundId.toString() == currentRoundId.toString() &&
@@ -1011,7 +950,7 @@ contract("Voting", function(accounts) {
     });
 
     // Events only get emitted if there were actually rewards issued. Is this the behavior we want?
-    result = await voting.retrieveRewards({ from: account4 });
+    result = await voting.retrieveRewards(roundId, [{ identifier, time }], { from: account4 });
     truffleAssert.eventNotEmitted(result, "RewardsRetrieved");
   });
 


### PR DESCRIPTION
Price requests are no longer tracked per round. Instead, all pending
price requests are maintained separately. Round finalization is no
longer O(# price requests) but O(1). Each price request is marked as
resolved separately.

Retrieving rewards is now more complicated, because the state of which
price requests a voter participated is maintained off-chain.

The motivation behind this change is to get rid of any O(# price
requests) operations, which could run out of gas if there are too many
price requests.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>