### PR TITLE
Removed require messages

### DIFF
--- a/core/contracts/financial_templates/Liquidatable.sol
+++ b/core/contracts/financial_templates/Liquidatable.sol
@@ -91,10 +91,7 @@ contract Liquidatable is PricelessPositionManager {
     // Callable before the liquidation's expiry AND there is no pending dispute on the liquidation
     modifier onlyPreExpiryAndPreDispute(uint id, address sponsor) {
         LiquidationData storage liquidation = _getLiquidationData(sponsor, id);
-        require(
-            (getCurrentTime() < liquidation.expiry) && (liquidation.state == Status.PreDispute),
-            "Liquidation has expired or has already been disputed"
-        );
+        require((getCurrentTime() < liquidation.expiry) && (liquidation.state == Status.PreDispute));
         _;
     }
     // Callable either post the liquidation's expiry or after a dispute has been resolved,
@@ -105,17 +102,13 @@ contract Liquidatable is PricelessPositionManager {
         require(
             (state == Status.DisputeSucceeded) ||
                 (state == Status.DisputeFailed) ||
-                ((liquidation.expiry <= getCurrentTime()) && (state == Status.PreDispute)),
-            "Liquidation has not expired or is pending dispute"
+                ((liquidation.expiry <= getCurrentTime()) && (state == Status.PreDispute))
         );
         _;
     }
     // Callable only after a liquidation has been disputed but has not yet resolved
     modifier onlyPendingDispute(uint id, address sponsor) {
-        require(
-            _getLiquidationData(sponsor, id).state == Status.PendingDispute,
-            "Liquidation is not currently pending dispute"
-        );
+        require(_getLiquidationData(sponsor, id).state == Status.PendingDispute);
         _;
     }
 
@@ -151,11 +144,8 @@ contract Liquidatable is PricelessPositionManager {
             params.syntheticSymbol
         )
     {
-        require(params.collateralRequirement.isGreaterThan(1), "The collateral requirement must be at minimum 100%");
-        require(
-            params.sponsorDisputeRewardPct.add(params.disputerDisputeRewardPct).isLessThan(1),
-            "Dispute rewards should sum to < 100%"
-        );
+        require(params.collateralRequirement.isGreaterThan(1));
+        require(params.sponsorDisputeRewardPct.add(params.disputerDisputeRewardPct).isLessThan(1));
 
         // Set liquidatable specific variables.
         liquidationLiveness = params.liquidationLiveness;
@@ -179,7 +169,7 @@ contract Liquidatable is PricelessPositionManager {
         // Attempt to retrieve Position data for sponsor
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
         FixedPoint.Unsigned memory positionCollateral = _getCollateral(positionToLiquidate);
-        require(positionCollateral.isGreaterThan(0), "Cant liquidate a position with no collateral");
+        require(positionCollateral.isGreaterThan(0));
 
         // Construct liquidation object.
         // Note: all dispute-related values are just zeroed out until a dispute occurs.
@@ -201,10 +191,7 @@ contract Liquidatable is PricelessPositionManager {
         uuid = newLength.sub(1);
 
         // Destroy tokens
-        require(
-            tokenCurrency.transferFrom(msg.sender, address(this), positionToLiquidate.tokensOutstanding.rawValue),
-            "failed to transfer synthetic tokens from sender"
-        );
+        require(tokenCurrency.transferFrom(msg.sender, address(this), positionToLiquidate.tokensOutstanding.rawValue));
         tokenCurrency.burn(positionToLiquidate.tokensOutstanding.rawValue);
 
         // Remove underlying collateral and debt from position and decrement the overall contract collateral and debt.
@@ -231,10 +218,7 @@ contract Liquidatable is PricelessPositionManager {
         LiquidationData storage disputedLiquidation = _getLiquidationData(sponsor, id);
 
         FixedPoint.Unsigned memory disputeBondAmount = disputedLiquidation.lockedCollateral.mul(disputeBondPct);
-        require(
-            collateralCurrency.transferFrom(msg.sender, address(this), disputeBondAmount.rawValue),
-            "failed to transfer dispute bond from sender"
-        );
+        require(collateralCurrency.transferFrom(msg.sender, address(this), disputeBondAmount.rawValue));
 
         // Request a price from DVM,
         // Liquidation is pending dispute until DVM returns a price
@@ -306,10 +290,7 @@ contract Liquidatable is PricelessPositionManager {
      */
     function withdrawLiquidation(uint id, address sponsor) public onlyPostExpiryOrPostDispute(id, sponsor) {
         LiquidationData storage liquidation = _getLiquidationData(sponsor, id);
-        require(
-            (msg.sender == liquidation.disputer) || (msg.sender == liquidation.liquidator) || (msg.sender == sponsor),
-            "must be a disputer, liquidator, or sponsor to request a withdrawal on a liquidation"
-        );
+        require(msg.sender == liquidation.disputer || msg.sender == liquidation.liquidator || msg.sender == sponsor);
 
         FixedPoint.Unsigned memory tokenRedemptionValue = liquidation.tokensOutstanding.mul(
             liquidation.settlementPrice
@@ -331,19 +312,13 @@ contract Liquidatable is PricelessPositionManager {
 
                 // Pay DISPUTER: disputer reward + dispute bond
                 FixedPoint.Unsigned memory payToDisputer = disputerDisputeReward.add(disputeBondAmount);
-                require(
-                    collateralCurrency.transfer(msg.sender, payToDisputer.rawValue),
-                    "failed to transfer reward for a successful dispute to disputer"
-                );
+                require(collateralCurrency.transfer(msg.sender, payToDisputer.rawValue));
             } else if (msg.sender == sponsor) {
                 // Pay SPONSOR: remaining collateral (locked collateral - TRV) + sponsor reward
                 FixedPoint.Unsigned memory remainingCollateral;
                 remainingCollateral = liquidation.lockedCollateral.sub(tokenRedemptionValue);
                 FixedPoint.Unsigned memory payToSponsor = sponsorDisputeReward.add(remainingCollateral);
-                require(
-                    collateralCurrency.transfer(msg.sender, payToSponsor.rawValue),
-                    "failed to transfer reward for a successful dispute to sponsor"
-                );
+                require(collateralCurrency.transfer(msg.sender, payToSponsor.rawValue));
             } else if (msg.sender == liquidation.liquidator) {
                 // Pay LIQUIDATOR: TRV - dispute reward - sponsor reward
                 // If TRV > Collateral, then subtract rewards from locked collateral
@@ -351,10 +326,7 @@ contract Liquidatable is PricelessPositionManager {
                 // the constructor when these params are set
                 FixedPoint.Unsigned memory payToLiquidator;
                 payToLiquidator = tokenRedemptionValue.sub(sponsorDisputeReward).sub(disputerDisputeReward);
-                require(
-                    collateralCurrency.transfer(msg.sender, payToLiquidator.rawValue),
-                    "failed to transfer reward for a successful dispute to liquidator"
-                );
+                require(collateralCurrency.transfer(msg.sender, payToLiquidator.rawValue));
             }
             // Free up space once all locked collateral is withdrawn
             if (collateralCurrency.balanceOf(address(this)) == 0) {
@@ -364,24 +336,18 @@ contract Liquidatable is PricelessPositionManager {
             // Pay LIQUIDATOR: lockedCollateral + dispute bond
             if (msg.sender == liquidation.liquidator) {
                 FixedPoint.Unsigned memory payToLiquidator = liquidation.lockedCollateral.add(disputeBondAmount);
-                require(
-                    collateralCurrency.transfer(msg.sender, payToLiquidator.rawValue),
-                    "failed to transfer locked collateral plus dispute bond to liquidator"
-                );
+                require(collateralCurrency.transfer(msg.sender, payToLiquidator.rawValue));
                 delete liquidations[sponsor][id];
             } else {
-                require(false, "only the liquidator can withdraw on an unsuccessfully disputed liquidation");
+                require(false);
             }
         } else if (liquidation.state == Status.PreDispute) {
             // Pay LIQUIDATOR: lockedCollateral
             if (msg.sender == liquidation.liquidator) {
-                require(
-                    collateralCurrency.transfer(msg.sender, liquidation.lockedCollateral.rawValue),
-                    "failed to transfer locked collateral to liquidator"
-                );
+                require(collateralCurrency.transfer(msg.sender, liquidation.lockedCollateral.rawValue));
                 delete liquidations[sponsor][id];
             } else {
-                require(false, "only the liquidator can withdraw on a non-disputed, expired liquidation");
+                require(false);
             }
         }
 
@@ -397,10 +363,7 @@ contract Liquidatable is PricelessPositionManager {
 
         // Revert if the caller is attempting to access an invalid liquidation (one that has never been created or one
         // that was deleted after resolution).
-        require(
-            uuid < liquidationArray.length && liquidationArray[uuid].liquidator != address(0),
-            "Invalid liquidation: liquidator address is not set"
-        );
+        require(uuid < liquidationArray.length && liquidationArray[uuid].liquidator != address(0));
         return liquidationArray[uuid];
     }
 }

--- a/core/contracts/financial_templates/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/PricelessPositionManager.sol
@@ -79,17 +79,17 @@ contract PricelessPositionManager is FeePayer {
     );
 
     modifier onlyPreExpiration() {
-        require(getCurrentTime() < expirationTimestamp, "Cannot operate on a position past its expiry time");
+        require(getCurrentTime() < expirationTimestamp);
         _;
     }
 
     modifier onlyPostExpiration() {
-        require(getCurrentTime() >= expirationTimestamp, "Cannot operate on a position before its expiry time");
+        require(getCurrentTime() >= expirationTimestamp);
         _;
     }
 
     modifier onlyCollateralizedPosition(address sponsor) {
-        require(_getCollateral(positions[sponsor]).isGreaterThan(0), "Position has no collateral and so is invalid");
+        require(_getCollateral(positions[sponsor]).isGreaterThan(0));
         _;
     }
 
@@ -118,12 +118,9 @@ contract PricelessPositionManager is FeePayer {
      * @param newSponsorAddress is the address to which the position will be transfered.
      */
     function transfer(address newSponsorAddress) public onlyPreExpiration() onlyCollateralizedPosition(msg.sender) {
-        require(
-            getCollateral(newSponsorAddress).isEqual(FixedPoint.fromUnscaledUint(0)),
-            "Cannot transfer to an address that already has a position"
-        );
+        require(getCollateral(newSponsorAddress).isEqual(FixedPoint.fromUnscaledUint(0)));
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp == 0, "Cannot transfer with a pending withdrawal request");
+        require(positionData.requestPassTimestamp == 0);
         positions[newSponsorAddress] = positionData;
         delete positions[msg.sender];
 
@@ -139,15 +136,12 @@ contract PricelessPositionManager is FeePayer {
     // TODO: should this check if the position is valid first?
     function deposit(FixedPoint.Unsigned memory collateralAmount) public onlyPreExpiration() fees() {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp == 0, "Cannot deposit with a pending withdrawal request");
+        require(positionData.requestPassTimestamp == 0);
         _addCollateral(positionData, collateralAmount);
         totalPositionCollateral = totalPositionCollateral.add(collateralAmount);
 
         // Move collateral currency from sender to contract.
-        require(
-            collateralCurrency.transferFrom(msg.sender, address(this), collateralAmount.rawValue),
-            "Deposit collateral currency transfer failed"
-        );
+        require(collateralCurrency.transferFrom(msg.sender, address(this), collateralAmount.rawValue));
 
         emit Deposit(msg.sender, collateralAmount.rawValue);
     }
@@ -165,17 +159,14 @@ contract PricelessPositionManager is FeePayer {
         fees()
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp == 0, "Cannot withdraw with a pending withdrawal request");
+        require(positionData.requestPassTimestamp == 0);
 
         _removeCollateral(positionData, collateralAmount);
-        require(_checkCollateralizationRatio(positionData), "Cannot withdraw below global collateralization ratio");
+        require(_checkCollateralizationRatio(positionData));
         totalPositionCollateral = totalPositionCollateral.sub(collateralAmount);
 
         // Move collateral currency from contract to sender.
-        require(
-            collateralCurrency.transfer(msg.sender, collateralAmount.rawValue),
-            "Withdrawal of collateral currency failed."
-        );
+        require(collateralCurrency.transfer(msg.sender, collateralAmount.rawValue));
 
         emit Withdrawal(msg.sender, collateralAmount.rawValue);
     }
@@ -193,14 +184,11 @@ contract PricelessPositionManager is FeePayer {
         onlyCollateralizedPosition(msg.sender)
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp == 0, "Cannot have concurrent withdrawal requests");
+        require(positionData.requestPassTimestamp == 0);
 
         // Not just pre-expiration: make sure the proposed expiration of this request is itself before expiry.
         uint requestPassTime = getCurrentTime() + withdrawalLiveness;
-        require(
-            requestPassTime < expirationTimestamp,
-            "Cannot request withdrawal that would pass after contract expires"
-        );
+        require(requestPassTime < expirationTimestamp);
 
         // Update the position object for the user.
         positionData.requestPassTimestamp = requestPassTime;
@@ -218,7 +206,7 @@ contract PricelessPositionManager is FeePayer {
     // TODO: Decide whether to fold this functionality into withdraw() method above.
     function withdrawPassedRequest() public onlyPreExpiration() onlyCollateralizedPosition(msg.sender) {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp < getCurrentTime(), "Cannot withdraw before request is passed");
+        require(positionData.requestPassTimestamp < getCurrentTime());
 
         _removeCollateral(positionData, positionData.withdrawalRequestAmount);
         totalPositionCollateral = totalPositionCollateral.sub(positionData.withdrawalRequestAmount);
@@ -226,10 +214,7 @@ contract PricelessPositionManager is FeePayer {
         positionData.requestPassTimestamp = 0;
 
         // Transfer approved withdrawal amount from the contract to the caller.
-        require(
-            collateralCurrency.transfer(msg.sender, positionData.withdrawalRequestAmount.rawValue),
-            "Withdrawing tokens from position to caller failed."
-        );
+        require(collateralCurrency.transfer(msg.sender, positionData.withdrawalRequestAmount.rawValue));
 
         emit RequestWithdrawalExecuted(msg.sender, positionData.withdrawalRequestAmount.rawValue);
     }
@@ -239,7 +224,7 @@ contract PricelessPositionManager is FeePayer {
      */
     function cancelWithdrawal() public onlyPreExpiration() {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp != 0, "Cannot cancel if no pending withdrawal request");
+        require(positionData.requestPassTimestamp != 0);
 
         emit RequestWithdrawalCanceled(msg.sender, positionData.withdrawalRequestAmount.rawValue);
 
@@ -261,20 +246,17 @@ contract PricelessPositionManager is FeePayer {
         fees()
     {
         PositionData storage positionData = positions[msg.sender];
-        require(positionData.requestPassTimestamp == 0, "Cannot create with a pending withdrawal request");
+        require(positionData.requestPassTimestamp == 0);
         _addCollateral(positionData, collateralAmount);
         positionData.tokensOutstanding = positionData.tokensOutstanding.add(numTokens);
-        require(_checkCollateralizationRatio(positionData), "Cannot create below global collateralization ratio");
+        require(_checkCollateralizationRatio(positionData));
 
         totalPositionCollateral = totalPositionCollateral.add(collateralAmount);
         totalTokensOutstanding = totalTokensOutstanding.add(numTokens);
 
         // Transfer tokens into the contract from caller and mint the caller synthetic tokens.
-        require(
-            collateralCurrency.transferFrom(msg.sender, address(this), collateralAmount.rawValue),
-            "Transferring collateral failed"
-        );
-        require(tokenCurrency.mint(msg.sender, numTokens.rawValue), "Minting synthetic tokens failed");
+        require(collateralCurrency.transferFrom(msg.sender, address(this), collateralAmount.rawValue));
+        require(tokenCurrency.mint(msg.sender, numTokens.rawValue));
 
         emit PositionCreated(msg.sender, collateralAmount.rawValue, numTokens.rawValue);
     }
@@ -289,8 +271,8 @@ contract PricelessPositionManager is FeePayer {
         fees()
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(positionData.requestPassTimestamp == 0, "Cannot redeem with a pending withdrawal request");
-        require(!numTokens.isGreaterThan(positionData.tokensOutstanding), "Can't redeem more than position size");
+        require(positionData.requestPassTimestamp == 0);
+        require(!numTokens.isGreaterThan(positionData.tokensOutstanding));
 
         FixedPoint.Unsigned memory fractionRedeemed = numTokens.div(positionData.tokensOutstanding);
         FixedPoint.Unsigned memory collateralRedeemed = fractionRedeemed.mul(_getCollateral(positionData));
@@ -309,15 +291,9 @@ contract PricelessPositionManager is FeePayer {
         }
 
         // Transfer collateral from contract to caller and burn callers synthetic tokens.
-        require(
-            collateralCurrency.transfer(msg.sender, collateralRedeemed.rawValue),
-            "Transfering collateral from caller to contract failed"
-        );
+        require(collateralCurrency.transfer(msg.sender, collateralRedeemed.rawValue));
 
-        require(
-            tokenCurrency.transferFrom(msg.sender, address(this), numTokens.rawValue),
-            "Burning tokens from caller failed"
-        );
+        require(tokenCurrency.transferFrom(msg.sender, address(this), numTokens.rawValue));
         tokenCurrency.burn(numTokens.rawValue);
 
         emit Redeem(msg.sender, collateralRedeemed.rawValue, numTokens.rawValue);
@@ -393,14 +369,8 @@ contract PricelessPositionManager is FeePayer {
         }
 
         // Transfer tokens and collateral.
-        require(
-            collateralCurrency.transfer(msg.sender, totalRedeemableCollateral.rawValue),
-            "Collateral redemption send failed"
-        );
-        require(
-            tokenCurrency.transferFrom(msg.sender, address(this), tokensToRedeem.rawValue),
-            "Token redemption send failed"
-        );
+        require(collateralCurrency.transfer(msg.sender, totalRedeemableCollateral.rawValue));
+        require(tokenCurrency.transferFrom(msg.sender, address(this), tokensToRedeem.rawValue));
         tokenCurrency.burn(tokensToRedeem.rawValue);
 
         // Decrement total contract collateral and oustanding debt.


### PR DESCRIPTION
This PR removes all require messages from liquidatable and priceless position manager to decrease contract bytecode size within a manageable limit issue #911 will add these back to the contracts once we've been able to better optimize the implementation.