### PR TITLE
Uniform inflation rate handeling

### DIFF
--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -408,6 +408,10 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         inflationRate = _inflationRate;
     }
 
+    /**
+     * @notice Resets the Gat percentage. Note: this change only applies to rounds that have not yet begun.
+     * @dev This method is public because calldata structs are not currently supported by solidity.
+     */
     function setGatPercentage(FixedPoint.Unsigned memory _gatPercentage) public onlyOwner {
         gatPercentage = _gatPercentage;
     }

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -413,6 +413,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      * @dev This method is public because calldata structs are not currently supported by solidity.
      */
     function setGatPercentage(FixedPoint.Unsigned memory _gatPercentage) public onlyOwner {
+        require(_gatPercentage.isLessThan(1), "GAT percentage must be < 100%");
         gatPercentage = _gatPercentage;
     }
 

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -81,7 +81,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         uint snapshotId;
         // Inflation rate set for this round.
         FixedPoint.Unsigned inflationRate;
-        // Gat rate set for this round
+        // Gat rate set for this round.
         FixedPoint.Unsigned gatPercentage;
     }
 

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -516,6 +516,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
     function _freezeRoundVariables(uint roundId) private {
         Round storage round = rounds[roundId];
+        // Only on the first reveal should the snapshot be captured for that round.
         if (round.snapshotId == 0) {
             // There is no snapshot ID set, so create one.
             round.snapshotId = votingToken.snapshot();

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -523,6 +523,9 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
             // Set the round inflation rate to the current global inflation rate.
             rounds[roundId].inflationRate = inflationRate;
+
+            // Set the round gat percentage to the current global gat rate.
+            rounds[roundId].gatPercentage = gatPercentage;
         }
     }
 
@@ -544,22 +547,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
         priceRequest.index = UINT_MAX;
         emit PriceResolved(priceRequest.lastVotingRound, priceRequest.identifier, priceRequest.time, resolvedPrice);
