### PR TITLE
Batch reveal gas estimation

### DIFF
--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -580,8 +580,8 @@ library TokenizedDerivativeUtils {
         // Subtract the oracle fees from the short balance.
         newShortMarginBalance = isContractLive
             ? newShortMarginBalance.sub(
-                _safeIntCast(s._computeExpectedOracleFees(s.currentTokenState.time, recomputeTime))
-            )
+            _safeIntCast(s._computeExpectedOracleFees(s.currentTokenState.time, recomputeTime))
+        )
             : newShortMarginBalance;
 
         // Compute the new NAV

--- a/core/contracts/TokenizedDerivative.sol
+++ b/core/contracts/TokenizedDerivative.sol
@@ -580,8 +580,8 @@ library TokenizedDerivativeUtils {
         // Subtract the oracle fees from the short balance.
         newShortMarginBalance = isContractLive
             ? newShortMarginBalance.sub(
-            _safeIntCast(s._computeExpectedOracleFees(s.currentTokenState.time, recomputeTime))
-        )
+                _safeIntCast(s._computeExpectedOracleFees(s.currentTokenState.time, recomputeTime))
+            )
             : newShortMarginBalance;
 
         // Compute the new NAV

--- a/core/scripts/local/BatchGasEstimation.js
+++ b/core/scripts/local/BatchGasEstimation.js
@@ -12,7 +12,7 @@ const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 
-let results = {}; //array to store maximum results achieved
+let results = {}; // Array to store maximum results achieved.
 
 async function run() {
   const voting = await Voting.deployed();

--- a/core/scripts/local/BatchGasEstimation.js
+++ b/core/scripts/local/BatchGasEstimation.js
@@ -47,7 +47,7 @@ async function run() {
 
   console.log("Executing the following tests:", tests, "\nThis script can take a while to run.");
 
-  for (j = 1; j < tests.length; j++) {
+  for (j = 0; j < tests.length; j++) {
     // Binary search parameters. search starts at 64 and will either half our double if it finds
     // it can fit that number within one block. Algorithm iterates until there is convergence
     let requestNum = 64;

--- a/core/scripts/local/BatchGasEstimation.js
+++ b/core/scripts/local/BatchGasEstimation.js
@@ -135,7 +135,7 @@ const cycleCommit = async (voting, identifier, time, requestNum, registeredDeriv
 const cycleReveal = async (voting, identifier, time, requestNum, registeredDerivative, voter) => {
   await generatePriceRequests(requestNum, voting, identifier, time, registeredDerivative);
 
-    await moveToNextRound(voting);
+  await moveToNextRound(voting);
 
   const salts = {};
   const price = getRandomSignedInt();
@@ -166,7 +166,7 @@ const cycleClaim = async (voting, identifier, time, requestNum, registeredDeriva
   await generatePriceRequests(requestNum, voting, identifier, time, registeredDerivative);
 
   await moveToNextRound(voting);
-  
+
   const salts = {};
   const price = getRandomSignedInt();
 

--- a/core/scripts/local/BatchGasEstimation.js
+++ b/core/scripts/local/BatchGasEstimation.js
@@ -1,0 +1,99 @@
+const { RegistryRolesEnum, VotePhasesEnum } = require("../../../common/Enums.js");
+const { getRandomSignedInt, getRandomUnsignedInt } = require("../../../common/Random.js");
+const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
+
+const Registry = artifacts.require("Registry");
+const Voting = artifacts.require("Voting");
+const VotingToken = artifacts.require("VotingToken");
+
+async function run() {
+  const voting = await Voting.deployed();
+  const votingToken = await VotingToken.deployed();
+  const registry = await Registry.deployed();
+
+  const accounts = await web3.eth.getAccounts();
+  const owner = accounts[0];
+  const registeredDerivative = accounts[1];
+  const voter = accounts[2];
+
+  await voting.setInflationRate({ rawValue: web3.utils.toWei("0.01", "ether") });
+  await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, owner);
+
+  if (!(await registry.isDerivativeRegistered(registeredDerivative))) {
+    await registry.registerDerivative([], registeredDerivative, { from: owner });
+  }
+
+  const identifier = web3.utils.utf8ToHex("test-identifier");
+  await voting.addSupportedIdentifier(identifier);
+
+  // Allow owner to mint new tokens
+  await votingToken.addMember("1", owner);
+
+  const balance = await votingToken.balanceOf(voter);
+  const floorBalance = web3.utils.toBN(web3.utils.toWei("100", "ether"));
+  if (balance.lt(floorBalance)) {
+    console.log("Minting tokens for", voter);
+    await votingToken.mint(voter, web3.utils.toWei("100", "ether"));
+  }
+
+  // Pick a random time. Probabilistically, this won't request a duplicate time from a previous run.
+  let time = Math.floor(Math.random() * (await voting.getCurrentTime()));
+
+  let i = 64;
+  let converged = false;
+  let lowestFailed = 0;
+  let highestPassed = 0;
+  while (!converged) {
+    console.log("*size:", i, "*");
+    if (lowestFailed - highestPassed == 1) {
+      console.log("Maximum =", highestPassed);
+      converged = true;
+      break;
+    }
+    try {
+      await cycleCommit(voting, identifier, time, i, registeredDerivative, voter);
+      highestPassed = i;
+      if (lowestFailed != 0) {
+        i = Math.floor((lowestFailed + highestPassed) / 2);
+      } else {
+        i = i * 2;
+      }
+    } catch (error) {
+      lowestFailed = i;
+      i = Math.floor((lowestFailed + highestPassed) / 2);
+    }
+    time += 1;
+  }
+  console.log("Done");
+}
+
+const cycleCommit = async (voting, identifier, time, requestNumber, registeredDerivative, voter) => {
+  for (var i = 0; i < requestNumber; i++) {
+    const result = await voting.requestPrice(identifier, time + i, { from: registeredDerivative });
+  }
+
+  await moveToNextRound(voting);
+  const salts = {};
+  const price = getRandomSignedInt();
+  const commitments = [];
+  for (var i = 0; i < requestNumber; i++) {
+    const salt = getRandomUnsignedInt();
+    const hash = web3.utils.soliditySha3(price, salt);
+    salts[i] = salt;
+    commitments[i] = { identifier: identifier, time: time + i, hash: hash, encryptedVote: [] };
+  }
+
+  const result = await voting.batchCommit(commitments, { from: voter });
+  console.log("commitVote", result.receipt.gasUsed);
+};
+
+// const cycleReveal = async () => {};
+
+module.exports = async function(cb) {
+  try {
+    await run();
+  } catch (err) {
+    console.log(err);
+  }
+  cb();
+};

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -56,19 +56,21 @@ async function run() {
   console.log("Voting tokens total supply:", (await votingToken.totalSupply()).toString());
 
   for (var i = 0; i < numRounds; i++) {
-    console.group(`\nRound ${i}`);
+    console.group(`\n*** Round ${i} ***`);
     await cycleRound(voting, votingToken, identifier, time, accounts);
     time += numPriceRequests;
     console.groupEnd();
   }
 
+  console.group(`\nVoter token balances post-test:`);
   for (var i = 0; i < numVoters; i++) {
     const voter = getVoter(accounts, i);
-    console.log("balance", (await votingToken.balanceOf(voter)).toString());
+    const balance = await votingToken.balanceOf(voter)
+    console.log(`- Voter #${i}: ${balance.toString()}`);
   }
-  console.log("total supply", (await votingToken.totalSupply()).toString());
+  console.groupEnd();
+  console.log("Voting tokens total supply", (await votingToken.totalSupply()).toString());
 
-  console.log("Done\n");
   console.groupEnd();
 }
 
@@ -78,12 +80,16 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts
   /**
    * Estimating gas usage: requestPrice
    */
+  let gasUsedPriceRequest = 0;
   console.group(`\nEstimating gas usage: requestPrice`);
+
   for (var i = 0; i < numPriceRequests; i++) {
     const result = await voting.requestPrice(identifier, time + i, { from: accounts[1] });
     const _gasUsed = result.receipt.gasUsed;
-    console.log(`- Price Request #${i}: ${_gasUsed}`);
+    console.log(`Price Request #${i}: ${_gasUsed}`);
+    gasUsedPriceRequest += _gasUsed;
   }
+  console.log(`Total gas: ${gasUsedPriceRequest}`);
   console.groupEnd();
 
   // Advance to commit phase
@@ -119,7 +125,7 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts
     }
     console.groupEnd();
   }
-  console.log(`- total gas: ${gasUsedCommitVote}`)
+  console.log(`Total gas: ${gasUsedCommitVote}`)
   console.groupEnd();
 
   // Advance to reveal phase
@@ -144,7 +150,7 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts
     }
     console.groupEnd();
   }
-  console.log(`- total gas: ${gasUsedRevealVote}`)
+  console.log(`Total gas: ${gasUsedRevealVote}`)
   console.groupEnd();
   
 };

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -76,17 +76,15 @@ async function run() {
 
 // Cycle through each round--consisting of a price request, commit, and reveal phase
 const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
-  /**
-   * Estimating gas usage: requestPrice
-   */
+  // Estimating gas usage: requestPrice.
   let gasUsedPriceRequest = 0;
   console.group(`\nEstimating gas usage: requestPrice`);
 
   for (var i = 0; i < numPriceRequests; i++) {
     const result = await voting.requestPrice(identifier, time + i, { from: accounts[1] });
-    const _gasUsed = result.receipt.gasUsed;
-    console.log(`Price Request #${i}: ${_gasUsed}`);
-    gasUsedPriceRequest += _gasUsed;
+    const gasUsed = result.receipt.gasUsed;
+    console.log(`Price Request #${i}: ${gasUsed}`);
+    gasUsedPriceRequest += gasUsed;
   }
   console.log(`Total gas: ${gasUsedPriceRequest}`);
   console.groupEnd();
@@ -97,9 +95,7 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
   const salts = {};
   const price = getRandomSignedInt();
 
-  /**
-   * Estimating gas usage: commitVote
-   */
+  // Estimating gas usage: commitVote
   let gasUsedCommitVote = 0;
   console.group(`\nEstimating gas usage: commitVote`);
 
@@ -113,9 +109,9 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
       const voter = getVoter(accounts, j);
 
       const result = await voting.commitVote(identifier, time + i, hash, { from: voter });
-      const _gasUsed = result.receipt.gasUsed;
-      console.log(`- Commit #${j}: ${_gasUsed}`);
-      gasUsedCommitVote += _gasUsed;
+      const gasUsed = result.receipt.gasUsed;
+      console.log(`- Commit #${j}: ${gasUsed}`);
+      gasUsedCommitVote += gasUsed;
 
       if (salts[i] == null) {
         salts[i] = {};
@@ -130,9 +126,7 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
   // Advance to reveal phase
   await moveToNextPhase(voting);
 
-  /**
-   * Estimating gas usage: revealVote
-   */
+  // Estimating gas usage: revealVote
   let gasUsedRevealVote = 0;
   console.group(`\nEstimating gas usage: revealVote`);
 
@@ -143,9 +137,9 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
       const voter = getVoter(accounts, j);
 
       const result = await voting.revealVote(identifier, time + i, price, salts[i][j], { from: voter });
-      const _gasUsed = result.receipt.gasUsed;
-      console.log(`- Reveal #${j}: ${_gasUsed}`);
-      gasUsedRevealVote += _gasUsed;
+      const gasUsed = result.receipt.gasUsed;
+      console.log(`- Reveal #${j}: ${gasUsed}`);
+      gasUsedRevealVote += gasUsed;
     }
     console.groupEnd();
   }

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -65,7 +65,7 @@ async function run() {
   console.group(`\nVoter token balances post-test:`);
   for (var i = 0; i < numVoters; i++) {
     const voter = getVoter(accounts, i);
-    const balance = await votingToken.balanceOf(voter)
+    const balance = await votingToken.balanceOf(voter);
     console.log(`- Voter #${i}: ${balance.toString()}`);
   }
   console.groupEnd();
@@ -75,8 +75,7 @@ async function run() {
 }
 
 // Cycle through each round--consisting of a price request, commit, and reveal phase
-const cycleRound = async (voting, votingToken, identifier, time, accounts
-) => {
+const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
   /**
    * Estimating gas usage: requestPrice
    */
@@ -106,7 +105,7 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts
 
   for (var i = 0; i < numPriceRequests; i++) {
     console.group(`Price request #${i}`);
-    
+
     for (var j = 0; j < numVoters; j++) {
       const salt = getRandomUnsignedInt();
       const hash = web3.utils.soliditySha3(price, salt);
@@ -125,7 +124,7 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts
     }
     console.groupEnd();
   }
-  console.log(`Total gas: ${gasUsedCommitVote}`)
+  console.log(`Total gas: ${gasUsedCommitVote}`);
   console.groupEnd();
 
   // Advance to reveal phase
@@ -150,14 +149,13 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts
     }
     console.groupEnd();
   }
-  console.log(`Total gas: ${gasUsedRevealVote}`)
+  console.log(`Total gas: ${gasUsedRevealVote}`);
   console.groupEnd();
-  
 };
 
 module.exports = async function(cb) {
   try {
-    await run()
+    await run();
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
This PR contains a new script `BatchGasEstimation.js` which determines the max number of batched commits, reveals, and reward retrievals that can fit into a single transaction. 

To optimize the execution time of the script, a variant of a binary search algorithm is used to decrease the number of brute force searches that need to be conducted. 

Based off a default ganache configuration with gas limit set to `60000000000` and gas price set to `2000` the following maximums are possible with the current contracts:

| Function        	| Max in one tx 	| Gas used 	|
|-----------------	|---------------	|----------	|
| batchCommit     	| 184              	| 6701759  	|
| batchReveal     	| 58            	| 5828051  	|
| retrieveRewards 	| 130           	| 3314252  	|
