### PR TITLE
Improve contract viewability

### DIFF
--- a/core/contracts/AddressWhitelist.sol
+++ b/core/contracts/AddressWhitelist.sol
@@ -7,9 +7,9 @@ import "@openzeppelin/contracts/ownership/Ownable.sol";
  */
 contract AddressWhitelist is Ownable {
     enum Status { None, In, Out }
-    mapping(address => Status) private whitelist;
+    mapping(address => Status) public whitelist;
 
-    address[] private whitelistIndices;
+    address[] public whitelistIndices;
 
     event AddedToWhitelist(address indexed addedAddress);
     event RemovedFromWhitelist(address indexed removedAddress);

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -22,7 +22,7 @@ contract Registry is RegistryInterface, MultiRole {
     }
 
     // Array of all derivatives that are approved to use the UMA Oracle.
-    address[] private registeredDerivatives;
+    address[] public registeredDerivatives;
 
     // This enum is required because a WasValid state is required to ensure that derivatives cannot be re-registered.
     enum PointerValidity { Invalid, Valid }

--- a/core/contracts/Store.sol
+++ b/core/contracts/Store.sol
@@ -17,11 +17,11 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
 
     enum Roles { Owner, Withdrawer }
 
-    FixedPoint.Unsigned private fixedOracleFeePerSecond; // Percentage of 1 E.g., .1 is 10% Oracle fee.
+    FixedPoint.Unsigned public fixedOracleFeePerSecond; // Percentage of 1 E.g., .1 is 10% Oracle fee.
 
-    FixedPoint.Unsigned private weeklyDelayFee; // Percentage of 1 E.g., .1 is 10% weekly delay fee.
-    mapping(address => FixedPoint.Unsigned) private finalFees;
-    uint private constant SECONDS_PER_WEEK = 604800;
+    FixedPoint.Unsigned public weeklyDelayFee; // Percentage of 1 E.g., .1 is 10% weekly delay fee.
+    mapping(address => FixedPoint.Unsigned) public finalFees;
+    uint public constant SECONDS_PER_WEEK = 604800;
 
     event NewFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
 

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -99,28 +99,28 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
     }
 
     // Maps round numbers to the rounds.
-    mapping(uint => Round) private rounds;
+    mapping(uint => Round) public rounds;
 
     // Maps price request IDs to the PriceRequest struct.
-    mapping(bytes32 => PriceRequest) private priceRequests;
+    mapping(bytes32 => PriceRequest) public priceRequests;
 
     // Price request ids for price requests that haven't yet been marked as resolved. These requests may be for future
     // rounds.
-    bytes32[] private pendingPriceRequests;
+    bytes32[] public pendingPriceRequests;
 
-    VoteTiming.Data private voteTiming;
+    VoteTiming.Data public voteTiming;
 
     IdentifierWhitelistInterface public identifierWhitelist;
 
     // Percentage of the total token supply that must be used in a vote to create a valid price resolution.
     // 1 == 100%.
-    FixedPoint.Unsigned private gatPercentage;
+    FixedPoint.Unsigned public gatPercentage;
 
     // Global setting for the rate of inflation per vote. This is the percentage of the snapshotted total supply that
     // should be split among the correct voters. Note: this value is used to set per-round inflation at the beginning
     // of each round.
     // 1 = 100%
-    FixedPoint.Unsigned private inflationRate;
+    FixedPoint.Unsigned public inflationRate;
 
     // Reference to the voting token.
     VotingToken private votingToken;

--- a/core/contracts/Voting.sol
+++ b/core/contracts/Voting.sol
@@ -123,14 +123,14 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
     FixedPoint.Unsigned public inflationRate;
 
     // Reference to the voting token.
-    VotingToken private votingToken;
+    VotingToken public votingToken;
 
     // Reference to the Finder.
     Finder private finder;
 
     // If non-zero, this contract has been migrated to this address. All voters and financial contracts should query the
     // new address only.
-    address private migratedAddress;
+    address public migratedAddress;
 
     // Max value of an unsigned integer.
     uint private constant UINT_MAX = ~uint(0);


### PR DESCRIPTION
This PR makes a number of functions that were previously private public. This makes building front ends and components that connect to the contract easier.

One consideration was making `FixedPoint.Unsigned`'s public and how this would work in the case of contract readability. This was tested with truffle console to ensure that the public interfaces are useable and all contract state was able to be read directly from the console. 

close #829