### PR TITLE
Downgrade truffle temporarily to fix ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "moment": "^2.24.0",
     "node-fetch": "^2.3.0",
     "secp256k1": "^3.7.1",
-    "truffle": "^5.1.0",
+    "truffle": "5.1.4",
     "truffle-assertions": "^0.9.2",
     "web3": "^1.2.4",
     "web3-core-promievent": "^1.2.4",


### PR DESCRIPTION
Continuous integration is broken because of a breakage in test isolation in a recent truffle release. Since it's a bug on their end, I think we should just downgrade until it's fixed.

See https://github.com/trufflesuite/truffle/issues/2710 for more details.