### PR TITLE
Refactor Voting supportedIdentifier struct and methods

### DIFF
--- a/core/contracts/Governor.sol
+++ b/core/contracts/Governor.sol
@@ -7,6 +7,7 @@ import "./MultiRole.sol";
 import "./FixedPoint.sol";
 import "./Voting.sol";
 import "./Testable.sol";
+import "./IdentifierWhitelistInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
@@ -127,10 +128,11 @@ contract Governor is MultiRole, Testable {
 
         // Request a vote on this proposal in the DVM.
         Voting voting = _getVoting();
-        voting.addSupportedIdentifier(identifier);
+        IdentifierWhitelistInterface supportedIdentifiers = _getIdentifierWhitelist();
+        supportedIdentifiers.addSupportedIdentifier(identifier);
 
         voting.requestPrice(identifier, time);
-        voting.removeSupportedIdentifier(identifier);
+        supportedIdentifiers.removeSupportedIdentifier(identifier);
 
         emit NewProposal(id, transactions);
     }
@@ -157,6 +159,10 @@ contract Governor is MultiRole, Testable {
 
     function _getVoting() private view returns (Voting voting) {
         return Voting(finder.getImplementationAddress("Oracle"));
+    }
+
+    function _getIdentifierWhitelist() private view returns (IdentifierWhitelistInterface supportedIdentifiers) {
+        return IdentifierWhitelistInterface(finder.getImplementationAddress("IdentifierWhitelist"));
     }
 
     // This method is based off of this code: https://ethereum.stackexchange.com/a/6613/47801.

--- a/core/contracts/IdentifierWhitelist.sol
+++ b/core/contracts/IdentifierWhitelist.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/contracts/ownership/Ownable.sol";
+
+/**
+ * @title A contract to track a whitelist of supported identifiers that the oracle can provide prices for.
+ */
+contract IdentifierWhitelist is Ownable {
+    mapping(bytes32 => bool) private supportedIdentifiers;
+
+    event SupportedIdentifierAdded(bytes32 indexed identifier);
+    event SupportedIdentifierRemoved(bytes32 indexed identifier);
+
+    /**
+     * @notice Adds the provided identifier as a supported identifier. Price requests using this identifier will be
+     * succeed after this call.
+     */
+    function addSupportedIdentifier(bytes32 identifier) external onlyOwner {
+        if (!supportedIdentifiers[identifier]) {
+            supportedIdentifiers[identifier] = true;
+            emit SupportedIdentifierAdded(identifier);
+        }
+    }
+
+    /**
+     * @notice Removes the identifier from the whitelist. Price requests using this identifier will no longer succeed
+     * after this call.
+     */
+    function removeSupportedIdentifier(bytes32 identifier) external onlyOwner {
+        if (supportedIdentifiers[identifier]) {
+            supportedIdentifiers[identifier] = false;
+            emit SupportedIdentifierRemoved(identifier);
+        }
+    }
+
+    /**
+     * @notice Checks whether an identifier is on the whitelist.
+     */
+    function isIdentifierSupported(bytes32 identifier) external view returns (bool) {
+        return supportedIdentifiers[identifier];
+    }
+}

--- a/core/contracts/IdentifierWhitelist.sol
+++ b/core/contracts/IdentifierWhitelist.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.5.0;
 import "./IdentifierWhitelistInterface.sol";
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 
+
 /**
  * @title Stores a whitelist of supported identifiers that the oracle can provide prices for.
  */
 contract IdentifierWhitelist is IdentifierWhitelistInterface, Ownable {
+
     mapping(bytes32 => bool) private supportedIdentifiers;
 
     event SupportedIdentifierAdded(bytes32 indexed identifier);

--- a/core/contracts/IdentifierWhitelist.sol
+++ b/core/contracts/IdentifierWhitelist.sol
@@ -1,11 +1,12 @@
 pragma solidity ^0.5.0;
 
+import "./IdentifierWhitelistInterface.sol";
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 
 /**
- * @title A contract to track a whitelist of supported identifiers that the oracle can provide prices for.
+ * @title Stores a whitelist of supported identifiers that the oracle can provide prices for.
  */
-contract IdentifierWhitelist is Ownable {
+contract IdentifierWhitelist is IdentifierWhitelistInterface, Ownable {
     mapping(bytes32 => bool) private supportedIdentifiers;
 
     event SupportedIdentifierAdded(bytes32 indexed identifier);

--- a/core/contracts/IdentifierWhitelistInterface.sol
+++ b/core/contracts/IdentifierWhitelistInterface.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.0;
+
+pragma experimental ABIEncoderV2;
+
+
+/**
+ * @title Interface for whitelists of supported identifiers that the oracle can provide prices for.
+ */
+interface IdentifierWhitelistInterface {
+    /**
+     * @notice Adds the provided identifier as a supported identifier. Price requests using this identifier will be
+     * succeed after this call.
+     */
+    function addSupportedIdentifier(bytes32 identifier) external;
+
+    /**
+     * @notice Removes the identifier from the whitelist. Price requests using this identifier will no longer succeed
+     * after this call.
+     */
+    function removeSupportedIdentifier(bytes32 identifier) external;
+
+    /**
+     * @notice Checks whether an identifier is on the whitelist.
+     */
+    function isIdentifierSupported(bytes32 identifier) external view returns (bool);
+}

--- a/core/contracts/OracleInterface.sol
+++ b/core/contracts/OracleInterface.sol
@@ -13,11 +13,6 @@ interface OracleInterface {
     function requestPrice(bytes32 identifier, uint time) external;
 
     /**
-     * @notice Whether the Oracle provides prices for this identifier.
-     */
-    function isIdentifierSupported(bytes32 identifier) external view returns (bool);
-
-    /**
      * @notice Whether the price for `identifier` and `time` is available.
      */
     function hasPrice(bytes32 identifier, uint time) external view returns (bool);

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -673,7 +673,9 @@ library TokenizedDerivativeUtils {
         s.externalAddresses.priceFeed = PriceFeedInterface(params.priceFeedAddress);
 
         // Verify that the price feed and Oracle support the given s.fixedParameters.product.
-        IdentifierWhitelistInterface supportedIdentifiers = IdentifierWhitelistInterface(_getIdentifierWhitelistAddress(s));
+        IdentifierWhitelistInterface supportedIdentifiers = IdentifierWhitelistInterface(
+            _getIdentifierWhitelistAddress(s)
+        );
         require(supportedIdentifiers.isIdentifierSupported(params.product));
         require(s.externalAddresses.priceFeed.isIdentifierSupported(params.product));
 

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -10,6 +10,7 @@ import "./OracleInterface.sol";
 import "./PriceFeedInterface.sol";
 import "./ReturnCalculatorInterface.sol";
 import "./StoreInterface.sol";
+import "./IdentifierWhitelistInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/drafts/SignedSafeMath.sol";
@@ -545,6 +546,11 @@ library TokenizedDerivativeUtils {
         return s.externalAddresses.finder.getImplementationAddress(oracleInterface);
     }
 
+    function _getIdentifierWhitelistAddress(TDS.Storage storage s) internal view returns (address) {
+        bytes32 identifierWhitelistInterface = "IdentifierWhitelist";
+        return s.externalAddresses.finder.getImplementationAddress(identifierWhitelistInterface);
+    }
+
     function _getStoreAddress(TDS.Storage storage s) internal view returns (address) {
         bytes32 storeInterface = "Store";
         return s.externalAddresses.finder.getImplementationAddress(storeInterface);
@@ -667,8 +673,8 @@ library TokenizedDerivativeUtils {
         s.externalAddresses.priceFeed = PriceFeedInterface(params.priceFeedAddress);
 
         // Verify that the price feed and Oracle support the given s.fixedParameters.product.
-        OracleInterface oracle = OracleInterface(_getOracleAddress(s));
-        require(oracle.isIdentifierSupported(params.product));
+        IdentifierWhitelistInterface supportedIdentifiers = IdentifierWhitelistInterface(_getIdentifierWhitelistAddress(s));
+        require(supportedIdentifiers.isIdentifierSupported(params.product));
         require(s.externalAddresses.priceFeed.isIdentifierSupported(params.product));
 
         s.externalAddresses.sponsor = params.sponsor;

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -12,7 +12,7 @@ import "./Testable.sol";
 import "./VoteTiming.sol";
 import "./VotingToken.sol";
 import "./VotingInterface.sol";
-import "./IdentifierWhitelist.sol";
+import "./IdentifierWhitelistInterface.sol";
 
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -121,7 +121,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
     VoteTiming.Data private voteTiming;
 
-    IdentifierWhitelist public identifierWhitelist;
+    IdentifierWhitelistInterface public identifierWhitelist;
 
     // Percentage of the total token supply that must be used in a vote to create a valid price resolution.
     // 1 == 100%.
@@ -176,6 +176,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         FixedPoint.Unsigned memory _gatPercentage,
         FixedPoint.Unsigned memory _inflationRate,
         address _votingToken,
+        address _identifierWhitelist,
         address _finder,
         bool _isTest
     ) public Testable(_isTest) {
@@ -184,7 +185,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         gatPercentage = _gatPercentage;
         inflationRate = _inflationRate;
         votingToken = VotingToken(_votingToken);
-        identifierWhitelist = new IdentifierWhitelist();
+        identifierWhitelist = IdentifierWhitelistInterface(_identifierWhitelist);
         finder = Finder(_finder);
     }
 
@@ -263,22 +264,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      */
     function setMigrated(address newVotingAddress) external onlyOwner {
         migratedAddress = newVotingAddress;
-    }
-
-    /**
-     * @notice Adds the provided identifier as a supported identifier. Price requests using this identifier will
-     * succeed after this call.
-     */
-    function addSupportedIdentifier(bytes32 identifier) external onlyOwner {
-        identifierWhitelist.addSupportedIdentifier(identifier);
-    }
-
-    /**
-     * @notice Removes the identifier from the whitelist. Price requests using this identifier will no longer succeed
-     * after this call.
-     */
-    function removeSupportedIdentifier(bytes32 identifier) external onlyOwner {
-        identifierWhitelist.removeSupportedIdentifier(identifier);
     }
 
     function isIdentifierSupported(bytes32 identifier) external view returns (bool) {

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -266,10 +266,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         migratedAddress = newVotingAddress;
     }
 
-    function isIdentifierSupported(bytes32 identifier) external view returns (bool) {
-        return identifierWhitelist.isIdentifierSupported(identifier);
-    }
-
     function hasPrice(bytes32 identifier, uint time) external view onlyRegisteredDerivative() returns (bool _hasPrice) {
         (_hasPrice, ,) = _getPriceOrError(identifier, time);
     }

--- a/core/contracts/test/MockOracle.sol
+++ b/core/contracts/test/MockOracle.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import "../OracleInterface.sol";
 import "../Testable.sol";
-import "../IdentifierWhitelist.sol";
+import "../IdentifierWhitelistInterface.sol";
 
 // A mock oracle used for testing.
 contract MockOracle is OracleInterface, Testable {
@@ -30,7 +30,7 @@ contract MockOracle is OracleInterface, Testable {
         uint time;
     }
 
-    IdentifierWhitelist public identifierWhitelist;
+    IdentifierWhitelistInterface public identifierWhitelist;
 
     // Conceptually we want a (time, identifier) -> price map.
     mapping(bytes32 => mapping(uint => Price)) private verifiedPrices;
@@ -42,8 +42,8 @@ contract MockOracle is OracleInterface, Testable {
 
     // TODO: Is this solhint command required anymore?
     // solhint-disable-next-line no-empty-blocks
-    constructor() public Testable(true) {
-        identifierWhitelist = new IdentifierWhitelist();
+    constructor(address _identifierWhitelist) public Testable(true) {
+        identifierWhitelist = IdentifierWhitelistInterface(_identifierWhitelist);
     }
 
     // Enqueues a request (if a request isn't already present) for the given (identifier, time) pair.
@@ -74,11 +74,6 @@ contract MockOracle is OracleInterface, Testable {
             requestedPrices[indexToReplace] = queryToCopy;
         }
         requestedPrices.length = requestedPrices.length - 1;
-    }
-
-    // Adds the provided identifier as a supported identifier.
-    function addSupportedIdentifier(bytes32 identifier) external {
-        identifierWhitelist.addSupportedIdentifier(identifier);
     }
 
     // Checks whether a price has been resolved.

--- a/core/contracts/test/MockOracle.sol
+++ b/core/contracts/test/MockOracle.sol
@@ -6,6 +6,7 @@ import "../OracleInterface.sol";
 import "../Testable.sol";
 import "../IdentifierWhitelistInterface.sol";
 
+
 // A mock oracle used for testing.
 contract MockOracle is OracleInterface, Testable {
 

--- a/core/contracts/test/MockOracle.sol
+++ b/core/contracts/test/MockOracle.sol
@@ -41,8 +41,6 @@ contract MockOracle is OracleInterface, Testable {
     mapping(bytes32 => mapping(uint => QueryIndex)) private queryIndices;
     QueryPoint[] private requestedPrices;
 
-    // TODO: Is this solhint command required anymore?
-    // solhint-disable-next-line no-empty-blocks
     constructor(address _identifierWhitelist) public Testable(true) {
         identifierWhitelist = IdentifierWhitelistInterface(_identifierWhitelist);
     }
@@ -95,10 +93,5 @@ contract MockOracle is OracleInterface, Testable {
     // Gets the queries that still need verified prices.
     function getPendingQueries() external view returns (QueryPoint[] memory queryPoints) {
         return requestedPrices;
-    }
-
-    // Whether the oracle provides verified prices for the provided identifier.
-    function isIdentifierSupported(bytes32 identifier) external view returns (bool isSupported) {
-        return identifierWhitelist.isIdentifierSupported(identifier);
     }
 }

--- a/core/migrations/10_support_identifiers.js
+++ b/core/migrations/10_support_identifiers.js
@@ -1,14 +1,15 @@
 const Voting = artifacts.require("Voting");
+const IdentiferWhitelist = artifacts.require("IdentifierWhitelist");
 const { getKeysForNetwork } = require("../../common/MigrationUtils.js");
 const identifiers = require("../config/identifiers");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const voting = await Voting.deployed();
+  const supportedIdentifiers = await IdentiferWhitelist.deployed();
 
   for (const identifier of Object.keys(identifiers)) {
     const identifierBytes = web3.utils.utf8ToHex(identifier);
-    await voting.addSupportedIdentifier(identifierBytes, { from: keys.deployer });
+    await supportedIdentifiers.addSupportedIdentifier(identifierBytes, { from: keys.deployer });
   }
 };

--- a/core/migrations/4_deploy_voting.js
+++ b/core/migrations/4_deploy_voting.js
@@ -1,6 +1,7 @@
 const Finder = artifacts.require("Finder");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const { getKeysForNetwork, deploy, addToTdr, enableControllableTiming } = require("../../common/MigrationUtils.js");
 const { interfaceName } = require("../utils/Constants.js");
 
@@ -8,6 +9,12 @@ module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
   const controllableTiming = enableControllableTiming(network);
 
+  // Deploy whitelist of identifiers
+  const { contract: identifierWhitelist } = await deploy(deployer, network, IdentifierWhitelist, {
+    from: keys.deployer
+  });
+
+  
   // Set the GAT percentage to 5%
   const gatPercentage = { rawValue: web3.utils.toWei("0.05", "ether") };
 
@@ -29,12 +36,16 @@ module.exports = async function(deployer, network, accounts) {
     gatPercentage,
     inflationRate,
     votingToken.address,
+    identifierWhitelist.address,
     finder.address,
     controllableTiming,
     { from: keys.deployer }
   );
 
   await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle), voting.address, {
+    from: keys.deployer
+  });
+  await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.IdentifierWhitelist), identifierWhitelist.address, {
     from: keys.deployer
   });
 

--- a/core/migrations/4_deploy_voting.js
+++ b/core/migrations/4_deploy_voting.js
@@ -14,7 +14,6 @@ module.exports = async function(deployer, network, accounts) {
     from: keys.deployer
   });
 
-  
   // Set the GAT percentage to 5%
   const gatPercentage = { rawValue: web3.utils.toWei("0.05", "ether") };
 
@@ -45,9 +44,13 @@ module.exports = async function(deployer, network, accounts) {
   await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle), voting.address, {
     from: keys.deployer
   });
-  await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.IdentifierWhitelist), identifierWhitelist.address, {
-    from: keys.deployer
-  });
+  await finder.changeImplementationAddress(
+    web3.utils.utf8ToHex(interfaceName.IdentifierWhitelist),
+    identifierWhitelist.address,
+    {
+      from: keys.deployer
+    }
+  );
 
   // Corresponds to VotingToken.Roles.Minter.
   const minterRoleEnumValue = 1;

--- a/core/networks/4.json
+++ b/core/networks/4.json
@@ -12,6 +12,10 @@
     "address": "0x00526C1ede46255b752D280620318ab50B24c20e"
   },
   {
+    "contractName": "IdentifierWhitelist",
+    "address": "0x26f65d7Da395F01A3e9C21595D1A2C0e173d82A4"
+  },
+  {
     "contractName": "Voting",
     "address": "0x5545092553Cf5Bf786e87a87192E902D50D8f022"
   },

--- a/core/networks/42.json
+++ b/core/networks/42.json
@@ -12,6 +12,10 @@
     "address": "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96"
   },
   {
+    "contractName": "IdentifierWhitelist",
+    "address": "0xEb8F58418d2A05Da909f8Fc11b86D41ca37c0D6a"
+  },
+  {
     "contractName": "Voting",
     "address": "0x2271a5E74eA8A29764ab10523575b41AA52455f0"
   },

