### PR TITLE
Make salt generation in dApp more consistent with unit tests

### DIFF
--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -15,6 +15,7 @@ import { VotePhasesEnum } from "./common/Enums.js";
 import { decryptMessage, deriveKeyPairFromSignatureMetamask, encryptMessage } from "./common/Crypto.js";
 import { useTableStyles } from "./Styles.js";
 const { getKeyGenMessage } = require("./common/EncryptionHelper.js");
+const { getRandomUnsignedInt } = require("./common/Random.js");
 
 const editStateReducer = (state, action) => {
   switch (action.type) {
@@ -159,7 +160,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
           identifier: pendingRequests[index].identifier,
           time: pendingRequests[index].time,
           price: decryptedCommits[index].price.toString(),
-          salt: web3.utils.hexToNumberString(decryptedCommits[index].salt)
+          salt: decryptedCommits[index].salt
         });
       }
     }
@@ -178,10 +179,10 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         continue;
       }
       const price = web3.utils.toWei(editState[index]);
-      const salt = getRandomUnsignedInt();
+      const salt = getRandomUnsignedInt().toString();
       const encryptedVote = await encryptMessage(
         decryptionKeys[account][currentRoundId].publicKey,
-        JSON.stringify({ price: price.toString(), salt: salt.toString() })
+        JSON.stringify({ price, salt })
       );
       commits.push({
         identifier: pendingRequests[index].identifier,

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -178,10 +178,10 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         continue;
       }
       const price = web3.utils.toWei(editState[index]);
-      const salt = web3.utils.toBN(web3.utils.randomHex(32));
+      const salt = getRandomUnsignedInt();
       const encryptedVote = await encryptMessage(
         decryptionKeys[account][currentRoundId].publicKey,
-        JSON.stringify({ price, salt })
+        JSON.stringify({ price: price.toString(), salt: salt.toString() })
       );
       commits.push({
         identifier: pendingRequests[index].identifier,


### PR DESCRIPTION
Use the same utility function to generate random salt in the dApp that the Truffle unit tests use. In optimized mode, BN's aren't always recognized as BN's due to a known issue, so we have to call .toString().

Truffle test:
https://github.com/UMAprotocol/protocol/blob/f3a2ce6a0f9036c58dcc9f91d062556862df30c8/core/test/Voting.js#L1023

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>