### PR TITLE
Update permissioning for Finder, Registry, Admin, and Store

### DIFF
--- a/common/Enums.js
+++ b/common/Enums.js
@@ -1,8 +1,7 @@
 // Corresponds to Registry.Roles.
 const RegistryRolesEnum = {
-  GOVERNANCE: "0",
-  WRITER: "1",
-  DERIVATIVE_CREATOR: "2"
+  OWNER: "0",
+  DERIVATIVE_CREATOR: "1"
 };
 
 // Corresponds to VoteTiming.Phase.

--- a/core/contracts/FinancialContractsAdmin.sol
+++ b/core/contracts/FinancialContractsAdmin.sol
@@ -1,34 +1,19 @@
 pragma solidity ^0.5.0;
 
 import "./AdministrateeInterface.sol";
-import "./MultiRole.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 
 /**
  * @title Admin for financial contracts in the UMA system.
  * @dev Allows appropriately permissioned admin roles to interact with financial contracts.
  */
-contract FinancialContractsAdmin is MultiRole {
-
-    enum Roles {
-        // Can set the `Remargin` and `EmergencyShutdown` roles.
-        Governance,
-        // Is authorized to call `remargin()` on any financial contract in the system.
-        Remargin,
-        // Is authorized to shutdown any financial contract in the system.
-        EmergencyShutdown
-    }
-
-    constructor() public {
-        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
-        _createSharedRole(uint(Roles.Remargin), uint(Roles.Governance), new address[](0));
-        _createExclusiveRole(uint(Roles.EmergencyShutdown), uint(Roles.Governance), msg.sender);
-    }
+contract FinancialContractsAdmin is Ownable {
 
     /**
      * @dev Calls emergency shutdown on the provided financial contract.
      */
-    function callEmergencyShutdown(address financialContract) external onlyRoleHolder(uint(Roles.EmergencyShutdown)) {
+    function callEmergencyShutdown(address financialContract) external onlyOwner {
         AdministrateeInterface administratee = AdministrateeInterface(financialContract);
         administratee.emergencyShutdown();
     }
@@ -36,7 +21,7 @@ contract FinancialContractsAdmin is MultiRole {
     /**
      * @dev Calls remargin on the provided financial contract.
      */
-    function callRemargin(address financialContract) external onlyRoleHolder(uint(Roles.Remargin)) {
+    function callRemargin(address financialContract) external onlyOwner {
         AdministrateeInterface administratee = AdministrateeInterface(financialContract);
         administratee.remargin();
     }

--- a/core/contracts/Finder.sol
+++ b/core/contracts/Finder.sol
@@ -1,36 +1,24 @@
 pragma solidity ^0.5.0;
 
-import "./MultiRole.sol";
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 
 /**
  * @title Provides addresses of the live contracts implementing certain interfaces. 
  * @dev Examples are the Oracle or Store interfaces.
  */
-contract Finder is MultiRole {
-
-    enum Roles {
-        // Can set the writer.
-        Governance,
-        // Can update/write the addresses which implement a given interface.
-        Writer
-    }
+contract Finder is Ownable {
 
     mapping(bytes32 => address) public interfacesImplemented;
 
     event InterfaceImplementationChanged(bytes32 indexed interfaceName, address indexed newImplementationAddress);
-
-    constructor() public {
-        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
-        _createExclusiveRole(uint(Roles.Writer), uint(Roles.Governance), msg.sender);
-    }
 
     /**
      * @dev Updates the address of the contract that implements `interfaceName`.
      */
     function changeImplementationAddress(bytes32 interfaceName, address implementationAddress)
         external
-        onlyRoleHolder(uint(Roles.Writer))
+        onlyOwner
     {
         interfacesImplemented[interfaceName] = implementationAddress;
         emit InterfaceImplementationChanged(interfaceName, implementationAddress);

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -17,10 +17,8 @@ contract Registry is RegistryInterface, MultiRole {
     using SafeMath for uint;
 
     enum Roles {
-        // The ultimate owner-type role that can change the writer.
-        Governance,
-        // Can add or remove DerivativeCreators.
-        Writer,
+        // The owner manages the set of DerivativeCreators.
+        Owner,
         // Can register derivatives.
         DerivativeCreator
     }
@@ -55,10 +53,9 @@ contract Registry is RegistryInterface, MultiRole {
     event NewDerivativeRegistered(address indexed derivativeAddress, address indexed creator, address[] parties);
 
     constructor() public {
-        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
-        _createExclusiveRole(uint(Roles.Writer), uint(Roles.Governance), msg.sender);
+        _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
         // Start with no derivative creators registered.
-        _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Writer), new address[](0));
+        _createSharedRole(uint(Roles.DerivativeCreator), uint(Roles.Owner), new address[](0));
     }
 
     function registerDerivative(address[] calldata parties, address derivativeAddress)

--- a/core/contracts/Store.sol
+++ b/core/contracts/Store.sol
@@ -18,7 +18,8 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
     using FixedPoint for uint;
 
     enum Roles {
-        Governance
+        Owner,
+        Withdrawer
     }
 
     FixedPoint.Unsigned private fixedOracleFeePerSecond; // Percentage of 1 E.g., .1 is 10% Oracle fee.
@@ -30,7 +31,8 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
     event NewFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
 
     constructor() public {
-        _createExclusiveRole(uint(Roles.Governance), uint(Roles.Governance), msg.sender);
+        _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
+        createWithdrawRole(uint(Roles.Withdrawer), uint(Roles.Owner), msg.sender);
     }
 
     function payOracleFees() external payable {
@@ -72,7 +74,7 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
      */ 
     function setFixedOracleFeePerSecond(FixedPoint.Unsigned memory newOracleFee) 
         public 
-        onlyRoleHolder(uint(Roles.Governance)) 
+        onlyRoleHolder(uint(Roles.Owner)) 
     {
         // Oracle fees at or over 100% don't make sense.
         require(newOracleFee.isLessThan(1));
@@ -85,7 +87,7 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
      */ 
     function setWeeklyDelayFee(FixedPoint.Unsigned memory newWeeklyDelayFee) 
         public 
-        onlyRoleHolder(uint(Roles.Governance)) 
+        onlyRoleHolder(uint(Roles.Owner)) 
     {
         weeklyDelayFee = newWeeklyDelayFee;
     }
@@ -95,7 +97,7 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
      */ 
     function setFinalFee(address currency, FixedPoint.Unsigned memory finalFee) 
         public 
-        onlyRoleHolder(uint(Roles.Governance))
+        onlyRoleHolder(uint(Roles.Owner))
     {
         finalFees[currency] = finalFee;
     }

--- a/core/migrations/15_deploy_governor.js
+++ b/core/migrations/15_deploy_governor.js
@@ -3,6 +3,7 @@ const Finder = artifacts.require("Finder");
 const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
 const { getKeysForNetwork, deploy, enableControllableTiming } = require("../../common/MigrationUtils.js");
+const { RegistryRolesEnum } = require("../../common/Enums.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
@@ -14,10 +15,9 @@ module.exports = async function(deployer, network, accounts) {
 
   // Add governor to registry so it can send price requests.
   const registry = await Registry.deployed();
-  const derivativeCreatorRole = 2;
-  await registry.addMember(derivativeCreatorRole, keys.deployer, { from: keys.deployer });
+  await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, keys.deployer, { from: keys.deployer });
   await registry.registerDerivative([], governor.address, { from: keys.deployer });
-  await registry.removeMember(derivativeCreatorRole, keys.deployer, { from: keys.deployer });
+  await registry.removeMember(RegistryRolesEnum.DERIVATIVE_CREATOR, keys.deployer, { from: keys.deployer });
 
   // Make the governor a writer in the Voting contract.
   const voting = await Voting.deployed();

--- a/core/migrations/7_deploy_financial_contracts_admin.js
+++ b/core/migrations/7_deploy_financial_contracts_admin.js
@@ -10,9 +10,6 @@ module.exports = async function(deployer, network, accounts) {
     from: keys.deployer
   });
 
-  const remarginRole = "1"; // Corresponds to FinancialContractsAdmin.Roles.Remargin.
-  await financialContractsAdmin.addMember(remarginRole, keys.deployer, { from: keys.deployer });
-
   const finder = await Finder.deployed();
   await finder.changeImplementationAddress(
     web3.utils.utf8ToHex(interfaceName.FinancialContractsAdmin),

--- a/core/test/FinancialContractsAdmin.js
+++ b/core/test/FinancialContractsAdmin.js
@@ -37,9 +37,7 @@ contract("FinancialContractsAdmin", function(accounts) {
 
     // Can't call emergencyShutdown without being the owner.
     assert(
-      await didContractThrow(
-        financialContractsAdmin.callEmergencyShutdown(mockAdministratee.address, { from: rando })
-      )
+      await didContractThrow(financialContractsAdmin.callEmergencyShutdown(mockAdministratee.address, { from: rando }))
     );
 
     // Change the owner and verify that emergencyShutdown can be called.

--- a/core/test/Registry.js
+++ b/core/test/Registry.js
@@ -74,9 +74,7 @@ contract("Registry", function(accounts) {
     await registry.resetMember(RegistryRolesEnum.OWNER, rando1, { from: owner });
 
     // The owner can no longer add or remove derivative creators.
-    assert(
-      await didContractThrow(registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner }))
-    );
+    assert(await didContractThrow(registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner })));
     assert(
       await didContractThrow(registry.removeMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner }))
     );

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -14,6 +14,7 @@ contract("Store", function(accounts) {
   const owner = accounts[0];
   const derivative = accounts[1];
   const erc20TokenOwner = accounts[2];
+  const rando = accounts[3];
 
   const identifier = web3.utils.utf8ToHex("id");
   const arbitraryTokenAddr = web3.utils.randomHex(20);
@@ -176,5 +177,31 @@ contract("Store", function(accounts) {
     secondTokenBalanceInStore = await secondMarginToken.balanceOf(store.address);
     assert.equal(secondTokenBalanceInOwner.toString(), web3.utils.toWei("20", "ether"));
     assert.equal(secondTokenBalanceInStore.toString(), web3.utils.toWei("0", "ether"));
+  });
+
+  it("Withdraw permissions", async function() {
+    const withdrawRole = "1";
+    await store.payOracleFees({ from: derivative, value: web3.utils.toWei("1", "ether") });
+
+    // Rando cannot initially withdraw.
+    assert(
+      await didContractThrow(
+        store.withdraw(web3.utils.toWei("0.5", "ether"), { from: rando })
+      )
+    );
+
+    // Owner can delegate the withdraw permissions to rando, allowing them to withdraw.
+    await store.resetMember(withdrawRole, rando, { from: owner });
+    await store.withdraw(web3.utils.toWei("0.5", "ether"), { from: rando });
+
+    // Owner can no longer withdraw since that permission has been moved to rando.
+    assert(
+      await didContractThrow(
+        store.withdraw(web3.utils.toWei("0.5", "ether"), { from: owner })
+      )
+    );
+
+    // Change withdraw back to owner.
+    await store.resetMember(withdrawRole, owner, { from: owner });
   });
 });

--- a/core/test/Store.js
+++ b/core/test/Store.js
@@ -184,22 +184,14 @@ contract("Store", function(accounts) {
     await store.payOracleFees({ from: derivative, value: web3.utils.toWei("1", "ether") });
 
     // Rando cannot initially withdraw.
-    assert(
-      await didContractThrow(
-        store.withdraw(web3.utils.toWei("0.5", "ether"), { from: rando })
-      )
-    );
+    assert(await didContractThrow(store.withdraw(web3.utils.toWei("0.5", "ether"), { from: rando })));
 
     // Owner can delegate the withdraw permissions to rando, allowing them to withdraw.
     await store.resetMember(withdrawRole, rando, { from: owner });
     await store.withdraw(web3.utils.toWei("0.5", "ether"), { from: rando });
 
     // Owner can no longer withdraw since that permission has been moved to rando.
-    assert(
-      await didContractThrow(
-        store.withdraw(web3.utils.toWei("0.5", "ether"), { from: owner })
-      )
-    );
+    assert(await didContractThrow(store.withdraw(web3.utils.toWei("0.5", "ether"), { from: owner })));
 
     // Change withdraw back to owner.
     await store.resetMember(withdrawRole, owner, { from: owner });

--- a/core/test/TokenizedDerivative.js
+++ b/core/test/TokenizedDerivative.js
@@ -70,8 +70,6 @@ contract("TokenizedDerivative", function(accounts) {
     const oracleInterfaceName = web3.utils.hexToBytes(web3.utils.utf8ToHex("Oracle"));
     await deployedFinder.changeImplementationAddress(oracleInterfaceName, mockOracle.address);
 
-    await deployedAdmin.addMember(adminRemarginRole, owner);
-
     // Create an arbitrary ERC20 margin token.
     marginToken = await ERC20Mintable.new({ from: sponsor });
     await marginToken.mint(sponsor, web3.utils.toWei("100", "ether"), { from: sponsor });


### PR DESCRIPTION
Part of #781.

This PR updates the permissions for the Finder, Registry, Admin, and Store as described in https://github.com/UMAprotocol/protocol/issues/781#issuecomment-563495306.

It also fixes a small issue in the store where the `0` role was implicitly being used for the Withdrawer role.