### PR TITLE
Fix bug in voter dapp deployment due to build warning

### DIFF
--- a/scripts/deploy_dapp.sh
+++ b/scripts/deploy_dapp.sh
@@ -56,7 +56,8 @@ set -e
 # Link the contracts dir to the dapp dir and build the dapp.
 cd $DAPP_DIR
 echo "Building dapp."
-npm run build
+# Due a webpack build warning from AbiUtils.js, we have to set `CI=false` to allow the build to not error out.
+CI=false npm run build
 
 # Make sure to cleanup the temp directory for any exits after this line.
 function cleanup() {


### PR DESCRIPTION
The one weird thing is that this change also applies to the sponsor
dapp, where it isn't necessary.
Options here are to:
1. Set CI=false on the entire `deploy_dapp.sh` invocation for voter dapp
only
2. Parameterize `deploy_dapp.sh`
3. Do nothing. What's good for the goose is good for the gander.

PR #880 imports AbiUtils from the voter dapp, which results in a build
warning that has to be ignored. AFAIK the only way to ignore webpack
build warnings from React is to turn off CI mode.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>