### PR TITLE
Enable truffle optimization

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -105,7 +105,13 @@ module.exports = {
   plugins: ["solidity-coverage"],
   compilers: {
     solc: {
-      version: "0.5.13"
+      version: "0.5.13",
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 500
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
This small change enables the truffle optimizer. This results in decreasing bytecode size and makes interacting with contracts cheaper.

For example, the `voting.sol` contract bytecode was decreased from `22916` to `15694`. This is a considerable saving of 7222 bytes without sacrificing any performance or functionality.