### PR TITLE
Fix rounding errors in ExpiringMultiparty

### DIFF
--- a/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
@@ -319,9 +319,10 @@ contract PricelessPositionManager is FeePayer {
             return totalPaid;
         }
 
-        // TODO(#873): add divCeil and mulCeil to make sure that all rounding favors the contract rather than the user.
         // Adjust internal variables below.
         // Compute fee percentage that was paid by the entire contract (fees / pfc).
+        // TODO(#873): do we want to add add divCeil and mulCeil here to make sure that all rounding favors the contract rather than the user?
+        // Similar issue to _payOracleFees
         FixedPoint.Unsigned memory feePercentage = totalPaid.div(initialPfc);
 
         // Compute adjustment to be applied to the position collateral (1 - feePercentage).
@@ -465,19 +466,22 @@ contract PricelessPositionManager is FeePayer {
         require(totalPositionCollateral.isGreaterThan(totalPaid));
         // TODO(#925): If this reverts here, then the position cannot expire. Collateral may be locked in contract.
 
-        // TODO(#873): add divCeil and mulCeil to make sure that all rounding favors the contract rather than the user.
-        // Adjust internal variables below.
         // Compute fee percentage that was paid by the entire contract (fees / collateral).
         // Unlike payFees, we are spreading fees across all locked collateral and NOT all PfC, which
         // implies that we are not forcing liquidations to be responsible for paying final fees when the position expires
-        FixedPoint.Unsigned memory feePercentage = totalPaid.div(totalPositionCollateral);
+
+        // TODO(#934. #925) we ceil() the fee percentage so that the contract behaves as if MORE fees were paid
+        // than in actuality. This causes the contract to act as if it has LESS collateral than in actuality.
+        // Therefore we avoid the situation in which there is MORE adjusted-collateral in the contract
+        // than in actuality. This could have the side effect of having leftover collateral in the contract, which we want to upper bound.
+        FixedPoint.Unsigned memory feePercentage = totalPaid.divCeil(totalPositionCollateral);
 
         // Compute adjustment to be applied to the position collateral (1 - feePercentage).
         FixedPoint.Unsigned memory adjustment = FixedPoint.fromUnscaledUint(1).sub(feePercentage);
 
         // Apply fee percentage to adjust totalPositionCollateral and positionFeeAdjustment.
-        totalPositionCollateral = totalPositionCollateral.mul(adjustment);
-        positionFeeAdjustment = positionFeeAdjustment.mul(adjustment);
+        totalPositionCollateral = totalPositionCollateral.mulCeil(adjustment);
+        positionFeeAdjustment = positionFeeAdjustment.mulCeil(adjustment);
     }
 
     function _getOraclePrice(uint requestedTime) internal view returns (FixedPoint.Unsigned memory) {

--- a/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
@@ -329,8 +329,8 @@ contract PricelessPositionManager is FeePayer {
         FixedPoint.Unsigned memory adjustment = FixedPoint.fromUnscaledUint(1).sub(feePercentage);
 
         // Apply fee percentage to adjust totalPositionCollateral and positionFeeAdjustment.
-        totalPositionCollateral = totalPositionCollateral.mulCeil(adjustment);
-        positionFeeAdjustment = positionFeeAdjustment.mulCeil(adjustment);
+        totalPositionCollateral = totalPositionCollateral.mul(adjustment);
+        positionFeeAdjustment = positionFeeAdjustment.mul(adjustment);
     }
 
     /**
@@ -480,8 +480,8 @@ contract PricelessPositionManager is FeePayer {
         FixedPoint.Unsigned memory adjustment = FixedPoint.fromUnscaledUint(1).sub(feePercentage);
 
         // Apply fee percentage to adjust totalPositionCollateral and positionFeeAdjustment.
-        totalPositionCollateral = totalPositionCollateral.mulCeil(adjustment);
-        positionFeeAdjustment = positionFeeAdjustment.mulCeil(adjustment);
+        totalPositionCollateral = totalPositionCollateral.mul(adjustment);
+        positionFeeAdjustment = positionFeeAdjustment.mul(adjustment);
     }
 
     function _getOraclePrice(uint requestedTime) internal view returns (FixedPoint.Unsigned memory) {

--- a/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial_templates/implementation/PricelessPositionManager.sol
@@ -323,14 +323,14 @@ contract PricelessPositionManager is FeePayer {
         // Compute fee percentage that was paid by the entire contract (fees / pfc).
         // TODO(#873): do we want to add add divCeil and mulCeil here to make sure that all rounding favors the contract rather than the user?
         // Similar issue to _payOracleFees
-        FixedPoint.Unsigned memory feePercentage = totalPaid.div(initialPfc);
+        FixedPoint.Unsigned memory feePercentage = totalPaid.divCeil(initialPfc);
 
         // Compute adjustment to be applied to the position collateral (1 - feePercentage).
         FixedPoint.Unsigned memory adjustment = FixedPoint.fromUnscaledUint(1).sub(feePercentage);
 
         // Apply fee percentage to adjust totalPositionCollateral and positionFeeAdjustment.
-        totalPositionCollateral = totalPositionCollateral.mul(adjustment);
-        positionFeeAdjustment = positionFeeAdjustment.mul(adjustment);
+        totalPositionCollateral = totalPositionCollateral.mulCeil(adjustment);
+        positionFeeAdjustment = positionFeeAdjustment.mulCeil(adjustment);
     }
 
     /**

--- a/core/test/financial_templates/PricelessPositionManager.js
+++ b/core/test/financial_templates/PricelessPositionManager.js
@@ -757,24 +757,24 @@ contract("PricelessPositionManager", function(accounts) {
   });
 
   it("Final Fees: Rounding error causes redeemable collateral to sometimes be lower than expected", async () => {
-    // Setting the amount of collateral = 150 and the final fee to 1 will result in rounding errors
+    // Setting the amount of collateral = 30 wei and the final fee to 1 wei will result in rounding errors
     // because of the intermediate calculation in payFees for % of ( fees paid ) / (total collateral)
-    // which is 0.0066... repeating, which cannot be represented precisely by a fixed point
+    // which is 0.033... repeating, which cannot be represented precisely by a fixed point
 
     // Create a new position
-    await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
-    const numTokens = toWei("100");
-    const amountCollateral = toWei("150");
+    await collateral.approve(pricelessPositionManager.address, "100000", { from: sponsor });
+    const numTokens = "20";
+    const amountCollateral = "30";
     await pricelessPositionManager.create({ rawValue: amountCollateral }, { rawValue: numTokens }, { from: sponsor });
 
     // Transfer half the tokens from the sponsor to a tokenHolder. IRL this happens through the sponsor selling tokens.
-    const tokenHolderTokens = toWei("50");
+    const tokenHolderTokens = "10";
     await tokenCurrency.transfer(tokenHolder, tokenHolderTokens, {
       from: sponsor
     });
 
-    // Set store final fees to 1 collateral token.
-    const finalFeePaid = toWei("1");
+    // Set store final fees to 1e-18 collateral token.
+    const finalFeePaid = "1";
     await store.setFinalFee(collateral.address, { rawValue: finalFeePaid });
 
     const expirationTime = await pricelessPositionManager.expirationTimestamp();
@@ -784,22 +784,22 @@ contract("PricelessPositionManager", function(accounts) {
 
     // Because of the use of mulCeil and divCeil in _payFinalFees, getCollateral() should return slightly less
     // collateral than expected. When calculating the new `feeAdjustment`, we need to know the % of fees paid / pfc, which is
-    // 1/150. However, 1/150 = 0.006666... repeating, which cannot be represented in FixedPoint. Normally mul() would floor
-    // this value to 0.0066....6, but mulCeil sets this to 0.0066..7. A higher `feeAdjustment` causes a lower `adjustment` and ultimately
+    // 1/30. However, 1/30 = 0.03333... repeating, which cannot be represented in FixedPoint. Normally mul() would floor
+    // this value to 0.033....33, but mulCeil sets this to 0.033...34. A higher `feeAdjustment` causes a lower `adjustment` and ultimately
     // lower `totalPositionCollateral` and `positionAdjustment` values.
     let collateralAmount = await pricelessPositionManager.getCollateral(sponsor);
-    assert(toBN(collateralAmount.rawValue).lt(toBN(toWei("149"))));
-    // The actual amount of fees paid to the store is as expected = 1
+    assert(toBN(collateralAmount.rawValue).lt(toBN("29")));
+    // The actual amount of fees paid to the store is as expected = 1e-18
     assert.equal((await collateral.balanceOf(store.address)).toString(), expectedStoreBalance.toString());
 
     // Push a settlement price into the mock oracle to simulate a DVM vote. Say settlement occurs at 1.2 Stock/USD for the price
-    // feed. With 100 units of outstanding tokens this results in a token redemption value of: TRV = 100 * 1.2 = 120 USD.
+    // feed. With 20 units of outstanding tokens this results in a token redemption value of: TRV = 20 * 1.2 = 24 USD.
     const redemptionPrice = 1.2;
     const redemptionPriceWei = toWei(redemptionPrice.toString());
     await mockOracle.pushPrice(priceTrackingIdentifier, expirationTime.toNumber(), redemptionPriceWei);
 
     // From the token holders, they are entitled to the value of their tokens, notated in the underlying.
-    // They have 50 tokens settled at a price of 1.2 should yield 60 units of underling (or 60 USD as underlying is Dai).
+    // They have 10 tokens settled at a price of 1.2 should yield 12 units of collateral.
     const tokenHolderInitialCollateral = await collateral.balanceOf(tokenHolder);
     const tokenHolderInitialSynthetic = await tokenCurrency.balanceOf(tokenHolder);
 
@@ -811,20 +811,17 @@ contract("PricelessPositionManager", function(accounts) {
     const tokenHolderFinalSynthetic = await tokenCurrency.balanceOf(tokenHolder);
 
     // The token holder should gain the value of their synthetic tokens in underlying.
-    // The value in underlying is the number of tokens they held in the beginning * settlement price as TRV
-    // When redeeming 50 tokens at a price of 1.2 we expect to receive 60 collateral tokens (50 * 1.2)
-    const expectedTokenHolderFinalCollateral = toWei("60");
+    const expectedTokenHolderFinalCollateral = "12";
     assert.equal(tokenHolderFinalCollateral.sub(tokenHolderInitialCollateral), expectedTokenHolderFinalCollateral);
 
     // The token holder should have no synthetic positions left after settlement.
     assert.equal(tokenHolderFinalSynthetic, 0);
 
     // For the sponsor, they are entitled to the underlying value of their remaining synthetic tokens + the excess collateral
-    // in their position at time of settlement - final fees. The sponsor had 150 units of collateral in their position and the final TRV
-    // of their synthetics they sold is 60. Their redeemed amount for this excess collateral is the difference between the two.
+    // in their position at time of settlement - final fees.
     //
     // HOWEVER, the excess collateral calculated will be slightly less than expected because of the aformentioned rounding issues.
-    // The sponsor also has 50 synthetic tokens that they did not sell. This makes their expected redemption = 150 - 120 + 50 * 1.2 - 1 - rounding-error <= 89
+    // The sponsor also has 10 synthetic tokens that they did not sell. This makes their expected redemption = 30 - (20 * 1.2) + (10 * 1.2) - 1 - rounding-error <= 17
     const sponsorInitialCollateral = await collateral.balanceOf(sponsor);
     const sponsorInitialSynthetic = await tokenCurrency.balanceOf(sponsor);
 
@@ -837,10 +834,10 @@ contract("PricelessPositionManager", function(accounts) {
 
     // The token Sponsor should gain the value of their synthetics in underlying
     // + their excess collateral from the over collateralization in their position
-    // Excess collateral = 150 - 100 * 1.2 - 1 - roundingErrors <= 29
-    const expectedSponsorCollateralUnderlying = toBN(toWei("29"));
-    // Value of remaining synthetic tokens = 50 * 1.2 = 60
-    const expectedSponsorCollateralSynthetic = toBN(toWei("60"));
+    // Excess collateral = 30 - 20 * 1.2 - 1 - roundingErrors <= 5
+    const expectedSponsorCollateralUnderlying = toBN("5");
+    // Value of remaining synthetic tokens = 10 * 1.2 = 12
+    const expectedSponsorCollateralSynthetic = toBN("12");
     const expectedTotalSponsorCollateralReturned = expectedSponsorCollateralUnderlying.add(
       expectedSponsorCollateralSynthetic
     );
@@ -851,8 +848,8 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(sponsorFinalSynthetic, 0);
 
     // The contract should have a small remainder of collateral tokens due to rounding
-    // TODO(#934): Put a more precise upper bound on the rounding error
-    assert((await collateral.balanceOf(pricelessPositionManager.address)).gt(0));
+    // TODO(#934): Put a more precise upper bound on the rounding error. I purposefully choose small enough numbers here that I know before hand what the rounding error will be.
+    assert.equal((await collateral.balanceOf(pricelessPositionManager.address)).toString(), "1");
 
     // Last check is that after redemption the position in the positions mapping has been removed.
     const sponsorsPosition = await pricelessPositionManager.positions(sponsor);

--- a/core/test/financial_templates/PricelessPositionManager.js
+++ b/core/test/financial_templates/PricelessPositionManager.js
@@ -781,6 +781,7 @@ contract("PricelessPositionManager", function(accounts) {
     // Expire the contract, causing the contract to pay its final fees
     const expirationTime = await pricelessPositionManager.expirationTimestamp();
     await pricelessPositionManager.setCurrentTime(expirationTime.toNumber() + 1);
+    const expectedStoreBalance = (await collateral.balanceOf(store.address)).add(toBN(finalFeePaid));
     await pricelessPositionManager.expire({ from: other });
 
     // Absent any rounding errors, `getCollateral` should return (initial-collateral - final-fees) = 30 wei - 1 wei = 29 wei.
@@ -793,7 +794,6 @@ contract("PricelessPositionManager", function(accounts) {
     assert(toBN(collateralAmount.rawValue).lt(toBN("29")));
 
     // The actual amount of fees paid to the store is as expected = 1e-18
-    const expectedStoreBalance = (await collateral.balanceOf(store.address)).add(toBN(finalFeePaid));
     assert.equal((await collateral.balanceOf(store.address)).toString(), expectedStoreBalance.toString());
 
     // Push a settlement price into the mock oracle to simulate a DVM vote. Say settlement occurs at 1.2 Stock/USD for the price


### PR DESCRIPTION
Adds `mulCeil` and `divCeil` to fee adjustment calculations in `_payOracleFees` and `payFees`. It is possible that the `feePaid` divided by the `totalPositionCollateral` needs to be "ceil'd" rather than "floor'd". If this "fee %" is lower than what we expect, then all of the position collaterals become slightly higher than what we expect, potentially causing some token redemptions to not be fully backed by collateral. Therefore, we must "ceil" the "fee %"

Fixes #873
Signed-off-by: Nick Pai <npai.nyc@gmail.com>