### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN git clone https://github.com/UMAprotocol/protocol.git
 WORKDIR protocol
 
 # Install dependencies and compile contracts.
+RUN apt-get update
+RUN apt-get install -y libudev-dev libusb-1.0-0-dev
 RUN npm install
 RUN scripts/buildContracts.sh
 


### PR DESCRIPTION
The docker build has been failing for the past few commits on master because of new dependencies. This PR adds those dependencies to the docker container.