### PR TITLE
Quick fix where Token is TokenInterface

### DIFF
--- a/core/contracts/financial_templates/implementation/Token.sol
+++ b/core/contracts/financial_templates/implementation/Token.sol
@@ -3,10 +3,12 @@ import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
 
+import "../interfaces/TokenInterface.sol";
+
 /**
  * @notice A burnable and mintable ERC20.
  */
-contract Token is ERC20Detailed, ERC20Mintable, ERC20Burnable {
+contract Token is TokenInterface, ERC20Detailed, ERC20Mintable, ERC20Burnable {
     constructor(string memory tokenName, string memory tokenSymbol, uint8 tokenDecimals)
         public
         ERC20Detailed(tokenName, tokenSymbol, tokenDecimals)


### PR DESCRIPTION
In PR #922 I forgot to add the dependency `Token is TokenInterface ...`

Signed-off-by: Nick Pai <npai.nyc@gmail.com>