### PR TITLE
Update to Node v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   checkout_and_install:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
     working_directory: ~/protocol
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v4-dependency-cache-{{ checksum "package.json" }}
-            - v4-dependency-cache-
+            - v7-dependency-cache-{{ checksum "package.json" }}
+            - v7-dependency-cache-
       - run:
           name: Install Prereqs
           command: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev
@@ -17,7 +17,7 @@ jobs:
           name: Install Dependencies
           command: npm install --quiet
       - save_cache:
-          key: v4-dependency-cache-{{ checksum "package.json" }}
+          key: v7-dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - save_cache:
@@ -26,7 +26,7 @@ jobs:
             - ~/protocol
   build:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -40,7 +40,7 @@ jobs:
             - ~/protocol
   lint:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -50,7 +50,7 @@ jobs:
           command: ./ci/lint.sh
   docs:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -100,7 +100,7 @@ jobs:
           command: ./ci/run_slither.sh
   test:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 6720000
     working_directory: ~/protocol
@@ -179,7 +179,7 @@ jobs:
           command: ./ci/run_echidna_tests.sh
   dapp_test:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 6720000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
     working_directory: ~/protocol
@@ -192,8 +192,8 @@ jobs:
           command: $(npm bin)/truffle migrate --reset --network test
       - restore_cache:
           keys: 
-            - v3-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
-            - v3-dapp-dep-cache-
+            - v6-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
+            - v6-dapp-dep-cache-
       - run:
           name: Install Voter dApp Dependencies
           working_directory: ~/protocol/voter-dapp
@@ -203,7 +203,7 @@ jobs:
           working_directory: ~/protocol/sponsor-dapp-v2
           command: npm install
       - save_cache:
-          key: v3-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
+          key: v6-dapp-dep-cache-{{ checksum "voter-dapp/package.json" }}-{{ checksum "sponsor-dapp-v2/package.json" }}
           paths:
             - voter-dapp/node_modules
             - sponsor-dapp-v2/node_modules
@@ -217,7 +217,7 @@ jobs:
           command: ./ci/run_dapp_tests.sh
   dapp_build:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -242,7 +242,7 @@ jobs:
           destination: sponsor-dapp-v2-build
   deploy_to_staging:
     docker:
-      - image: circleci/node:11.5.0
+      - image: circleci/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:

--- a/documentation/tutorials/prerequisites.md
+++ b/documentation/tutorials/prerequisites.md
@@ -6,7 +6,7 @@ After completing these set up steps, we'll be ready to start developing with the
 
 Start in the top-level directory in this repository, `protocol/`.
 
-1. Install nodejs v11.15.0 and ensure that npm is installed along with it.
+1. Install the latest stable version of nodejs and ensure that npm is installed along with it.
 2. Run `npm install` in `protocol/`.
 
 We should be able to compile the smart contracts from `protocol/core`:

--- a/sponsor-dapp-v2/package.json
+++ b/sponsor-dapp-v2/package.json
@@ -7,7 +7,7 @@
     "classnames": "^2.2.6",
     "moment": "^2.24.0",
     "node-sass": "^4.12.0",
-    "drizzle": "github:UMAprotocol/drizzle#1.4.0-fix2",
+    "drizzle": "github:UMAprotocol/drizzle#1.4.0-fix4",
     "drizzle-react": "github:UMAprotocol/drizzle-react#develop",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/voter-dapp/package.json
+++ b/voter-dapp/package.json
@@ -6,7 +6,7 @@
     "@material-ui/styles": "^4.3.0",
     "@material-ui/core": "^4.3.1",
     "@material-ui/icons": "^3.0.2",
-    "drizzle": "github:UMAprotocol/drizzle#1.4.0-fix2",
+    "drizzle": "github:UMAprotocol/drizzle#1.4.0-fix4",
     "drizzle-react": "^1.3.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
UMAProtocol's fork of Drizzle needed to have its web3 version updated as well, otherwise certain packages (e.g., scrypt) fail to build with node12.

Issue #795 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>