### PR TITLE
Check that liquidated amount is >= underlying collateral amount instead of ==

### DIFF
--- a/core/contracts/financial_templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial_templates/implementation/Liquidatable.sol
@@ -181,7 +181,11 @@ contract Liquidatable is PricelessPositionManager {
         require(positionCollateral.isGreaterThan(0));
 
         // Caller is required to include in order to prevent front-running attacks that modify the liquidatedCollateral amount
-        require(amountToLiquidate.isEqual(positionCollateral.sub(positionToLiquidate.withdrawalRequestAmount)));
+        // @dev amountToLiquidate is >= underlying collateral because the position is still liquidatable if the underlying collateral declines
+        // while the liquidation transaction is pending
+        require(
+            amountToLiquidate.isGreaterThanOrEqual(positionCollateral.sub(positionToLiquidate.withdrawalRequestAmount))
+        );
 
         // Construct liquidation object.
         // Note: all dispute-related values are just zeroed out until a dispute occurs.

--- a/core/test/financial_templates/Liquidatable.js
+++ b/core/test/financial_templates/Liquidatable.js
@@ -267,8 +267,8 @@ contract("Liquidatable", function(accounts) {
           .toString()
       );
     });
-    it("Liquidation amount is not specified correctly", async () => {
-      const invalidAmount = amountOfCollateralToLiquidate.sub(toBN(toWei("1")));
+    it("Liquidation amount not greater than or equal to the underlying collateral in the contract", async () => {
+      const invalidAmount = amountOfCollateralToLiquidate.sub(toBN(toWei("149.99")));
       assert(
         await didContractThrow(
           liquidationContract.createLiquidation(sponsor, { rawValue: invalidAmount.toString() }, { from: liquidator })


### PR DESCRIPTION
Makes small change to #926 which added a parameter to `createLiquidation` to prevent front-running. I changed `IsEqual` to `IsGreaterThanOrEqual` when comparing the new parameter to the underlying collateral (returned by `_getCollateral`). We do not need to revert any liquidations if the collateral declines, as the collateralization ratio has only gotten worst.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>