### PR TITLE
Remove unnecessary package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eth-crypto": "^1.3.4",
     "express": "^4.17.1",
     "ganache-cli": "^6.7.0",
-    "gitbook-cli": "^2.3.2",
     "gmail-send": "^1.2.14",
     "lodash.startcase": "^4.4.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
This package snuck in in https://github.com/UMAprotocol/protocol/pull/723, but we aren't using it.