### PR TITLE
Support voting through DesignatedVoting from voter dapp

### DIFF
--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -43,10 +43,24 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     }
 
     /**
+     * @notice Forwards a batch commit to Voting.
+     */
+    function batchCommit(Voting.Commitment[] calldata commits) external {
+        _getVotingAddress().batchCommit(commits);
+    }
+
+    /**
      * @notice Forwards a reveal to Voting.
      */
     function revealVote(bytes32 identifier, uint time, int price, int salt) external onlyRoleHolder(uint(Roles.Voter)) {
         _getVotingAddress().revealVote(identifier, time, price, salt);
+    }
+
+    /**
+     * @notice Forwards a batch reveal to Voting.
+     */
+    function batchReveal(Voting.Reveal[] calldata reveals) external {
+        _getVotingAddress().batchReveal(reveals);
     }
 
     /**

--- a/core/contracts/DesignatedVoting.sol
+++ b/core/contracts/DesignatedVoting.sol
@@ -45,7 +45,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     /**
      * @notice Forwards a batch commit to Voting.
      */
-    function batchCommit(Voting.Commitment[] calldata commits) external {
+    function batchCommit(Voting.Commitment[] calldata commits) external onlyRoleHolder(uint(Roles.Voter)) {
         _getVotingAddress().batchCommit(commits);
     }
 
@@ -59,7 +59,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     /**
      * @notice Forwards a batch reveal to Voting.
      */
-    function batchReveal(Voting.Reveal[] calldata reveals) external {
+    function batchReveal(Voting.Reveal[] calldata reveals) external onlyRoleHolder(uint(Roles.Voter)) {
         _getVotingAddress().batchReveal(reveals);
     }
 

--- a/core/scripts/DeployDesignatedVoting.js
+++ b/core/scripts/DeployDesignatedVoting.js
@@ -1,0 +1,30 @@
+const argv = require("minimist")(process.argv.slice(), { string: ["ownershipAddress"] });
+
+const Finder = artifacts.require("Finder");
+const DesignatedVotingFactory = artifacts.require("DesignatedVotingFactory");
+
+async function run(deployedFactory, ownershipAddress) {
+  const account = (await web3.eth.getAccounts())[0];
+  // TODO(ptare): Handle the case where a DesignatedVoting is already deployed for this voting address `account`.
+  await deployedFactory.newDesignatedVoting(ownershipAddress, { from: account });
+  const designatedVotingAddress = await deployedFactory.designatedVotingContracts(account);
+  console.log("VOTING ADDRESS:", account);
+  console.log("DESIGNATED VOTING ADDRESS:", designatedVotingAddress);
+}
+
+const deployDesignatedVoting = async function(callback) {
+  if (!argv.ownershipAddress) {
+    callback("Must include <ownershipAddress>");
+  }
+  try {
+    const factory = await DesignatedVotingFactory.deployed();
+    await run(factory, argv.ownershipAddress);
+  } catch (e) {
+    console.log("ERROR:", e);
+    callback(e);
+  }
+  callback();
+};
+
+deployDesignatedVoting.run = run;
+module.exports = deployDesignatedVoting;

--- a/core/test/DesignatedVoting.js
+++ b/core/test/DesignatedVoting.js
@@ -166,6 +166,7 @@ contract("DesignatedVoting", function(accounts) {
       { identifier, time: time1, hash: hash1, encryptedVote: message1 },
       { identifier, time: time2, hash: hash2, encryptedVote: message2 }
     ];
+    assert(await didContractThrow(designatedVoting.batchCommit(commits, { from: tokenOwner })));
     await designatedVoting.batchCommit(commits, { from: voter });
 
     // Move to the reveal phase.
@@ -186,6 +187,7 @@ contract("DesignatedVoting", function(accounts) {
       { identifier, time: time1, price: price1.toString(), salt: salt1.toString() },
       { identifier, time: time2, price: price2.toString(), salt: salt2.toString() }
     ];
+    assert(await didContractThrow(designatedVoting.batchReveal(reveals, { from: tokenOwner })));
     await designatedVoting.batchReveal(reveals, { from: voter });
 
     // Check the resolved price.

--- a/core/test/DesignatedVoting.js
+++ b/core/test/DesignatedVoting.js
@@ -8,6 +8,7 @@ const VotingToken = artifacts.require("VotingToken");
 const { RegistryRolesEnum } = require("../../common/Enums.js");
 const { getRandomSignedInt, getRandomUnsignedInt } = require("../../common/Random.js");
 const { moveToNextRound, moveToNextPhase } = require("../utils/Voting.js");
+const { computeTopicHash, getKeyGenMessage } = require("../../common/EncryptionHelper.js");
 
 contract("DesignatedVoting", function(accounts) {
   const umaAdmin = accounts[0];
@@ -134,5 +135,65 @@ contract("DesignatedVoting", function(accounts) {
     // Throw away the reward tokens to avoid interacting with other test cases.
     await votingToken.transfer(umaAdmin, expectedInflation, { from: tokenOwner });
     await votingToken.burn(expectedInflation, { from: umaAdmin });
+  });
+
+  it("Batch commit and reveal", async function() {
+    await votingToken.transfer(designatedVoting.address, tokenBalance, { from: tokenOwner });
+
+    // Request a price.
+    const identifier = web3.utils.utf8ToHex("batch");
+    const time1 = "1000";
+    const time2 = "2000";
+    await voting.addSupportedIdentifier(identifier);
+    await voting.requestPrice(identifier, time1, { from: registeredDerivative });
+    await voting.requestPrice(identifier, time2, { from: registeredDerivative });
+    await moveToNextRound(voting);
+
+    const roundId = await voting.getCurrentRoundId();
+
+    const price1 = getRandomSignedInt();
+    const salt1 = getRandomUnsignedInt();
+    const hash1 = web3.utils.soliditySha3(price1, salt1);
+    const message1 = web3.utils.randomHex(4);
+
+    const price2 = getRandomSignedInt();
+    const salt2 = getRandomUnsignedInt();
+    const hash2 = web3.utils.soliditySha3(price2, salt2);
+    const message2 = web3.utils.randomHex(4);
+
+    // Batch commit.
+    const commits = [
+      { identifier, time: time1, hash: hash1, encryptedVote: message1 },
+      { identifier, time: time2, hash: hash2, encryptedVote: message2 }
+    ];
+    await designatedVoting.batchCommit(commits, { from: voter });
+
+    // Move to the reveal phase.
+    await moveToNextPhase(voting);
+
+    // Check message retrieval.
+    assert.equal(
+      await voting.getMessage(designatedVoting.address, computeTopicHash({ identifier, time: time1 }, roundId)),
+      message1
+    );
+    assert.equal(
+      await voting.getMessage(designatedVoting.address, computeTopicHash({ identifier, time: time2 }, roundId)),
+      message2
+    );
+
+    // Batch reveal.
+    const reveals = [
+      { identifier, time: time1, price: price1.toString(), salt: salt1.toString() },
+      { identifier, time: time2, price: price2.toString(), salt: salt2.toString() }
+    ];
+    await designatedVoting.batchReveal(reveals, { from: voter });
+
+    // Check the resolved price.
+    await moveToNextRound(voting);
+    assert.equal((await voting.getPrice(identifier, time1, { from: registeredDerivative })).toString(), price1);
+    assert.equal((await voting.getPrice(identifier, time2, { from: registeredDerivative })).toString(), price2);
+
+    // Reset the state.
+    await designatedVoting.withdrawErc20(votingToken.address, tokenBalance, { from: tokenOwner });
   });
 });

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -166,7 +166,7 @@ function ActiveRequests({ votingGateway }) {
         });
       }
     }
-    batchRevealFunction(reveals);
+    batchRevealFunction(reveals, { from: account });
     setCheckboxesChecked({});
   };
 

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -33,7 +33,7 @@ const editStateReducer = (state, action) => {
   }
 };
 
