### PR TITLE
Add limit on max # of transactions that can fit into batch commits/reveals to AVS

### DIFF
--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -105,7 +105,7 @@ const SUPPORTED_IDENTIFIERS = {
       value: "100"
     }
   },
-  '0.5': {
+  "0.5": {
     numerator: {
       dataSource: "Constant",
       value: "1"

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -134,7 +134,7 @@ const getJson = async url => {
   return json;
 };
 
-async function fetchCryptoComparePrice(request, isProd=false) {
+async function fetchCryptoComparePrice(request, isProd = false) {
   const identifier = request.identifier;
   const time = request.time;
 
@@ -177,7 +177,7 @@ async function fetchCryptoComparePrice(request, isProd=false) {
   return web3.utils.toWei(price.toString());
 }
 
-function fetchConstantPrice(request, config, isProd=false) {
+function fetchConstantPrice(request, config, isProd = false) {
   if (isProd) {
     console.log(
       `Returning constant price [${config.value}] at [${request.time}] for asset [${web3.utils.hexToUtf8(
@@ -198,7 +198,7 @@ function getIntrinioTimeArguments(time) {
   return ["&end_date=" + requestDate, "&end_time=" + requestTime];
 }
 
-async function fetchIntrinioEquitiesPrice(request, config, isProd=false) {
+async function fetchIntrinioEquitiesPrice(request, config, isProd = false) {
   const url = [
     "https://api-v2.intrinio.com/securities/",
     config.symbol,
@@ -209,7 +209,7 @@ async function fetchIntrinioEquitiesPrice(request, config, isProd=false) {
   ]
     .concat(getIntrinioTimeArguments(request.time))
     .join("");
-  
+
   if (isProd) {
     console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
   }
@@ -230,7 +230,7 @@ async function fetchIntrinioEquitiesPrice(request, config, isProd=false) {
   return web3.utils.toWei(price.toString());
 }
 
-async function fetchIntrinioForexPrice(request, config, isProd=false) {
+async function fetchIntrinioForexPrice(request, config, isProd = false) {
   const url = [
     "https://api-v2.intrinio.com/forex/prices/",
     config.symbol,
@@ -262,7 +262,7 @@ async function fetchIntrinioForexPrice(request, config, isProd=false) {
   return web3.utils.toWei(price.toString());
 }
 
-async function fetchIntrinioCryptoPrice(request, config, isProd=false) {
+async function fetchIntrinioCryptoPrice(request, config, isProd = false) {
   const url = [
     "https://api-v2.intrinio.com/crypto/prices?",
     "api_key=" + process.env.INTRINIO_API_KEY,
@@ -272,7 +272,7 @@ async function fetchIntrinioCryptoPrice(request, config, isProd=false) {
   ]
     .concat(getIntrinioTimeArguments(request.time))
     .join("");
-  if(isProd) {
+  if (isProd) {
     console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
   }
   const jsonOutput = await getJson(url);
@@ -293,7 +293,7 @@ async function fetchIntrinioCryptoPrice(request, config, isProd=false) {
 }
 
 // Works for equities and futures (even though it uses the _EQUITIES_API_KEY).
-async function fetchBarchartPrice(request, config, isProd=false) {
+async function fetchBarchartPrice(request, config, isProd = false) {
   // NOTE: this API only provides data up to a month in the past and only to minute granularities. If the requested
   // `time` has a nonzero number of seconds (not a round minute) or is longer than 1 month in the past, this call will
   // fail.
@@ -333,13 +333,16 @@ async function fetchBarchartPrice(request, config, isProd=false) {
   throw "Failed to get a matching timestamp";
 }
 
-async function fetchPriceInner(request, config, isProd=false) {
+async function fetchPriceInner(request, config, isProd = false) {
   switch (config.dataSource) {
     case "CryptoCompare":
-      return await fetchCryptoComparePrice({
-        identifier: { first: config.identifiers.first, second: config.identifiers.second },
-        time: request.time
-      }, isProd);
+      return await fetchCryptoComparePrice(
+        {
+          identifier: { first: config.identifiers.first, second: config.identifiers.second },
+          time: request.time
+        },
+        isProd
+      );
     case "Constant":
       return await fetchConstantPrice(request, config, isProd);
     case "IntrinioEquities":
@@ -355,7 +358,7 @@ async function fetchPriceInner(request, config, isProd=false) {
   }
 }
 
-async function fetchPrice(request, isProd=false) {
+async function fetchPrice(request, isProd = false) {
   const plainTextIdentifier = web3.utils.hexToUtf8(request.identifier);
   if (plainTextIdentifier.startsWith("test")) {
     return web3.utils.toWei("1.5");
@@ -408,10 +411,10 @@ function getNotifiers() {
 }
 
 class ConsoleNotifier {
-  async sendNotification(subject, body, isProd=false) {
+  async sendNotification(subject, body, isProd = false) {
     if (isProd) {
       console.log(`Notification subject: ${subject}`);
-      console.log(`Notification body: ${body}`);  
+      console.log(`Notification body: ${body}`);
     }
   }
 }
@@ -465,7 +468,7 @@ class VotingSystem {
     return await this.voting.getMessage(this.account, topicHash, { from: this.account });
   }
 
-  async constructCommitment(request, roundId, isProd=false) {
+  async constructCommitment(request, roundId, isProd = false) {
     const fetchedPrice = await fetchPrice(request, isProd);
     const salt = web3.utils.toBN(web3.utils.randomHex(32));
     const hash = web3.utils.soliditySha3(fetchedPrice, salt);
@@ -484,7 +487,7 @@ class VotingSystem {
     };
   }
 
-  async runBatchCommit(requests, roundId, isProd=false) {
+  async runBatchCommit(requests, roundId, isProd = false) {
     let commitments = [];
     const skipped = [];
     const failures = [];
@@ -710,7 +713,7 @@ class VotingSystem {
     return { subject, body };
   }
 
-  async innerRunIteration(isProd=false) {
+  async innerRunIteration(isProd = false) {
     const phase = await this.voting.getVotePhase();
     const roundId = await this.voting.getCurrentRoundId();
     const pendingRequests = await this.voting.getPendingRequests();
@@ -720,7 +723,11 @@ class VotingSystem {
     let failures = [];
     let batches = 0;
     if (phase == VotePhasesEnum.COMMIT) {
-      ({ commitments: updates, skipped, failures, batches } = await this.runBatchCommit(pendingRequests, roundId, isProd));
+      ({ commitments: updates, skipped, failures, batches } = await this.runBatchCommit(
+        pendingRequests,
+        roundId,
+        isProd
+      ));
       if (isProd) {
         console.log(
           `Completed ${updates.length} commits, skipped ${skipped.length} commits, failed ${
@@ -743,7 +750,7 @@ class VotingSystem {
     return { updates, skipped, failures, batches };
   }
 
-  async runIteration(isProd=false) {
+  async runIteration(isProd = false) {
     if (isProd) {
       console.log("Starting voting iteration");
     }
@@ -767,7 +774,7 @@ class VotingSystem {
   }
 }
 
-async function runVoting(isProd=false) {
+async function runVoting(isProd = false) {
   try {
     if (isProd) {
       console.log("Running Voting system");

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -104,6 +104,16 @@ const SUPPORTED_IDENTIFIERS = {
       dataSource: "Constant",
       value: "100"
     }
+  },
+  '0.5': {
+    numerator: {
+      dataSource: "Constant",
+      value: "1"
+    },
+    denominator: {
+      dataSource: "Constant",
+      value: "2"
+    }
   }
 };
 
@@ -147,9 +157,9 @@ async function fetchCryptoComparePrice(request) {
     "&limit=1",
     "&api_key=" + CC_API_KEY
   ].join("");
-  console.log(`\n    ***** \n Querying with [${stripApiKey(url, CC_API_KEY)}]\n    ****** \n`);
+  // console.log(`\n    ***** \n Querying with [${stripApiKey(url, CC_API_KEY)}]\n    ****** \n`);
   const jsonOutput = await getJson(url);
-  console.log(`Response [${JSON.stringify(jsonOutput)}]`);
+  // console.log(`Response [${JSON.stringify(jsonOutput)}]`);
 
   if (jsonOutput.Type != "100") {
     throw "Request failed";
@@ -165,17 +175,17 @@ async function fetchCryptoComparePrice(request) {
   }
 
   const tradeTime = jsonOutput.Data[0].time;
-  console.log(`Retrieved quote [${price}] at [${tradeTime}] for asset [${identifier.first}${identifier.second}]`);
+  // console.log(`Retrieved quote [${price}] at [${tradeTime}] for asset [${identifier.first}${identifier.second}]`);
 
   return web3.utils.toWei(price.toString());
 }
 
 function fetchConstantPrice(request, config) {
-  console.log(
-    `Returning constant price [${config.value}] at [${request.time}] for asset [${web3.utils.hexToUtf8(
-      request.identifier
-    )}]`
-  );
+  // console.log(
+  //   `Returning constant price [${config.value}] at [${request.time}] for asset [${web3.utils.hexToUtf8(
+  //     request.identifier
+  //   )}]`
+  // );
   return web3.utils.toWei(config.value);
 }
 
@@ -200,9 +210,9 @@ async function fetchIntrinioEquitiesPrice(request, config) {
   ]
     .concat(getIntrinioTimeArguments(request.time))
     .join("");
-  console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  // console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
   const jsonOutput = await getJson(url);
-  console.log("Intrinio response:", jsonOutput);
+  // console.log("Intrinio response:", jsonOutput);
 
   if (!jsonOutput.intraday_prices || jsonOutput.intraday_prices.length === 0) {
     throw "Failed to get data from Intrinio";
@@ -210,7 +220,7 @@ async function fetchIntrinioEquitiesPrice(request, config) {
 
   const price = jsonOutput.intraday_prices[0].last_price;
   const time = jsonOutput.intraday_prices[0].time;
-  console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  // console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
   return web3.utils.toWei(price.toString());
 }
 
@@ -523,7 +533,7 @@ class VotingSystem {
       const { privateKey } = await deriveKeyPairFromSignatureTruffle(web3, getKeyGenMessage(roundId), this.account);
       vote = JSON.parse(await decryptMessage(privateKey, encryptedCommit));
     } catch (e) {
-      console.error("Failed to decrypt message:", encryptedCommit, "\n", e);
+      // console.error("Failed to decrypt message:", encryptedCommit, "\n", e);
       return null;
     }
 
@@ -686,14 +696,14 @@ class VotingSystem {
     let batches = 0;
     if (phase == VotePhasesEnum.COMMIT) {
       ({ commitments: updates, skipped, failures, batches } = await this.runBatchCommit(pendingRequests, roundId));
-      console.log(
-        `Completed ${updates.length} commits, skipped ${skipped.length} commits, failed ${
-          failures.length
-        } commits, split into ${batches} batch${batches != 1 ? `es` : ``}`
-      );
+      // console.log(
+      //   `Completed ${updates.length} commits, skipped ${skipped.length} commits, failed ${
+      //     failures.length
+      //   } commits, split into ${batches} batch${batches != 1 ? `es` : ``}`
+      // );
     } else {
       ({ reveals: updates, batches } = await this.runBatchReveal(pendingRequests, roundId));
-      console.log(`Completed ${updates.length} reveals, split into ${batches} batch${batches != 1 ? `es` : ``}`);
+      // console.log(`Completed ${updates.length} reveals, split into ${batches} batch${batches != 1 ? `es` : ``}`);
     }
 
     const notification = this.constructNotification(updates, skipped, failures, phase);
@@ -705,7 +715,7 @@ class VotingSystem {
   }
 
   async runIteration() {
-    console.log("Starting voting iteration");
+    // console.log("Starting voting iteration");
 
     let results;
     try {
@@ -719,7 +729,7 @@ class VotingSystem {
       );
     }
 
-    console.log("Finished voting iteration");
+    // console.log("Finished voting iteration");
     return results;
   }
 }

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -104,16 +104,6 @@ const SUPPORTED_IDENTIFIERS = {
       dataSource: "Constant",
       value: "100"
     }
-  },
-  "0.5": {
-    numerator: {
-      dataSource: "Constant",
-      value: "1"
-    },
-    denominator: {
-      dataSource: "Constant",
-      value: "2"
-    }
   }
 };
 
@@ -144,7 +134,7 @@ const getJson = async url => {
   return json;
 };
 
-async function fetchCryptoComparePrice(request) {
+async function fetchCryptoComparePrice(request, isProd=false) {
   const identifier = request.identifier;
   const time = request.time;
 
@@ -158,9 +148,13 @@ async function fetchCryptoComparePrice(request) {
     "&limit=1",
     "&api_key=" + CC_API_KEY
   ].join("");
-  // console.log(`\n    ***** \n Querying with [${stripApiKey(url, CC_API_KEY)}]\n    ****** \n`);
+  if (isProd) {
+    console.log(`\n    ***** \n Querying with [${stripApiKey(url, CC_API_KEY)}]\n    ****** \n`);
+  }
   const jsonOutput = await getJson(url);
-  // console.log(`Response [${JSON.stringify(jsonOutput)}]`);
+  if (isTest) {
+    console.log(`Response [${JSON.stringify(jsonOutput)}]`);
+  }
 
   if (jsonOutput.Type != "100") {
     throw "Request failed";
@@ -176,17 +170,21 @@ async function fetchCryptoComparePrice(request) {
   }
 
   const tradeTime = jsonOutput.Data[0].time;
-  // console.log(`Retrieved quote [${price}] at [${tradeTime}] for asset [${identifier.first}${identifier.second}]`);
+  if (isTest) {
+    console.log(`Retrieved quote [${price}] at [${tradeTime}] for asset [${identifier.first}${identifier.second}]`);
+  }
 
   return web3.utils.toWei(price.toString());
 }
 
-function fetchConstantPrice(request, config) {
-  // console.log(
-  //   `Returning constant price [${config.value}] at [${request.time}] for asset [${web3.utils.hexToUtf8(
-  //     request.identifier
-  //   )}]`
-  // );
+function fetchConstantPrice(request, config, isProd=false) {
+  if (isProd) {
+    console.log(
+      `Returning constant price [${config.value}] at [${request.time}] for asset [${web3.utils.hexToUtf8(
+        request.identifier
+      )}]`
+    );
+  }
   return web3.utils.toWei(config.value);
 }
 
@@ -200,7 +198,7 @@ function getIntrinioTimeArguments(time) {
   return ["&end_date=" + requestDate, "&end_time=" + requestTime];
 }
 
-async function fetchIntrinioEquitiesPrice(request, config) {
+async function fetchIntrinioEquitiesPrice(request, config, isProd=false) {
   const url = [
     "https://api-v2.intrinio.com/securities/",
     config.symbol,
@@ -211,9 +209,14 @@ async function fetchIntrinioEquitiesPrice(request, config) {
   ]
     .concat(getIntrinioTimeArguments(request.time))
     .join("");
-  // console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  
+  if (isProd) {
+    console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  }
   const jsonOutput = await getJson(url);
-  // console.log("Intrinio response:", jsonOutput);
+  if (isProd) {
+    console.log("Intrinio response:", jsonOutput);
+  }
 
   if (!jsonOutput.intraday_prices || jsonOutput.intraday_prices.length === 0) {
     throw "Failed to get data from Intrinio";
@@ -221,11 +224,13 @@ async function fetchIntrinioEquitiesPrice(request, config) {
 
   const price = jsonOutput.intraday_prices[0].last_price;
   const time = jsonOutput.intraday_prices[0].time;
-  // console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  if (isProd) {
+    console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  }
   return web3.utils.toWei(price.toString());
 }
 
-async function fetchIntrinioForexPrice(request, config) {
+async function fetchIntrinioForexPrice(request, config, isProd=false) {
   const url = [
     "https://api-v2.intrinio.com/forex/prices/",
     config.symbol,
@@ -236,9 +241,13 @@ async function fetchIntrinioForexPrice(request, config) {
   ]
     .concat(getIntrinioTimeArguments(request.time))
     .join("");
-  console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  if (isProd) {
+    console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  }
   const jsonOutput = await getJson(url);
-  console.log("Intrinio response:", jsonOutput);
+  if (isProd) {
+    console.log("Intrinio response:", jsonOutput);
+  }
 
   if (!jsonOutput.prices || jsonOutput.prices.length === 0) {
     throw "Failed to get data from Intrinio";
@@ -247,11 +256,13 @@ async function fetchIntrinioForexPrice(request, config) {
   // TODO(ptare): Forex quotes don't appear to have trade prices!?
   const price = jsonOutput.prices[0].open_bid;
   const time = jsonOutput.prices[0].occurred_at;
-  console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  if (isProd) {
+    console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  }
   return web3.utils.toWei(price.toString());
 }
 
-async function fetchIntrinioCryptoPrice(request, config) {
+async function fetchIntrinioCryptoPrice(request, config, isProd=false) {
   const url = [
     "https://api-v2.intrinio.com/crypto/prices?",
     "api_key=" + process.env.INTRINIO_API_KEY,
@@ -261,9 +272,13 @@ async function fetchIntrinioCryptoPrice(request, config) {
   ]
     .concat(getIntrinioTimeArguments(request.time))
     .join("");
-  console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  if(isProd) {
+    console.log(`\n    ***** \n Querying with [${stripApiKey(url, process.env.INTRINIO_API_KEY)}]\n    ****** \n`);
+  }
   const jsonOutput = await getJson(url);
-  console.log("Intrinio response:", jsonOutput);
+  if (isProd) {
+    console.log("Intrinio response:", jsonOutput);
+  }
 
   if (!jsonOutput.prices || jsonOutput.prices.length === 0) {
     throw "Failed to get data from Intrinio";
@@ -271,12 +286,14 @@ async function fetchIntrinioCryptoPrice(request, config) {
 
   const price = jsonOutput.prices[0].open;
   const time = jsonOutput.prices[0].time;
-  console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  if (isProd) {
+    console.log(`Retrieved quote [${price}] at [${time}] for asset [${web3.utils.hexToUtf8(request.identifier)}]`);
+  }
   return web3.utils.toWei(price.toString());
 }
 
 // Works for equities and futures (even though it uses the _EQUITIES_API_KEY).
-async function fetchBarchartPrice(request, config) {
+async function fetchBarchartPrice(request, config, isProd=false) {
   // NOTE: this API only provides data up to a month in the past and only to minute granularities. If the requested
   // `time` has a nonzero number of seconds (not a round minute) or is longer than 1 month in the past, this call will
   // fail.
@@ -290,12 +307,16 @@ async function fetchBarchartPrice(request, config) {
     "&type=minutes",
     "&startDate=" + startDate
   ].join("");
-  console.log(`\n    ***** \n Querying with [${stripApiKey(url, key)}]\n    ****** \n`);
+  if (isProd) {
+    console.log(`\n    ***** \n Querying with [${stripApiKey(url, key)}]\n    ****** \n`);
+  }
 
   const jsonOutput = await getJson(url);
 
   if (jsonOutput.status.code != 200) {
-    console.log("Barchart response:", jsonOutput);
+    if (isProd) {
+      console.log("Barchart response:", jsonOutput);
+    }
     throw "Barchart request failed";
   }
 
@@ -312,21 +333,21 @@ async function fetchBarchartPrice(request, config) {
   throw "Failed to get a matching timestamp";
 }
 
-async function fetchPriceInner(request, config) {
+async function fetchPriceInner(request, config, isProd=false) {
   switch (config.dataSource) {
     case "CryptoCompare":
       return await fetchCryptoComparePrice({
         identifier: { first: config.identifiers.first, second: config.identifiers.second },
         time: request.time
-      });
+      }, isProd);
     case "Constant":
-      return await fetchConstantPrice(request, config);
+      return await fetchConstantPrice(request, config, isProd);
     case "IntrinioEquities":
-      return await fetchIntrinioEquitiesPrice(request, config);
+      return await fetchIntrinioEquitiesPrice(request, config, isProd);
     case "IntrinioForex":
-      return await fetchIntrinioForexPrice(request, config);
+      return await fetchIntrinioForexPrice(request, config, isProd);
     case "Barchart":
-      return await fetchBarchartPrice(request, config);
+      return await fetchBarchartPrice(request, config, isProd);
     case "Manual":
       throw "Unsupported config. Please vote manually using the dApp";
     default:
@@ -334,15 +355,15 @@ async function fetchPriceInner(request, config) {
   }
 }
 
-async function fetchPrice(request) {
+async function fetchPrice(request, isProd=false) {
   const plainTextIdentifier = web3.utils.hexToUtf8(request.identifier);
   if (plainTextIdentifier.startsWith("test")) {
     return web3.utils.toWei("1.5");
   }
   const config = SUPPORTED_IDENTIFIERS[plainTextIdentifier];
-  const numerator = await fetchPriceInner(request, config.numerator);
+  const numerator = await fetchPriceInner(request, config.numerator, isProd);
   if (config.denominator) {
-    const denominator = await fetchPriceInner(request, config.denominator);
+    const denominator = await fetchPriceInner(request, config.denominator, isProd);
     return web3.utils
       .toBN(numerator)
       .mul(web3.utils.toBN(web3.utils.toWei("1")))
@@ -387,9 +408,11 @@ function getNotifiers() {
 }
 
 class ConsoleNotifier {
-  async sendNotification(subject, body) {
-    console.log(`Notification subject: ${subject}`);
-    console.log(`Notification body: ${body}`);
+  async sendNotification(subject, body, isProd=false) {
+    if (isProd) {
+      console.log(`Notification subject: ${subject}`);
+      console.log(`Notification body: ${body}`);  
+    }
   }
 }
 
@@ -442,8 +465,8 @@ class VotingSystem {
     return await this.voting.getMessage(this.account, topicHash, { from: this.account });
   }
 
-  async constructCommitment(request, roundId) {
-    const fetchedPrice = await fetchPrice(request);
+  async constructCommitment(request, roundId, isProd=false) {
+    const fetchedPrice = await fetchPrice(request, isProd);
     const salt = web3.utils.toBN(web3.utils.randomHex(32));
     const hash = web3.utils.soliditySha3(fetchedPrice, salt);
 
@@ -461,7 +484,7 @@ class VotingSystem {
     };
   }
 
-  async runBatchCommit(requests, roundId) {
+  async runBatchCommit(requests, roundId, isProd=false) {
     let commitments = [];
     const skipped = [];
     const failures = [];
@@ -490,9 +513,9 @@ class VotingSystem {
         }
 
         try {
-          newCommitments.push(await this.constructCommitment(request, roundId));
+          newCommitments.push(await this.constructCommitment(request, roundId, isProd));
         } catch (error) {
-          console.log("Failed", error);
+          // console.error("Failed to construct commitment", error);
           failures.push({ request, error });
         }
       }
@@ -687,7 +710,7 @@ class VotingSystem {
     return { subject, body };
   }
 
-  async innerRunIteration() {
+  async innerRunIteration(isProd=false) {
     const phase = await this.voting.getVotePhase();
     const roundId = await this.voting.getCurrentRoundId();
     const pendingRequests = await this.voting.getPendingRequests();
@@ -697,61 +720,71 @@ class VotingSystem {
     let failures = [];
     let batches = 0;
     if (phase == VotePhasesEnum.COMMIT) {
-      ({ commitments: updates, skipped, failures, batches } = await this.runBatchCommit(pendingRequests, roundId));
-      // console.log(
-      //   `Completed ${updates.length} commits, skipped ${skipped.length} commits, failed ${
-      //     failures.length
-      //   } commits, split into ${batches} batch${batches != 1 ? `es` : ``}`
-      // );
+      ({ commitments: updates, skipped, failures, batches } = await this.runBatchCommit(pendingRequests, roundId, isProd));
+      if (isProd) {
+        console.log(
+          `Completed ${updates.length} commits, skipped ${skipped.length} commits, failed ${
+            failures.length
+          } commits, split into ${batches} batch${batches != 1 ? `es` : ``}`
+        );
+      }
     } else {
       ({ reveals: updates, batches } = await this.runBatchReveal(pendingRequests, roundId));
-      // console.log(`Completed ${updates.length} reveals, split into ${batches} batch${batches != 1 ? `es` : ``}`);
+      if (isProd) {
+        console.log(`Completed ${updates.length} reveals, split into ${batches} batch${batches != 1 ? `es` : ``}`);
+      }
     }
 
     const notification = this.constructNotification(updates, skipped, failures, phase);
     await Promise.all(
-      this.notifiers.map(notifier => notifier.sendNotification(notification.subject, notification.body))
+      this.notifiers.map(notifier => notifier.sendNotification(notification.subject, notification.body, isProd))
     );
 
     return { updates, skipped, failures, batches };
   }
 
-  async runIteration() {
-    // console.log("Starting voting iteration");
+  async runIteration(isProd=false) {
+    if (isProd) {
+      console.log("Starting voting iteration");
+    }
 
     let results;
     try {
-      results = await this.innerRunIteration();
+      results = await this.innerRunIteration(isProd);
     } catch (error) {
       // A catch-all error handler, so the user gets notified if the AVS crashes. Note that errors fetching prices for
       // some feeds is not considered a crash, and the user will be sent a more detailed message in that case.
       const notification = this.constructErrorNotification(error);
       await Promise.all(
-        this.notifiers.map(notifier => notifier.sendNotification(notification.subject, notification.body))
+        this.notifiers.map(notifier => notifier.sendNotification(notification.subject, notification.body, isProd))
       );
     }
 
-    // console.log("Finished voting iteration");
+    if (isProd) {
+      console.log("Finished voting iteration");
+    }
     return results;
   }
 }
 
-async function runVoting() {
+async function runVoting(isProd=false) {
   try {
-    console.log("Running Voting system");
+    if (isProd) {
+      console.log("Running Voting system");
+    }
     sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
     const voting = await Voting.deployed();
     const account = (await web3.eth.getAccounts())[0];
     const votingSystem = new VotingSystem(voting, account, getNotifiers());
-    return await votingSystem.runIteration();
+    return await votingSystem.runIteration(isProd);
   } catch (error) {
-    console.log(error);
+    console.error(`AVS Failed:`, error);
   }
 }
 
 run = async function(callback) {
   // For production script, unnecessary to return stats on successful, skipped, failed requests or batch data
-  await runVoting();
+  await runVoting({ isProd: true });
   callback();
 };
 

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -152,7 +152,7 @@ async function fetchCryptoComparePrice(request, isProd) {
     console.log(`\n    ***** \n Querying with [${stripApiKey(url, CC_API_KEY)}]\n    ****** \n`);
   }
   const jsonOutput = await getJson(url);
-  if (isTest) {
+  if (isProd) {
     console.log(`Response [${JSON.stringify(jsonOutput)}]`);
   }
 
@@ -170,7 +170,7 @@ async function fetchCryptoComparePrice(request, isProd) {
   }
 
   const tradeTime = jsonOutput.Data[0].time;
-  if (isTest) {
+  if (isProd) {
     console.log(`Retrieved quote [${price}] at [${tradeTime}] for asset [${identifier.first}${identifier.second}]`);
   }
 

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -23,44 +23,44 @@ class MockNotifier {
 }
 
 const TEST_IDENTIFIERS = {
-  'test': {
+  test: {
     key: web3.utils.utf8ToHex("test"),
     expectedPrice: web3.utils.toWei("1.5")
   },
-  'test-bad-reveal': {
+  "test-bad-reveal": {
     key: web3.utils.utf8ToHex("test-bad-reveal")
   },
-  'test-overlapping1': {
+  "test-overlapping1": {
     key: web3.utils.utf8ToHex("test-overlapping1"),
     expectedPrice: web3.utils.toWei("1.5")
   },
-  'test-overlapping2': {
+  "test-overlapping2": {
     key: web3.utils.utf8ToHex("test-overlapping2"),
     expectedPrice: web3.utils.toWei("1.5")
   },
-  'TSLA': {
+  TSLA: {
     key: web3.utils.utf8ToHex("TSLA"),
-    hardcodedTimestamp: '1573513368',
+    hardcodedTimestamp: "1573513368",
     expectedPrice: web3.utils.toWei("345.07")
   },
-  'Custom Index (1)': {
+  "Custom Index (1)": {
     key: web3.utils.utf8ToHex("Custom Index (1)"),
     expectedPrice: web3.utils.toWei("1")
   },
-  'Custom Index (100)': {
+  "Custom Index (100)": {
     key: web3.utils.utf8ToHex("Custom Index (100)"),
     expectedPrice: web3.utils.toWei("100")
   },
-  '0.5': {
+  "0.5": {
     key: web3.utils.utf8ToHex("0.5"),
     expectedPrice: web3.utils.toWei("0.5")
   }
-}
+};
 
 const getRandomTimestampInPast = () => {
-  const salt = Math.floor(Math.random() * 100)
-  return Math.round(Date.now()/1000 - 1000 * 60 * (60 + salt)).toString();
-}
+  const salt = Math.floor(Math.random() * 100);
+  return Math.round(Date.now() / 1000 - 1000 * 60 * (60 + salt)).toString();
+};
 
 contract("scripts/Voting.js", function(accounts) {
   let voting;
@@ -97,7 +97,7 @@ contract("scripts/Voting.js", function(accounts) {
   });
 
   it("basic case", async function() {
-    const identifier = TEST_IDENTIFIERS['test'].key;
+    const identifier = TEST_IDENTIFIERS["test"].key;
     const time = getRandomTimestampInPast();
 
     // Request an Oracle price.
@@ -142,7 +142,7 @@ contract("scripts/Voting.js", function(accounts) {
 
     await moveToNextRound(voting);
     // The previous `runIteration()` should have revealed the vote, so the price request should be resolved.
-    const hardcodedPrice = TEST_IDENTIFIERS['test'].expectedPrice;
+    const hardcodedPrice = TEST_IDENTIFIERS["test"].expectedPrice;
     assert.equal(await voting.getPrice(identifier, time), hardcodedPrice);
   });
 
@@ -326,7 +326,10 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(result.updates.length, 1);
     await moveToNextRound(voting);
 
-    assert.equal((await voting.getPrice(identifier, time)).toString(), TEST_IDENTIFIERS["Custom Index (1)"].expectedPrice);
+    assert.equal(
+      (await voting.getPrice(identifier, time)).toString(),
+      TEST_IDENTIFIERS["Custom Index (1)"].expectedPrice
+    );
   });
 
   it("Numerator/Denominator", async function() {
@@ -415,6 +418,9 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(pendingVotes.length, 0, `There should be 0 pending requests during post-reveal phase`);
 
     // Sanity check.
-    assert.equal((await voting.getPrice(identifier, time)).toString(), TEST_IDENTIFIERS["Custom Index (100)"].expectedPrice);
+    assert.equal(
+      (await voting.getPrice(identifier, time)).toString(),
+      TEST_IDENTIFIERS["Custom Index (100)"].expectedPrice
+    );
   });
 });

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -336,7 +336,7 @@ contract("scripts/Voting.js", function(accounts) {
   it("Only batches up to the maximum number of commits or reveals that can fit in one block", async function() {
     const identifier = web3.utils.utf8ToHex("Custom Index (100)");
     const time = "1560762000";
-    let testTransactions = 100;
+    let testTransactions = 101;
 
     // Request Oracle prices.
     await supportedIdentifiers.addSupportedIdentifier(identifier);
@@ -377,7 +377,7 @@ contract("scripts/Voting.js", function(accounts) {
       `There should be ${testTransactions} pending requests during reveal phase`
     );
     let result = await votingSystem.runIteration();
-    let batchesExpected = testTransactions / VotingScript.BATCH_MAX_TXNS;
+    let batchesExpected = Math.floor(testTransactions / VotingScript.BATCH_MAX_TXNS);
     if (testTransactions % VotingScript.BATCH_MAX_TXNS > 0) {
       batchesExpected += 1;
     }

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -9,7 +9,7 @@ const { computeTopicHash } = require("../../../common/EncryptionHelper.js");
 const { createVisibleAccount } = require("../../../common/Crypto");
 
 // Set this to TRUE to print out logs that a production AVS would display
-const USE_PROD_LOGS = true;
+const USE_PROD_LOGS = false;
 
 class MockNotifier {
   constructor() {
@@ -83,8 +83,8 @@ contract("scripts/Voting.js", function(accounts) {
     await votingToken.transfer(voter, initialSupply);
 
     // Add supported identifiers
-    for (k = 0; k < Object.keys(TEST_IDENTIFIERS).length; k++) {
-      let key = TEST_IDENTIFIERS[Object.keys(TEST_IDENTIFIERS)[k]].key;
+    for (const identifier in TEST_IDENTIFIERS) {
+      const key = TEST_IDENTIFIERS[identifier].key;
       await supportedIdentifiers.addSupportedIdentifier(key);
     }
   });

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -362,8 +362,8 @@ contract("scripts/Voting.js", function(accounts) {
 
   it("Only batches up to the maximum number of commits or reveals that can fit in one block", async function() {
     const identifier = TEST_IDENTIFIERS["Custom Index (100)"].key;
-    let testTransactions = Math.round(VotingScript.BATCH_MAX_COMMITS * 2 + 1);
-    const time = (parseInt((await voting.getCurrentTime()).toString()) - testTransactions).toString();
+    let testTransactions = VotingScript.BATCH_MAX_COMMITS * 2 + 1;
+    const time = (await voting.getCurrentTime()).toNumber() - testTransactions;
 
     // Request Oracle prices.
     for (i = 0; i < testTransactions; i++) {
@@ -388,10 +388,7 @@ contract("scripts/Voting.js", function(accounts) {
       `There should be ${testTransactions} pending requests during commit phase`
     );
     let result = await votingSystem.runIteration(USE_PROD_LOGS);
-    batchesExpected = Math.floor(testTransactions / VotingScript.BATCH_MAX_COMMITS);
-    if (testTransactions % VotingScript.BATCH_MAX_COMMITS > 0) {
-      batchesExpected += 1;
-    }
+    batchesExpected = Math.ceil(testTransactions / VotingScript.BATCH_MAX_COMMITS);
     assert.equal(batchesExpected, result.batches);
     assert.equal(result.updates.length, testTransactions);
     assert.equal(result.skipped.length, 0);
@@ -406,10 +403,7 @@ contract("scripts/Voting.js", function(accounts) {
       `There should be ${testTransactions} pending requests during reveal phase`
     );
     result = await votingSystem.runIteration(USE_PROD_LOGS);
-    batchesExpected = Math.floor(testTransactions / VotingScript.BATCH_MAX_REVEALS);
-    if (testTransactions % VotingScript.BATCH_MAX_REVEALS > 0) {
-      batchesExpected += 1;
-    }
+    batchesExpected = Math.ceil(testTransactions / VotingScript.BATCH_MAX_REVEALS);
     assert.equal(batchesExpected, result.batches);
     assert.equal(result.updates.length, testTransactions);
 

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -367,7 +367,7 @@ contract("scripts/Voting.js", function(accounts) {
 
     // Request Oracle prices.
     for (i = 0; i < testTransactions; i++) {
-      let timeToVote = parseInt(time) + i;
+      let timeToVote = time + i;
       await voting.requestPrice(identifier, timeToVote.toString());
     }
 


### PR DESCRIPTION
AVS now batches commits & reveals up to a specified amount of transactions that we have deemed safely under the block gas limit. Based on the total pending requests available to the user, the AVS will use as few batches as possible to execute all requests. For example, if the transaction limit is 25, and there are 101 pending requests, then the AVS will use 5 batches => (25, 25, 25, 25, 1),

Added a unit test to check that AVS is using optimal amount of batch commits & reveals, and refactored existing AVS unit tests to check for correct number of batch commits & reveals.

Importantly, I suppressed all console.log's in the AVS test script to keep consistent with rest of the truffle test suite that does not print to console.

Similar to #826

Fixes #562 

Signed-off-by: Nick Pai <npai.nyc@gmail.com>