### PR TITLE
[WIP] Update node version in documentation and ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   checkout_and_install:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
     working_directory: ~/protocol
     steps:
       - checkout
@@ -26,7 +26,7 @@ jobs:
             - ~/protocol
   build:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -40,7 +40,7 @@ jobs:
             - ~/protocol
   lint:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -50,7 +50,7 @@ jobs:
           command: ./ci/lint.sh
   docs:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -100,7 +100,7 @@ jobs:
           command: ./ci/run_slither.sh
   test:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 6720000
     working_directory: ~/protocol
@@ -179,7 +179,7 @@ jobs:
           command: ./ci/run_echidna_tests.sh
   dapp_test:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 6720000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
     working_directory: ~/protocol
@@ -217,7 +217,7 @@ jobs:
           command: ./ci/run_dapp_tests.sh
   dapp_build:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -242,7 +242,7 @@ jobs:
           destination: sponsor-dapp-v2-build
   deploy_to_staging:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node
     working_directory: ~/protocol
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v4-dependency-cache-{{ checksum "package.json" }}
-            - v4-dependency-cache-
+            - v5-dependency-cache-{{ checksum "package.json" }}
+            - v5-dependency-cache-
       - run:
           name: Install Prereqs
           command: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev
@@ -17,7 +17,7 @@ jobs:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: v4-dependency-cache-{{ checksum "package.json" }}
+          key: v5-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - save_cache:
@@ -192,8 +192,8 @@ jobs:
           command: $(npm bin)/truffle migrate --reset --network test
       - restore_cache:
           keys: 
-            - v3-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
-            - v3-dapp-dep-cache-
+            - v4-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
+            - v4-dapp-dep-cache-
       - run:
           name: Install Voter dApp Dependencies
           working_directory: ~/protocol/voter-dapp
@@ -203,7 +203,7 @@ jobs:
           working_directory: ~/protocol/sponsor-dapp-v2
           command: npm install
       - save_cache:
-          key: v3-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
+          key: v4-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
           paths:
             - voter-dapp/node_modules
             - sponsor-dapp-v2/node_modules

--- a/documentation/tutorials/prerequisites.md
+++ b/documentation/tutorials/prerequisites.md
@@ -6,7 +6,7 @@ After completing these set up steps, we'll be ready to start developing with the
 
 Start in the top-level directory in this repository, `protocol/`.
 
-1. Install nodejs v11.15.0 and ensure that npm is installed along with it.
+1. Install the latest stable version of nodejs and ensure that npm is installed along with it.
 2. Run `npm install` in `protocol/`.
 
 We should be able to compile the smart contracts from `protocol/core`:


### PR DESCRIPTION
As @nicholaspai pointed out in #795, our current code may work with the latest stable node release. To that end, this PR un-pins the node version in ci and updates the documentation to tell users to install the latest version of node, since that will be the version we're officially supporting going forward.