### PR TITLE
Added bytecode calculator tool

### DIFF
--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -9,10 +9,18 @@ if (!contractName) {
   return;
 }
 
-console.log("loading", contractName + ".json");
-let obj = require("./../../build/contracts/" + contractName + ".json");
+console.log("compiling contracts...🤓");
+var child = require("child_process").exec("truffle compile");
+child.stdout.pipe(process.stdout);
+child.on("exit", function() {
+  console.log("finished compiling 🚀!");
+  console.log("loading", contractName + ".json");
+  let obj = require("./../../build/contracts/" + contractName + ".json");
 
-const byteCodeSize = (obj.bytecode.length - 2) / 2;
-const remainingSize = 2 ** 14 + 2 ** 13 - (obj.bytecode.length - 2) / 2;
-console.log("Contract is", byteCodeSize, "bytes in size.");
-console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
+  const byteCodeSize = (obj.bytecode.length - 2) / 2;
+  const remainingSize = 2 ** 14 + 2 ** 13 - (obj.bytecode.length - 2) / 2;
+  console.log("Contract is", byteCodeSize, "bytes in size.");
+  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit 🔥.");
+
+  process.exit();
+});

--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -1,5 +1,8 @@
 // This simple script tells you how big your contract byte code is and how much you have until you exceed
-// the current block limit as defined by EIP170.
+// the current block limit as defined by EIP170. This script should be run from the /core directory.
+// To run the script navigate to /core and then run:
+// node scripts/local/CalculateContractBytecode.js --contract Voting
+// where voting is the name of the contract you want to check.
 
 const argv = require("minimist")(process.argv.slice(), { string: ["contract"] });
 const contractName = argv.contract;
@@ -8,17 +11,16 @@ if (!contractName) {
   console.log("Please enter the contract name as a parameter as `--contract <name>`.");
   return;
 }
-var child = require("child_process").exec("truffle compile");
+const child = require("child_process").exec("$(npm bin)/truffle compile");
 child.stdout.pipe(process.stdout);
 child.on("exit", function() {
-  console.log("finished compiling 🚀!");
   console.log("loading", contractName + ".json");
   let obj = require("./../../build/contracts/" + contractName + ".json");
 
   const byteCodeSize = (obj.bytecode.length - 2) / 2;
-  const remainingSize = 2 ** 14 + 2 ** 13 - (obj.bytecode.length - 2) / 2;
+  const remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
   console.log("Contract is", byteCodeSize, "bytes in size.");
-  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit 🔥.");
+  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
 
   process.exit();
 });

--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -1,0 +1,18 @@
+// This simple script tells you how big your contract byte code is and how much you have until you exceed
+// the current block limit as defined by EIP170.
+
+const argv = require("minimist")(process.argv.slice(), { string: ["contract"] });
+const contractName = argv.contract;
+
+if (!contractName) {
+  console.log("Please enter the contract name as a parameter as `--contract <name>`.");
+  return;
+}
+
+console.log("loading", contractName + ".json");
+let obj = require("./../../build/contracts/" + contractName + ".json");
+
+const byteCodeSize = (obj.bytecode.length - 2) / 2;
+const remainingSize = 2 ** 14 + 2 ** 13 - (obj.bytecode.length - 2) / 2;
+console.log("Contract is", byteCodeSize, "bytes in size.");
+console.log("This leaves a total of", remainingSize, " within EIP170");

--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -8,8 +8,6 @@ if (!contractName) {
   console.log("Please enter the contract name as a parameter as `--contract <name>`.");
   return;
 }
-
-console.log("compiling contracts...🤓");
 var child = require("child_process").exec("truffle compile");
 child.stdout.pipe(process.stdout);
 child.on("exit", function() {

--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -1,26 +1,35 @@
 // This simple script tells you how big your contract byte code is and how much you have until you exceed
 // the current block limit as defined by EIP170. This script should be run from the /core directory.
 // To run the script navigate to /core and then run:
-// node scripts/local/CalculateContractBytecode.js --contract Voting
+// truffle exec ./scripts/local/CalculateContractBytecode.js --contract Voting --network test
 // where voting is the name of the contract you want to check.
 
 const argv = require("minimist")(process.argv.slice(), { string: ["contract"] });
-const contractName = argv.contract;
+const truffle = require("truffle");
 
-if (!contractName) {
-  console.log("Please enter the contract name as a parameter as `--contract <name>`.");
-  return;
-}
-const child = require("child_process").exec("$(npm bin)/truffle compile");
-child.stdout.pipe(process.stdout);
-child.on("exit", function() {
-  console.log("loading", contractName + ".json");
-  let obj = require("./../../build/contracts/" + contractName + ".json");
+module.exports = async function(callback) {
+  if (!argv.contract) {
+    console.log("Please enter the contract name as a parameter as `--contract <name>`.");
+    callback();
+  }
+  // Compile contracts with truffle.
+  await truffle.contracts
+    .compile({
+      contracts_directory: "./contracts",
+      contracts_build_directory: "./build/contracts"
+    })
+    .then(() => console.log("Compilation complete!"))
+    .catch(e => {
+      console.error(e);
+      callback();
+    });
 
+  // Load contracts into script and output info.
+  console.log("loading", argv.contract + ".json");
+  let obj = require("./../../build/contracts/" + argv.contract + ".json");
   const byteCodeSize = (obj.bytecode.length - 2) / 2;
   const remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
   console.log("Contract is", byteCodeSize, "bytes in size.");
   console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
-
-  process.exit();
-});
+  callback();
+};

--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -15,4 +15,4 @@ let obj = require("./../../build/contracts/" + contractName + ".json");
 const byteCodeSize = (obj.bytecode.length - 2) / 2;
 const remainingSize = 2 ** 14 + 2 ** 13 - (obj.bytecode.length - 2) / 2;
 console.log("Contract is", byteCodeSize, "bytes in size.");
-console.log("This leaves a total of", remainingSize, " within EIP170");
+console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");


### PR DESCRIPTION
This simple script enables quick checking of byte code size and validation if the contract is currently below the block limit defined by EIP170. It can be run from the core directory by specifying the contract name you wish to check.

For example, say you wish to find the bytecode size of the `Voting.sol` build created by truffle. You would run the following from `/core`:

```
node scripts/local/CalculateContractBytecode.js --contract Voting
```

and the output would look like this:
```
Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.

finished compiling 🚀!
loading Voting.json
Contract is 15504 bytes in size.
This leaves a total of 9072 bytes within the EIP170 limit 🔥.
```