### PR TITLE
Support DesignatedVoting when filtering events

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -348,23 +348,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         return voteTiming.computeCurrentRoundId(getCurrentTime());
     }
 
-    /**
-     * @notice Whether the caller has a revealed vote for the current round for an (identifier, time).
-     * @dev If the price request was resolved in a previous round, this function will return `false` even if the caller
-     * did reveal a vote.
-     */
-    function hasRevealedVote(bytes32 identifier, uint time) external view returns (bool) {
-        PriceRequest storage priceRequest = _getPriceRequest(identifier, time);
-        uint currentRoundId = voteTiming.computeCurrentRoundId(getCurrentTime());
-        if (_getRequestStatus(priceRequest, currentRoundId) != RequestStatus.Active) {
-            return false;
-        }
-        VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
-        VoteSubmission storage voteSubmission = voteInstance.voteSubmissions[msg.sender];
-
-        return voteSubmission.revealHash != bytes32(0);
-    }
-
     function commitVote(bytes32 identifier, uint time, bytes32 hash) public onlyIfNotMigrated() {
         // TODO(#779): Committed hash of 0 is disallowed, choose a different salt
         require(hash != bytes32(0));

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -807,20 +807,6 @@ contract("Voting", function(accounts) {
     await voting.commitVote(identifier, time, hash2, { from: account2 });
 
     await moveToNextPhase(voting);
-
-    // Account 1 reveals.
-    await voting.revealVote(identifier, time, price, salt1, { from: account1 });
-
-    // Check if hasRevealedVote gives correct results for each voter.
-    assert.isTrue(await voting.hasRevealedVote(identifier, time, { from: account1 }));
-    assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account2 }));
-    assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account3 }));
-
-    // Once in the next round, no voter is considered to have revealed.
-    await moveToNextRound(voting);
-    assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account1 }));
-    assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account2 }));
-    assert.isFalse(await voting.hasRevealedVote(identifier, time, { from: account3 }));
   });
 
   it("Basic Inflation", async function() {

--- a/voter-dapp/src/Dashboard.js
+++ b/voter-dapp/src/Dashboard.js
@@ -44,25 +44,26 @@ function Dashboard() {
   }
   const hasDesignatedVoting = deployedDesignatedVotingAddress !== addressZero;
   let votingGateway = "Voting";
-  let votingAccount = "";
 
   if (hasDesignatedVoting) {
     if (designatedVoting) {
       votingGateway = deployedDesignatedVotingAddress;
-      votingAccount = deployedDesignatedVotingAddress;
     } else {
       // Waiting for drizzle finish loading DesignatedVoting.
       return <div>LOADING</div>;
     }
   }
+  // If commits/reveals are through a DesignatedVoting instance, then the address of the DesignatedVoting is the
+  // voting account as far as `Voting.sol` is concerned.
+  const votingAccount = votingGateway === "Voting" ? account : votingGateway;
 
   return (
     <div>
       <AppBar color="secondary" position="static">
         <Header votingAccount={votingAccount} />
       </AppBar>
-      <ActiveRequests votingGateway={votingGateway} />
-      <ResolvedRequests />
+      <ActiveRequests votingGateway={votingGateway} votingAccount={votingAccount} />
+      <ResolvedRequests votingAccount={votingAccount} />
     </div>
   );
 }

--- a/voter-dapp/src/Header.js
+++ b/voter-dapp/src/Header.js
@@ -17,7 +17,7 @@ export default function Header({ votingAccount }) {
     account: drizzleState.accounts[0]
   })).account;
 
-  const balance = useCacheCall("VotingToken", "balanceOf", votingAccount ? votingAccount : account);
+  const balance = useCacheCall("VotingToken", "balanceOf", votingAccount);
   const supply = useCacheCall("VotingToken", "totalSupply");
   let tokenBalance;
 
@@ -78,7 +78,7 @@ export default function Header({ votingAccount }) {
             <div align="right" style={textStyle}>
               Your Address: {account}
             </div>
-            {votingAccount && (
+            {votingAccount !== account && (
               <div align="right" style={textStyle}>
                 Voting with contract: {votingAccount}
               </div>

--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -12,16 +12,12 @@ import { useTableStyles } from "./Styles.js";
 import { formatDate } from "./common/FormattingUtils.js";
 import { MAX_UINT_VAL } from "./common/Constants.js";
 
-function ResolvedRequests() {
+function ResolvedRequests({ votingAccount }) {
   const { drizzle, useCacheCall, useCacheEvents } = drizzleReactHooks.useDrizzle();
   const { web3 } = drizzle;
   const classes = useTableStyles();
 
   const currentRoundId = useCacheCall("Voting", "getCurrentRoundId");
-
-  const { account } = drizzleReactHooks.useDrizzleState(drizzleState => ({
-    account: drizzleState.accounts[0]
-  }));
 
   const [showAllResolvedRequests, setShowAllResolvedRequests] = useState(false);
 
@@ -44,10 +40,10 @@ function ResolvedRequests() {
         const indexRoundId = currentRoundId == null ? MAX_UINT_VAL : currentRoundId - 1;
         // If all resolved requests are being shown, don't filter by round id.
         return {
-          filter: { resolutionRoundId: showAllResolvedRequests ? undefined : indexRoundId, voter: account },
+          filter: { resolutionRoundId: showAllResolvedRequests ? undefined : indexRoundId, voter: votingAccount },
           fromBlock: 0
         };
-      }, [currentRoundId, account, showAllResolvedRequests])
+      }, [currentRoundId, votingAccount, showAllResolvedRequests])
     ) || [];
 
   // Handler for when the user clicks the button to toggle showing all resolved requests.


### PR DESCRIPTION
This PR also removes the method `Voting::hasRevealed`, is there a reason
to keep it around? If so, we'd have to either 1) add it to
`DesignatedVoting.sol`, or 2) have it take in a voter address rather
than relying on `msg.sender`.

Issue #787 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>