--- a/core/scripts/TransferPermissions.js
+++ b/core/scripts/TransferPermissions.js
@@ -37,6 +37,10 @@ async function transferPermissions(multisig) {
   const supportedIdentifiers = await IdentifierWhitelist.deployed();
   await supportedIdentifiers.transferOwnership(governor.address);
 
+  // Voting should be owned by governor
+  const voting = await Voting.deployed();
+  await voting.transferOwnership(governor.address);
+
   // VotingToken should be owned by the governor.
   const votingToken = await VotingToken.deployed();
   await votingToken.resetMember(ownerRole, governor.address);

--- a/core/scripts/TransferPermissions.js
+++ b/core/scripts/TransferPermissions.js
@@ -33,10 +33,6 @@ async function transferPermissions(multisig) {
   const store = await Store.deployed();
   await store.resetMember(ownerRole, governor.address);
 
-  // Voting should be owned by the governor.
-  const voting = await Voting.deployed();
-  await voting.transferOwnership(governor.address);
-
   // Identifier Whitelist should be owned by governor
   const supportedIdentifiers = await IdentifierWhitelist.deployed();
   await supportedIdentifiers.transferOwnership(governor.address);

--- a/core/scripts/TransferPermissions.js
+++ b/core/scripts/TransferPermissions.js
@@ -3,6 +3,7 @@ const Finder = artifacts.require("Finder");
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 const Store = artifacts.require("Store");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const VotingToken = artifacts.require("VotingToken");
 const Governor = artifacts.require("Governor");
 
@@ -35,6 +36,10 @@ async function transferPermissions(multisig) {
   // Voting should be owned by the governor.
   const voting = await Voting.deployed();
   await voting.transferOwnership(governor.address);
+
+  // Identifier Whitelist should be owned by governor
+  const supportedIdentifiers = await IdentifierWhitelist.deployed();
+  await supportedIdentifiers.transferOwnership(governor.address);
 
   // VotingToken should be owned by the governor.
   const votingToken = await VotingToken.deployed();

--- a/core/scripts/local/ApproveIdentifiers.js
+++ b/core/scripts/local/ApproveIdentifiers.js
@@ -1,4 +1,3 @@
-const Voting = artifacts.require("Voting");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const identifiers = require("../../config/identifiers");
 
@@ -6,12 +5,11 @@ const approveIdentifiers = async function(callback) {
   try {
     const deployer = (await web3.eth.getAccounts())[0];
 
-    const voting = await Voting.deployed();
     const supportedIdentifiers = await IdentifierWhitelist.deployed();
 
     for (const identifier of Object.keys(identifiers)) {
       const identifierBytes = web3.utils.utf8ToHex(identifier);
-      if (!(await voting.isIdentifierSupported(identifierBytes))) {
+      if (!(await supportedIdentifiers.isIdentifierSupported(identifierBytes))) {
         await supportedIdentifiers.addSupportedIdentifier(identifierBytes, { from: deployer });
         console.log(`Approved new identifier: ${identifier}`);
       } else {

--- a/core/scripts/local/ApproveIdentifiers.js
+++ b/core/scripts/local/ApproveIdentifiers.js
@@ -1,4 +1,5 @@
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const identifiers = require("../../config/identifiers");
 
 const approveIdentifiers = async function(callback) {
@@ -6,11 +7,12 @@ const approveIdentifiers = async function(callback) {
     const deployer = (await web3.eth.getAccounts())[0];
 
     const voting = await Voting.deployed();
+    const supportedIdentifiers = await IdentifierWhitelist.deployed();
 
     for (const identifier of Object.keys(identifiers)) {
       const identifierBytes = web3.utils.utf8ToHex(identifier);
       if (!(await voting.isIdentifierSupported(identifierBytes))) {
-        await voting.addSupportedIdentifier(identifierBytes, { from: deployer });
+        await supportedIdentifiers.addSupportedIdentifier(identifierBytes, { from: deployer });
         console.log(`Approved new identifier: ${identifier}`);
       } else {
         console.log(`${identifier} is already approved.`);

--- a/core/scripts/local/InitializeSystem.js
+++ b/core/scripts/local/InitializeSystem.js
@@ -35,7 +35,7 @@ const initializeSystem = async function(callback) {
     );
     const deployedIdentifierWhitelist = await IdentifierWhitelist.at(
       await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.IdentiferWhitelist))
-    )
+    );
     const deployedManualPriceFeed = await ManualPriceFeed.deployed();
 
     const tokenizedDerivativeCreator = await TokenizedDerivativeCreator.deployed();

--- a/core/scripts/local/InitializeSystem.js
+++ b/core/scripts/local/InitializeSystem.js
@@ -1,5 +1,6 @@
 const Finder = artifacts.require("Finder");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const ManualPriceFeed = artifacts.require("ManualPriceFeed");
 const LeveragedReturnCalculator = artifacts.require("LeveragedReturnCalculator");
 const Registry = artifacts.require("Registry");
@@ -32,6 +33,9 @@ const initializeSystem = async function(callback) {
     const deployedVoting = await Voting.at(
       await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle))
     );
+    const deployedIdentifierWhitelist = await IdentifierWhitelist.at(
+      await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.IdentiferWhitelist))
+    )
     const deployedManualPriceFeed = await ManualPriceFeed.deployed();
 
     const tokenizedDerivativeCreator = await TokenizedDerivativeCreator.deployed();
@@ -50,7 +54,7 @@ const initializeSystem = async function(callback) {
     // Add support for each identifier.
     for (const identifier of supportedIdentifiers) {
       const identifierBytes = web3.utils.hexToBytes(web3.utils.utf8ToHex(identifier));
-      await deployedVoting.addSupportedIdentifier(identifierBytes);
+      await deployedIdentifierWhitelist.addSupportedIdentifier(identifierBytes);
       await deployedManualPriceFeed.pushLatestPrice(identifierBytes, latestTime, price);
     }
 

--- a/core/scripts/local/RequestOraclePrice.js
+++ b/core/scripts/local/RequestOraclePrice.js
@@ -2,6 +2,7 @@ const argv = require("minimist")(process.argv.slice(), { string: ["identifier", 
 
 const Finder = artifacts.require("Finder");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const Registry = artifacts.require("Registry");
 const { interfaceName } = require("../../utils/Constants.js");
 const { triggerOnRequest } = require("../../utils/Serving.js");
@@ -56,7 +57,10 @@ async function run(deployedFinder, identifier, timeString) {
     const deployedVoting = await Voting.at(
       await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle))
     );
-    await deployedVoting.addSupportedIdentifier(identifierInBytes);
+    const deployedIdentifierWhitelist = await IdentifierWhitelist.at(
+      await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.IdentiferWhitelist))
+    )
+    await deployedIdentifierWhitelist.addSupportedIdentifier(identifierInBytes);
     const priceExists = await deployedVoting.hasPrice(identifierInBytes, timeInBN);
     if (priceExists) {
       console.log(`Price already exists for ${identifier} @ ${time}`);

--- a/core/scripts/local/RequestOraclePrice.js
+++ b/core/scripts/local/RequestOraclePrice.js
@@ -59,7 +59,7 @@ async function run(deployedFinder, identifier, timeString) {
     );
     const deployedIdentifierWhitelist = await IdentifierWhitelist.at(
       await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.IdentiferWhitelist))
-    )
+    );
     await deployedIdentifierWhitelist.addSupportedIdentifier(identifierInBytes);
     const priceExists = await deployedVoting.hasPrice(identifierInBytes, timeInBN);
     if (priceExists) {

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -4,6 +4,7 @@ const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
 
 const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const VotingToken = artifacts.require("VotingToken");
 
 const numPriceRequests = 5;
@@ -17,6 +18,7 @@ const getVoter = (accounts, id) => {
 
 async function run() {
   const voting = await Voting.deployed();
+  const supportedIdentifiers = await IdentifierWhitelist.deployed();
   const votingToken = await VotingToken.deployed();
   const registry = await Registry.deployed();
 
@@ -32,7 +34,7 @@ async function run() {
   }
 
   const identifier = web3.utils.utf8ToHex("test-identifier");
-  await voting.addSupportedIdentifier(identifier);
+  await supportedIdentifiers.addSupportedIdentifier(identifier);
 
   // Allow owner to mint new tokens
   await votingToken.addMember("1", owner);

--- a/core/test/DesignatedVoting.js
+++ b/core/test/DesignatedVoting.js
@@ -4,6 +4,7 @@ const DesignatedVoting = artifacts.require("DesignatedVoting");
 const Finder = artifacts.require("Finder");
 const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const VotingToken = artifacts.require("VotingToken");
 const { RegistryRolesEnum } = require("../../common/Enums.js");
 const { getRandomSignedInt, getRandomUnsignedInt } = require("../../common/Random.js");
@@ -27,6 +28,7 @@ contract("DesignatedVoting", function(accounts) {
 
   before(async function() {
     voting = await Voting.deployed();
+    supportedIdentifiers = await IdentifierWhitelist.deployed();
     votingToken = await VotingToken.deployed();
     const finder = await Finder.deployed();
     designatedVoting = await DesignatedVoting.new(finder.address, tokenOwner, voter);
@@ -84,7 +86,7 @@ contract("DesignatedVoting", function(accounts) {
     // Request a price.
     const identifier = web3.utils.utf8ToHex("one-voter");
     const time = "1000";
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
     await moveToNextRound(voting);
 
@@ -143,7 +145,7 @@ contract("DesignatedVoting", function(accounts) {
     const identifier = web3.utils.utf8ToHex("batch");
     const time1 = "1000";
     const time2 = "2000";
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time1, { from: registeredDerivative });
     await voting.requestPrice(identifier, time2, { from: registeredDerivative });
     await moveToNextRound(voting);

--- a/core/test/Governor.js
+++ b/core/test/Governor.js
@@ -50,9 +50,8 @@ contract("Governor", function(accounts) {
     // Set the inflation rate to 0 by default, so the balances stay fixed.
     await setNewInflationRate("0");
 
-    // To work, the governor must be the owner of the Voting and IdentifierWhitelist contracts. This is not the default setup in the test
+    // To work, the governor must be the owner of the IdentifierWhitelist contract. This is not the default setup in the test
     // environment, so ownership must be transferred.
-    await voting.transferOwnership(governor.address);
     await supportedIdentifiers.transferOwnership(governor.address);
   });
 

--- a/core/test/Governor.js
+++ b/core/test/Governor.js
@@ -5,6 +5,7 @@ const truffleAssert = require("truffle-assertions");
 
 const Governor = artifacts.require("Governor");
 const Registry = artifacts.require("Registry");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 const TestnetERC20 = artifacts.require("TestnetERC20");
@@ -16,6 +17,7 @@ contract("Governor", function(accounts) {
   let voting;
   let governor;
   let testToken;
+  let supportedIdentifiers;
 
   const account1 = accounts[0];
   const account2 = accounts[1];
@@ -30,6 +32,7 @@ contract("Governor", function(accounts) {
 
   before(async function() {
     voting = await Voting.deployed();
+    supportedIdentifiers = await IdentifierWhitelist.deployed();
     governor = await Governor.deployed();
     testToken = await TestnetERC20.deployed();
     let votingToken = await VotingToken.deployed();
@@ -47,9 +50,10 @@ contract("Governor", function(accounts) {
     // Set the inflation rate to 0 by default, so the balances stay fixed.
     await setNewInflationRate("0");
 
-    // To work, the governor must be the owner of the Voting contract. This is not the default setup in the test
+    // To work, the governor must be the owner of the Voting and IdentifierWhitelist contracts. This is not the default setup in the test
     // environment, so ownership must be transferred.
     await voting.transferOwnership(governor.address);
+    await supportedIdentifiers.transferOwnership(governor.address);
   });
 
   beforeEach(async function() {

--- a/core/test/Governor.js
+++ b/core/test/Governor.js
@@ -50,9 +50,10 @@ contract("Governor", function(accounts) {
     // Set the inflation rate to 0 by default, so the balances stay fixed.
     await setNewInflationRate("0");
 
-    // To work, the governor must be the owner of the IdentifierWhitelist contract. This is not the default setup in the test
+    // To work, the governor must be the owner of the IdentifierWhitelist and Voting contracts. This is not the default setup in the test
     // environment, so ownership must be transferred.
     await supportedIdentifiers.transferOwnership(governor.address);
+    await voting.transferOwnership(governor.address);
   });
 
   beforeEach(async function() {

--- a/core/test/Governor.js
+++ b/core/test/Governor.js
@@ -50,10 +50,9 @@ contract("Governor", function(accounts) {
     // Set the inflation rate to 0 by default, so the balances stay fixed.
     await setNewInflationRate("0");
 
-    // To work, the governor must be the owner of the IdentifierWhitelist and Voting contracts. This is not the default setup in the test
+    // To work, the governor must be the owner of the IdentifierWhitelist contracts. This is not the default setup in the test
     // environment, so ownership must be transferred.
     await supportedIdentifiers.transferOwnership(governor.address);
-    await voting.transferOwnership(governor.address);
   });
 
   beforeEach(async function() {

--- a/core/test/IdentifierWhitelist.js
+++ b/core/test/IdentifierWhitelist.js
@@ -24,7 +24,9 @@ contract("IdentifierWhitelist", function(accounts) {
     await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
 
     // Rando cannot remove from the whitelist.
-    assert(await didContractThrow(identifierWhitelist.removeSupportedIdentifier(randomIdentifierToAdd, { from: rando })));
+    assert(
+      await didContractThrow(identifierWhitelist.removeSupportedIdentifier(randomIdentifierToAdd, { from: rando }))
+    );
 
     // Owner can remove from the whitelist.
     await identifierWhitelist.removeSupportedIdentifier(randomIdentifierToAdd, { from: owner });

--- a/core/test/IdentifierWhitelist.js
+++ b/core/test/IdentifierWhitelist.js
@@ -1,0 +1,87 @@
+const { didContractThrow } = require("../../common/SolidityTestUtils.js");
+
+const truffleAssert = require("truffle-assertions");
+
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+
+contract("IdentifierWhitelist", function(accounts) {
+  const owner = accounts[0];
+  const rando = accounts[1];
+
+  let identifierWhitelist;
+  let randomIdentifierToAdd;
+
+  beforeEach(async function() {
+    identifierWhitelist = await IdentifierWhitelist.new({ from: owner });
+    randomIdentifierToAdd = web3.utils.utf8ToHex("random-identifier");
+  });
+
+  it("Only Owner", async function() {
+    // Rando cannot add to the whitelist.
+    assert(await didContractThrow(identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: rando })));
+
+    // Owner can add to the whitelist.
+    await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+
+    // Rando cannot remove from the whitelist.
+    assert(await didContractThrow(identifierWhitelist.removeSupportedIdentifier(randomIdentifierToAdd, { from: rando })));
+
+    // Owner can remove from the whitelist.
+    await identifierWhitelist.removeSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+  });
+
+  it("Add to whitelist", async function() {
+    // Owner can add to the whitelist.
+    const result = await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+
+    truffleAssert.eventEmitted(result, "SupportedIdentifierAdded", ev => {
+      return web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(randomIdentifierToAdd);
+    });
+
+    // Verify that the addition is reflected in isOnWhitelist().
+    assert.isTrue(await identifierWhitelist.isIdentifierSupported(randomIdentifierToAdd));
+
+    const incorrectIdentifier = web3.utils.utf8ToHex("wrong-identifier");
+    assert.isFalse(await identifierWhitelist.isIdentifierSupported(incorrectIdentifier));
+  });
+
+  it("Remove from whitelist", async function() {
+    const identifierToRemove = web3.utils.utf8ToHex("remove-me");
+
+    // Owner can add to the whitelist.
+    await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+    await identifierWhitelist.addSupportedIdentifier(identifierToRemove, { from: owner });
+
+    // Remove identifierToRemove
+    let result = await identifierWhitelist.removeSupportedIdentifier(identifierToRemove, { from: owner });
+
+    truffleAssert.eventEmitted(result, "SupportedIdentifierRemoved", ev => {
+      return web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifierToRemove);
+    });
+
+    // Verify that the additions and removal were applied correctly.
+    assert.isTrue(await identifierWhitelist.isIdentifierSupported(randomIdentifierToAdd));
+    assert.isFalse(await identifierWhitelist.isIdentifierSupported(identifierToRemove));
+
+    // Double remove from whitelist. Shouldn't error, but shouldn't generate an event.
+    result = await identifierWhitelist.removeSupportedIdentifier(identifierToRemove, { from: owner });
+    truffleAssert.eventNotEmitted(result, "SupportedIdentifierRemoved");
+  });
+
+  it("Add to whitelist twice", async function() {
+    await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+    const result = await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+
+    truffleAssert.eventNotEmitted(result, "SupportedIdentifierAdded");
+
+    assert.isTrue(await identifierWhitelist.isIdentifierSupported(randomIdentifierToAdd));
+  });
+
+  it("Re-add to whitelist", async function() {
+    await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+    await identifierWhitelist.removeSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+    await identifierWhitelist.addSupportedIdentifier(randomIdentifierToAdd, { from: owner });
+
+    assert.isTrue(await identifierWhitelist.isIdentifierSupported(randomIdentifierToAdd));
+  });
+});

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -441,15 +441,15 @@ contract("Voting", function(accounts) {
     const supported = web3.utils.utf8ToHex("supported");
 
     // No identifiers are originally suppported.
-    assert.isFalse(await voting.isIdentifierSupported(supported));
+    assert.isFalse(await supportedIdentifiers.isIdentifierSupported(supported));
 
     // Verify that supported identifiers can be added.
     await supportedIdentifiers.addSupportedIdentifier(supported);
-    assert.isTrue(await voting.isIdentifierSupported(supported));
+    assert.isTrue(await supportedIdentifiers.isIdentifierSupported(supported));
 
     // Verify that supported identifiers can be removed.
     await supportedIdentifiers.removeSupportedIdentifier(supported);
-    assert.isFalse(await voting.isIdentifierSupported(supported));
+    assert.isFalse(await supportedIdentifiers.isIdentifierSupported(supported));
 
     // Can't request prices for unsupported identifiers.
     assert(await didContractThrow(voting.requestPrice(supported, "0", { from: registeredDerivative })));

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -9,6 +9,7 @@ const truffleAssert = require("truffle-assertions");
 const Finder = artifacts.require("Finder");
 const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const VotingToken = artifacts.require("VotingToken");
 
 contract("Voting", function(accounts) {
@@ -30,6 +31,7 @@ contract("Voting", function(accounts) {
 
   before(async function() {
     voting = await Voting.deployed();
+    supportedIdentifiers = await IdentifierWhitelist.deployed();
     votingToken = await VotingToken.deployed();
     registry = await Registry.deployed();
 
@@ -85,7 +87,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
@@ -139,7 +141,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
     await moveToNextRound(voting);
@@ -193,8 +195,8 @@ contract("Voting", function(accounts) {
     const time2 = "2000";
 
     // Make the Oracle support these two identifiers.
-    await voting.addSupportedIdentifier(identifier1);
-    await voting.addSupportedIdentifier(identifier2);
+    await supportedIdentifiers.addSupportedIdentifier(identifier1);
+    await supportedIdentifiers.addSupportedIdentifier(identifier2);
 
     // Send the requests.
     await voting.requestPrice(identifier1, time2, { from: registeredDerivative });
@@ -235,8 +237,8 @@ contract("Voting", function(accounts) {
     const time2 = "2000";
 
     // Make the Oracle support these two identifiers.
-    await voting.addSupportedIdentifier(identifier1);
-    await voting.addSupportedIdentifier(identifier2);
+    await supportedIdentifiers.addSupportedIdentifier(identifier1);
+    await supportedIdentifiers.addSupportedIdentifier(identifier2);
 
     // Requests should not be added to the current voting round.
     await voting.requestPrice(identifier1, time1, { from: registeredDerivative });
@@ -305,7 +307,7 @@ contract("Voting", function(accounts) {
     const identifier = web3.utils.utf8ToHex("future-request");
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Time 1 is in the future and should fail.
     const timeFail = startingTime.addn(1).toString();
@@ -335,7 +337,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Two stage call is required to get the expected return value from the second call.
     // The expected resolution time should be the end of the *next* round.
@@ -381,8 +383,8 @@ contract("Voting", function(accounts) {
     const time2 = "1001";
 
     // Make the Oracle support these identifiers.
-    await voting.addSupportedIdentifier(identifier1);
-    await voting.addSupportedIdentifier(identifier2);
+    await supportedIdentifiers.addSupportedIdentifier(identifier1);
+    await supportedIdentifiers.addSupportedIdentifier(identifier2);
 
     // Pending requests should be empty for this new round.
     assert.equal((await voting.getPendingRequests()).length, 0);
@@ -436,19 +438,17 @@ contract("Voting", function(accounts) {
   });
 
   it("Supported identifiers", async function() {
-    const voting = await Voting.deployed();
-
     const supported = web3.utils.utf8ToHex("supported");
 
     // No identifiers are originally suppported.
     assert.isFalse(await voting.isIdentifierSupported(supported));
 
     // Verify that supported identifiers can be added.
-    await voting.addSupportedIdentifier(supported);
+    await supportedIdentifiers.addSupportedIdentifier(supported);
     assert.isTrue(await voting.isIdentifierSupported(supported));
 
     // Verify that supported identifiers can be removed.
-    await voting.removeSupportedIdentifier(supported);
+    await supportedIdentifiers.removeSupportedIdentifier(supported);
     assert.isFalse(await voting.isIdentifierSupported(supported));
 
     // Can't request prices for unsupported identifiers.
@@ -460,7 +460,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
@@ -495,7 +495,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
@@ -532,7 +532,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
@@ -574,7 +574,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
@@ -626,7 +626,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
@@ -681,7 +681,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Unregistered derivatives can't request prices.
     assert(await didContractThrow(voting.requestPrice(identifier, time, { from: unregisteredDerivative })));
@@ -711,7 +711,7 @@ contract("Voting", function(accounts) {
     const time = "1000";
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Verify view methods `hasPrice` and `getPrice` for a price was that was never requested.
     assert.isFalse(await voting.hasPrice(identifier, time, { from: registeredDerivative }));
@@ -755,7 +755,7 @@ contract("Voting", function(accounts) {
     const initialTotalSupply = await votingToken.totalSupply();
 
     // Make the Oracle support this identifier.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     // Request a price and move to the next round where that will be voted on.
     await voting.requestPrice(identifier, time1, { from: registeredDerivative });
@@ -837,13 +837,7 @@ contract("Voting", function(accounts) {
     const identifier = web3.utils.utf8ToHex("events");
     const time = "1000";
 
-    // An event should be emitted when a new supported identifier is added (but not on repeated no-op calls).
-    let result = await voting.addSupportedIdentifier(identifier);
-    truffleAssert.eventEmitted(result, "SupportedIdentifierAdded", ev => {
-      return web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier);
-    });
-    result = await voting.addSupportedIdentifier(identifier);
-    truffleAssert.eventNotEmitted(result, "SupportedIdentifierAdded");
+    let result = await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     await moveToNextRound(voting);
     let currentRoundId = await voting.getCurrentRoundId();
@@ -931,20 +925,12 @@ contract("Voting", function(accounts) {
     // RewardsRetrieved event gets emitted for every reward retrieval that's attempted, even if no tokens are minted.
     result = await voting.retrieveRewards(account4, roundId, [{ identifier, time }]);
     truffleAssert.eventEmitted(result, "RewardsRetrieved", ev => true);
-
-    // An event should be emitted when a new supported identifier is added (but not on repeated no-op calls).
-    result = await voting.removeSupportedIdentifier(identifier);
-    truffleAssert.eventEmitted(result, "SupportedIdentifierRemoved", ev => {
-      return web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier);
-    });
-    result = await voting.removeSupportedIdentifier(identifier);
-    truffleAssert.eventNotEmitted(result, "SupportedIdentifierRemoved");
   });
 
   it("Commit and persist the encrypted price", async function() {
     const identifier = web3.utils.utf8ToHex("commit-and-persist");
     const time = "1000";
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
     await moveToNextRound(voting);
@@ -989,7 +975,7 @@ contract("Voting", function(accounts) {
   it("Commit and persist the encrypted price against the same identifier/time pair multiple times", async function() {
     const identifier = web3.utils.utf8ToHex("commit-and-persist2");
     const time = "1000";
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
     await moveToNextRound(voting);
@@ -1034,7 +1020,7 @@ contract("Voting", function(accounts) {
         encryptedVote: web3.utils.utf8ToHex(`some encrypted message ${i}`)
       });
 
-      await voting.addSupportedIdentifier(identifier);
+      await supportedIdentifiers.addSupportedIdentifier(identifier);
       await voting.requestPrice(identifier, requestTime, { from: registeredDerivative });
     }
 
@@ -1097,7 +1083,7 @@ contract("Voting", function(accounts) {
     const identifier = web3.utils.utf8ToHex("batch-reveal");
     const time1 = "1000";
     const time2 = "1001";
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     await voting.requestPrice(identifier, time1, { from: registeredDerivative });
     await voting.requestPrice(identifier, time2, { from: registeredDerivative });
@@ -1181,10 +1167,11 @@ contract("Voting", function(accounts) {
       { rawValue: "0" },
       { rawValue: "0" },
       votingToken.address,
+      supportedIdentifiers.address,
       (await Finder.deployed()).address,
       true
     );
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
 
     await voting.requestPrice(identifier, time1, { from: registeredDerivative });
     await voting.requestPrice(identifier, time2, { from: registeredDerivative });

--- a/core/test/scripts/EmergencyShutdown.js
+++ b/core/test/scripts/EmergencyShutdown.js
@@ -8,6 +8,7 @@ const LeveragedReturnCalculator = artifacts.require("LeveragedReturnCalculator")
 const ManualPriceFeed = artifacts.require("ManualPriceFeed");
 const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 
 contract("scripts/EmergencyShutdown.js", function(accounts) {
   const ethAddress = "0x0000000000000000000000000000000000000000";
@@ -28,6 +29,7 @@ contract("scripts/EmergencyShutdown.js", function(accounts) {
     registry = await Registry.deployed();
     admin = await FinancialContractsAdmin.deployed();
     voting = await Voting.deployed();
+    supportedIdentifiers = await IdentifierWhitelist.deployed();
     leverage = await LeveragedReturnCalculator.deployed();
     priceFeed = await ManualPriceFeed.deployed();
 
@@ -38,7 +40,7 @@ contract("scripts/EmergencyShutdown.js", function(accounts) {
     await marginCurrencyWhitelist.addToWhitelist(ethAddress);
 
     // Add identifier to Voting
-    await voting.addSupportedIdentifier(identifierBytes);
+    await supportedIdentifiers.addSupportedIdentifier(identifierBytes);
 
     // Push a price to the price feed
     const latestTime = parseInt(await priceFeed.getCurrentTime(), 10);

--- a/core/test/scripts/TransferPermissions.js
+++ b/core/test/scripts/TransferPermissions.js
@@ -4,6 +4,7 @@ const assertPackage = require("assert");
 const Finder = artifacts.require("Finder");
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 const Store = artifacts.require("Store");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 const Governor = artifacts.require("Governor");
@@ -32,12 +33,13 @@ contract("scripts/TransferPermissions.js", function(accounts) {
     assert.equal(await store.getMember("1"), accounts[0]);
 
     // Governor should be the owner.
-    const voting = await Voting.deployed();
-    assert.equal(await voting.owner(), governor.address);
+    const supportedIdentifiers = await IdentifierWhitelist.deployed();
+    assert.equal(await supportedIdentifiers.owner(), governor.address);
 
     // Governor should be the owner, the hot wallet should NOT be able to mint or burn, and the Voting contract should
     // be able to mint.
     const votingToken = await VotingToken.deployed();
+    const voting = await Voting.deployed();
     assert.equal(await votingToken.getMember("0"), governor.address);
     assert.isFalse(await votingToken.holdsRole("1", accounts[0]));
     assert.isFalse(await votingToken.holdsRole("2", accounts[0]));

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -1,5 +1,6 @@
 const VotingScript = require("../../scripts/Voting.js");
 const Voting = artifacts.require("Voting");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const VotingToken = artifacts.require("VotingToken");
 const Registry = artifacts.require("Registry");
 const { RegistryRolesEnum, VotePhasesEnum } = require("../../../common/Enums.js");
@@ -31,6 +32,7 @@ contract("scripts/Voting.js", function(accounts) {
 
   before(async function() {
     voting = await Voting.deployed();
+    supportedIdentifiers = await IdentifierWhitelist.deployed();
     votingToken = await VotingToken.deployed();
     registry = await Registry.deployed();
 
@@ -53,7 +55,7 @@ contract("scripts/Voting.js", function(accounts) {
     const time = "1000";
 
     // Request an Oracle price.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
 
     // Move to the round in which voters will vote on the requested price.
@@ -94,7 +96,7 @@ contract("scripts/Voting.js", function(accounts) {
     const time = "1000";
 
     // Request an Oracle price.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
 
     // Move to the round in which voters will vote on the requested price.
@@ -131,8 +133,8 @@ contract("scripts/Voting.js", function(accounts) {
     const time2 = "1000";
 
     // Add both identifiers.
-    await voting.addSupportedIdentifier(identifier1);
-    await voting.addSupportedIdentifier(identifier2);
+    await supportedIdentifiers.addSupportedIdentifier(identifier1);
+    await supportedIdentifiers.addSupportedIdentifier(identifier2);
 
     // Send three overlapping requests such that each parameter overlaps with one other request.
     await voting.requestPrice(identifier1, time1);
@@ -169,7 +171,7 @@ contract("scripts/Voting.js", function(accounts) {
     const time = "1573513368";
 
     // Request an Oracle price.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
 
     // Move to the round in which voters will vote on the requested price.
@@ -203,7 +205,7 @@ contract("scripts/Voting.js", function(accounts) {
     const time = "1560762000";
 
     // Request an Oracle price.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
 
     const notifier = new MockNotifier();
@@ -238,7 +240,7 @@ contract("scripts/Voting.js", function(accounts) {
     const time = "1560762000";
 
     // Request an Oracle price.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
 
     const votingSystem = new VotingScript.VotingSystem(voting, voter, [new MockNotifier()]);
@@ -266,7 +268,7 @@ contract("scripts/Voting.js", function(accounts) {
       }
     };
     // Request an Oracle price.
-    await voting.addSupportedIdentifier(identifier);
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
     await voting.requestPrice(identifier, time);
 
     const votingSystem = new VotingScript.VotingSystem(voting, voter, [new MockNotifier()]);

--- a/core/utils/Constants.js
+++ b/core/utils/Constants.js
@@ -4,7 +4,7 @@ const interfaceName = {
   Oracle: "Oracle",
   Registry: "Registry",
   Store: "Store",
-  IdentifierWhitelist: "IdentiferWhitelist"
+  IdentifierWhitelist: "IdentifierWhitelist"
 };
 
 module.exports = {

--- a/core/utils/Constants.js
+++ b/core/utils/Constants.js
@@ -3,7 +3,8 @@ const interfaceName = {
   FinancialContractsAdmin: "FinancialContractsAdmin",
   Oracle: "Oracle",
   Registry: "Registry",
-  Store: "Store"
+  Store: "Store",
+  IdentifierWhitelist: "IdentiferWhitelist"
 };
 
 module.exports = {

--- a/documentation/explainers/dvm_interfaces.md
+++ b/documentation/explainers/dvm_interfaces.md
@@ -19,16 +19,8 @@ The Oracle Interface is used by financial contracts to retrieve prices. This int
 contracts that request prices _sparingly_. This is dependent on the specifics of the financial contract, but, in
 general, prices should only be requested for dispute resolution and contract settlement.
 
-There are four methods that make up the Oracle Interface: `isIdentifierSupported`, `requestPrice`, `hasPrice`, and
+There are four methods that make up the Oracle Interface: `requestPrice`, `hasPrice`, and
 `getPrice`.
-
-### `isIdentifierSupported`
-
-During deployment, if a financial contract could, at some point, require a price for an asset (identifier), it should
-double check that the DVM supports that asset by calling `isIdentifierSupported(identifier)`. If that asset is not
-supported, the deployment should revert.
-
-This method doesn't require the contract to be approved, and it can be called by an EOA for informational purposes.
 
 ### `requestPrice`
 

--- a/documentation/tutorials/customizing-tokens-via-cli.md
+++ b/documentation/tutorials/customizing-tokens-via-cli.md
@@ -53,24 +53,24 @@ Pass `--network=test` for local runs. For the UMA testnet deployment on Rinkeby,
 provide your mnemonic in an environment variable `MNEMONIC`. We'll type the rest of the commands in this document into
 the Truffle console.
 
-We'll grab an instance of the `Voting` contract.
+We'll grab an instance of the `IdentifierWhitelist` contract.
 
 ```js
-const voting = await Voting.deployed()
+const supportedIdentifiers = await IdentifierWhitelist.deployed()
 ```
 
 Next, we'll verify that the identifier `BTC/USD` is supported (note that `isIdentifierSupported` takes a bytes32 not a
 string):
 
 ```js
-await voting.isIdentifierSupported(web3.utils.utf8ToHex("BTC/USD"))
+await supportedIdentifiers.isIdentifierSupported(web3.utils.utf8ToHex("BTC/USD"))
 // returns true
 ```
 
 As an example, the identifier `UNSUPPORTED` is not supported and we'd see:
 
 ```js
-> await voting.isIdentifierSupported(web3.utils.utf8ToHex("UNSUPPORTED"))
+> await supportedIdentifiers.isIdentifierSupported(web3.utils.utf8ToHex("UNSUPPORTED"))
 // returns false
 ```
 

--- a/sponsor-dapp-v2/src/drizzleOptions.js
+++ b/sponsor-dapp-v2/src/drizzleOptions.js
@@ -1,6 +1,7 @@
 import Finder from "contracts/Finder.json";
 import Registry from "contracts/Registry.json";
 import Voting from "contracts/Voting.json";
+import IdentifierWhitelist from "contracts/IdentifierWhitelist.json";
 import ManualPriceFeed from "contracts/ManualPriceFeed.json";
 import TokenizedDerivativeCreator from "contracts/TokenizedDerivativeCreator.json";
 import LeveragedReturnCalculator from "contracts/LeveragedReturnCalculator.json";
@@ -11,6 +12,7 @@ const options = {
     Registry,
     Finder,
     Voting,
+    IdentifierWhitelist,
     ManualPriceFeed,
     TokenizedDerivativeCreator,
     LeveragedReturnCalculator,

--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -430,7 +430,7 @@ export function useEnabledIdentifierConfig() {
       const narrowedConfig = {};
       for (const identifier in config) {
         if (
-          call("Voting", "isIdentifierSupported", web3.utils.utf8ToHex(identifier)) &&
+          call("IdentifierWhitelist", "isIdentifierSupported", web3.utils.utf8ToHex(identifier)) &&
           call("ManualPriceFeed", "isIdentifierSupported", web3.utils.utf8ToHex(identifier))
         ) {
           narrowedConfig[identifier] = config[identifier];


### PR DESCRIPTION
moved struct and Setter/Getters to a new Contract

Upon construction, `Voting.sol` and `MockOracle` instantiate new instances of this struct

contracts compile, migrations fail

Signed-off-by: Nick Pai <npai.nyc@gmail.com>