### PR TITLE
Remove re-entrancy events check

### DIFF
--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -11,7 +11,7 @@ run_slither() {
     truffle compile 
 
     cd $PROTOCOL_DIR
-    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether,reentrancy-eth,uninitialized-state-variables,incorrect-equality $1
+    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether,reentrancy-eth,uninitialized-state-variables,incorrect-equality,reentrancy-events $1
 }
 
 run_slither $PROTOCOL_DIR/core


### PR DESCRIPTION
Just to get CI back up and running, disabling the low severity events-reentrancy check that causes events to be emitted out of order in the case of a reentrancy.