-function ActiveRequests() {
+function ActiveRequests({ votingGateway }) {
   const { drizzle, useCacheCall, useCacheEvents, useCacheSend } = drizzleReactHooks.useDrizzle();
   const { web3 } = drizzle;
   const classes = useTableStyles();
@@ -66,7 +66,9 @@ function ActiveRequests() {
       committedValue: call(
         "Voting",
         "getMessage",
-        account,
+        // If commits/reveals are through a DesignatedVoting instance, then the address of the DesignatedVoting is the
+        // `recipient` for saved messages.
+        votingGateway === "Voting" ? account : votingGateway,
         web3.utils.soliditySha3(request.identifier, request.time, currentRoundId)
       ),
       hasRevealed:
@@ -151,7 +153,7 @@ function ActiveRequests() {
   }, [subsequentFetchComplete, voteStatusesStringified, decryptionKeys, account]);
   const decryptionComplete = decryptedCommits && voteStatuses && decryptedCommits.length === voteStatuses.length;
 
-  const { send: batchRevealFunction, status: revealStatus } = useCacheSend("Voting", "batchReveal");
+  const { send: batchRevealFunction, status: revealStatus } = useCacheSend(votingGateway, "batchReveal");
   const onClickHandler = () => {
     const reveals = [];
     for (const index in checkboxesChecked) {
@@ -170,7 +172,7 @@ function ActiveRequests() {
 
   const [editState, dispatchEditState] = useReducer(editStateReducer, {});
 
-  const { send: batchCommitFunction, status: commitStatus } = useCacheSend("Voting", "batchCommit");
+  const { send: batchCommitFunction, status: commitStatus } = useCacheSend(votingGateway, "batchCommit");
   const onSaveHandler = async () => {
     const commits = [];
     const indicesCommitted = [];
@@ -195,7 +197,7 @@ function ActiveRequests() {
     if (commits.length < 1) {
       return;
     }
-    batchCommitFunction(commits);
+    batchCommitFunction(commits, { from: account });
     setCheckboxesChecked({});
     dispatchEditState({ type: "SUBMIT_COMMIT", indicesCommitted });
   };

--- a/voter-dapp/src/Dashboard.js
+++ b/voter-dapp/src/Dashboard.js
@@ -1,16 +1,67 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Header from "./Header.js";
 import AppBar from "@material-ui/core/AppBar";
 import ActiveRequests from "./ActiveRequests.js";
 import ResolvedRequests from "./ResolvedRequests.js";
+import DesignatedVoting from "./contracts/DesignatedVoting.json";
+
+import { drizzleReactHooks } from "drizzle-react";
 
 function Dashboard() {
+  const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
+  const { account } = drizzleReactHooks.useDrizzleState(drizzleState => ({
+    account: drizzleState.accounts[0]
+  }));
+
+  const addressZero = "0x0000000000000000000000000000000000000000";
+
+  const deployedDesignatedVotingAddress = useCacheCall("DesignatedVotingFactory", "designatedVotingContracts", account);
+  const { designatedVoting } = drizzleReactHooks.useDrizzleState(drizzleState => ({
+    designatedVoting: drizzleState.contracts[deployedDesignatedVotingAddress]
+  }));
+
+  // We only want to run `drizzle.addContract` once, even if a change deep inside the `drizzle` object retriggers this
+  // `useEffect`.
+  const [hasAdded, setHasAdded] = useState(false);
+  useEffect(() => {
+    if (!deployedDesignatedVotingAddress) {
+      return;
+    }
+    if (designatedVoting || hasAdded) {
+      return;
+    }
+    if (deployedDesignatedVotingAddress !== addressZero) {
+      drizzle.addContract({
+        contractName: deployedDesignatedVotingAddress,
+        web3Contract: new drizzle.web3.eth.Contract(DesignatedVoting.abi, deployedDesignatedVotingAddress)
+      });
+      setHasAdded(true);
+    }
+  }, [deployedDesignatedVotingAddress, hasAdded, drizzle, designatedVoting]);
+  if (!deployedDesignatedVotingAddress) {
+    // Waiting to see if the user has a deployed DesignatedVoting.
+    return <div>LOADING</div>;
+  }
+  const hasDesignatedVoting = deployedDesignatedVotingAddress !== addressZero;
+  let votingGateway = "Voting";
+  let votingAccount = "";
+
+  if (hasDesignatedVoting) {
+    if (designatedVoting) {
+      votingGateway = deployedDesignatedVotingAddress;
+      votingAccount = deployedDesignatedVotingAddress;
+    } else {
+      // Waiting for drizzle finish loading DesignatedVoting.
+      return <div>LOADING</div>;
+    }
+  }
+
   return (
     <div>
       <AppBar color="secondary" position="static">
-        <Header />
+        <Header votingAccount={votingAccount} />
       </AppBar>
-      <ActiveRequests />
+      <ActiveRequests votingGateway={votingGateway} />
       <ResolvedRequests />
     </div>
   );

--- a/voter-dapp/src/Header.js
+++ b/voter-dapp/src/Header.js
@@ -10,14 +10,14 @@ import BigNumber from "bignumber.js";
 // style this component, either edit the theme which should propogate
 // through inheritance, or change the properties (props) of this component.
 
-export default function Header() {
+export default function Header({ votingAccount }) {
   const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
   const { web3 } = drizzle;
   const account = drizzleReactHooks.useDrizzleState(drizzleState => ({
     account: drizzleState.accounts[0]
   })).account;
 
-  const balance = useCacheCall("VotingToken", "balanceOf", account);
+  const balance = useCacheCall("VotingToken", "balanceOf", votingAccount ? votingAccount : account);
   const supply = useCacheCall("VotingToken", "totalSupply");
   let tokenBalance;
 
@@ -78,6 +78,11 @@ export default function Header() {
             <div align="right" style={textStyle}>
               Your Address: {account}
             </div>
+            {votingAccount && (
+              <div align="right" style={textStyle}>
+                Voting with contract: {votingAccount}
+              </div>
+            )}
             <div align="right" style={textStyle}>
               {tokenBalance}
             </div>

--- a/voter-dapp/src/drizzleOptions.js
+++ b/voter-dapp/src/drizzleOptions.js
@@ -1,8 +1,9 @@
+import DesignatedVotingFactory from "./contracts/DesignatedVotingFactory.json";
 import Voting from "./contracts/Voting.json";
 import VotingToken from "./contracts/VotingToken.json";
 
 const options = {
-  contracts: [Voting, VotingToken],
+  contracts: [DesignatedVotingFactory, Voting, VotingToken],
   polls: {
     accounts: 1000,
     blocks: 3000


### PR DESCRIPTION
In this first-pass implementation, if the account selected in Metamask
has a DesignatedVoting contract deployed, the voter dapp will prefer to
use that contract instead.

Follow-up PRs can improve the UX (significantly) and build a flow
to deploy the contract from the dapp.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>