### PR TITLE
Decode admin proposals in voter dapp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
       - run:
           name: Build Voter dApp
           working_directory: ~/protocol/voter-dapp
-          command: npm run build
+          command: CI=false npm run build
       - store_artifacts:
           path: ~/protocol/voter-dapp/build
           destination: voter-dapp-build

--- a/common/AdminUtils.js
+++ b/common/AdminUtils.js
@@ -1,0 +1,31 @@
+const abiDecoder = require("./AbiUtils.js").getAbiDecoder();
+
+function decodeTransaction(transaction) {
+    let returnValue = "";
+
+    // Give to and value.
+    returnValue += "To: " + transaction.to;
+    returnValue += "\nValue (in Wei): " + transaction.value;
+
+    if (!transaction.data || transaction.data.length === 0 || transaction.data === "0x") {
+      // No data -> simple ETH send.
+    returnValue += "\nTransaction is a simple ETH send (no data)."
+    } else {
+      // Txn data isn't empty -- attempt to decode.
+      const decodedTxn = abiDecoder.decodeMethod(transaction.data);
+      if (!decodedTxn) {
+        // Cannot decode txn, just give the user the raw data.
+        returnValue += "\nCannot decode transaction (does not match any UMA Protocol Signature.";
+        returnValue += "\nRaw transaction data: " + transaction.data;
+      } else {
+        // Decode was successful -- pretty print the results.
+        returnValue += "\nTransaction details:\n";
+        returnValue += JSON.stringify(decodedTxn, null, 4);
+      }
+    }
+    return returnValue;
+}
+
+module.exports = {
+    decodeTransaction,
+};

