### PR TITLE
Refactor _get[interface] functions

### DIFF
--- a/core/contracts/financial_templates/FeePayer.sol
+++ b/core/contracts/financial_templates/FeePayer.sol
@@ -49,7 +49,7 @@ contract FeePayer is Testable {
      */
 
     function payFees() public returns (FixedPoint.Unsigned memory totalPaid) {
-        StoreInterface store = StoreInterface(finder.getImplementationAddress("Store"));
+        StoreInterface store = _getStore();
         uint time = getCurrentTime();
         (FixedPoint.Unsigned memory regularFee, FixedPoint.Unsigned memory latePenalty) = store.computeRegularFee(
             lastPaymentTime,
@@ -77,4 +77,10 @@ contract FeePayer is Testable {
      */
 
     function pfc() public view returns (FixedPoint.Unsigned memory);
+
+
+    function _getStore() internal view returns (StoreInterface) {
+        bytes32 storeInterface = "Store";
+        return StoreInterface(finder.getImplementationAddress(storeInterface));
+    }
 }

--- a/core/contracts/financial_templates/FeePayer.sol
+++ b/core/contracts/financial_templates/FeePayer.sol
@@ -78,7 +78,6 @@ contract FeePayer is Testable {
 
     function pfc() public view returns (FixedPoint.Unsigned memory);
 
-
     function _getStore() internal view returns (StoreInterface) {
         bytes32 storeInterface = "Store";
         return StoreInterface(finder.getImplementationAddress(storeInterface));

--- a/core/contracts/financial_templates/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/PricelessPositionManager.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../common/FixedPoint.sol";
 import "../common/Testable.sol";
 import "../oracle/interfaces/OracleInterface.sol";
+import "../oracle/interfaces/IdentifierWhitelistInterface.sol";
 import "../Finder.sol";
 import "./Token.sol";
 import "./FeePayer.sol";
@@ -447,14 +448,9 @@ contract PricelessPositionManager is FeePayer {
         return positions[sponsor];
     }
 
-    function _getIdentifierWhitelistAddress() internal view returns (address) {
+    function _getIdentifierWhitelist() internal view returns (IdentifierWhitelistInterface) {
         bytes32 identifierWhitelistInterface = "IdentifierWhitelist";
-        return finder.getImplementationAddress(identifierWhitelistInterface);
-    }
-
-    function _getStoreAddress() internal view returns (address) {
-        bytes32 storeInterface = "Store";
-        return finder.getImplementationAddress(storeInterface);
+        return IdentifierWhitelistInterface(finder.getImplementationAddress(identifierWhitelistInterface));
     }
 
     function _getCollateral(PositionData storage positionData)

--- a/core/contracts/financial_templates/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/PricelessPositionManager.sol
@@ -471,19 +471,19 @@ contract PricelessPositionManager is FeePayer {
         positionData.rawCollateral = positionData.rawCollateral.add(adjustedCollateral);
     }
 
-    function _getOracleAddress() internal view returns (address) {
+    function _getOracle() internal view returns (OracleInterface) {
         bytes32 oracleInterface = "Oracle";
-        return finder.getImplementationAddress(oracleInterface);
+        return OracleInterface(finder.getImplementationAddress(oracleInterface));
     }
 
     function _requestOraclePrice(uint requestedTime) internal {
-        OracleInterface oracle = OracleInterface(_getOracleAddress());
+        OracleInterface oracle = _getOracle();
         oracle.requestPrice(priceIdentifer, requestedTime);
     }
 
     function _getOraclePrice(uint requestedTime) public view returns (FixedPoint.Unsigned memory) {
         // Create an instance of the oracle and get the price. If the price is not resolved revert.
-        OracleInterface oracle = OracleInterface(_getOracleAddress());
+        OracleInterface oracle = _getOracle();
         require(oracle.hasPrice(priceIdentifer, requestedTime), "Can only get a price once the DVM has resolved");
         int oraclePrice = oracle.getPrice(priceIdentifer, requestedTime);
 


### PR DESCRIPTION
This moves the _getStore() method to the FeePayer contract since that's the only place where it would be needed.

It also changes the types returned by _getStore and _getIdentifierWhitelist to return a contract type rather than an address so the caller doesn't have to cast.