### PR TITLE
Build ability to set Voting.sol as migrated

### DIFF
--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -55,8 +55,9 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     function retrieveRewards(uint roundId, VotingInterface.PendingRequest[] memory toRetrieve)
         public
         onlyRoleHolder(uint(Roles.Voter))
+        returns (FixedPoint.Unsigned memory rewardsIssued)
     {
-        _getVotingAddress().retrieveRewards(address(this), roundId, toRetrieve);
+        return _getVotingAddress().retrieveRewards(address(this), roundId, toRetrieve);
     }
 
     function _getVotingAddress() private view returns (Voting) {

--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -56,7 +56,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
         public
         onlyRoleHolder(uint(Roles.Voter))
     {
-        _getVotingAddress().retrieveRewards(roundId, toRetrieve);
+        _getVotingAddress().retrieveRewards(address(this), roundId, toRetrieve);
     }
 
     function _getVotingAddress() private view returns (Voting) {

--- a/core/contracts/VotingInterface.sol
+++ b/core/contracts/VotingInterface.sol
@@ -46,5 +46,5 @@ contract VotingInterface {
     /**
      * @notice Retrieves rewards owed for a set of resolved price requests.
      */
-    function retrieveRewards(uint roundId, PendingRequest[] memory) public;
+    function retrieveRewards(address voterAddress, uint roundId, PendingRequest[] memory) public;
 }

--- a/core/contracts/VotingInterface.sol
+++ b/core/contracts/VotingInterface.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.0;
 
 pragma experimental ABIEncoderV2;
 
+import "./FixedPoint.sol";
 import "./VoteTiming.sol";
 
 
@@ -46,5 +47,6 @@ contract VotingInterface {
     /**
      * @notice Retrieves rewards owed for a set of resolved price requests.
      */
-    function retrieveRewards(address voterAddress, uint roundId, PendingRequest[] memory) public;
+    function retrieveRewards(address voterAddress, uint roundId, PendingRequest[] memory) public returns
+    (FixedPoint.Unsigned memory);
 }

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -339,9 +339,11 @@ contract("Voting", function(accounts) {
 
     // Two stage call is required to get the expected return value from the second call.
     // The expected resolution time should be the end of the *next* round.
-    const preRoundExpectedResolution = (await voting.requestPrice.call(identifier, time, {
-      from: registeredDerivative
-    })).toNumber();
+    const preRoundExpectedResolution = (
+      await voting.requestPrice.call(identifier, time, {
+        from: registeredDerivative
+      })
+    ).toNumber();
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
     // Calling request price again should be safe and should return the same value.
     const recheckedExpectedResolution = await voting.requestPrice.call(identifier, time, {

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -665,7 +665,7 @@ contract("Voting", function(accounts) {
 
     // Can't claim rewards if the price wasn't resolved.
     const req = [{ identifier: identifier, time: time }];
-    assert(await didContractThrow(voting.retrieveRewards(initialRoundId, req, { from: account4 })));
+    assert(await didContractThrow(voting.retrieveRewards(account4, initialRoundId, req)));
 
     // With a larger vote, the GAT should be hit and the price should resolve.
     // Commit votes.
@@ -684,8 +684,8 @@ contract("Voting", function(accounts) {
     );
 
     // Must specify the right roundId when retrieving rewards.
-    assert(await didContractThrow(voting.retrieveRewards(initialRoundId, req, { from: account4 })));
-    await voting.retrieveRewards(newRoundId, req, { from: account4 });
+    assert(await didContractThrow(voting.retrieveRewards(account4, initialRoundId, req)));
+    await voting.retrieveRewards(account4, newRoundId, req);
   });
 
   it("Basic Snapshotting", async function() {
@@ -869,18 +869,18 @@ contract("Voting", function(accounts) {
 
     const req = [{ identifier: identifier, time: time1 }];
     // Can't claim rewards for current round (even if the request will definitely be resolved).
-    assert(await didContractThrow(voting.retrieveRewards(roundId, req, { from: account1 })));
+    assert(await didContractThrow(voting.retrieveRewards(account1, roundId, req)));
 
     // Move to the next round to begin retrieving rewards.
     await moveToNextRound(voting);
 
-    await voting.retrieveRewards(roundId, req, { from: account1 });
-    await voting.retrieveRewards(roundId, req, { from: account2 });
+    await voting.retrieveRewards(account1, roundId, req);
+    await voting.retrieveRewards(account2, roundId, req);
 
     // Voters can wait until the next round to claim rewards.
     await moveToNextRound(voting);
-    await voting.retrieveRewards(roundId, req, { from: account3 });
-    await voting.retrieveRewards(roundId, req, { from: account4 });
+    await voting.retrieveRewards(account3, roundId, req);
+    await voting.retrieveRewards(account4, roundId, req);
 
     // account1 is not rewarded because account1 was wrong.
     assert.equal((await votingToken.balanceOf(account1)).toString(), initialAccount1Balance.toString());
@@ -981,7 +981,7 @@ contract("Voting", function(accounts) {
     await moveToNextRound(voting);
 
     // When the round updates, the price request should be resolved.
-    result = await voting.retrieveRewards(roundId, [{ identifier, time }], { from: account1 });
+    result = await voting.retrieveRewards(account1, roundId, [{ identifier, time }]);
     truffleAssert.eventEmitted(result, "PriceResolved", ev => {
       return (
         ev.resolutionRoundId.toString() == currentRoundId.toString() &&
@@ -1000,7 +1000,7 @@ contract("Voting", function(accounts) {
     });
 
     // Events only get emitted if there were actually rewards issued. Is this the behavior we want?
-    result = await voting.retrieveRewards(roundId, [{ identifier, time }], { from: account4 });
+    result = await voting.retrieveRewards(account4, roundId, [{ identifier, time }]);
     truffleAssert.eventNotEmitted(result, "RewardsRetrieved");
   });
 

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -1252,7 +1252,7 @@ contract("Voting", function(accounts) {
     assert.isNull(await voting.getMessage(account1, topicHash2));
   });
 
-  it.only("Migration", async function() {
+  it("Migration", async function() {
     const identifier = web3.utils.utf8ToHex("migration");
     const time1 = "1000";
     const time2 = "2000";

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -1243,9 +1243,10 @@ contract("Voting", function(accounts) {
     assert.isNull(await voting.getMessage(account1, topicHash2));
   });
 
-  it("Migration", async function() {
+  it.only("Migration", async function() {
     const identifier = web3.utils.utf8ToHex("migration");
     const time1 = "1000";
+    const time2 = "2000";
     // Deploy our own voting because this test case will migrate it.
     const voting = await Voting.new(
       "86400",
@@ -1258,6 +1259,7 @@ contract("Voting", function(accounts) {
     await voting.addSupportedIdentifier(identifier);
 
     await voting.requestPrice(identifier, time1, { from: registeredDerivative });
+    await voting.requestPrice(identifier, time2, { from: registeredDerivative });
     await moveToNextRound(voting);
     const price = 123;
     const salt = getRandomSignedInt();
@@ -1278,5 +1280,7 @@ contract("Voting", function(accounts) {
     // Now only new voting can call methods.
     assert(await voting.hasPrice(identifier, time1, { from: migratedVoting }));
     assert(await didContractThrow(voting.hasPrice(identifier, time1, { from: registeredDerivative })));
+    assert(await didContractThrow(voting.commitVote(identifier, time2, hash, { from: account1 })));
+    voting.commitVote(identifier, time2, hash, { from: account1 });
   });
 });

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -1290,6 +1290,5 @@ contract("Voting", function(accounts) {
     assert(await voting.hasPrice(identifier, time1, { from: migratedVoting }));
     assert(await didContractThrow(voting.hasPrice(identifier, time1, { from: registeredDerivative })));
     assert(await didContractThrow(voting.commitVote(identifier, time2, hash, { from: account1 })));
-    voting.commitVote(identifier, time2, hash, { from: account1 });
   });
 });


### PR DESCRIPTION
Build ability to set Voting.sol as migrated

Setting Voting as migrated prevents financial contracts from querying it: they must query the new Voting system instead. The new Voting system can call `getPrice` and `hasPrice` on the old Voting, allowing it to serve queries about previously resolved price requests.

Pending votes are effectively cancelled, in that financial contracts can never access their results and rewards won't be issued.

NOTE: we are trying to make the minimum set of changes to enable the migration, since we don't know anything about what the next Voting.sol will look like.

Issue #774 