### PR TITLE
Add claim rewards to voter dApp

### DIFF
--- a/common/Constants.js
+++ b/common/Constants.js
@@ -1,1 +1,4 @@
 export const MAX_UINT_VAL = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+// Max integer that can be safely stored in a vanilla js int.
+export const MAX_SAFE_JS_INT = 2147483647;

--- a/voter-dapp/src/Dashboard.js
+++ b/voter-dapp/src/Dashboard.js
@@ -6,6 +6,7 @@ import ResolvedRequests from "./ResolvedRequests.js";
 import DesignatedVotingDeployment from "./DesignatedVotingDeployment.js";
 import DesignatedVotingTransfer from "./DesignatedVotingTransfer.js";
 import DesignatedVoting from "./contracts/DesignatedVoting.json";
+import RetrieveRewards from "./RetrieveRewards.js";
 
 import { drizzleReactHooks } from "drizzle-react";
 
@@ -80,6 +81,7 @@ function Dashboard() {
         <Header votingAccount={votingAccount} />
       </AppBar>
       {designatedVotingHelpers}
+      <RetrieveRewards votingAccount={votingAccount} />
       <ActiveRequests votingGateway={votingGateway} votingAccount={votingAccount} />
       <ResolvedRequests votingAccount={votingAccount} />
     </div>

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -106,7 +106,6 @@ function RetrieveRewards({ votingAccount }) {
   const classes = useTableStyles();
 
   const currentRoundId = useCacheCall("Voting", "getCurrentRoundId");
-  const pendingRequests = useCacheCall("Voting", "getPendingRequests");
 
   // This variable tracks whether the user only wants to query a limited lookback or all history for unclaimed rewards.
   const [queryAllRounds, setQueryAllRounds] = useState(false);
@@ -163,7 +162,6 @@ function RetrieveRewards({ votingAccount }) {
     retrievedRewardsEvents,
     revealedVoteEvents,
     priceResolvedEvents,
-    pendingRequests,
     votingAccount
   );
 

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -143,7 +143,7 @@ function RetrieveRewards({ votingAccount }) {
     "PriceResolved",
     useMemo(() => {
       return { filter: { resolutionRoundId: roundIds }, fromBlock: 0 };
-    }, [roundIds, votingAccount])
+    }, [roundIds])
   );
 
   const revealedVoteEvents = useCacheEvents(

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -187,7 +187,7 @@ function RetrieveRewards({ votingAccount }) {
       </>
     );
   } else {
-    body = "No unclaimed rewards found.";
+    body = "No unclaimed rewards found, yet.";
   }
 
   return (

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -74,7 +74,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 
     // Extract identifiers and times from the round we picked.
     const toRetrieve = [];
-    const maxBatchRetrievals = 25;
+    const maxBatchRetrievals = 100;
     for (const [key, voteState] of Object.entries(state)) {
       if (
         !voteState.retrievedRewards &&

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -22,7 +22,6 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
   const { web3 } = drizzle;
 
   const { send, status } = useCacheSend("Voting", "retrieveRewards");
-  const priceRequests = useCacheCall("Voting", "getPendingRequests");
 
   if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceResolvedEvents == undefined) {
     // Requests haven't been completed.

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -4,10 +4,7 @@ import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 
 import { useTableStyles } from "./Styles.js";
-import { MAX_UINT_VAL } from "./common/Constants.js";
-
-// Max integer that can be safely stored in a vanilla js int.
-const MAX_SAFE_INT = 2147483647;
+import { MAX_UINT_VAL, MAX_SAFE_JS_INT } from "./common/Constants.js";
 
 function getOrCreateObj(containingObj, field) {
   if (!containingObj[field]) {
@@ -55,7 +52,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
     // Since this loop is the last one, we can use the state to determine if this identifer, time, roundId combo
     // is eligible for a reward claim. We track the oldestUnclaimedRound to determine which round the transaction
     // should query (since only one can be chosen).
-    let oldestUnclaimedRound = MAX_SAFE_INT;
+    let oldestUnclaimedRound = MAX_SAFE_JS_INT;
     for (const event of revealedVoteEvents) {
       const voteState = getVoteState(event.returnValues.identifier, event.returnValues.time);
       const revealRound = event.returnValues.roundId.toString();
@@ -67,7 +64,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
       }
     }
 
-    if (oldestUnclaimedRound === MAX_SAFE_INT) {
+    if (oldestUnclaimedRound === MAX_SAFE_JS_INT) {
       // No unclaimed rounds were found.
       return { ready: true, status };
     }

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -45,8 +45,8 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, pendi
     const getVoteState = (event) => {
       const identifier = web3.utils.hexToUtf8(event.returnValues.identifier);
       const time = event.returnValues.time.toString();
-      
-      return getOrCreateObj(roundState, `${identifier}|${time}`);
+
+      return getOrCreateObj(state, `${identifier}|${time}`);
     };
 
     for (const event of retrievedRewardsEvents) {

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -142,7 +142,7 @@ function RetrieveRewards({ votingAccount }) {
     "Voting",
     "PriceResolved",
     useMemo(() => {
-      return { filter: { voter: votingAccount, resolutionRoundId: roundIds }, fromBlock: 0 };
+      return { filter: { resolutionRoundId: roundIds }, fromBlock: 0 };
     }, [roundIds, votingAccount])
   );
 

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -181,7 +181,7 @@ function RetrieveRewards({ votingAccount }) {
       </Button>
     );
   } else {
-    body = "You have no unclaimed rewards to claim.";
+    body = "No unclaimed rewards found.";
   }
 
   return (

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -178,12 +178,10 @@ function RetrieveRewards({ votingAccount }) {
   } else if (!queryAllRounds) {
     body = (
       <>
-      <div>
-        No unclaimed rewards found in the last 10 rounds.
-      </div>
-      <Button onClick={() => setQueryAllRounds(true)} variant="contained" color="primary" disabled={hasPendingTxns}>
-        Search all past rounds for unclaimed rewards
-      </Button>
+        <div>No unclaimed rewards found in the last 10 rounds.</div>
+        <Button onClick={() => setQueryAllRounds(true)} variant="contained" color="primary" disabled={hasPendingTxns}>
+          Search all past rounds for unclaimed rewards
+        </Button>
       </>
     );
   } else {

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -6,6 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import { useTableStyles } from "./Styles.js";
 import { MAX_UINT_VAL } from "./common/Constants.js";
 
+// Max integer that can be safely stored in a vanilla js int.
 const MAX_SAFE_INT = 2147483647;
 
 function getOrCreateObj(containingObj, field) {

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -23,7 +23,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 
   const { send, status } = useCacheSend("Voting", "retrieveRewards");
 
-  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceResolvedEvents == undefined) {
+  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceResolvedEvents === undefined) {
     // Requests haven't been completed.
     return { ready: false };
   } else {
@@ -102,7 +102,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 }
 
 function RetrieveRewards({ votingAccount }) {
-  const { drizzle, useCacheCall, useCacheEvents } = drizzleReactHooks.useDrizzle();
+  const { useCacheCall, useCacheEvents } = drizzleReactHooks.useDrizzle();
   const classes = useTableStyles();
 
   const currentRoundId = useCacheCall("Voting", "getCurrentRoundId");


### PR DESCRIPTION
This adds a rudimentary rewards claiming section to the voter dapp.

The flow works as follows:
1. The dapp searches the last 10 rounds for rewards.
2. If there are any rewards to claim, the dapp will select a batch and display a "Claim Rewards" button to allow the user to send the transaction to claim those rewards.
3. If none are found, it displays a button to allow the user to do a query across all past rounds if they wish.
4. If they query all rounds and no rewards are found, the dapp displays text that no unclaimed rewards are found.

A few notes:
- The PriceResolved event is not emitted until the first individual claims rewards for that request. This means that for each price request someone must claim rewards on the command line before that option will be available in the dApp. We'll be adding better offchain visibility into the Voting contract to rectify this in the future.
- If a user queries beyond 10 rounds, the dapp is unable to tell when this query finishes because of a limitation in the drizzle API. This means that the user will see a message saying no rewards are found until the query finishes at which point, the message may stay the same or turn into a button letting the user claim their rewards. This is obviously undesirable, but I'm not sure of a way around it unless we use our promisified drizzle fork.

Below is a screenshot of the UI: 

![Screen Shot 2020-01-24 at 3 13 05 PM](https://user-images.githubusercontent.com/11791551/73100681-082a8700-3ebc-11ea-9a57-3b2838903080.png)



