### PR TITLE
Edit Slither CI script: filter out @openzeppelin contracts, add back detectors

### DIFF
--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -10,7 +10,7 @@ run_slither() {
     cp -r ../node_modules/@openzeppelin ./node_modules/@openzeppelin
 
     cd $PROTOCOL_DIR
-    slither --exclude=naming-convention,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
+    slither --exclude=naming-convention,pragma,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
 }
 
 run_slither $PROTOCOL_DIR/core

--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -8,10 +8,9 @@ run_slither() {
     cd $1
     mkdir -p node_modules/
     cp -r ../node_modules/@openzeppelin ./node_modules/@openzeppelin
-    truffle compile 
 
     cd $PROTOCOL_DIR
-    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,locked-ether,reentrancy-eth,uninitialized-state-variables,incorrect-equality,reentrancy-events,assembly,shadowing-local,low-level-calls,constant-function-state $1
+    slither --exclude=naming-convention,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
 }
 
 run_slither $PROTOCOL_DIR/core

--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -10,7 +10,7 @@ run_slither() {
     cp -r ../node_modules/@openzeppelin ./node_modules/@openzeppelin
 
     cd $PROTOCOL_DIR
-    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
+    slither --exclude=naming-convention,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
 }
 
 run_slither $PROTOCOL_DIR/core

--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -10,7 +10,7 @@ run_slither() {
     cp -r ../node_modules/@openzeppelin ./node_modules/@openzeppelin
 
     cd $PROTOCOL_DIR
-    slither --exclude=naming-convention,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
+    slither --exclude=naming-convention,solc-version,pragma,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths=@openzeppelin $1
 }
 
 run_slither $PROTOCOL_DIR/core


### PR DESCRIPTION
This PR includes several changes to `run_slither.sh`:
- Remove unnecessary `truffle compile` before running `slither`: `build.sh` (earlier in CI workflow) already compiles contracts
- add --filter-paths=@openzeppelin to slither script to ignore Openzeppelin contracts. Although we depend on these contracts and therefore we must ensure that they are secure as well, we should ignore for a couple reasons. One being that presumably openzeppelin rigorously tests their contracts before publishing. Second, we added a bunch of detectors to exclude while running Slither just because the openzeppelin contracts throw
- Detectors that we can remove from the `--exclude` flag: `locked-ether`, `reentrancy-eth`, `uninitialized-state-variables`, `shadowing-local`, `low-level-calls`, `constant-function-state`

Incidentally, I tried running `--triage-mode` (see #444) but one issue with this is that the generated `slither.db.json` remembers line numbers. I think that we still need to look into triage-mode
 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>