### PR TITLE
Add a factory to create DesignatedVoting instances

### DIFF
--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -27,9 +27,9 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     // this contract.
     Finder private finder;
 
-    constructor(address finderAddress) public {
-        _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
-        _createExclusiveRole(uint(Roles.Voter), uint(Roles.Owner), msg.sender);
+    constructor(address finderAddress, address ownerAddress, address voterAddress) public {
+        _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), ownerAddress);
+        _createExclusiveRole(uint(Roles.Voter), uint(Roles.Owner), voterAddress);
         setWithdrawRole(uint(Roles.Owner));
 
         finder = Finder(finderAddress);

--- a/core/contracts/DesignatedVotingFactory.sol
+++ b/core/contracts/DesignatedVotingFactory.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.5.0;
+
+pragma experimental ABIEncoderV2;
+
+import "./DesignatedVoting.sol";
+import "./Finder.sol";
+import "./Withdrawable.sol";
+
+
+/**
+ * @title Factory to allow looking up deployed DesignatedVoting instances
+ * @dev Allows off-chain infrastructure, such as a dApp, to look up a hot wallet's deployed DesignatedVoting contract.
+ */
+contract DesignatedVotingFactory is Withdrawable {
+
+    enum Roles {
+        // Can withdraw any ETH or ERC20 sent accidentally to this contract.
+        Withdrawer
+    }
+
+    address private finder;
+    mapping(address => DesignatedVoting) public designatedVotingContracts;
+
+    constructor(address finderAddress) public {
+        finder = finderAddress;
+
+        createWithdrawRole(uint(Roles.Withdrawer), uint(Roles.Withdrawer), msg.sender);
+    }
+
+    /**
+     * @notice Deploys a new `DesignatedVoting` contract.
+     */
+    function newDesignatedVoting(address ownerAddress) external returns (DesignatedVoting designatedVoting) {
+        require(address(designatedVotingContracts[msg.sender]) == address(0), "Duplicate hot key not permitted");
+
+        designatedVoting = new DesignatedVoting(finder, ownerAddress, msg.sender);
+        designatedVotingContracts[msg.sender] = designatedVoting;
+    }
+}

--- a/core/contracts/DesignatedVotingFactory.sol
+++ b/core/contracts/DesignatedVotingFactory.sol
@@ -36,4 +36,12 @@ contract DesignatedVotingFactory is Withdrawable {
         designatedVoting = new DesignatedVoting(finder, ownerAddress, msg.sender);
         designatedVotingContracts[msg.sender] = designatedVoting;
     }
+
+    /**
+     * @notice Associates a `DesignatedVoting` instance with `msg.sender`.
+     */
+    function setDesignatedVoting(address designatedVotingAddress) external {
+        require(address(designatedVotingContracts[msg.sender]) == address(0), "Duplicate hot key not permitted");
+        designatedVotingContracts[msg.sender] = DesignatedVoting(designatedVotingAddress);
+    }
 }

--- a/core/migrations/16_deploy_designated_voting_factory.js
+++ b/core/migrations/16_deploy_designated_voting_factory.js
@@ -1,0 +1,9 @@
+const DesignatedVotingFactory = artifacts.require("DesignatedVotingFactory");
+const Finder = artifacts.require("Finder");
+const { getKeysForNetwork, deploy } = require("../../common/MigrationUtils.js");
+
+module.exports = async function(deployer, network, accounts) {
+  const keys = getKeysForNetwork(network, accounts);
+
+  await deploy(deployer, network, DesignatedVotingFactory, Finder.address, { from: keys.deployer });
+};

