### PR TITLE
Move events declarations after state variables

### DIFF
--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -12,6 +12,9 @@ contract AddressWhitelist is Ownable {
 
     address[] private whitelistIndices;
 
+    event AddedToWhitelist(address indexed addedAddress);
+    event RemovedFromWhitelist(address indexed removedAddress);
+
     /**
      * @notice Adds an address to the whitelist.
      */
@@ -75,7 +78,4 @@ contract AddressWhitelist is Ownable {
             }
         }
     }
-
-    event AddedToWhitelist(address indexed addedAddress);
-    event RemovedFromWhitelist(address indexed removedAddress);
 }

--- a/core/contracts/Finder.sol
+++ b/core/contracts/Finder.sol
@@ -18,6 +18,8 @@ contract Finder is MultiRole {
 
     mapping(bytes32 => address) public interfacesImplemented;
 
+    event InterfaceImplementationChanged(bytes32 indexed interfaceName, address indexed newImplementationAddress);
+
     constructor() public {
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
         _createExclusiveRole(uint(Roles.Writer), uint(Roles.Governance), msg.sender);
@@ -45,6 +47,4 @@ contract Finder is MultiRole {
         implementationAddress = interfacesImplemented[interfaceName];
         require(implementationAddress != address(0x0), "No implementation for interface found");
     }
-
-    event InterfaceImplementationChanged(bytes32 indexed interfaceName, address indexed newImplementationAddress);
 }

--- a/core/contracts/Store.sol
+++ b/core/contracts/Store.sol
@@ -31,6 +31,8 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
     // Figure out what's going wrong with coverage to necessitate this hack.
     bool private rolesInitialized;
 
+    event NewFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
+
     constructor() public {
         initializeRolesOnce();
     }
@@ -112,7 +114,4 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
         rolesInitialized = true;
         _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
     }
-
-    event NewFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
-
 }

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -153,6 +153,25 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
     // Max value of an unsigned integer.
     uint constant private UINT_MAX = ~uint(0);
 
+    event VoteCommitted(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time);
+
+    event VoteRevealed(
+        address indexed voter,
+        uint indexed roundId,
+        bytes32 indexed identifier,
+        uint time,
+        int price,
+        uint numTokens
+    );
+
+    event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);
+
+    event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
+
+    event PriceResolved(uint indexed resolutionRoundId, bytes32 indexed identifier, uint time, int price);
+
+    event SupportedIdentifierAdded(bytes32 indexed identifier);
+
     /**
      * @notice Construct the Voting contract.
      * @param phaseLength length of the commit and reveal phases in seconds.
@@ -584,23 +603,4 @@ contract Voting is Testable, MultiRole, OracleInterface, VotingInterface, Encryp
             return RequestStatus.Future;
         }
     }
-
-    event VoteCommitted(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time);
-
-    event VoteRevealed(
-        address indexed voter,
-        uint indexed roundId,
-        bytes32 indexed identifier,
-        uint time,
-        int price,
-        uint numTokens
-    );
-
-    event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);
-
-    event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
-
-    event PriceResolved(uint indexed resolutionRoundId, bytes32 indexed identifier, uint time, int price);
-
-    event SupportedIdentifierAdded(bytes32 indexed identifier);
 }


### PR DESCRIPTION
This change is to comply with the Solidity style guide:
https://solidity.readthedocs.io/en/v0.5.12/style-guide.html

Resolves bug #744.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>