### PR TITLE
Make RewardsRetrieved event more consistent

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -157,7 +157,8 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         uint numTokens
     );
 
-    event RewardsRetrieved(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time, uint numTokens);
+    event RewardsRetrieved(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time,
+        uint numTokens);
 
     event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
 
@@ -477,7 +478,8 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
                 totalRewardToIssue = totalRewardToIssue.add(reward);
 
                 // Emit reward retrieval for this vote.
-                emit RewardsRetrieved(voterAddress, roundId, toRetrieve[i].identifier, toRetrieve[i].time, reward.rawValue);
+                emit RewardsRetrieved(voterAddress, roundId, toRetrieve[i].identifier, toRetrieve[i].time,
+                    reward.rawValue);
             } else {
                 // Emit a 0 token retrieval on incorrect votes.
                 emit RewardsRetrieved(voterAddress, roundId, toRetrieve[i].identifier, toRetrieve[i].time, 0);

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -157,7 +157,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         uint numTokens
     );
 
-    event RewardsRetrieved(address indexed voter, uint indexed rewardsRoundId, uint numTokens);
+    event RewardsRetrieved(address indexed voter, uint indexed roundId, bytes32 indexed identifier, uint time, uint numTokens);
 
     event PriceRequestAdded(uint indexed votingRoundId, bytes32 indexed identifier, uint time);
 
@@ -461,13 +461,12 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         for (uint i = 0; i < toRetrieve.length; i++) {
             PriceRequest storage priceRequest = _getPriceRequest(toRetrieve[i].identifier, toRetrieve[i].time);
             VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
-            VoteSubmission storage voteSubmission = voteInstance.voteSubmissions[voterAddress];
 
             require(priceRequest.lastVotingRound == roundId, "Only retrieve rewards for votes resolved in same round");
 
             _resolvePriceRequest(priceRequest, voteInstance);
 
-            if (voteInstance.resultComputation.wasVoteCorrect(voteSubmission.revealHash)) {
+            if (voteInstance.resultComputation.wasVoteCorrect(voteInstance.voteSubmissions[voterAddress].revealHash)) {
                 // The price was successfully resolved during the voter's last voting round, the voter revealed and was
                 // correct, so they are elgible for a reward.
                 FixedPoint.Unsigned memory correctTokens = voteInstance.resultComputation.
@@ -476,16 +475,21 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
                 // Compute the reward and add to the cumulative reward.
                 FixedPoint.Unsigned memory reward = snapshotBalance.mul(totalRewardPerVote).div(correctTokens);
                 totalRewardToIssue = totalRewardToIssue.add(reward);
+
+                // Emit reward retrieval for this vote.
+                emit RewardsRetrieved(voterAddress, roundId, toRetrieve[i].identifier, toRetrieve[i].time, reward.rawValue);
+            } else {
+                // Emit a 0 token retrieval on incorrect votes.
+                emit RewardsRetrieved(voterAddress, roundId, toRetrieve[i].identifier, toRetrieve[i].time, 0);
             }
 
             // Delete the submission to capture any refund and clean up storage.
-            delete voteSubmission.revealHash;
+            delete voteInstance.voteSubmissions[voterAddress].revealHash;
         }
 
         // Issue any accumulated rewards.
         if (totalRewardToIssue.isGreaterThan(0)) {
             require(votingToken.mint(voterAddress, totalRewardToIssue.rawValue));
-            emit RewardsRetrieved(voterAddress, roundId, totalRewardToIssue.rawValue);
         }
     }
 

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -990,15 +990,17 @@ contract("Voting", function(accounts) {
     truffleAssert.eventEmitted(result, "RewardsRetrieved", ev => {
       return (
         ev.voter.toString() == account1.toString() &&
-        ev.rewardsRoundId.toString() == currentRoundId.toString() &&
+        ev.roundId.toString() == currentRoundId.toString() &&
+        web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier) &&
+        ev.time == time &&
         // Inflation is 100% and there was only one voter.
         ev.numTokens.toString() == initialTotalSupply.toString()
       );
     });
 
-    // Events only get emitted if there were actually rewards issued. Is this the behavior we want?
+    // RewardsRetrieved event gets emitted for every reward retrieval that's attempted, even if no tokens are minted.
     result = await voting.retrieveRewards(account4, roundId, [{ identifier, time }]);
-    truffleAssert.eventNotEmitted(result, "RewardsRetrieved");
+    truffleAssert.eventEmitted(result, "RewardsRetrieved", ev => true);
 
     // An event should be emitted when a new supported identifier is added (but not on repeated no-op calls).
     result = await voting.removeSupportedIdentifier(identifier);


### PR DESCRIPTION
The point of this PR is to make it easier for offchain applications to match up RewardsRetrieved events with VoteRevealed and PriceResolved events.

This PR changes the RewardsRetrieved event in the following ways:
- If a voter passes 10 votes to retrieveRewards (and the transaction succeeds), they should see 10 RewardsRetrieved events emitted.
- 2 new fields have been added: identifier and time.

Note: voters can retrieve rewards for the same vote multiple times and, therefore emit multiple RewardsRetrieved events, but tokens will be awarded and documented in the event on the first call only.

Any changes unrelated to the RewardsRetrieved event are workarounds for solidity "stack too deep" errors.