### PR TITLE
Separate finder into interface and implementation

### DIFF
--- a/core/contracts/financial_templates/implementation/FeePayer.sol
+++ b/core/contracts/financial_templates/implementation/FeePayer.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "../../common/FixedPoint.sol";
 import "../../common/Testable.sol";
 import "../../oracle/interfaces/StoreInterface.sol";
-import "../../Finder.sol";
+import "../../oracle/interfaces/FinderInterface.sol";
 
 contract FeePayer is Testable {
     using SafeMath for uint;
@@ -22,7 +22,7 @@ contract FeePayer is Testable {
     /**
      * Finder contract used to look up addresses for UMA system contracts.
      */
-    Finder public finder;
+    FinderInterface public finder;
 
     /**
      * Tracks the last block time when the fees were paid.
@@ -39,7 +39,7 @@ contract FeePayer is Testable {
 
     constructor(address collateralAddress, address finderAddress, bool _isTest) public Testable(_isTest) {
         collateralCurrency = IERC20(collateralAddress);
-        finder = Finder(finderAddress);
+        finder = FinderInterface(finderAddress);
         lastPaymentTime = getCurrentTime();
     }
 

--- a/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
@@ -8,7 +8,6 @@ import "../../common/FixedPoint.sol";
 import "../../common/Testable.sol";
 import "../../oracle/interfaces/OracleInterface.sol";
 import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
-import "../../Finder.sol";
 import "./TokenFactory.sol";
 import "../interfaces/TokenInterface.sol";
 import "./FeePayer.sol";

--- a/core/contracts/oracle/implementation/DesignatedVoting.sol
+++ b/core/contracts/oracle/implementation/DesignatedVoting.sol
@@ -5,7 +5,7 @@ pragma experimental ABIEncoderV2;
 import "../../common/MultiRole.sol";
 import "../../common/Withdrawable.sol";
 import "../interfaces/VotingInterface.sol";
-import "../../Finder.sol";
+import "../interfaces/FinderInterface.sol";
 import "./Voting.sol";
 
 /**
@@ -23,14 +23,14 @@ contract DesignatedVoting is MultiRole, Withdrawable {
 
     // Reference to the UMA Finder contract, allowing Voting upgrades to be performed without requiring any calls to
     // this contract.
-    Finder private finder;
+    FinderInterface private finder;
 
     constructor(address finderAddress, address ownerAddress, address voterAddress) public {
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), ownerAddress);
         _createExclusiveRole(uint(Roles.Voter), uint(Roles.Owner), voterAddress);
         setWithdrawRole(uint(Roles.Owner));
 
-        finder = Finder(finderAddress);
+        finder = FinderInterface(finderAddress);
     }
 
     /**

--- a/core/contracts/oracle/implementation/DesignatedVotingFactory.sol
+++ b/core/contracts/oracle/implementation/DesignatedVotingFactory.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "../../common/Withdrawable.sol";
-import "../../Finder.sol";
 import "./DesignatedVoting.sol";
 
 /**

--- a/core/contracts/oracle/implementation/Finder.sol
+++ b/core/contracts/oracle/implementation/Finder.sol
@@ -2,26 +2,21 @@ pragma solidity ^0.5.0;
 
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 
+import "../interfaces/FinderInterface.sol";
+
 /**
- * @title Provides addresses of the live contracts implementing certain interfaces. 
- * @dev Examples are the Oracle or Store interfaces.
+ * @title Implementation of the FinderInterface.
  */
-contract Finder is Ownable {
+contract Finder is FinderInterface, Ownable {
     mapping(bytes32 => address) public interfacesImplemented;
 
     event InterfaceImplementationChanged(bytes32 indexed interfaceName, address indexed newImplementationAddress);
 
-    /**
-     * @dev Updates the address of the contract that implements `interfaceName`.
-     */
     function changeImplementationAddress(bytes32 interfaceName, address implementationAddress) external onlyOwner {
         interfacesImplemented[interfaceName] = implementationAddress;
         emit InterfaceImplementationChanged(interfaceName, implementationAddress);
     }
 
-    /**
-     * @dev Gets the address of the contract that implements the given `interfaceName`.
-     */
     function getImplementationAddress(bytes32 interfaceName) external view returns (address implementationAddress) {
         implementationAddress = interfacesImplemented[interfaceName];
         require(implementationAddress != address(0x0), "No implementation for interface found");

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -5,7 +5,7 @@ pragma experimental ABIEncoderV2;
 import "../../common/MultiRole.sol";
 import "../../common/FixedPoint.sol";
 import "../../common/Testable.sol";
-import "../../Finder.sol";
+import "../interfaces/FinderInterface.sol";
 import "../interfaces/IdentifierWhitelistInterface.sol";
 import "./Voting.sol";
 
@@ -35,7 +35,7 @@ contract Governor is MultiRole, Testable {
         uint requestTime;
     }
 
-    Finder private finder;
+    FinderInterface private finder;
     Proposal[] public proposals;
 
     /**
@@ -49,7 +49,7 @@ contract Governor is MultiRole, Testable {
     event ProposalExecuted(uint indexed id, uint transactionIndex);
 
     constructor(address _finderAddress, bool _isTest) public Testable(_isTest) {
-        finder = Finder(_finderAddress);
+        finder = FinderInterface(_finderAddress);
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
         _createExclusiveRole(uint(Roles.Proposer), uint(Roles.Owner), msg.sender);
     }

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../common/FixedPoint.sol";
 import "../../common/Testable.sol";
-import "../../Finder.sol";
+import "../interfaces/FinderInterface.sol";
 import "../interfaces/OracleInterface.sol";
 import "../interfaces/VotingInterface.sol";
 import "../interfaces/IdentifierWhitelistInterface.sol";
@@ -138,7 +138,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
     VotingToken public votingToken;
 
     // Reference to the Finder.
-    Finder private finder;
+    FinderInterface private finder;
 
     // If non-zero, this contract has been migrated to this address. All voters and financial contracts should query the
     // new address only.
@@ -193,7 +193,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         inflationRate = _inflationRate;
         votingToken = VotingToken(_votingToken);
         identifierWhitelist = IdentifierWhitelistInterface(_identifierWhitelist);
-        finder = Finder(_finder);
+        finder = FinderInterface(_finder);
         rewardsExpirationTimeout = _rewardsExpirationTimeout;
     }
 

--- a/core/contracts/oracle/interfaces/FinderInterface.sol
+++ b/core/contracts/oracle/interfaces/FinderInterface.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @title Provides addresses of the live contracts implementing certain interfaces. 
+ * @dev Examples are the Oracle or Store interfaces.
+ */
+interface FinderInterface {
+    /**
+     * @dev Updates the address of the contract that implements `interfaceName`.
+     */
+    function changeImplementationAddress(bytes32 interfaceName, address implementationAddress) external;
+
+    /**
+     * @dev Gets the address of the contract that implements the given `interfaceName`.
+     */
+    function getImplementationAddress(bytes32 interfaceName) external view returns (address implementationAddress);
+}

--- a/core/contracts/tokenized_derivative/ContractCreator.sol
+++ b/core/contracts/tokenized_derivative/ContractCreator.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "../Finder.sol";
+import "../oracle/interfaces/FinderInterface.sol";
 import "../oracle/implementation/Registry.sol";
 
 // TODO(ptare): Make this (and all contracts) Withdrawable.
@@ -15,7 +15,7 @@ contract ContractCreator {
     }
 
     function _registerContract(address[] memory parties, address contractToRegister) internal {
-        Finder finder = Finder(finderAddress);
+        FinderInterface finder = FinderInterface(finderAddress);
         bytes32 registryInterface = "Registry";
         Registry registry = Registry(finder.getImplementationAddress(registryInterface));
         registry.registerDerivative(parties, contractToRegister);

--- a/core/contracts/tokenized_derivative/TokenizedDerivative.sol
+++ b/core/contracts/tokenized_derivative/TokenizedDerivative.sol
@@ -8,7 +8,7 @@ import "../oracle/interfaces/AdministrateeInterface.sol";
 import "../oracle/interfaces/OracleInterface.sol";
 import "../oracle/interfaces/StoreInterface.sol";
 import "../oracle/interfaces/IdentifierWhitelistInterface.sol";
-import "../Finder.sol";
+import "../oracle/interfaces/FinderInterface.sol";
 import "./PriceFeedInterface.sol";
 import "./ReturnCalculatorInterface.sol";
 
@@ -112,7 +112,7 @@ library TDS {
         // Other addresses/contracts
         address sponsor;
         address apDelegate;
-        Finder finder;
+        FinderInterface finder;
         PriceFeedInterface priceFeed;
         ReturnCalculatorInterface returnCalculator;
         IERC20 marginCurrency;
@@ -645,7 +645,7 @@ library TokenizedDerivativeUtils {
         s.externalAddresses.marginCurrency = IERC20(params.marginCurrency);
 
         s.externalAddresses.returnCalculator = ReturnCalculatorInterface(params.returnCalculator);
-        s.externalAddresses.finder = Finder(params.finderAddress);
+        s.externalAddresses.finder = FinderInterface(params.finderAddress);
         s.externalAddresses.priceFeed = PriceFeedInterface(params.priceFeedAddress);
 
         // Verify that the price feed and Oracle support the given s.fixedParameters.product.


### PR DESCRIPTION
This moves the finder into the oracle directory and separates it into an interface and implementation.