### PR TITLE
Limit the number of batch commits & reveals that can be done

### DIFF
--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -260,7 +260,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     // It was calculated by testing the batchCommit and batch revealFunctions to identify the
     // maximum that can be placed within one tx. The actual number that can be fit is slightly
     // more but is set to a lower amount for safety here.
-    return totalSelected < 50;
+    return totalSelected < 3;
   };
 
   const revealButtonShown = votePhase.toString() === VotePhasesEnum.REVEAL;
@@ -368,7 +368,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         ""
       )}
       {!canExecuteBatch() ? (
-        <span style={{ paddingLeft: "10px", paddingTop: "10px" }}>
+        <span style={{ paddingLeft: "10px", paddingTop: "15px" }}>
           You can only commit or reveal up to 50 requests at once. Please select fewer.
         </span>
       ) : (

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -253,7 +253,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
 
   const canExecuteBatch = () => {
     let totalSelected = 0;
-    for (var checked in checkboxesChecked) {
+    for (let checked in checkboxesChecked) {
       totalSelected += checkboxesChecked[checked];
     }
     // This number defines the maximum number of transactions that can be fit within one block.

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -260,7 +260,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     // It was calculated by testing the batchCommit and batch revealFunctions to identify the
     // maximum that can be placed within one tx. The actual number that can be fit is slightly
     // more but is set to a lower amount for safety here.
-    return totalSelected < 3;
+    return totalSelected <= 25;
   };
 
   const revealButtonShown = votePhase.toString() === VotePhasesEnum.REVEAL;
@@ -368,8 +368,8 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         ""
       )}
       {!canExecuteBatch() ? (
-        <span style={{ paddingLeft: "10px", paddingTop: "15px" }}>
-          You can only commit or reveal up to 50 requests at once. Please select fewer.
+        <span style={{ paddingLeft: "10px", color: "#FF4F4D" }}>
+          You can only commit or reveal up to 25 requests at once. Please select fewer.
         </span>
       ) : (
         ""

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -250,10 +250,23 @@ function ActiveRequests({ votingAccount, votingGateway }) {
       return { statusString: "Cannot be revealed", currentVote: "", enabled: false };
     }
   });
+
+  const canExecuteBatch = () => {
+    let totalSelected = 0;
+    for (var checked in checkboxesChecked) {
+      totalSelected += checkboxesChecked[checked];
+    }
+    // This number defines the maximum number of transactions that can be fit within one block.
+    // It was calculated by testing the batchCommit and batch revealFunctions to identify the
+    // maximum that can be placed within one tx. The actual number that can be fit is slightly
+    // more but is set to a lower amount for safety here.
+    return totalSelected < 50;
+  };
+
   const revealButtonShown = votePhase.toString() === VotePhasesEnum.REVEAL;
-  const revealButtonEnabled = statusDetails.some(statusDetail => statusDetail.enabled);
+  const revealButtonEnabled = statusDetails.some(statusDetail => statusDetail.enabled) && canExecuteBatch();
   const saveButtonShown = votePhase.toString() === VotePhasesEnum.COMMIT;
-  const saveButtonEnabled = Object.values(checkboxesChecked).some(checked => checked);
+  const saveButtonEnabled = Object.values(checkboxesChecked).some(checked => checked) && canExecuteBatch();
 
   const editCommit = index => {
     dispatchEditState({ type: "EDIT_COMMIT", index, price: statusDetails[index].currentVote });
@@ -351,6 +364,13 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         >
           Save
         </Button>
+      ) : (
+        ""
+      )}
+      {!canExecuteBatch() ? (
+        <span style={{ paddingLeft: "10px", paddingTop: "10px" }}>
+          You can only commit or reveal up to 50 requests at once. Please select fewer.
+        </span>
       ) : (
         ""
       )}


### PR DESCRIPTION
This PR adds a limitation on the number of batch commit and reveals that can be done on one transaction by the user. This is done by defining a `canExecuteBatch` function that checks how many check boxes have been selected. If this exceeds a threshold of 20 the button is disabled and the user is informed. 

The screenshot below shows how the front end limits the max number that can be committed and revealed within one transaction.

![image](https://user-images.githubusercontent.com/12886084/72915325-16d33b80-3d0e-11ea-98ef-a2592ddb598f.png)

The number 25 was informed by the work done in #828