### PR TITLE
Add network for updated ledger derivation path

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -58,10 +58,10 @@ function addPublicNetwork(networks, name, networkId) {
 
   // The default derivation path matches the "legacy" ledger account in Ledger Live.
   const legacyLedgerOptions = {
-    networkId: networkId,
+    networkId: networkId
   };
 
-  // Legacy ledger wallet network
+  // Legacy ledger wallet network.
   networks[name + "_ledger_legacy"] = {
     ...options,
     provider: new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -44,14 +44,27 @@ function addPublicNetwork(networks, name, networkId) {
     provider: new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2)
   };
 
+  // Ledger has changed their standard derivation path since this library was created, so we must override the default one.
   const ledgerOptions = {
-    networkId: networkId
-  }; // default options
+    networkId: networkId,
+    path: "44'/60'/0'/0/0"
+  };
 
-  // Ledger wallet network
+  // Normal ledger wallet network.
   networks[name + "_ledger"] = {
     ...options,
     provider: new LedgerWalletProvider(ledgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
+  };
+
+  // The default derivation path matches the "legacy" ledger account in Ledger Live.
+  const legacyLedgerOptions = {
+    networkId: networkId,
+  };
+
+  // Legacy ledger wallet network
+  networks[name + "_ledger_legacy"] = {
+    ...options,
+    provider: new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
   };
 }
 

--- a/documentation/explainers/keys-and-networks.md
+++ b/documentation/explainers/keys-and-networks.md
@@ -63,7 +63,8 @@ To set up a Ledger hardware wallet for use with our system:
 5. Go to the Ethereum app settings on the device and change the "Contract data" setting to yes if it isn't already.
 
 Now that you're set up, you should be able to run truffle commands with the network argument
-`--network [NETWORK_NAME]_ledger`.
+`--network [NETWORK_NAME]_ledger`. Note: this network uses the default Ledger Live derivation path: `m/44'/60'/x'/0/0`. 
+For the legacy derivation path (`m/44'/60'/0'/x`), use `[NETWORK_NAME]_legder_legacy`.
 
 For example, you could connect your ledger wallet to the truffle console and begin running commands against mainnet
 with the following command:


### PR DESCRIPTION
Ledger changed the standard derivation path they used in Ledger Live (their desktop app). This means that most people get funneled into the `"44'/60'/0'/0/0"` derivation path by default rather than the legacy one that our library assumes.

This PR changes the derivation path for the *_ledger networks to `"44'/60'/0'/0/0"`. The legacy (as ledger calls it) derivation path will be moved to *_ledger_legacy.