--- a/core/test/DesignatedVoting.js
+++ b/core/test/DesignatedVoting.js
@@ -28,8 +28,7 @@ contract("DesignatedVoting", function(accounts) {
     voting = await Voting.deployed();
     votingToken = await VotingToken.deployed();
     const finder = await Finder.deployed();
-    designatedVoting = await DesignatedVoting.new(finder.address, { from: tokenOwner });
-    await designatedVoting.resetMember(voterRole, voter, { from: tokenOwner });
+    designatedVoting = await DesignatedVoting.new(finder.address, tokenOwner, voter);
 
     tokenBalance = web3.utils.toWei("1");
     // The admin can burn and mint tokens for the purposes of this test.

--- a/core/test/DesignatedVotingFactory.js
+++ b/core/test/DesignatedVotingFactory.js
@@ -7,6 +7,7 @@ const Finder = artifacts.require("Finder");
 contract("DesignatedVotingFactory", function(accounts) {
   const owner = accounts[1];
   const voter = accounts[2];
+  const voter2 = accounts[3];
 
   let factory;
 
@@ -20,10 +21,16 @@ contract("DesignatedVotingFactory", function(accounts) {
     assert(await didContractThrow(factory.newDesignatedVoting(owner, { from: voter })));
 
     assert.equal(designatedVotingAddress.toString(), (await factory.designatedVotingContracts(voter)).toString());
-    designatedVoting = await DesignatedVoting.at(designatedVotingAddress);
+    const designatedVoting = await DesignatedVoting.at(designatedVotingAddress);
     const ownerRole = "0";
     assert(await designatedVoting.holdsRole(ownerRole, owner));
     const voterRole = "1";
     assert(await designatedVoting.holdsRole(voterRole, voter));
+
+    // Reassign.
+    await designatedVoting.resetMember(voterRole, voter2, { from: owner });
+    assert(await didContractThrow(factory.setDesignatedVoting(designatedVotingAddress, { from: voter })));
+    await factory.setDesignatedVoting(designatedVotingAddress, { from: voter2 });
+    assert.equal(designatedVotingAddress.toString(), (await factory.designatedVotingContracts(voter2)).toString());
   });
 });

--- a/core/test/DesignatedVotingFactory.js
+++ b/core/test/DesignatedVotingFactory.js
@@ -1,0 +1,29 @@
+const { didContractThrow } = require("../../common/SolidityTestUtils.js");
+
+const DesignatedVoting = artifacts.require("DesignatedVoting");
+const DesignatedVotingFactory = artifacts.require("DesignatedVotingFactory");
+const Finder = artifacts.require("Finder");
+
+contract("DesignatedVotingFactory", function(accounts) {
+  const owner = accounts[1];
+  const voter = accounts[2];
+
+  let factory;
+
+  before(async function() {
+    factory = await DesignatedVotingFactory.deployed();
+  });
+
+  it("Deploy new", async function() {
+    const designatedVotingAddress = await factory.newDesignatedVoting.call(owner, { from: voter });
+    await factory.newDesignatedVoting(owner, { from: voter });
+    assert(await didContractThrow(factory.newDesignatedVoting(owner, { from: voter })));
+
+    assert.equal(designatedVotingAddress.toString(), (await factory.designatedVotingContracts(voter)).toString());
+    designatedVoting = await DesignatedVoting.at(designatedVotingAddress);
+    const ownerRole = "0";
+    assert(await designatedVoting.holdsRole(ownerRole, owner));
+    const voterRole = "1";
+    assert(await designatedVoting.holdsRole(voterRole, voter));
+  });
+});


### PR DESCRIPTION
Add a factory to create `DesignatedVoting` instances. That factory maintains a mapping of the instances it has deployed, to allow off-chain infrastructure to be able to find DesignatedVoting contracts based on the hot wallet address.

An additional benefit of that approach is that no transactions need to be issued from the cold wallet as part of setup.

Note several limitations of this approach:
1. No way to look up by cold wallet address
2. Won't work with DesignatedVoting instances deployed without the factory
3. Won't work if you change the voter address in DesignatedVoting.

IMO these limitations don't justify adding unnecessary functionality, but curious about your thoughts.

Issue #778 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>