### PR TITLE
Update `liquidatable` `disputeTime` to use `LiquidationTime`

### DIFF
--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -65,8 +65,6 @@ contract Liquidatable is PricelessPositionManager {
         address disputer;
         // Time when liquidation is initiated, needed to get price from Oracle
         uint liquidationTime;
-        // Time when the dispute is initialized
-        uint disputeTime;
         // Final price as determined by an Oracle following a dispute
         FixedPoint.Unsigned settlementPrice;
     }
@@ -203,7 +201,6 @@ contract Liquidatable is PricelessPositionManager {
                 liquidatedCollateral: positionToLiquidate.collateral.sub(positionToLiquidate.withdrawalRequestAmount),
                 disputer: address(0),
                 liquidationTime: getCurrentTime(),
-                disputeTime: 0,
                 settlementPrice: FixedPoint.fromUnscaledUint(0)
             })
         );
@@ -240,7 +237,6 @@ contract Liquidatable is PricelessPositionManager {
         // Liquidation is pending dispute until DVM returns a price
         disputedLiquidation.state = Status.PendingDispute;
         disputedLiquidation.disputer = msg.sender;
-        disputedLiquidation.disputeTime = getCurrentTime();
 
         // Enqueue a request with the DVM.
         _requestOraclePrice(disputedLiquidation.liquidationTime);

--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -186,7 +186,10 @@ contract Liquidatable is PricelessPositionManager {
     function createLiquidation(address sponsor) public returns (uint uuid) {
         // Attempt to retrieve Position data for sponsor
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
-        require(positionToLiquidate.collateral.rawValue > 0, "Cant liquidate a position with no collateral");
+        require(
+            FixedPoint.isGreaterThan(positionToLiquidate.collateral, 0),
+            "Cant liquidate a position with no collateral"
+        );
 
         // Construct liquidation object.
         // Note: all dispute-related values are just zeroed out until a dispute occurs.

--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -245,6 +245,8 @@ contract Liquidatable is PricelessPositionManager {
 
         // Enqueue a request with the DVM.
         _requestOraclePrice(disputedLiquidation.liquidationTime);
+
+        emit LiquidationDisputed(sponsor, disputedLiquidation.liquidator, msg.sender, id, disputeBondAmount.rawValue);
     }
 
     /**

--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -36,16 +36,9 @@ contract Liquidatable is PricelessPositionManager {
         FixedPoint.Unsigned lockedCollateral; // Collateral locked by contract and released upon expiry or post-dispute
         FixedPoint.Unsigned liquidatedCollateral; // Amount of collateral being liquidated, which could be different from
         // lockedCollateral if there were pending withdrawals at the time of liquidation
-        FixedPoint.Unsigned liquidatedCollateral;
-        // * Following variables set upon a dispute request *
-        address disputer;  // Person who is disputing a liquidation
-        uint liquidationTime; // Time when liquidation is initiated, needed to get price from Oracle
-        FixedPoint.Unsigned settlementPrice;  // Final price as determined by an Oracle following a dispute
-    }
-
         // * Following variables set upon a dispute request *
         address disputer; // Person who is disputing a liquidation
-        uint disputeTime; // Time when dispute is initiated, needed to get price from Oracle
+        uint liquidationTime; // Time when liquidation is initiated, needed to get price from Oracle
         FixedPoint.Unsigned settlementPrice; // Final price as determined by an Oracle following a dispute
     }
 

--- a/core/test/financial_templates/Liquidatable.js
+++ b/core/test/financial_templates/Liquidatable.js
@@ -216,6 +216,7 @@ contract("Liquidatable", function(accounts) {
       // Transfer synthetic tokens to a liquidator
       await syntheticToken.transfer(liquidator, amountOfSynthetic, { from: sponsor });
       // Create a Liquidation
+      liquidationTime = await liquidationContract.getCurrentTime();
       await liquidationContract.createLiquidation(sponsor, { from: liquidator });
     });
 
@@ -245,6 +246,7 @@ contract("Liquidatable", function(accounts) {
         assert.equal(newLiquidation.liquidator, liquidator);
         assert.equal(newLiquidation.disputer, zeroAddress);
         assert.equal(newLiquidation.disputeTime.toString(), "0");
+        assert.equal(newLiquidation.liquidationTime.toString(), liquidationTime.toString());
         assert.equal(newLiquidation.settlementPrice.toString(), "0");
       });
       it("Liquidation does not exist", async () => {


### PR DESCRIPTION
This issue will close #895 which included a bug where `liquidatable` was using the `disputeTime` opposed to the `LiquidationTime` when creating and disputing liquidations.