### PR TITLE
Refactor Liquidatable withdraw

### DIFF
--- a/core/contracts/financial_templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial_templates/implementation/Liquidatable.sol
@@ -371,14 +371,11 @@ contract Liquidatable is PricelessPositionManager {
             delete liquidations[sponsor][id];
         }
 
-        if (withdrawalAmount.isGreaterThan(0)) {
-            collateralCurrency.safeTransfer(msg.sender, withdrawalAmount.rawValue);
+        require(withdrawalAmount.isGreaterThan(0));
+        collateralCurrency.safeTransfer(msg.sender, withdrawalAmount.rawValue);
 
-            // TODO: add this amount to the event in the issue #875.
-            emit LiquidationWithdrawn(msg.sender);
-            return withdrawalAmount;
-        }
-        require(false);
+        // TODO: add this amount to the event in the issue #875.
+        emit LiquidationWithdrawn(msg.sender);
     }
 
     function _getLiquidationData(address sponsor, uint uuid)


### PR DESCRIPTION
This PR cleans up the liquidatable withdraw method in a few ways:
- It removes the transfer call from each if statement and instead performs it at the bottom of the method where the event is emitted.
- The method now returns a fixed point number rather than a uint (matches the way we typically deal with these numbers).
- It separates the if elses in the dispute succeeded case into ifs in case one address holds multiple roles in the liquidation (technically one address could be all three).
- It fixes an issue where the liquidation data structure wasn't being wiped after all parties had withdrawn. This was because we were checking the balance of the contract rather than checking whether all parties were deleted.
- Modifies the method to use `safeTransfer` rather than vanilla transfer.