### PR TITLE
Eip747 implementation

### DIFF
--- a/sponsor-dapp-v2/src/components/Step3.js
+++ b/sponsor-dapp-v2/src/components/Step3.js
@@ -45,6 +45,7 @@ function useCreateContract(userSelectionsRef, identifierConfig, onNextStep, stat
       userSelectionsRef.current.contractAddress =
         TXObjects[TXObjects.length - 1].receipt.events.CreatedTokenizedDerivative.returnValues.contractAddress;
 
+      userSelectionsRef.current.symbol = state.tokenSymbol;
       // Transition to the next step since the txn is complete.
       onNextStep();
     }

--- a/sponsor-dapp-v2/src/components/Step6.js
+++ b/sponsor-dapp-v2/src/components/Step6.js
@@ -14,7 +14,7 @@ function Step6(props) {
   const { toWei, toBN } = web3.utils;
 
   // Grab variables to display.
-  const { identifier, contractAddress, tokensBorrowed } = props.userSelectionsRef.current;
+  const { identifier, contractAddress, tokensBorrowed, symbol } = props.userSelectionsRef.current;
   const etherscanUrl = useEtherscanUrl();
   const {
     [identifier]: { supportedMove }
@@ -24,6 +24,21 @@ function Step6(props) {
       .add(toBN(toWei("1")))
       .muln(100)
   );
+
+  // Add token to users metamask wallet.
+  window.web3.currentProvider.sendAsync({
+    method: "wallet_watchAsset",
+    params: {
+      type: "ERC20",
+      options: {
+        address: contractAddress,
+        symbol: symbol.substring(0, 6),
+        decimals: 18,
+        image: "https://umaproject.org/assets/images/UMA_square_red_logo.png"
+      }
+    },
+    id: Math.round(Math.random() * 100000)
+  });
 
   return (
     <>

--- a/sponsor-dapp-v2/src/components/Step6.js
+++ b/sponsor-dapp-v2/src/components/Step6.js
@@ -34,7 +34,7 @@ function Step6(props) {
         address: contractAddress,
         symbol: symbol.substring(0, 6),
         decimals: 18,
-        image: "https://umaproject.org/assets/images/UMA_square_red_logo.png"
+        image: "https://umaproject.org/assets/images/UMA_square_grey_logo.png"
       }
     },
     id: Math.round(Math.random() * 100000)

--- a/voter-dapp/src/Dashboard.js
+++ b/voter-dapp/src/Dashboard.js
@@ -7,7 +7,6 @@ import DesignatedVotingDeployment from "./DesignatedVotingDeployment.js";
 import DesignatedVotingTransfer from "./DesignatedVotingTransfer.js";
 import DesignatedVoting from "./contracts/DesignatedVoting.json";
 import RetrieveRewards from "./RetrieveRewards.js";
-
 import { drizzleReactHooks } from "@umaprotocol/react-plugin";
 
 function Dashboard() {

--- a/voter-dapp/src/DesignatedVotingTransfer.js
+++ b/voter-dapp/src/DesignatedVotingTransfer.js
@@ -40,6 +40,7 @@ function DesignatedVotingTransfer({ votingAccount }) {
       <div>
         You have {web3.utils.fromWei(currentAccountBalance)} tokens that will NOT be voted with. You'll need to first
         transfer them to your DesignatedVoting instance at address {votingAccount}.
+        <br />
         <b>Make sure you control the cold wallet key before transferring!</b>
       </div>
       <div>

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { drizzleReactHooks } from "drizzle-react";
+import { drizzleReactHooks } from "@umaprotocol/react-plugin";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 

--- a/voter-dapp/src/TokenTracker.js
+++ b/voter-dapp/src/TokenTracker.js
@@ -1,0 +1,35 @@
+import React from "react";
+import Button from "@material-ui/core/Button";
+import { drizzleReactHooks } from "@umaprotocol/react-plugin";
+import { useTableStyles } from "./Styles.js";
+
+function TokenTracker() {
+  const { drizzle } = drizzleReactHooks.useDrizzle();
+  const classes = useTableStyles();
+
+  const addTokenToWallet = () => {
+    window.web3.currentProvider.sendAsync({
+      method: "wallet_watchAsset",
+      params: {
+        type: "ERC20",
+        options: {
+          address: drizzle.contracts.VotingToken.address,
+          symbol: "UMA",
+          decimals: 18,
+          image: "https://umaproject.org/assets/images/UMA_square_red_logo.png"
+        }
+      },
+      id: Math.round(Math.random() * 100000)
+    });
+  };
+
+  return (
+    <div className={classes.root}>
+      <Button variant="contained" color="primary" onClick={() => addTokenToWallet()}>
+        Track UMA token in your wallet
+      </Button>
+    </div>
+  );
+}
+
+export default TokenTracker;


### PR DESCRIPTION
This PR implements [EIP747](https://ethereum-magicians.org/t/eip-747-wallet-watchasset/1048) which provides a simple mechanism to enable users to track tokens from their wallet. In the case of the voter dapp this will enable voters to track UMA tokens from their metamask wallet. For the sponsor dapp this will enable sponsors to add their newly minted tokens to their metamask wallet token tracker.

The screenshot below shows the metamask window.

![image](https://user-images.githubusercontent.com/12886084/73301008-fad50b80-41df-11ea-8a6a-ddf39abd5bd9.png)

Right now EIP747 does not provide any interface to detect if a token is already tracked. This makes the UX clunky for users that have already tracked a token. Ideally a "track token" button should only be shown if and only if user is not already tracking it. For this reason the track token button has been excluded from the voter dapp. When EIP747 provides a more responsive API for this interaction this will be updated. 

In the case of the sponsor dapp, at the completion of deployment and token creation the user is automatically prompted to track their new token.