### PR TITLE
Modify bytecode script to use external compilation

### DIFF
--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -1,7 +1,7 @@
 // This simple script tells you how big your contract byte code is and how much you have until you exceed
 // the current block limit as defined by EIP170. This script should be run from the /core directory.
 // To run the script navigate to /core and then run:
-// truffle exec ./scripts/local/CalculateContractBytecode.js --contract Voting --network test
+// truffle exec -c ./scripts/local/CalculateContractBytecode.js --contract Voting --network test
 // where voting is the name of the contract you want to check.
 
 const argv = require("minimist")(process.argv.slice(), { string: ["contract"] });
@@ -12,17 +12,6 @@ module.exports = async function(callback) {
     console.log("Please enter the contract name as a parameter as `--contract <name>`.");
     callback();
   }
-  // Compile contracts with truffle.
-  await truffle.contracts
-    .compile({
-      contracts_directory: "./contracts",
-      contracts_build_directory: "./build/contracts"
-    })
-    .then(() => console.log("Compilation complete!"))
-    .catch(e => {
-      console.error(e);
-      callback();
-    });
 
   // Load contracts into script and output info.
   console.log("loading", argv.contract + ".json");


### PR DESCRIPTION
When running the bytecode script, users should now specify the `-c` flag so truffle will compile before running. Previously the script was compiling the contracts, itself, but it was doing so without respecting the repo's truffle config.