### PR TITLE
Add methods to `VotingInterface` to eliminate imports of `Voting`

### DIFF
--- a/core/contracts/oracle/implementation/DesignatedVoting.sol
+++ b/core/contracts/oracle/implementation/DesignatedVoting.sol
@@ -6,7 +6,6 @@ import "../../common/MultiRole.sol";
 import "../../common/Withdrawable.sol";
 import "../interfaces/VotingInterface.sol";
 import "../interfaces/FinderInterface.sol";
-import "./Voting.sol";
 
 /**
  * @title Proxy to allow voting from another address
@@ -43,7 +42,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     /**
      * @notice Forwards a batch commit to Voting.
      */
-    function batchCommit(Voting.Commitment[] calldata commits) external onlyRoleHolder(uint(Roles.Voter)) {
+    function batchCommit(VotingInterface.Commitment[] calldata commits) external onlyRoleHolder(uint(Roles.Voter)) {
         _getVotingAddress().batchCommit(commits);
     }
 
@@ -57,7 +56,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
     /**
      * @notice Forwards a batch reveal to Voting.
      */
-    function batchReveal(Voting.Reveal[] calldata reveals) external onlyRoleHolder(uint(Roles.Voter)) {
+    function batchReveal(VotingInterface.Reveal[] calldata reveals) external onlyRoleHolder(uint(Roles.Voter)) {
         _getVotingAddress().batchReveal(reveals);
     }
 
@@ -72,7 +71,7 @@ contract DesignatedVoting is MultiRole, Withdrawable {
         return _getVotingAddress().retrieveRewards(address(this), roundId, toRetrieve);
     }
 
-    function _getVotingAddress() private view returns (Voting) {
-        return Voting(finder.getImplementationAddress("Oracle"));
+    function _getVotingAddress() private view returns (VotingInterface) {
+        return VotingInterface(finder.getImplementationAddress("Oracle"));
     }
 }

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -7,7 +7,7 @@ import "../../common/FixedPoint.sol";
 import "../../common/Testable.sol";
 import "../interfaces/FinderInterface.sol";
 import "../interfaces/IdentifierWhitelistInterface.sol";
-import "../interfaces/VotingInterface.sol";
+import "../interfaces/OracleInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
@@ -59,7 +59,7 @@ contract Governor is MultiRole, Testable {
      */
     function executeProposal(uint id, uint transactionIndex) external {
         Proposal storage proposal = proposals[id];
-        int price = _getVoting().getPrice(_constructIdentifier(id), proposal.requestTime);
+        int price = _getOracle().getPrice(_constructIdentifier(id), proposal.requestTime);
 
         Transaction storage transaction = proposal.transactions[transactionIndex];
 
@@ -127,11 +127,11 @@ contract Governor is MultiRole, Testable {
         bytes32 identifier = _constructIdentifier(id);
 
         // Request a vote on this proposal in the DVM.
-        VotingInterface voting = _getVoting();
+        OracleInterface oracle = _getOracle();
         IdentifierWhitelistInterface supportedIdentifiers = _getIdentifierWhitelist();
         supportedIdentifiers.addSupportedIdentifier(identifier);
 
-        voting.requestPrice(identifier, time);
+        oracle.requestPrice(identifier, time);
         supportedIdentifiers.removeSupportedIdentifier(identifier);
 
         emit NewProposal(id, transactions);
@@ -154,8 +154,8 @@ contract Governor is MultiRole, Testable {
         }
     }
 
-    function _getVoting() private view returns (VotingInterface voting) {
-        return VotingInterface(finder.getImplementationAddress("Oracle"));
+    function _getOracle() private view returns (OracleInterface oracle) {
+        return OracleInterface(finder.getImplementationAddress("Oracle"));
     }
 
     function _getIdentifierWhitelist() private view returns (IdentifierWhitelistInterface supportedIdentifiers) {

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -7,7 +7,7 @@ import "../../common/FixedPoint.sol";
 import "../../common/Testable.sol";
 import "../interfaces/FinderInterface.sol";
 import "../interfaces/IdentifierWhitelistInterface.sol";
-import "./Voting.sol";
+import "../interfaces/VotingInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
@@ -127,7 +127,7 @@ contract Governor is MultiRole, Testable {
         bytes32 identifier = _constructIdentifier(id);
 
         // Request a vote on this proposal in the DVM.
-        Voting voting = _getVoting();
+        VotingInterface voting = _getVoting();
         IdentifierWhitelistInterface supportedIdentifiers = _getIdentifierWhitelist();
         supportedIdentifiers.addSupportedIdentifier(identifier);
 
@@ -154,8 +154,8 @@ contract Governor is MultiRole, Testable {
         }
     }
 
-    function _getVoting() private view returns (Voting voting) {
-        return Voting(finder.getImplementationAddress("Oracle"));
+    function _getVoting() private view returns (VotingInterface voting) {
+        return VotingInterface(finder.getImplementationAddress("Oracle"));
     }
 
     function _getIdentifierWhitelist() private view returns (IdentifierWhitelistInterface supportedIdentifiers) {

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -57,26 +57,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         bytes32 revealHash;
     }
 
-    // Captures the necessary data for making a commitment.
-    // Used as a parameter when making batch commitments.
-    // Not used as a data structure for storage.
-    struct Commitment {
-        bytes32 identifier;
-        uint time;
-        bytes32 hash;
-        bytes encryptedVote;
-    }
-
-    // Captures the necessary data for revealing a vote.
-    // Used as a parameter when making batch reveals.
-    // Not used as a data structure for storage.
-    struct Reveal {
-        bytes32 identifier;
-        uint time;
-        int price;
-        int salt;
-    }
-
     struct Round {
         // Voting token snapshot ID for this round. If this is 0, no snapshot has been taken.
         uint snapshotId;

--- a/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -13,6 +13,26 @@ contract VotingInterface {
         uint time;
     }
 
+    // Captures the necessary data for making a commitment.
+    // Used as a parameter when making batch commitments.
+    // Not used as a data structure for storage.
+    struct Commitment {
+        bytes32 identifier;
+        uint time;
+        bytes32 hash;
+        bytes encryptedVote;
+    }
+
+    // Captures the necessary data for revealing a vote.
+    // Used as a parameter when making batch reveals.
+    // Not used as a data structure for storage.
+    struct Reveal {
+        bytes32 identifier;
+        uint time;
+        int price;
+        int salt;
+    }
+
     // Note: the phases must be in order. Meaning the first enum value must be the first phase, etc.
     // `NUM_PHASES_PLACEHOLDER` is to get the number of phases. It isn't an actual phase, and it should always be last.
     enum Phase { Commit, Reveal, NUM_PHASES_PLACEHOLDER }
@@ -25,11 +45,23 @@ contract VotingInterface {
     function commitVote(bytes32 identifier, uint time, bytes32 hash) external;
 
     /**
+     * @notice Commit multiple votes in a single transaction. Look at `project-root/common/Constants.js` for the tested maximum number of commitments that can fit in one transaction.
+     * @dev For more information on commits, review the comment for `commitVote`.
+     */
+    function batchCommit(Commitment[] calldata commits) external;
+
+    /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.
      * @dev The revealed `price` and `salt` must match the latest `hash` that `commitVote()` was called with. Only the
      * committer can reveal their vote.
      */
     function revealVote(bytes32 identifier, uint time, int price, int salt) external;
+
+    /**
+     * @notice Reveal multiple votes in a single transaction. Look at `project-root/common/Constants.js` for the tested maximum number of reveals that can fit in one transaction.
+     * @dev For more information on reveals, review the comment for `revealVote`.
+     */
+    function batchReveal(Reveal[] calldata reveals) external;
 
     /**
      * @notice Gets the queries that are being voted on this round.
@@ -52,4 +84,19 @@ contract VotingInterface {
     function retrieveRewards(address voterAddress, uint roundId, PendingRequest[] memory)
         public
         returns (FixedPoint.Unsigned memory);
+
+    /**
+     * @notice Makes a price request to the Oracle uniquely identified by (`identifier`, `time`).
+     */
+    function requestPrice(bytes32 identifier, uint time) external;
+
+    /**
+     * @notice Checks to see if there is a price that has or can be resolved for an (identifier, time) pair.
+     */
+    function hasPrice(bytes32 identifier, uint time) external view returns (bool _hasPrice);
+
+    /**
+     * @notice Returns the price if it exists, otherwise throws.
+     */
+    function getPrice(bytes32 identifier, uint time) external view returns (int);
 }

--- a/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -84,19 +84,4 @@ contract VotingInterface {
     function retrieveRewards(address voterAddress, uint roundId, PendingRequest[] memory)
         public
         returns (FixedPoint.Unsigned memory);
-
-    /**
-     * @notice Makes a price request to the Oracle uniquely identified by (`identifier`, `time`).
-     */
-    function requestPrice(bytes32 identifier, uint time) external;
-
-    /**
-     * @notice Checks to see if there is a price that has or can be resolved for an (identifier, time) pair.
-     */
-    function hasPrice(bytes32 identifier, uint time) external view returns (bool _hasPrice);
-
-    /**
-     * @notice Returns the price if it exists, otherwise throws.
-     */
-    function getPrice(bytes32 identifier, uint time) external view returns (int);
 }


### PR DESCRIPTION
`Governor` currently imports `Voting` in order to call `getPrice()` and `requestPrice()`. Instead, it should import `OracleInterface` which has `getPrice()`. I renamed `_getVoting` and all instances of `Voting` to `Oracle`-related names.

`DesignatedVoting` imports `Voting` to call `batchCommit`, `batchReveal`, so I added these to `VotingInterface`.

Resolves #932 