### PR TITLE
NFCT Emergency Shutdown

### DIFF
--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -235,7 +235,7 @@ contract Liquidatable is PricelessPositionManager {
      * @param id of the disputed liquidation.
      * @param sponsor the address of the sponsor who's liquidation is being disputed.
      */
-    function dispute(uint id, address sponsor) external disputable(id, sponsor) fees() {
+    function dispute(uint id, address sponsor) external disputable(id, sponsor) onlyPreExpiration() fees() {
         LiquidationData storage disputedLiquidation = _getLiquidationData(sponsor, id);
 
         FixedPoint.Unsigned memory disputeBondAmount = _getCollateral(disputedLiquidation.rawLockedCollateral).mul(
@@ -270,6 +270,7 @@ contract Liquidatable is PricelessPositionManager {
      */
     function withdrawLiquidation(uint id, address sponsor)
         public
+        onlyPreExpiration()
         withdrawable(id, sponsor)
         fees()
         returns (FixedPoint.Unsigned memory withdrawalAmount)

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -174,6 +174,7 @@ contract Liquidatable is PricelessPositionManager {
     function createLiquidation(address sponsor, FixedPoint.Unsigned calldata amountToLiquidate)
         external
         fees()
+        onlyPreExpiration()
         returns (uint uuid)
     {
         // Attempt to retrieve Position data for sponsor

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -55,7 +55,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     // Unique identifier for DVM price feed ticker.
     bytes32 public priceIdentifer;
-    // Time that this contract expires. Is updated if emergency shutdown occures.
+    // Time that this contract expires. Should not change post-construction unless a emergency shutdown occurs.
     uint public expirationTimestamp;
     // Time that has to elapse for a withdrawal request to be considered passed, if no liquidations occur.
     uint public withdrawalLiveness;

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -378,9 +378,10 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     /**
     * @notice Premature contract settlement under emergency circumstances.
-    * @dev only the governer can call this function as they are permissioned within the FinancialContractAdmin.
-    * Apon emergencyshutdown the contract settlement time is set to the shutdown time. This enables withdrawls
-    * to occure via the standard settleExpired function call.
+    * @dev Only the governor can call this function as they are permissioned within the `FinancialContractAdmin`.
+    * Upon emergency shutdown, the contract settlement time is set to the shutdown time. This enables withdrawal
+    * to occur via the standard settleExpired function call. Contract state is set to `ExpiredPriceRequested`
+    * which prevents re-entreaty into this function or the `expire` function.
     */
     function emergencyShutdown() external onlyPreExpiration() onlyOpenState() {
         require(msg.sender == _getFinancialContractsAdminAddress());

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -338,6 +338,9 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
      * @dev This Burns all tokens from the caller of `tokenCurrency` and sends back the proportional amount of `collateralCurrency`.
      */
     function settleExpired() external onlyPostExpiration() fees() {
+        // If the contract state is open and onlyPostExpiration passed then `expire()` has not yet been called.
+        require(contractState != ContractState.Open);
+
         // Get the current settlement price and store it. If it is not resolved will revert.
         if (contractState != ContractState.ExpiredPriceReceived) {
             expiryPrice = _getOraclePrice(expirationTimestamp);

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -384,7 +384,8 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     * @dev Only the governor can call this function as they are permissioned within the `FinancialContractAdmin`.
     * Upon emergency shutdown, the contract settlement time is set to the shutdown time. This enables withdrawal
     * to occur via the standard settleExpired function call. Contract state is set to `ExpiredPriceRequested`
-    * which prevents re-entry into this function or the `expire` function.
+    * which prevents re-entry into this function or the `expire` function. No fees are paid when calling
+    * `emergencyShutdown` as the governor who would call the function would also receive the fees.
     */
     function emergencyShutdown() external onlyPreExpiration() onlyOpenState() {
         require(msg.sender == _getFinancialContractsAdminAddress());

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -378,7 +378,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     function emergencyShutdown() external onlyPreExpiration() onlyOpenState() {
         require(msg.sender == _getFinancialContractsAdminAddress());
-        
+
         contractState = ContractState.ExpiredPriceRequested;
         // Expiratory time now becomes the current time (emergency shutdown time).
         // Price requested at this time stamp. `settleExpired` can now withdraw at this timestamp.

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -376,6 +376,12 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         emit SettleExpiredPosition(msg.sender, totalRedeemableCollateral.rawValue, tokensToRedeem.rawValue);
     }
 
+    /**
+    * @notice Premature contract settlement under emergency circumstances.
+    * @dev only the governer can call this function as they are permissioned within the FinancialContractAdmin.
+    * Apon emergencyshutdown the contract settlement time is set to the shutdown time. This enables withdrawls
+    * to occure via the standard settleExpired function call.
+    */
     function emergencyShutdown() external onlyPreExpiration() onlyOpenState() {
         require(msg.sender == _getFinancialContractsAdminAddress());
 

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -381,7 +381,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     * @dev Only the governor can call this function as they are permissioned within the `FinancialContractAdmin`.
     * Upon emergency shutdown, the contract settlement time is set to the shutdown time. This enables withdrawal
     * to occur via the standard settleExpired function call. Contract state is set to `ExpiredPriceRequested`
-    * which prevents re-entreaty into this function or the `expire` function.
+    * which prevents re-entry into this function or the `expire` function.
     */
     function emergencyShutdown() external onlyPreExpiration() onlyOpenState() {
         require(msg.sender == _getFinancialContractsAdminAddress());
@@ -396,9 +396,9 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         emit EmergencyShutdown(msg.sender, oldExpirationTimestamp, expirationTimestamp);
     }
 
-    //TODO: is this how we want this function to be implemented?
+    //TODO is this how we want this function to be implemented?
     function remargin() external onlyPreExpiration() {
-        _payFinalFees(address(this));
+        return;
     }
 
     /**

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -395,6 +395,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         emit EmergencyShutdown(msg.sender, oldExpirationTimestamp, expirationTimestamp);
     }
 
+    //TODO: is this how we want this function to be implemented? 
     function remargin() external onlyPreExpiration() {
         _payFinalFees(address(this));
     }
@@ -507,7 +508,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
      * unnecessarily increase contract bytecode size.
      * source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
      */
-
     function _isContractStateOpen() internal view {
         require(contractState == ContractState.Open);
     }

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -396,7 +396,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         emit EmergencyShutdown(msg.sender, oldExpirationTimestamp, expirationTimestamp);
     }
 
-    //TODO: is this how we want this function to be implemented? 
+    //TODO: is this how we want this function to be implemented?
     function remargin() external onlyPreExpiration() {
         _payFinalFees(address(this));
     }

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -81,24 +81,24 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     event EmergencyShutdown(address indexed caller, uint originalExpirationTimestamp, uint shutdownTimestamp);
 
     modifier onlyPreExpiration() {
-        _isPreExpiration();
+        _onlyPreExpiration();
         _;
     }
 
     modifier onlyPostExpiration() {
-        _isPostExpiration();
+        _onlyPostExpiration();
         _;
     }
 
     modifier onlyCollateralizedPosition(address sponsor) {
-        _isCollateralizedPosition(sponsor);
+        _onlyCollateralizedPosition(sponsor);
         _;
     }
 
     // Check that the current state of the pricelessPositionManager is Open.
     // This prevents multiple calls to `expire` and `EmergencyShutdown` post expiration.
     modifier onlyOpenState() {
-        _isContractStateOpen();
+        _onlyOpenState();
         _;
     }
 
@@ -512,19 +512,19 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
      * unnecessarily increase contract bytecode size.
      * source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
      */
-    function _isContractStateOpen() internal view {
+    function _onlyOpenState() internal view {
         require(contractState == ContractState.Open);
     }
 
-    function _isPreExpiration() internal view {
+    function _onlyPreExpiration() internal view {
         require(getCurrentTime() < expirationTimestamp);
     }
 
-    function _isPostExpiration() internal view {
+    function _onlyPostExpiration() internal view {
         require(getCurrentTime() >= expirationTimestamp);
     }
 
-    function _isCollateralizedPosition(address sponsor) internal view {
+    function _onlyCollateralizedPosition(address sponsor) internal view {
         require(_getCollateral(positions[sponsor].rawCollateral).isGreaterThan(0));
     }
 }

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -55,7 +55,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     // Unique identifier for DVM price feed ticker.
     bytes32 public priceIdentifer;
-    // Time that this contract expires.
+    // Time that this contract expires. Is updated if emergency shutdown occures.
     uint public expirationTimestamp;
     // Time that has to elapse for a withdrawal request to be considered passed, if no liquidations occur.
     uint public withdrawalLiveness;
@@ -65,7 +65,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     // Enum to store the state of the PricelessPositionManager. Is set on expiration or emergency shutdown.
     enum ContractState { Open, ExpiredPriceRequested, ExpiredPriceReceived }
-    ContractState contractState;
+    ContractState public contractState;
 
     event Transfer(address indexed oldSponsor, address indexed newSponsor);
     event Deposit(address indexed sponsor, uint indexed collateralAmount);
@@ -377,7 +377,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     }
 
     function emergencyShutdown() external onlyPreExpiration() onlyOpenState() {
-        require(msg.sender == _getFinancialContractsAdminAddress);
+        require(msg.sender == _getFinancialContractsAdminAddress());
         
         contractState = ContractState.ExpiredPriceRequested;
         // Expiratory time now becomes the current time (emergency shutdown time).

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -984,7 +984,7 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(collateralPaid, toWei("120"));
   });
 
-  it.only("Emergency shutdown: lifecycle", async function() {
+  it("Emergency shutdown: lifecycle", async function() {
     // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
     // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.
     await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -1041,6 +1041,15 @@ contract("PricelessPositionManager", function(accounts) {
       )
     );
 
+    // Expire should not be able to be called as the contract has been emergency shutdown.
+    assert(
+      await didContractThrow(
+        pricelessPositionManager.expire({
+          from: other
+        })
+      )
+    );
+
     // Before the DVM has resolved a price withdrawals should be disabled (as with settlement at maturity).
     assert(
       await didContractThrow(

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -506,7 +506,7 @@ contract("PricelessPositionManager", function(accounts) {
     truffleAssert.eventEmitted(settleExpiredResult, "SettleExpiredPosition", ev => {
       return (
         ev.caller == tokenHolder &&
-        ev.collateralAmountReturned == tokenHolderFinalCollateral.sub(tokenHolderInitialCollateral).toString() &&
+        ev.collateralReturned == tokenHolderFinalCollateral.sub(tokenHolderInitialCollateral).toString() &&
         ev.tokensBurned == tokenHolderInitialSynthetic.toString()
       );
     });
@@ -733,7 +733,7 @@ contract("PricelessPositionManager", function(accounts) {
     truffleAssert.eventEmitted(settleExpiredResult, "SettleExpiredPosition", ev => {
       return (
         ev.caller == tokenHolder &&
-        ev.collateralAmountReturned == tokenHolderFinalCollateral.sub(tokenHolderInitialCollateral).toString() &&
+        ev.collateralReturned == tokenHolderFinalCollateral.sub(tokenHolderInitialCollateral).toString() &&
         ev.tokensBurned == tokenHolderInitialSynthetic.toString()
       );
     });
@@ -1137,10 +1137,10 @@ contract("PricelessPositionManager", function(accounts) {
       from: contractDeployer
     });
 
-    // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. 
+    // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral.
     await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
     await pricelessPositionManager.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: sponsor });
-    
+
     // Advance time until after expiration. Token holders and sponsors should now be able to start trying to settle.
     const expirationTime = await pricelessPositionManager.expirationTimestamp();
     await pricelessPositionManager.setCurrentTime(expirationTime.toNumber() + 1);

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -21,6 +21,7 @@ contract("PricelessPositionManager", function(accounts) {
   const tokenHolder = accounts[2];
   const other = accounts[3];
   const collateralOwner = accounts[4];
+  const mockGovernor = accounts[5];
 
   // Contracts
   let collateral;
@@ -973,5 +974,13 @@ contract("PricelessPositionManager", function(accounts) {
     await pricelessPositionManager.settleExpired({ from: other });
     collateralPaid = (await collateral.balanceOf(other)).sub(initialCollateral);
     assert.equal(collateralPaid, toWei("120"));
+  });
+
+  it("Emergency shutdown", async function() {
+    //To mock the emergency shutdown, register a controlled EOA as the Governor within the finder.
+    const mockFinancialContractsAdmin = web3.utils.utf8ToHex("FinancialContractsAdmin");
+    await finder.changeImplementationAddress(mockFinancialContractsAdmin, mockGovernor, {
+      from: contractDeployer
+    });
   });
 });

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -1051,7 +1051,7 @@ contract("PricelessPositionManager", function(accounts) {
     );
 
     // UMA token holders now vote to resolve of the price request to enable the emergency shutdown to continue.
-    // Say they resolve to a price of 1.1 USD per synthetic token. 
+    // Say they resolve to a price of 1.1 USD per synthetic token.
     await mockOracle.pushPrice(priceTrackingIdentifier, shutdownTimestamp, toWei("1.1"));
 
     // Token holders (`sponsor` and `tokenHolder`) should now be able to withdraw post emergency shutdown.
@@ -1100,7 +1100,7 @@ contract("PricelessPositionManager", function(accounts) {
     // For the sponsor, they are entitled to the underlying value of their remaining synthetic tokens + the excess collateral
     // in their position at time of settlement. The sponsor had 150 units of collateral in their position and the final TRV
     // of their synthetics they sold is 110. Their redeemed amount for this excess collateral is the difference between the two.
-    // The sponsor also has 50 synthetic tokens that they did not sell. 
+    // The sponsor also has 50 synthetic tokens that they did not sell.
     // This makes their expected redemption = 150 - 110 + 50 * 1.1 = 95
     const sponsorInitialCollateral = await collateral.balanceOf(sponsor);
     const sponsorInitialSynthetic = await tokenCurrency.balanceOf(sponsor);


### PR DESCRIPTION
This PR introduces emergency shutdown to the NFCT. This required a small change to how state pertaining to a price retrieval is stored within the `settleExpired` function. Previously a bool `hasExpiryPrice` was used to check if a price had been received. This is now changed to use a enum `ContractState` which defines three different states, including a pending and received price state.

At contract emergency shutdown, the expiring multiparty contract's `expirationTimestamp` is set to the shutdown time. This means that the normal exit process via `settleExpired` is still functional in the normal way, once the DVM has resolved the price request.

No fees are charged during an emergency shutdown.

This PR also fixes two vulnerabilities as a byproduct:
1) liquidations are now disabled post expiration with the `onlyPreExpiration` modifier. Before liquidations could be called after settlement.
2) `settleExpired` can only be called once. Before this could be called unlimited times resulting in contract funds being drained to the DVM for final fees.

close #981 
close #979 
close #978 
close #973