### PR TITLE
make pricerequest contract data private

### DIFF
--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -90,11 +90,11 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
     mapping(uint => Round) public rounds;
 
     // Maps price request IDs to the PriceRequest struct.
-    mapping(bytes32 => PriceRequest) public priceRequests;
+    mapping(bytes32 => PriceRequest) private priceRequests;
 
     // Price request ids for price requests that haven't yet been marked as resolved. These requests may be for future
     // rounds.
-    bytes32[] public pendingPriceRequests;
+    bytes32[] private pendingPriceRequests;
 
     VoteTiming.Data public voteTiming;
 


### PR DESCRIPTION
For improving security, make price request data private in `Voting.sol`
Fixes #982 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>