### PR TITLE
Minor Liquidatable refactor

### DIFF
--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -385,6 +385,14 @@ contract Liquidatable is PricelessPositionManager {
         view
         returns (LiquidationData storage liquidation)
     {
-        liquidation = liquidations[sponsor][uuid];
+        LiquidationData[] storage liquidationArray = liquidations[sponsor];
+
+        // Revert if the caller is attempting to access an invalid liquidation (one that has never been created or one
+        // that was deleted after resolution).
+        require(
+            uuid < liquidationArray.length && liquidationArray[uuid].liquidator != address(0),
+            "Invalid liquidation: liquidator address is not set"
+        );
+        return liquidationArray[uuid];
     }
 }

--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -174,6 +174,7 @@ contract Liquidatable is PricelessPositionManager {
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
 
         // Construct liquidation object.
+        // Note: all dispute-related values are just zeroed out until a dispute occurs.
         uint newLength = liquidations[sponsor].push(
             LiquidationData({
                 expiry: getCurrentTime() + liquidationLiveness,
@@ -182,8 +183,7 @@ contract Liquidatable is PricelessPositionManager {
                 lockedCollateral: positionToLiquidate.collateral,
                 tokensOutstanding: positionToLiquidate.tokensOutstanding,
                 liquidatedCollateral: positionToLiquidate.collateral.sub(positionToLiquidate.withdrawalRequestAmount),
-                disputer: // Note: the following values are just zeroed out until a dispute occurs.
-                address(0),
+                disputer: address(0),
                 disputeTime: 0,
                 settlementPrice: FixedPoint.fromUnscaledUint(0)
             })

--- a/core/test/financial_templates/Liquidatable.js
+++ b/core/test/financial_templates/Liquidatable.js
@@ -212,16 +212,9 @@ contract("Liquidatable", function(accounts) {
         assert.equal(newLiquidation.settlementPrice.toString(), "0");
       });
       it("Liquidation does not exist", async () => {
-        const uncreatedLiquidation = await liquidationContract.liquidations(sponsor, liquidationParams.falseUuid);
-        assert.equal(uncreatedLiquidation.state.toString(), STATES.PRE_DISPUTE);
-        assert.equal(uncreatedLiquidation.liquidator, zeroAddress);
-        assert.equal(uncreatedLiquidation.tokensOutstanding.toString(), "0");
-        assert.equal(uncreatedLiquidation.lockedCollateral.toString(), "0");
-        assert.equal(uncreatedLiquidation.liquidatedCollateral.toString(), "0");
-        assert.equal(uncreatedLiquidation.expiry.toString(), "0");
-        assert.equal(uncreatedLiquidation.disputer, zeroAddress);
-        assert.equal(uncreatedLiquidation.disputeTime.toString(), "0");
-        assert.equal(uncreatedLiquidation.settlementPrice.toString(), "0");
+        const uncreatedLiquidation = assert(
+          await didContractThrow(liquidationContract.liquidations(sponsor, liquidationParams.falseUuid))
+        );
       });
     });
 


### PR DESCRIPTION
This PR slightly refactors Liquidatable so that we track both the last used index and the liquidations in an array rather than using separate data structures.

All the methods continue to work similarly as they did before, except that when the array is accessed out of bounds, solidity automatically throws rather than giving an uninitialized struct.

This also includes a slight rewriting of some of the modifiers, so we don't repeatedly call the same method.