--- a/common/AdminUtils.js
+++ b/common/AdminUtils.js
@@ -15,7 +15,7 @@ function decodeTransaction(transaction) {
     const decodedTxn = abiDecoder.decodeMethod(transaction.data);
     if (!decodedTxn) {
       // Cannot decode txn, just give the user the raw data.
-      returnValue += "\nCannot decode transaction (does not match any UMA Protocol Signature.";
+      returnValue += "\nCannot decode transaction (does not match any UMA Protocol Signature).";
       returnValue += "\nRaw transaction data: " + transaction.data;
     } else {
       // Decode was successful -- pretty print the results.

--- a/common/AdminUtils.js
+++ b/common/AdminUtils.js
@@ -1,31 +1,31 @@
 const abiDecoder = require("./AbiUtils.js").getAbiDecoder();
 
 function decodeTransaction(transaction) {
-    let returnValue = "";
+  let returnValue = "";
 
-    // Give to and value.
-    returnValue += "To: " + transaction.to;
-    returnValue += "\nValue (in Wei): " + transaction.value;
+  // Give to and value.
+  returnValue += "To: " + transaction.to;
+  returnValue += "\nValue (in Wei): " + transaction.value;
 
-    if (!transaction.data || transaction.data.length === 0 || transaction.data === "0x") {
-      // No data -> simple ETH send.
-    returnValue += "\nTransaction is a simple ETH send (no data)."
+  if (!transaction.data || transaction.data.length === 0 || transaction.data === "0x") {
+    // No data -> simple ETH send.
+    returnValue += "\nTransaction is a simple ETH send (no data).";
+  } else {
+    // Txn data isn't empty -- attempt to decode.
+    const decodedTxn = abiDecoder.decodeMethod(transaction.data);
+    if (!decodedTxn) {
+      // Cannot decode txn, just give the user the raw data.
+      returnValue += "\nCannot decode transaction (does not match any UMA Protocol Signature.";
+      returnValue += "\nRaw transaction data: " + transaction.data;
     } else {
-      // Txn data isn't empty -- attempt to decode.
-      const decodedTxn = abiDecoder.decodeMethod(transaction.data);
-      if (!decodedTxn) {
-        // Cannot decode txn, just give the user the raw data.
-        returnValue += "\nCannot decode transaction (does not match any UMA Protocol Signature.";
-        returnValue += "\nRaw transaction data: " + transaction.data;
-      } else {
-        // Decode was successful -- pretty print the results.
-        returnValue += "\nTransaction details:\n";
-        returnValue += JSON.stringify(decodedTxn, null, 4);
-      }
+      // Decode was successful -- pretty print the results.
+      returnValue += "\nTransaction details:\n";
+      returnValue += JSON.stringify(decodedTxn, null, 4);
     }
-    return returnValue;
+  }
+  return returnValue;
 }
 
 module.exports = {
-    decodeTransaction,
+  decodeTransaction
 };

--- a/common/AdminUtils.js
+++ b/common/AdminUtils.js
@@ -26,6 +26,19 @@ function decodeTransaction(transaction) {
   return returnValue;
 }
 
+const adminPrefix = "Admin ";
+
+function isAdminRequest(identifierUtf8) {
+  return identifierUtf8.startsWith(adminPrefix);
+}
+
+// Assumes that `identifierUtf8` is an admin request, i.e., `isAdminRequest()` returns true for it.
+function getAdminRequestId(identifierUtf8) {
+  return parseInt(identifierUtf8.slice(adminPrefix.length), 10);
+}
+
 module.exports = {
-  decodeTransaction
+  decodeTransaction,
+  isAdminRequest,
+  getAdminRequestId
 };

--- a/core/scripts/cli/admin.js
+++ b/core/scripts/cli/admin.js
@@ -1,6 +1,7 @@
 const inquirer = require("inquirer");
 const abiDecoder = require("../../../common/AbiUtils.js").getAbiDecoder();
 const style = require("./textStyle");
+const {decodeTransaction} = require("../../../common/AdminUtils.js");
 
 async function decodeGovernorProposal(artifacts, id) {
   const Governor = artifacts.require("Governor");
@@ -15,27 +16,9 @@ async function decodeGovernorProposal(artifacts, id) {
     console.log("Transaction", i);
 
     const transaction = proposal.transactions[i];
+      const strForm = decodeTransaction(transaction);
+      console.log(strForm);
 
-    // Give to and value.
-    console.log("To: ", transaction.to);
-    console.log("Value (in Wei): ", transaction.value);
-
-    if (!transaction.data || transaction.data.length === 0 || transaction.data === "0x") {
-      // No data -> simple ETH send.
-      console.log("Transaction is a simple ETH send (no data).");
-    } else {
-      // Txn data isn't empty -- attempt to decode.
-      const decodedTxn = abiDecoder.decodeMethod(transaction.data);
-      if (!decodedTxn) {
-        // Cannot decode txn, just give the user the raw data.
-        console.log("Cannot decode transaction (does not match any UMA Protocol Signature.");
-        console.log("Raw transaction data:", transaction.data);
-      } else {
-        // Decode was successful -- pretty print the results.
-        console.log("Transaction details:");
-        console.log(JSON.stringify(decodedTxn, null, 4));
-      }
-    }
     console.groupEnd();
   }
   console.groupEnd();

--- a/core/scripts/cli/admin.js
+++ b/core/scripts/cli/admin.js
@@ -1,7 +1,7 @@
 const inquirer = require("inquirer");
 const abiDecoder = require("../../../common/AbiUtils.js").getAbiDecoder();
 const style = require("./textStyle");
-const {decodeTransaction} = require("../../../common/AdminUtils.js");
+const { decodeTransaction } = require("../../../common/AdminUtils.js");
 
 async function decodeGovernorProposal(artifacts, id) {
   const Governor = artifacts.require("Governor");
@@ -16,8 +16,8 @@ async function decodeGovernorProposal(artifacts, id) {
     console.log("Transaction", i);
 
     const transaction = proposal.transactions[i];
-      const strForm = decodeTransaction(transaction);
-      console.log(strForm);
+    const strForm = decodeTransaction(transaction);
+    console.log(strForm);
 
     console.groupEnd();
   }

--- a/core/scripts/cli/admin.js
+++ b/core/scripts/cli/admin.js
@@ -10,7 +10,9 @@ async function decodeGovernorProposal(artifacts, id) {
 
   console.group();
   console.log("Retrieved Admin Proposal for ID:", id);
-  console.log("Proposal has", proposal.transactions.length, " transaction(s)");
+  console.log(
+    `Proposal has ${proposal.transactions.length} transaction${proposal.transactions.length === 1 ? "" : "s"}`
+  );
   for (let i = 0; i < proposal.transactions.length; i++) {
     console.group();
     console.log("Transaction", i);

--- a/core/scripts/cli/admin.js
+++ b/core/scripts/cli/admin.js
@@ -1,7 +1,7 @@
 const inquirer = require("inquirer");
 const abiDecoder = require("../../../common/AbiUtils.js").getAbiDecoder();
 const style = require("./textStyle");
-const { decodeTransaction } = require("../../../common/AdminUtils.js");
+const { isAdminRequest, getAdminRequestId, decodeTransaction } = require("../../../common/AdminUtils.js");
 
 async function decodeGovernorProposal(artifacts, id) {
   const Governor = artifacts.require("Governor");
@@ -10,7 +10,7 @@ async function decodeGovernorProposal(artifacts, id) {
 
   console.group();
   console.log("Retrieved Admin Proposal for ID:", id);
-  console.log("Proposal has", proposal.transactions.length, " transactions");
+  console.log("Proposal has", proposal.transactions.length, " transaction(s)");
   for (let i = 0; i < proposal.transactions.length; i++) {
     console.group();
     console.log("Transaction", i);
@@ -31,13 +31,10 @@ async function decodeAllActiveGovernorProposals(artifacts, web3) {
   // Search through pending requests to find active governor proposals.
   const pendingRequests = await voting.getPendingRequests();
   const adminRequests = [];
-  const adminPrefix = "Admin ";
   for (const pendingRequest of pendingRequests) {
     const identifier = web3.utils.hexToUtf8(pendingRequest.identifier);
-    if (identifier.startsWith(adminPrefix)) {
-      // This is an admin proposal.
-      const id = parseInt(identifier.slice(adminPrefix.length));
-      adminRequests.push(id);
+    if (isAdminRequest(identifier)) {
+      adminRequests.push(getAdminRequestId(identifier));
     }
   }
 

--- a/core/scripts/cli/cli_entry.sh
+++ b/core/scripts/cli/cli_entry.sh
@@ -8,7 +8,7 @@ set -e
 # $(npm bin)/uma --network mainnet_ledger
 
 # Platform independent way of evaluating symlinks to find the real location of the script.
-SCRIPT_FILE=$(/usr/bin/env python2 -c "import os; print(os.path.realpath(\"$0\"))")
+SCRIPT_FILE=$(/usr/bin/env python -c "import os; print(os.path.realpath(\"$0\"))")
 SCRIPT_DIR=$(dirname $SCRIPT_FILE)
 
 # cd into the directory containing the cli file.

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useState, useReducer } from "react";
 import Button from "@material-ui/core/Button";
 import Checkbox from "@material-ui/core/Checkbox";
+import Dialog from "@material-ui/core/Dialog";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
 import { drizzleReactHooks } from "@umaprotocol/react-plugin";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -17,6 +20,7 @@ import { useTableStyles } from "./Styles.js";
 import { getKeyGenMessage } from "./common/EncryptionHelper.js";
 import { getRandomUnsignedInt } from "./common/Random.js";
 import { BATCH_MAX_COMMITS, BATCH_MAX_REVEALS } from "./common/Constants.js";
+import { decodeTransaction } from "./common/AdminUtils.js";
 
 const editStateReducer = (state, action) => {
   switch (action.type) {
@@ -38,7 +42,13 @@ const editStateReducer = (state, action) => {
 function ActiveRequests({ votingAccount, votingGateway }) {
   const { drizzle, useCacheCall, useCacheEvents, useCacheSend } = drizzleReactHooks.useDrizzle();
   const { web3 } = drizzle;
+  const { hexToUtf8 } = web3.utils;
   const classes = useTableStyles();
+
+  const isAdminRequest = identifier => {
+    const adminPrefix = "Admin ";
+    return drizzle.web3.utils.hexToUtf8(identifier).startsWith(adminPrefix);
+  };
 
   const [checkboxesChecked, setCheckboxesChecked] = useState({});
   const check = (index, event) => {
@@ -48,11 +58,16 @@ function ActiveRequests({ votingAccount, votingGateway }) {
   const pendingRequests = useCacheCall("Voting", "getPendingRequests");
   const currentRoundId = useCacheCall("Voting", "getCurrentRoundId");
   const votePhase = useCacheCall("Voting", "getVotePhase");
+
+  const [dialogOpen, setDialogOpen] = useState(-1);
+
+  // Deal with Hook crap here.
+  const proposal = useCacheCall("Governor", "getProposal", 0);
   const { account } = drizzleReactHooks.useDrizzleState(drizzleState => ({
     account: drizzleState.accounts[0]
   }));
 
-  const initialFetchComplete = pendingRequests && currentRoundId && votePhase && account;
+  const initialFetchComplete = pendingRequests && currentRoundId && votePhase && account && proposal;
 
   const revealEvents = useCacheEvents(
     "Voting",
@@ -62,6 +77,18 @@ function ActiveRequests({ votingAccount, votingGateway }) {
       currentRoundId
     ])
   );
+
+  const proposals = useCacheCall(["Governor"], call => {
+    if (!initialFetchComplete) {
+      return null;
+    }
+    const adminPrefix = "Admin ";
+    return pendingRequests.map(request => ({
+      proposal: isAdminRequest(request.identifier)
+        ? call("Governor", "getProposal", parseInt(hexToUtf8(request.identifier).slice(adminPrefix.length)))
+        : null
+    }));
+  });
 
   const voteStatuses = useCacheCall(["Voting"], call => {
     if (!initialFetchComplete) {
@@ -80,13 +107,29 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     voteStatuses &&
     // Each of the subfetches has to complete. In drizzle, `undefined` means incomplete, while `null` means complete
     // but the fetched value was null, e.g., no `comittedValue` existed.
-    voteStatuses.every(voteStatus => voteStatus.committedValue !== undefined);
+    voteStatuses.every(voteStatus => voteStatus.committedValue !== undefined) &&
+    proposals &&
+    proposals.every(prop => prop.proposal !== undefined);
   // Future hook calls that depend on `voteStatuses` should use `voteStatusesStringified` in their dependencies array
   // because `voteStatuses` will never compare equal after a re-render, even if no values in it actually changed.
   // Also note that `JSON.stringify` doesn't distinguish `undefined` and `null`, but in Drizzle, those mean different
   // things and should retrigger dependent hooks. The replace function (the second argument) stringifies `undefined` to
   // the string `"undefined"`, so that it can be distinguished from the string `"null"`.
   const voteStatusesStringified = JSON.stringify(voteStatuses, (k, v) => (v === undefined ? "undefined" : v));
+
+  const mdecodeTransaction = index => {
+    if (index === -1) {
+      return "";
+    }
+    const proposal = proposals[index].proposal;
+    let output =
+      hexToUtf8(pendingRequests[index].identifier) + " (" + proposal.transactions.length + " transaction(s))";
+    for (let i = 0; i < proposal.transactions.length; i++) {
+      const transaction = proposal.transactions[i];
+      output += "\n\nTransaction #" + i + ":\n" + decodeTransaction(transaction);
+    }
+    return output;
+  };
 
   // The decryption key is a function of the account and `currentRoundId`, so we need the user to re-sign a message
   // any time one of those changes. We also don't want to show multiple, identical notifications when this effect gets
@@ -304,11 +347,24 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     }
   };
 
+  const handleClickExplain = index => {
+    setDialogOpen(index);
+  };
+
+  const handleClickClose = () => {
+    setDialogOpen(-1);
+  };
+
   return (
     <div className={classes.root}>
       <Typography variant="h6" component="h6">
         Active Requests
       </Typography>
+      <Dialog open={dialogOpen !== -1} onClose={handleClickClose}>
+        <DialogContent>
+          <DialogContentText style={{ whiteSpace: "pre-wrap" }}>{mdecodeTransaction(dialogOpen)}</DialogContentText>
+        </DialogContent>
+      </Dialog>
       <Table style={{ marginBottom: "10px" }}>
         <TableHead>
           <TableRow>
@@ -325,7 +381,18 @@ function ActiveRequests({ votingAccount, votingGateway }) {
           {pendingRequests.map((pendingRequest, index) => {
             return (
               <TableRow key={index}>
-                <TableCell>{drizzle.web3.utils.hexToUtf8(pendingRequest.identifier)}</TableCell>
+                <TableCell>
+                  <span>
+                    {drizzle.web3.utils.hexToUtf8(pendingRequest.identifier)}{" "}
+                    {isAdminRequest(pendingRequest.identifier) && (
+                      <>
+                        <Button variant="contained" color="primary" onClick={() => handleClickExplain(index)}>
+                          Explain
+                        </Button>
+                      </>
+                    )}
+                  </span>
+                </TableCell>
                 <TableCell>
                   <Checkbox
                     disabled={!statusDetails[index].enabled}

--- a/voter-dapp/src/drizzleOptions.js
+++ b/voter-dapp/src/drizzleOptions.js
@@ -1,9 +1,10 @@
 import DesignatedVotingFactory from "./contracts/DesignatedVotingFactory.json";
+import Governor from "./contracts/Governor.json";
 import Voting from "./contracts/Voting.json";
 import VotingToken from "./contracts/VotingToken.json";
 
 const options = {
-  contracts: [DesignatedVotingFactory, Voting, VotingToken],
+  contracts: [DesignatedVotingFactory, Governor, Voting, VotingToken],
   polls: {
     accounts: 1000,
     blocks: 3000


### PR DESCRIPTION
Adds a button next to an admin proposal that shows up a dialog explaining the proposal. The explanation text is what the CLI shows: we could try to improve both over time. E.g., interpret the most common admin proposals and show special handling for "setInflationRate".

I tried a few different options, such as a separate table and a tooltip, but this option seemed like the best for now.
Table:
![image](https://user-images.githubusercontent.com/5361377/73959645-9ef13d80-48d7-11ea-990d-d5b526cc6755.png)

Popup:
![image](https://user-images.githubusercontent.com/5361377/73959681-af091d00-48d7-11ea-8ca0-d31e1841679a.png)

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>