### PR TITLE
Metamask truffle provider

### DIFF
--- a/common/MetaMaskTruffleProvider.js
+++ b/common/MetaMaskTruffleProvider.js
@@ -1,5 +1,4 @@
 const MetaMaskConnector = require("node-metamask");
-
 const argv = require("minimist")(process.argv.slice());
 
 class MetaMaskTruffleProvider {

--- a/common/MetaMaskTruffleProvider.js
+++ b/common/MetaMaskTruffleProvider.js
@@ -1,0 +1,75 @@
+const MetaMaskConnector = require("node-metamask");
+
+const argv = require("minimist")(process.argv.slice());
+
+class MetaMaskTruffleProvider {
+  constructor() {
+    this.wrappedProvider = null;
+    this.wrappedProviderPromise = this.getOrConstructWrappedProvider();
+  }
+
+  // Kicks off the construction of the wrapper provider. Call (and await on) this method before invoking any other
+  // methods.
+  async constructWrappedProvider() {
+    return this.wrappedProviderPromise;
+  }
+
+  // Passes the call through, by attaching a callback to the wrapper provider promise.
+  sendAsync(...all) {
+    this.wrappedProviderPromise.then(wrappedProvider => {
+      wrappedProvider.sendAsync(...all);
+    });
+  }
+
+  // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.
+  send(...all) {
+    this.wrappedProviderPromise.then(wrappedProvider => {
+      wrappedProvider.send(...all);
+    });
+  }
+
+  // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.
+  getAddress(idx) {
+    return getWrappedProviderOrThrow().getAddress(idx);
+  }
+
+  // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.
+  getAddress(...all) {
+    return getWrappedProviderOrThrow().getAddress(...all);
+  }
+
+  // Returns the underlying wrapped provider.
+  getWrappedProviderOrThrow() {
+    if (this.wrappedProvider) {
+      return this.wrappedProvider;
+    } else {
+      throw "Must init provider first, can't get value synchronously";
+    }
+  }
+
+  // Returns a Promise that resolves to the wrapped provider.
+  getOrConstructWrappedProvider() {
+    if (argv.network != "metamask") {
+      return;
+    }
+    console.log(
+      "Using MetaMask as your Truffle provider. To connect navigate your browser to http://localhost:3333 and sign into your account.\nAll transactions will be proceeded by your Metamask wallet. Ensure that you do not switch your network during usage of the CLI utility."
+    );
+
+    if (this.wrappedProvider) {
+      return Promise.resolve(this.wrappedProvider);
+    }
+    const connector = new MetaMaskConnector({
+      port: 3333,
+      onConnect() {
+        console.log("MetaMask client connected!");
+      }
+    });
+
+    return connector.start().then(() => {
+      return connector.getProvider();
+    });
+  }
+}
+
+module.exports = MetaMaskTruffleProvider;

--- a/common/MetaMaskTruffleProvider.js
+++ b/common/MetaMaskTruffleProvider.js
@@ -9,12 +9,6 @@ class MetaMaskTruffleProvider {
     this.wrappedProviderPromise = this.getOrConstructWrappedProvider();
   }
 
-  // Kicks off the construction of the wrapper provider. Call (and await on) this method before invoking any other
-  // methods.
-  async constructWrappedProvider() {
-    return this.wrappedProviderPromise;
-  }
-
   // Passes the call through, by attaching a callback to the wrapper provider promise.
   sendAsync(...all) {
     this.wrappedProviderPromise.then(wrappedProvider => {

--- a/common/MetaMaskTruffleProvider.js
+++ b/common/MetaMaskTruffleProvider.js
@@ -1,6 +1,8 @@
 const MetaMaskConnector = require("node-metamask");
 const argv = require("minimist")(process.argv.slice());
 
+// Wraps the MetaMask Connector enabling truffle to init a web3 provider and continue truffle execution until the
+// MetaMask connection has been established. This calls metaMask asynchronously while returning a provider synchronously.
 class MetaMaskTruffleProvider {
   constructor() {
     this.wrappedProvider = null;
@@ -48,11 +50,12 @@ class MetaMaskTruffleProvider {
 
   // Returns a Promise that resolves to the wrapped provider.
   getOrConstructWrappedProvider() {
+    // Only if the network is MetaMask should we init the wrapped provider.
     if (argv.network != "metamask") {
       return;
     }
     console.log(
-      "Using MetaMask as your Truffle provider. To connect navigate your browser to http://localhost:3333 and sign into your account.\nAll transactions will be proceeded by your Metamask wallet. Ensure that you do not switch your network during usage of the CLI utility."
+      "Using MetaMask as your Truffle provider. To connect navigate your browser to http://localhost:3333 and sign into your account.\nAll transactions will be proceeded by your MetaMask wallet. Ensure that you do not switch your network during usage of the CLI utility."
     );
 
     if (this.wrappedProvider) {

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -3,6 +3,7 @@ const GckmsConfig = require("./gckms/GckmsConfig.js");
 const ManagedSecretProvider = require("./gckms/ManagedSecretProvider.js");
 const publicNetworks = require("./PublicNetworks.js");
 const LedgerWalletProvider = require("@umaprotocol/truffle-ledger-provider");
+const MetaMaskTruffleProvider = require("./MetaMaskTruffleProvider.js");
 require("dotenv").config();
 
 // Fallback to a public mnemonic to prevent exceptions
@@ -110,6 +111,9 @@ addLocalNetwork(networks, "test");
 
 // Coverage requires specific parameters to allow very high cost transactions.
 addLocalNetwork(networks, "coverage", { port: 8545, network_id: 1234 });
+
+// MetaMask truffle provider
+addLocalNetwork(networks, "metamask", { provider: new MetaMaskTruffleProvider() });
 
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 pragma experimental ABIEncoderV2;
 
+
 /**
  * @title Registry for derivatives and approved derivative creators.
  * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives.

--- a/core/contracts/Registry.sol
+++ b/core/contracts/Registry.sol
@@ -7,7 +7,6 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 pragma experimental ABIEncoderV2;
 
-
 /**
  * @title Registry for derivatives and approved derivative creators.
  * @dev Maintains a whitelist of derivative creators that are allowed to register new derivatives.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "minimist": "^1.2.0",
     "moment": "^2.24.0",
     "node-fetch": "^2.3.0",
+    "node-metamask": "^1.1.2",
     "secp256k1": "^3.7.1",
     "truffle": "5.1.4",
     "truffle-assertions": "^0.9.2",


### PR DESCRIPTION
This PR enables metamask to be used as a truffle provider 🕺. This can be done by specifying the the metamask as a network parameter when calling truffle. For example, to open a console session with Metamask as the provider run:

```
truffle console --network metamask
```

This will use the network that metamask is connected to at the time of connection.