### PR TITLE
Registry contract refactor

### DIFF
--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -6,6 +6,7 @@ import "./RegistryInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
+
 /**
  * @title Registry for derivatives and approved derivative creators.
  * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives
@@ -122,11 +123,9 @@ contract Registry is RegistryInterface, MultiRole {
         // Update the lookup index with the new location.
         partyMember.derivativeIndex[lastDerivativeAddress] = deleteIndex;
 
-        // Delete the last derivative from the array, remove
-        // the index from the lookup map and shrink array length.
-        delete partyMember.derivatives[numberOfDerivatives - 1];
+        // Pop the last derivative from the array and update the lookup map.
+        partyMember.derivatives.pop();
         delete partyMember.derivativeIndex[derivativeAddress];
-        partyMember.derivatives.length--;
 
         emit PartyMemberRemoved(derivativeAddress, party);
     }

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -9,7 +9,8 @@ pragma experimental ABIEncoderV2;
 
 /**
  * @title Registry for derivatives and approved derivative creators.
- * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives.
+ * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives
+ * and stores party memebers of a derivative.
  */
 contract Registry is RegistryInterface, MultiRole {
     using SafeMath for uint;
@@ -81,39 +82,39 @@ contract Registry is RegistryInterface, MultiRole {
 
     function addPartyToDerivative(address party) external {
         // Only a derivative calling can add a member to it's own party.
-        address deriviativeAddress = msg.sender;
+        address derivativeAddress = msg.sender;
 
         require(
-            addressToDerivatives[deriviativeAddress].valid == DerivativeValidity.Valid,
+            addressToDerivatives[derivativeAddress].valid == DerivativeValidity.Valid,
             "Can add to valid derivative"
         );
-        require(addressToDerivatives[deriviativeAddress].parties[party] == false, "Can only register a party once");
+        require(addressToDerivatives[derivativeAddress].parties[party] == false, "Can only register a party once");
 
-        addressToDerivatives[deriviativeAddress].parties[party] = true;
-        partyMembersToDerivatives[party].push(deriviativeAddress);
+        addressToDerivatives[derivativeAddress].parties[party] = true;
+        partyMembersToDerivatives[party].push(derivativeAddress);
     }
 
     function removedPartyFromDerivative(address party) external {
-        address deriviativeAddress = msg.sender;
+        address derivativeAddress = msg.sender;
 
         require(
-            addressToDerivatives[deriviativeAddress].valid == DerivativeValidity.Valid,
+            addressToDerivatives[derivativeAddress].valid == DerivativeValidity.Valid,
             "Remove only from valid derivative"
         );
-        require(addressToDerivatives[deriviativeAddress].parties[party] == true, "Remove existing party only");
+        require(addressToDerivatives[derivativeAddress].parties[party] == true, "Remove existing party only");
 
-        addressToDerivatives[deriviativeAddress].parties[party] = false;
+        addressToDerivatives[derivativeAddress].parties[party] = false;
 
         // Need to delete the derivative from the partymembers array. This is vulnerable to a party member not being able
         // to remove a derivative from their array, if they have too many in their array and exceed gas limit.
         // However, this dos attack will not affect any party member other than the one who created too many.
 
-        // Deleting works by looping through all derivatives the party memeber has in their array until the location is
+        // Deleting works by looping through all derivatives the party member has in their array until the location is
         // found. This removed position is swapped with the final position in the array and then the array length
         // is shrunk by 1. This process does not preserve array order and does not keep blank positions.
         address[] storage partyArray = partyMembersToDerivatives[party];
         for (uint i = 0; i < partyArray.length; i.add(1)) {
-            if (partyArray[i] == deriviativeAddress) {
+            if (partyArray[i] == derivativeAddress) {
                 partyArray[i] = partyArray[partyArray.length - 1];
                 delete partyArray[partyArray.length - 1];
                 partyArray.length--;

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -6,7 +6,6 @@ import "./RegistryInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
-
 /**
  * @title Registry for derivatives and approved derivative creators.
  * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -42,6 +42,8 @@ contract Registry is RegistryInterface, MultiRole {
     mapping(address => address[]) public partyMembersToDerivatives;
 
     event NewDerivativeRegistered(address indexed derivativeAddress, address indexed creator, address[] parties);
+    event PartyMemberAdded(address indexed derivativeAddress, address indexed party);
+    event PartyMemberRemoved(address indexed derivativeAddress, address indexed party);
 
     constructor() public {
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
@@ -90,6 +92,8 @@ contract Registry is RegistryInterface, MultiRole {
 
         addressToDerivatives[derivativeAddress].parties[party] = true;
         partyMembersToDerivatives[party].push(derivativeAddress);
+
+        emit PartyMemberAdded(derivativeAddress, party);
     }
 
     function removedPartyFromDerivative(address party) external {
@@ -119,6 +123,8 @@ contract Registry is RegistryInterface, MultiRole {
                 break;
             }
         }
+
+        emit PartyMemberRemoved(derivativeAddress, party);
     }
 
     function getAllRegisteredDerivatives() external view returns (address[] memory derivatives) {

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -7,10 +7,11 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 pragma experimental ABIEncoderV2;
 
+
 /**
  * @title Registry for derivatives and approved derivative creators.
  * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives
- * and stores party memebers of a derivative.
+ * and stores party members of a derivative.
  */
 contract Registry is RegistryInterface, MultiRole {
     using SafeMath for uint;
@@ -94,7 +95,7 @@ contract Registry is RegistryInterface, MultiRole {
 
         require(
             addressToDerivatives[derivativeAddress].valid == DerivativeValidity.Valid,
-            "Can add to valid derivative"
+            "Can only add to valid derivative"
         );
         require(!isPartyMemberOfDerivative(party, derivativeAddress), "Can only register a party once");
 
@@ -114,7 +115,7 @@ contract Registry is RegistryInterface, MultiRole {
             addressToDerivatives[derivativeAddress].valid == DerivativeValidity.Valid,
             "Remove only from valid derivative"
         );
-        require(isPartyMemberOfDerivative(party, derivativeAddress), "Can only register a party once");
+        require(isPartyMemberOfDerivative(party, derivativeAddress), "Can only remove an existing party member");
 
         // Index of the current location of the derivative to remove.
         uint deleteIndex = partyMember.derivativeIndex[derivativeAddress];

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -63,6 +63,8 @@ contract Registry is RegistryInterface, MultiRole {
         // No length check necessary because we should never hit (2^127 - 1) derivatives.
         derivative.index = uint128(registeredDerivatives.length.sub(1));
 
+        // For all parties in the array add them to the derivative party members and
+        // add the derivative as one of the party members own derivatives.
         derivative.valid = DerivativeValidity.Valid;
         for (uint i = 0; i < parties.length; i = i.add(1)) {
             derivative.parties[parties[i]] = true;
@@ -81,7 +83,6 @@ contract Registry is RegistryInterface, MultiRole {
     }
 
     function addPartyToDerivative(address party) external {
-        // Only a derivative calling can add a member to it's own party.
         address derivativeAddress = msg.sender;
 
         require(

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -33,9 +33,9 @@ contract Registry is RegistryInterface, MultiRole {
 
     struct PartyMember {
         // Each derivative address is stored in this array.
-        address[] derivatives; 
+        address[] derivatives;
         // The index of each derivative is mapped to it's address for constant time look up and deletion.
-        mapping(address => uint) derivativeIndex; 
+        mapping(address => uint) derivativeIndex;
     }
 
     // Array of all derivatives that are approved to use the UMA Oracle.
@@ -140,7 +140,7 @@ contract Registry is RegistryInterface, MultiRole {
 
             // Update the lookup index with the new location.
             partyMember.derivativeIndex[lastDerivativeAddress] = deleteIndex;
-        // If there is only one derivative we simply need to delete it and set the index to zero.
+            // If there is only one derivative we simply need to delete it and set the index to zero.
         } else {
             delete partyMember.derivatives[numberOfDerivatives - 1];
             partyMember.derivatives.length--;

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -116,7 +116,7 @@ contract Registry is RegistryInterface, MultiRole {
         // found. This removed position is swapped with the final position in the array and then the array length
         // is shrunk by 1. This process does not preserve array order and does not keep blank positions.
         address[] storage partyArray = partyMembersToDerivatives[party];
-        for (uint i = 0; i < partyArray.length; i.add(1)) {
+        for (uint i = 0; i < partyArray.length; i = i.add(1)) {
             if (partyArray[i] == derivativeAddress) {
                 partyArray[i] = partyArray[partyArray.length - 1];
                 delete partyArray[partyArray.length - 1];

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -7,7 +7,6 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 pragma experimental ABIEncoderV2;
 
-
 /**
  * @title Registry for derivatives and approved derivative creators.
  * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -67,9 +67,7 @@ contract Registry is RegistryInterface, MultiRole {
             partyMembersToDerivatives[parties[i]].push(derivativeAddress);
         }
 
-        address[] memory partiesForEvent = parties;
-        emit NewDerivativeRegistered(derivativeAddress, msg.sender, partiesForEvent);
-
+        emit NewDerivativeRegistered(derivativeAddress, msg.sender, parties);
     }
 
     function isDerivativeRegistered(address derivative) external view returns (bool) {

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -1,11 +1,10 @@
 pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
 
 import "./MultiRole.sol";
 import "./RegistryInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
-
-pragma experimental ABIEncoderV2;
 
 
 /**

--- a/core/contracts/RegistryInterface.sol
+++ b/core/contracts/RegistryInterface.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.0;
 
 pragma experimental ABIEncoderV2;
 
+
 /**
  * @title Interface for a registry of derivatives and derivative creators.
  */
@@ -9,7 +10,7 @@ interface RegistryInterface {
     /**
      * @dev Registers a new derivative. Only authorized derivative creators can call this method.
      */
-    function registerDerivative(address[] calldata counterparties, address derivativeAddress) external;
+    function registerDerivative(address[] calldata parties, address derivativeAddress) external;
 
     /**
      * @dev Returns whether the derivative has been registered with the registry (and is therefore an authorized.
@@ -26,4 +27,21 @@ interface RegistryInterface {
      * @dev Returns all registered derivatives.
      */
     function getAllRegisteredDerivatives() external view returns (address[] memory derivatives);
+
+    /**
+     * @dev Adds a party member to the calling derivative. msg.sender must be the derivative contract
+     * to which the party member is added.
+     */
+    function addPartyToDerivative(address party) external view;
+
+    /**
+     * @dev Removes a party member to the calling derivative. msg.sender must be the derivative contract
+     * to which the party member is removed.
+     */
+    function removePartyFromDerivative(address party) external view;
+
+    /**
+     * @dev Returns if a party member is part of a derivative.
+     */
+    function isPartyMemberOfDerivative(address party, address derivativeAddress) external view returns (bool);
 }

--- a/core/contracts/RegistryInterface.sol
+++ b/core/contracts/RegistryInterface.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.0;
 
 pragma experimental ABIEncoderV2;
 
-
 /**
  * @title Interface for a registry of derivatives and derivative creators.
  */
@@ -32,13 +31,13 @@ interface RegistryInterface {
      * @dev Adds a party member to the calling derivative. msg.sender must be the derivative contract
      * to which the party member is added.
      */
-    function addPartyToDerivative(address party) external view;
+    function addPartyToDerivative(address party) external;
 
     /**
      * @dev Removes a party member to the calling derivative. msg.sender must be the derivative contract
      * to which the party member is removed.
      */
-    function removePartyFromDerivative(address party) external view;
+    function removePartyFromDerivative(address party) external;
 
     /**
      * @dev Returns if a party member is part of a derivative.

--- a/core/test/Registry.js
+++ b/core/test/Registry.js
@@ -128,8 +128,8 @@ contract("Registry", function(accounts) {
     assert.equal(derivativeStruct.index.toNumber(), 0);
 
     // Check party is correctly added to derivative.
-    assert.isTrue(await registry.isPartyMemberOfDerivativeParty(party2, derivative1));
-    assert.isFalse(await registry.isPartyMemberOfDerivativeParty(rando1, derivative1));
+    assert.isTrue(await registry.isPartyMemberOfDerivative(party2, derivative1));
+    assert.isFalse(await registry.isPartyMemberOfDerivative(rando1, derivative1));
   });
 
   it("Double-register derivative", async function() {
@@ -161,8 +161,8 @@ contract("Registry", function(accounts) {
     });
 
     // Check the party member was added to state.
-    assert.isTrue(await registry.isPartyMemberOfDerivativeParty(creator2, derivativeContract1));
-    assert.isFalse(await registry.isPartyMemberOfDerivativeParty(rando1, derivativeContract1));
+    assert.isTrue(await registry.isPartyMemberOfDerivative(creator2, derivativeContract1));
+    assert.isFalse(await registry.isPartyMemberOfDerivative(rando1, derivativeContract1));
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 1);
     assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract1);
 
@@ -177,8 +177,8 @@ contract("Registry", function(accounts) {
     await registry.addPartyToDerivative(creator2, { from: derivativeContract2 });
 
     // Check that creator2 is part of two derivatives.
-    assert.isTrue(await registry.isPartyMemberOfDerivativeParty(creator2, derivativeContract2));
-    assert.isFalse(await registry.isPartyMemberOfDerivativeParty(rando1, derivativeContract2));
+    assert.isTrue(await registry.isPartyMemberOfDerivative(creator2, derivativeContract2));
+    assert.isFalse(await registry.isPartyMemberOfDerivative(rando1, derivativeContract2));
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 2);
     assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract1);
     assert.equal((await registry.getRegisteredDerivatives(creator2))[1], derivativeContract2);
@@ -196,7 +196,7 @@ contract("Registry", function(accounts) {
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 2);
 
     // Remove party member from the first derivative and check they are part of only the second derivative.
-    let result = await registry.removedPartyFromDerivative(creator2, { from: derivativeContract1 });
+    let result = await registry.removePartyFromDerivative(creator2, { from: derivativeContract1 });
 
     truffleAssert.eventEmitted(result, "PartyMemberRemoved", ev => {
       return (
@@ -206,21 +206,24 @@ contract("Registry", function(accounts) {
     });
 
     // Check party member has been removed from state.
-    assert.isFalse(await registry.isPartyMemberOfDerivativeParty(creator2, derivativeContract1));
-    assert.isTrue(await registry.isPartyMemberOfDerivativeParty(creator2, derivativeContract2));
+    assert.isFalse(await registry.isPartyMemberOfDerivative(creator2, derivativeContract1));
+    assert.isTrue(await registry.isPartyMemberOfDerivative(creator2, derivativeContract2));
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 1);
     assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract2);
 
     // Cant remove a party from derivative multiple times.
-    assert(await didContractThrow(registry.removedPartyFromDerivative(creator2, { from: derivativeContract1 })));
+    assert(await didContractThrow(registry.removePartyFromDerivative(creator2, { from: derivativeContract1 })));
 
     // Cant remove a member to an invalid derivative.
-    assert(await didContractThrow(registry.removedPartyFromDerivative(creator2, { from: rando1 })));
+    assert(await didContractThrow(registry.removePartyFromDerivative(creator2, { from: rando1 })));
 
     // Remove party remember from second derivative and check that they are part of none.
-    await registry.removedPartyFromDerivative(creator2, { from: derivativeContract2 });
+    await registry.removePartyFromDerivative(creator2, { from: derivativeContract2 });
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 0);
-    assert.isFalse(await registry.isPartyMemberOfDerivativeParty(creator2, derivativeContract1));
-    assert.isFalse(await registry.isPartyMemberOfDerivativeParty(creator2, derivativeContract2));
+    assert.isFalse(await registry.isPartyMemberOfDerivative(creator2, derivativeContract1));
+    assert.isFalse(await registry.isPartyMemberOfDerivative(creator2, derivativeContract2));
+
+    // Cant remove a derivative if there is none left for the party.
+    assert(await didContractThrow(registry.removePartyFromDerivative(creator2, { from: derivativeContract1 })));
   });
 });

--- a/core/test/Registry.js
+++ b/core/test/Registry.js
@@ -191,6 +191,9 @@ contract("Registry", function(accounts) {
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 1);
     assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract2);
 
+    // Cant remove a party from derivative multiple times.
+    assert(await didContractThrow(registry.removedPartyFromDerivative(creator2, { from: derivativeContract1 })));
+
     // Remove party remember from second derivative and check that they are part of none.
     await registry.removedPartyFromDerivative(creator2, { from: derivativeContract2 });
     assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 0);

--- a/core/test/Registry.js
+++ b/core/test/Registry.js
@@ -123,7 +123,7 @@ contract("Registry", function(accounts) {
     assert.isTrue(areAddressesEqual(allDerivatives[2], derivative3));
 
     // Check derivative information.
-    const derivativeStruct = await registry.addressToDerivatives(derivative1);
+    const derivativeStruct = await registry.derivativeMap(derivative1);
     assert.equal(derivativeStruct.valid.toNumber(), 1);
     assert.equal(derivativeStruct.index.toNumber(), 0);
 

--- a/core/test/Registry.js
+++ b/core/test/Registry.js
@@ -169,6 +169,9 @@ contract("Registry", function(accounts) {
     // Cant add a member to a party more than once.
     assert(await didContractThrow(registry.addPartyToDerivative(creator2, { from: derivativeContract1 })));
 
+    // Cant add a member to an invalid derivative.
+    assert(await didContractThrow(registry.addPartyToDerivative(creator2, { from: rando1 })));
+
     // Create a second derivative and add it to the same user. Check that they are party of two.
     await registry.registerDerivative([], derivativeContract2, { from: creator1 });
     await registry.addPartyToDerivative(creator2, { from: derivativeContract2 });
@@ -210,6 +213,9 @@ contract("Registry", function(accounts) {
 
     // Cant remove a party from derivative multiple times.
     assert(await didContractThrow(registry.removedPartyFromDerivative(creator2, { from: derivativeContract1 })));
+
+    // Cant remove a member to an invalid derivative.
+    assert(await didContractThrow(registry.removedPartyFromDerivative(creator2, { from: rando1 })));
 
     // Remove party remember from second derivative and check that they are part of none.
     await registry.removedPartyFromDerivative(creator2, { from: derivativeContract2 });


### PR DESCRIPTION
This PR changes how the registry stores data about party members. These changes prevent derivative contracts from being removed from the registry, improved queriability for parties and dynamic party allocation to derivatives. 

close #833 and close #780