### PR TITLE
Correct timestamp display

### DIFF
--- a/sponsor-dapp-v2/src/components/Step2.js
+++ b/sponsor-dapp-v2/src/components/Step2.js
@@ -37,7 +37,7 @@ function Step2(props) {
     .map(expiry => {
       return {
         key: expiry,
-        value: expiry ? moment.unix(expiry).format("MMMM DD, YYYY LTS") : "Perpetual (alpha)"
+        value: expiry ? moment.unix(expiry).format("YYYY-MM-DD LTS") : "Perpetual (alpha)"
       };
     });
 

--- a/sponsor-dapp-v2/src/components/common/ExpandBox.js
+++ b/sponsor-dapp-v2/src/components/common/ExpandBox.js
@@ -26,7 +26,7 @@ class ExpandBox extends Component {
       } else if (timestamp === UINT_MAX) {
         return "None";
       } else {
-        return moment.unix(timestamp).format("YYYY-MM-DD, HH:MM:SS");
+        return moment.unix(timestamp).format("YYYY-MM-DD, LTS");
       }
     };
 


### PR DESCRIPTION
Timestamp was displaying months instead of minutes on the ManagePosition page.

I corrected this by using LTS (locale timestamp) as we do in Step 2. I went ahead and unified the two date displays in the process since there's no reason for them to use different formats.