-    }
-
-    function _updateRound(uint blockTime) private {
-        if (!voteTiming.shouldUpdateRoundId(blockTime)) {
-            return;
-        }
-        uint nextVotingRoundId = voteTiming.computeCurrentRoundId(blockTime);
-
-        // Set the round inflation rate to the current global inflation rate.
-        rounds[nextVotingRoundId].inflationRate = inflationRate;
-
-        // Set the round gat percentage to the current global gat rate
-        rounds[nextVotingRoundId].gatPercentage = gatPercentage;
-
-        // Update the stored round to the current one.
-        voteTiming.updateRoundId(blockTime);
     }
 
     function _computeGat(uint roundId) private view returns (FixedPoint.Unsigned memory) {

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -81,7 +81,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         uint snapshotId;
         // Inflation rate set for this round.
         FixedPoint.Unsigned inflationRate;
-
         // Gat rate set for this round
         FixedPoint.Unsigned gatPercentage;
     }

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -605,6 +605,9 @@ contract("Voting", function(accounts) {
     const req = [{ identifier: identifier, time: time }];
     assert(await didContractThrow(voting.retrieveRewards(account4, initialRoundId, req)));
 
+    // Setting GAT should revert if larger than 100%
+    assert(await didContractThrow(voting.setGatPercentage({ rawvalue: web3.utils.toWei("1.1", "ether") })));
+
     // With a smaller GAT value of 3%, account4 can pass the vote on their own with 4% of all tokens.
     await setNewGatPercentage(web3.utils.toWei("0.03", "ether"));
 
@@ -698,9 +701,9 @@ contract("Voting", function(accounts) {
     // Transfer the tokens back. This should have no effect on the outcome since the snapshot has already been taken.
     await votingToken.transfer(account1, web3.utils.toWei("24000000", "ether"), { from: account3 });
 
-    // Modification of the GAT or inflation rate should also not effect this rounds vote outcome as these have been
-    // locked into the snapshot. Increasing the GAT to 100% (requiring unanimous agreement) should therefore have no effect.
-    await setNewGatPercentage(web3.utils.toWei("1.00", "ether"));
+    // Modification of the GAT or inflation rate should also not effect this rounds vote outcome as these have been locked into
+    // the snapshot. Increasing the GAT to 90% (requiring close to unanimous agreement) should therefore have no effect.
+    await setNewGatPercentage(web3.utils.toWei("0.9", "ether"));
 
     // Do the final two reveals.
     await voting.revealVote(identifier, time, losingPrice, salt1, { from: account1 });

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -698,6 +698,10 @@ contract("Voting", function(accounts) {
     // Transfer the tokens back. This should have no effect on the outcome since the snapshot has already been taken.
     await votingToken.transfer(account1, web3.utils.toWei("24000000", "ether"), { from: account3 });
 
+    // Modification of the GAT or inflation rate should also not effect this rounds vote outcome as these have been
+    // locked into the snapshot. Increasing the GAT to 100% (requiring unanimous agreement) should therefore have no effect.
+    await setNewGatPercentage(web3.utils.toWei("1.00", "ether"));
+
     // Do the final two reveals.
     await voting.revealVote(identifier, time, losingPrice, salt1, { from: account1 });
     await voting.revealVote(identifier, time, winningPrice, salt3, { from: account3 });
@@ -708,6 +712,9 @@ contract("Voting", function(accounts) {
       (await voting.getPrice(identifier, time, { from: registeredDerivative })).toString(),
       winningPrice.toString()
     );
+
+    // Reset the GAT to 5% for subsequent rounds.
+    await setNewGatPercentage(web3.utils.toWei("0.05", "ether")); 
   });
 
   it("Only registered derivatives", async function() {

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -630,11 +630,11 @@ contract("Voting", function(accounts) {
     await setNewGatPercentage(web3.utils.toWei("0.05", "ether"));
 
     // As the previous request has been filled, we need to progress time such that we
-    // can vote on the same identifier and request a new price to vote on.    
+    // can vote on the same identifier and request a new price to vote on.
     time += 10;
     await voting.requestPrice(identifier, time, { from: registeredDerivative });
     await moveToNextRound(voting);
-    
+
     // Commit votes.
     await voting.commitVote(identifier, time, hash, { from: account4 });
     await voting.commitVote(identifier, time, hash, { from: account1 });
@@ -714,7 +714,7 @@ contract("Voting", function(accounts) {
     );
 
     // Reset the GAT to 5% for subsequent rounds.
-    await setNewGatPercentage(web3.utils.toWei("0.05", "ether")); 
+    await setNewGatPercentage(web3.utils.toWei("0.05", "ether"));
   });
 
   it("Only registered derivatives", async function() {

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -29,9 +29,9 @@ contract("Voting", function(accounts) {
   };
 
   const setNewGatPercentage = async gatPercentage => {
-    await voting.setGatPercentage({ rawValue: inflationRate.toString()})
-  }
-  
+    await voting.setGatPercentage({ rawValue: gatPercentage.toString() });
+  };
+
   before(async function() {
     voting = await Voting.deployed();
     votingToken = await VotingToken.deployed();
@@ -576,7 +576,7 @@ contract("Voting", function(accounts) {
 
   it("GAT", async function() {
     const identifier = web3.utils.utf8ToHex("gat");
-    const time = "1000";
+    let time = "1000";
 
     // Make the Oracle support this identifier.
     await voting.addSupportedIdentifier(identifier);
@@ -605,7 +605,36 @@ contract("Voting", function(accounts) {
     const req = [{ identifier: identifier, time: time }];
     assert(await didContractThrow(voting.retrieveRewards(account4, initialRoundId, req)));
 
-    // With a larger vote, the GAT should be hit and the price should resolve.
+    // With a smaller GAT value of 3%, account4 can pass the vote on their own with 4% of all tokens.
+    await setNewGatPercentage(web3.utils.toWei("0.03", "ether"));
+
+    // Commit votes.
+    await voting.commitVote(identifier, time, hash, { from: account4 });
+
+    // Reveal votes.
+    await moveToNextPhase(voting);
+    await voting.revealVote(identifier, time, price, salt, { from: account4 });
+
+    await moveToNextRound(voting);
+    assert.equal(
+      (await voting.getPrice(identifier, time, { from: registeredDerivative })).toString(),
+      price.toString()
+    );
+
+    // Must specify the right roundId when retrieving rewards.
+    assert(await didContractThrow(voting.retrieveRewards(account4, initialRoundId, req)));
+    await voting.retrieveRewards(account4, newRoundId, req);
+
+    // Set GAT back to 5% and test a larger vote. With more votes the GAT should be hit
+    // and the price should resolve.
+    await setNewGatPercentage(web3.utils.toWei("0.05", "ether"));
+
+    // As the previous request has been filled, we need to progress time such that we
+    // can vote on the same identifier and request a new price to vote on.    
+    time += 10;
+    await voting.requestPrice(identifier, time, { from: registeredDerivative });
+    await moveToNextRound(voting);
+    
     // Commit votes.
     await voting.commitVote(identifier, time, hash, { from: account4 });
     await voting.commitVote(identifier, time, hash, { from: account1 });

--- a/core/test/Voting.js
+++ b/core/test/Voting.js
@@ -28,6 +28,10 @@ contract("Voting", function(accounts) {
     await voting.setInflationRate({ rawValue: inflationRate.toString() });
   };
 
+  const setNewGatPercentage = async gatPercentage => {
+    await voting.setGatPercentage({ rawValue: inflationRate.toString()})
+  }
+  
   before(async function() {
     voting = await Voting.deployed();
     votingToken = await VotingToken.deployed();


### PR DESCRIPTION
This pull request modifies how the `gatPercentage` is set within `voting.sol`. Before the `gatPercentage` was set on construction and then could not be changed. In this PR, the `gatPercentage` is set on construction and can then be modified using a new function `setGatPercentage`. 

As with the `inflationRate`, the `gatPercentage` is locked at the start of the reveal phase with the internal function `_freezeRoundVariables`. This stores the `gatPercentage` and `inflationRate` for that round such that any modifications will only be applied to the following voting round.

Tests and comments encompass these changes.