### PR TITLE
Add shim of liquidator script

### DIFF
--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -64,7 +64,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     });
 
     emp = await ExpiringMultiParty.new(constructorParams);
-    client = new ExpiringMultiPartyClient(emp.address);
+    client = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
     await collateralToken.approve(emp.address, toWei("1000000"), { from: accounts[0] });
     await collateralToken.approve(emp.address, toWei("1000000"), { from: accounts[1] });
 

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -1,0 +1,37 @@
+const argv = require("minimist")(process.argv.slice(), { string: ["address"] });
+
+const { ExpiringMultiPartyClient } = require("../financial-templates-lib/ExpiringMultiPartyClient.js", { artifacts });
+const { delay } = require("../financial-templates-lib/delay.js");
+
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+
+// TODO: Figure out a good way to run this script, maybe with a wrapper shell script.
+// Currently, you can run it with `truffle exec ../liquidator/liquidator.js --address=<address>` *from the core
+// directory*.
+async function run() {
+  const client = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, argv.address);
+  client.start();
+  while (true) {
+    try {
+      console.log("Polling");
+      // Steps:
+      // Get most recent price from a price feed.
+      // Call client.getUnderCollateralizedPositions()
+      // Acquire synthetic tokens somehow. v0: assume the bot holds on to them.
+      // Liquidate any undercollateralized positions!
+      // Withdraw money from any liquidations that are expired or DisputeFailed.
+    } catch (error) {
+      console.log("Poll error:", error);
+    }
+    await delay(Number(10_000));
+  }
+}
+
+module.exports = async function(callback) {
+  try {
+    await run();
+  } catch (err) {
+    callback(err);
+  }
+  callback();
+};

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -1,6 +1,6 @@
 const argv = require("minimist")(process.argv.slice(), { string: ["address"] });
 
-const { ExpiringMultiPartyClient } = require("../financial-templates-lib/ExpiringMultiPartyClient.js", { artifacts });
+const { ExpiringMultiPartyClient } = require("../financial-templates-lib/ExpiringMultiPartyClient.js");
 const { delay } = require("../financial-templates-lib/delay.js");
 
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
@@ -20,6 +20,14 @@ async function run() {
       // Acquire synthetic tokens somehow. v0: assume the bot holds on to them.
       // Liquidate any undercollateralized positions!
       // Withdraw money from any liquidations that are expired or DisputeFailed.
+        //
+        //
+        // DISPUTER
+        // Steps:
+        // Call client.getUndisputedLiquidations()
+        // For each liquidation, get the price at liquidation time
+        // If that price makes the liquidation invalid, then dispute it!
+        // Withdraw money from any liquidations that are in DisputeSucceeded.
     } catch (error) {
       console.log("Poll error:", error);
     }

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -20,14 +20,6 @@ async function run() {
       // Acquire synthetic tokens somehow. v0: assume the bot holds on to them.
       // Liquidate any undercollateralized positions!
       // Withdraw money from any liquidations that are expired or DisputeFailed.
-        //
-        //
-        // DISPUTER
-        // Steps:
-        // Call client.getUndisputedLiquidations()
-        // For each liquidation, get the price at liquidation time
-        // If that price makes the liquidation invalid, then dispute it!
-        // Withdraw money from any liquidations that are in DisputeSucceeded.
     } catch (error) {
       console.log("Poll error:", error);
     }

--- a/liquidator/package.json
+++ b/liquidator/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "liquidator",
+  "version": "0.1.0",
+  "description": "Liquidator",
+  "private": true,
+  "dependencies": {}
+}


### PR DESCRIPTION
Nothing internal has been implemented in this PR.

Ideally, we'd want liquidator/ to depend on financial-templates-lib/ via an NPM dependency.

Issue #992 

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>