### PR TITLE
Expiring multi party `siphon`

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -14,6 +14,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
     struct Params {
         uint expirationTimestamp;
         uint withdrawalLiveness;
+        uint siphonDelay;
         address collateralAddress;
         address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
@@ -61,6 +62,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         // Input from function call
         constructorParams.expirationTimestamp = params.expirationTimestamp;
         constructorParams.withdrawalLiveness = params.withdrawalLiveness;
+        constructorParams.siphonDelay = params.siphonDelay;
         constructorParams.collateralAddress = params.collateralAddress;
         constructorParams.tokenFactoryAddress = params.tokenFactoryAddress;
         constructorParams.priceFeedIdentifier = params.priceFeedIdentifier;

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -121,6 +121,7 @@ contract Liquidatable is PricelessPositionManager {
         bool isTest;
         uint expirationTimestamp;
         uint withdrawalLiveness;
+        uint siphonDelay;
         address collateralAddress;
         address finderAddress;
         address tokenFactoryAddress;
@@ -141,6 +142,7 @@ contract Liquidatable is PricelessPositionManager {
             params.isTest,
             params.expirationTimestamp,
             params.withdrawalLiveness,
+            params.siphonDelay,
             params.collateralAddress,
             params.finderAddress,
             params.priceFeedIdentifier,

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -547,7 +547,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     }
 
     function _onlyPreSiphon() internal view {
-        require(getCurrentTime() < expirationTimestamp + siphonDelay);
+        require(getCurrentTime() < expirationTimestamp.add(siphonDelay));
     }
 
     function _onlyCollateralizedPosition(address sponsor) internal view {

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -21,7 +21,7 @@ import "./FeePayer.sol";
  */
 
 contract PricelessPositionManager is FeePayer, AdministrateeInterface {
-    using SafeMath for uin
+    using SafeMath for uint;
     using FixedPoint for FixedPoint.Unsigned;
     using SafeERC20 for IERC20;
     using SafeERC20 for ExpandedIERC20;
@@ -393,6 +393,9 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         require(getCurrentTime() > expirationTimestamp + siphonDelay);
         uint contractCollateralBalance = collateralCurrency.balanceOf(address(this));
         collateralCurrency.safeTransfer(_getStoreAddress(), contractCollateralBalance);
+    }
+
+    /**
     * @notice Premature contract settlement under emergency circumstances.
     * @dev Only the governor can call this function as they are permissioned within the `FinancialContractAdmin`.
     * Upon emergency shutdown, the contract settlement time is set to the shutdown time. This enables withdrawal
@@ -472,6 +475,8 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     function _getStoreAddress() internal view returns (address) {
         bytes32 storeInterface = "Store";
         return finder.getImplementationAddress(storeInterface);
+    }
+
     function _getFinancialContractsAdminAddress() internal view returns (address) {
         bytes32 financialContractsAdminInterface = "FinancialContractsAdmin";
         return finder.getImplementationAddress(financialContractsAdminInterface);

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -83,7 +83,6 @@ contract PricelessPositionManager is FeePayer {
         uint indexed collateralAmountReturned,
         uint indexed tokensBurned
     );
-    event test(string err);
 
     modifier onlyPreExpiration() {
         _isPreExpiration();

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -59,7 +59,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     uint public expirationTimestamp;
     // Time that has to elapse for a withdrawal request to be considered passed, if no liquidations occur.
     uint public withdrawalLiveness;
-    // Time that has to elapse for the contract to be siphoned. This occures if a long period (>6 months) has
+    // Time that has to elapse for the contract to be siphoned. This occures if a long period has
     // occured post expiration and there is remaining unclaimed collateral in the contract.
     uint public siphonDelay;
 
@@ -387,7 +387,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     /**
      * @notice If token holders or sponsors do not redeem their positions for underlying collateral within
      * a pre-defined `siphonDelay`, all underlying collateral is sent to the Store. This delay is set to
-     * be sufficiently long such that token holders have a reasonable period of time to withdrawal (>6 months).
+     * be sufficiently long such that token holders have a reasonable period of time to withdrawal.
      */
     function siphonContractCollateral() external {
         require(getCurrentTime() > expirationTimestamp.add(siphonDelay));

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -59,8 +59,9 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     uint public expirationTimestamp;
     // Time that has to elapse for a withdrawal request to be considered passed, if no liquidations occur.
     uint public withdrawalLiveness;
-    // Time that has to elapse for the contract to be siphoned. This occures if a long period has
-    // occured post expiration and there is remaining unclaimed collateral in the contract.
+    // Time that has to elapse for the contract to be siphoned. This occurs if `siphonDelay`
+    // seconds have past after the expiration timestamp and there is remaining unclaimed
+    // collateral in the contract.
     uint public siphonDelay;
 
     // The expiry price pulled from the DVM.

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -501,7 +501,7 @@ contract PricelessPositionManager is FeePayer {
     }
 
     function _isPreSiphon() internal view {
-        require (getCurrentTime() < expirationTimestamp + siphonDelay);
+        require(getCurrentTime() < expirationTimestamp + siphonDelay);
     }
 
     function _isCollateralizedPosition(address sponsor) internal view {

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -390,7 +390,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
      * be sufficiently long such that token holders have a reasonable period of time to withdrawal (>6 months).
      */
     function siphonContractCollateral() external {
-        require(getCurrentTime() > expirationTimestamp + siphonDelay);
+        require(getCurrentTime() > expirationTimestamp.add(siphonDelay));
         uint contractCollateralBalance = collateralCurrency.balanceOf(address(this));
         collateralCurrency.safeTransfer(_getStoreAddress(), contractCollateralBalance);
     }

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -387,8 +387,9 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     /**
      * @notice If token holders or sponsors do not redeem their positions for underlying collateral within
-     * a pre-defined `siphonDelay`, all underlying collateral is sent to the Store. This delay is set to
-     * be sufficiently long such that token holders have a reasonable period of time to withdrawal.
+     * a pre-defined `siphonDelay`, all underlying collateral is sent to the Store. This delay
+     * should be set to be sufficiently long such that token holders have a reasonable
+     * period of time to withdrawal.
      */
     function siphonContractCollateral() external {
         require(getCurrentTime() > expirationTimestamp.add(siphonDelay));

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -378,8 +378,8 @@ contract PricelessPositionManager is FeePayer {
      */
     function siphonContractCollateral() external {
         require(getCurrentTime() > expirationTimestamp + siphonDelay);
-        uint contractCollateralBallance = collateralCurrency.balanceOf(address(this));
-        collateralCurrency.safeTransfer(_getStoreAddress(), contractCollateralBallance);
+        uint contractCollateralBalance = collateralCurrency.balanceOf(address(this));
+        collateralCurrency.safeTransfer(_getStoreAddress(), contractCollateralBalance);
     }
 
     /**

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -122,7 +122,7 @@ contract PricelessPositionManager is FeePayer {
 
         priceIdentifer = _priceIdentifier;
     }
-
+\
     /**
      * @notice Transfers ownership of the caller's current position to `newSponsorAddress`. The address
      * `newSponsorAddress` isn't allowed to have a position of their own before the transfer.

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -379,7 +379,7 @@ contract PricelessPositionManager is FeePayer {
     function siphonContractCollateral() external {
         require(getCurrentTime() > expirationTimestamp + siphonDelay);
         uint contractCollateralBallance = collateralCurrency.balanceOf(address(this));
-        collateralCurrency.transfer(_getStoreAddress(), contractCollateralBallance);
+        collateralCurrency.safeTransfer(_getStoreAddress(), contractCollateralBallance);
     }
 
     /**

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -60,7 +60,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     // Time that has to elapse for a withdrawal request to be considered passed, if no liquidations occur.
     uint public withdrawalLiveness;
     // Time that has to elapse for the contract to be siphoned. This occures if a long period (>6 months) has
-    // occured post settlement and there is remaining unclaimed collateral in the contract.
+    // occured post expiration and there is remaining unclaimed collateral in the contract.
     uint public siphonDelay;
 
     // The expiry price pulled from the DVM.

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -122,7 +122,6 @@ contract PricelessPositionManager is FeePayer {
 
         priceIdentifer = _priceIdentifier;
     }
-\
     /**
      * @notice Transfers ownership of the caller's current position to `newSponsorAddress`. The address
      * `newSponsorAddress` isn't allowed to have a position of their own before the transfer.

--- a/core/test/financial-templates/ExpiringMultiParty.js
+++ b/core/test/financial-templates/ExpiringMultiParty.js
@@ -17,6 +17,7 @@ contract("ExpiringMultiParty", function(accounts) {
       isTest: true,
       expirationTimestamp: "1234567890",
       withdrawalLiveness: "1000",
+      siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -37,6 +37,7 @@ contract("ExpiringMultiParty", function(accounts) {
     constructorParams = {
       expirationTimestamp: "1234567890",
       withdrawalLiveness: "1000",
+      siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -53,6 +53,7 @@ contract("Liquidatable", function(accounts) {
   const expirationTimestamp = toBN(startTime)
     .add(positionLiveness)
     .toString();
+  const siphonDelay = "100000"
   const withdrawalLiveness = toBN(60)
     .muln(60)
     .muln(1);
@@ -114,6 +115,7 @@ contract("Liquidatable", function(accounts) {
       isTest: true,
       expirationTimestamp: expirationTimestamp,
       withdrawalLiveness: withdrawalLiveness.toString(),
+      siphonDelay: siphonDelay,
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -53,7 +53,7 @@ contract("Liquidatable", function(accounts) {
   const expirationTimestamp = toBN(startTime)
     .add(positionLiveness)
     .toString();
-  const siphonDelay = "100000"
+  const siphonDelay = "100000";
   const withdrawalLiveness = toBN(60)
     .muln(60)
     .muln(1);

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -1023,9 +1023,8 @@ contract("PricelessPositionManager", function(accounts) {
     const ppmCollateralBefore = await collateral.balanceOf(pricelessPositionManager.address);
     assert.equal(ppmCollateralBefore.toString(), toWei("60"));
 
-    // The store should have zero balance before.
+    // Grab the store balance from before. This is non-zero as fees have been accrued in previous tests.
     const storeCollateralBefore = await collateral.balanceOf(store.address);
-    assert.equal(storeCollateralBefore.toString(), 0);
 
     // Execute the siphon action. Anyone can call this
     await pricelessPositionManager.siphonContractCollateral({ from: other });

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -90,7 +90,7 @@ contract("PricelessPositionManager", function(accounts) {
       true, // _isTest
       expirationTimestamp, // _expirationTimestamp
       withdrawalLiveness, // _withdrawalLiveness
-      siphonDelay, //__siphonDelay
+      siphonDelay, // __siphonDelay
       collateral.address, // _collateralAddress
       Finder.address, // _finderAddress
       priceTrackingIdentifier, // _priceFeedIdentifier
@@ -976,7 +976,7 @@ contract("PricelessPositionManager", function(accounts) {
     collateralPaid = (await collateral.balanceOf(other)).sub(initialCollateral);
     assert.equal(collateralPaid, toWei("120"));
   });
-  
+
   it.only("Contract siphon", async function() {
     // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
     // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -977,7 +977,7 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(collateralPaid, toWei("120"));
   });
 
-  it.only("Contract siphon", async function() {
+  it("Contract siphon", async function() {
     // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
     // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.
     await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -36,6 +36,7 @@ contract("PricelessPositionManager", function(accounts) {
   const syntheticSymbol = "UMATEST";
   const withdrawalLiveness = 1000;
   const expirationTimestamp = Math.floor(Date.now() / 1000) + 10000;
+  const siphonDelay = 100000;
   const priceTrackingIdentifier = web3.utils.utf8ToHex("UMATEST");
 
   const checkBalances = async (expectedSponsorTokens, expectedSponsorCollateral) => {
@@ -89,6 +90,7 @@ contract("PricelessPositionManager", function(accounts) {
       true, // _isTest
       expirationTimestamp, // _expirationTimestamp
       withdrawalLiveness, // _withdrawalLiveness
+      siphonDelay, //__siphonDelay
       collateral.address, // _collateralAddress
       Finder.address, // _finderAddress
       priceTrackingIdentifier, // _priceFeedIdentifier
@@ -973,5 +975,70 @@ contract("PricelessPositionManager", function(accounts) {
     await pricelessPositionManager.settleExpired({ from: other });
     collateralPaid = (await collateral.balanceOf(other)).sub(initialCollateral);
     assert.equal(collateralPaid, toWei("120"));
+  });
+  
+  it.only("Contract siphon", async function() {
+    // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
+    // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.
+    await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
+    const numTokens = toWei("100");
+    const amountCollateral = toWei("150");
+    await pricelessPositionManager.create({ rawValue: amountCollateral }, { rawValue: numTokens }, { from: sponsor });
+
+    // Transfer half the tokens from the sponsor to a tokenHolder. IRL this happens through the sponsor selling tokens.
+    const tokenHolderTokens = toWei("50");
+    await tokenCurrency.transfer(tokenHolder, tokenHolderTokens, {
+      from: sponsor
+    });
+
+    // Siphon should revert if before the siphon delay.
+    assert(await didContractThrow(pricelessPositionManager.siphonContractCollateral({ from: other })));
+
+    // Advance time until after expiration. Token holders and sponsors should now be able to to settle.
+    const expirationTime = await pricelessPositionManager.expirationTimestamp();
+    await pricelessPositionManager.setCurrentTime(expirationTime.toNumber() + 1);
+
+    // To settle positions the DVM needs to be to be queried to get the price at the settlement time.
+    await pricelessPositionManager.expire({ from: other });
+
+    // Push a settlement price into the mock oracle to simulate a DVM vote. Say settlement occurs at 1.2 Stock/USD for the price.
+    await mockOracle.pushPrice(priceTrackingIdentifier, expirationTime.toNumber(), toWei("1.2"));
+
+    // At this point, as it is post expiry,  token sponsor and token holder should be able to redeem their tokens.
+    // Let the token sponsor withdraw their expected collateral however the token holder never redeems their tokens.
+    await tokenCurrency.approve(pricelessPositionManager.address, amountCollateral, {
+      from: sponsor
+    });
+    await pricelessPositionManager.settleExpired({ from: sponsor });
+
+    // Siphon should revert if after the expired, but before the siphon delay.
+    assert(await didContractThrow(pricelessPositionManager.siphonContractCollateral({ from: other })));
+
+    // Advance time to after the siphon delay. Siphon should now work.
+    await pricelessPositionManager.setCurrentTime(expirationTime.toNumber() + siphonDelay + 1);
+
+    // The pricelessPositionManager should have the original collateral (150) - the amount withdrawn by the sponsor.
+    // The net of this is that the pricelessPositionManager should have exactly the value unclaimed tokens from the token holder
+    // denominated in collateral. The tokenHolder has 50 unclaimed tokens, valued at 1.2 Dai per token should yield: 50 * 1.2 = 60
+    const ppmCollateralBefore = await collateral.balanceOf(pricelessPositionManager.address);
+    assert.equal(ppmCollateralBefore.toString(), toWei("60"));
+
+    // The store should have zero balance before.
+    const storeCollateralBefore = await collateral.balanceOf(store.address);
+    assert.equal(storeCollateralBefore.toString(), 0);
+
+    // Execute the siphon action. Anyone can call this
+    await pricelessPositionManager.siphonContractCollateral({ from: other });
+
+    // After the siphon is done the pricelessPositionManager should have 0 collateral left in it.
+    const ppmCollateralAfter = await collateral.balanceOf(pricelessPositionManager.address);
+    assert.equal(ppmCollateralAfter.toString(), 0);
+
+    // The store should gain all of the pricelessPositionManager's collateral that was present before the siphon
+    const storeCollateralAfter = await collateral.balanceOf(store.address);
+    assert.equal(storeCollateralAfter.sub(storeCollateralBefore).toString(), ppmCollateralBefore.toString());
+
+    // If the token holder tries to withdraw now they cant as it is post siphon.
+    assert(await didContractThrow(pricelessPositionManager.settleExpired({ from: tokenHolder })));
   });
 });

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -986,8 +986,7 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(collateralPaid, toWei("120"));
   });
 
-  it("Contract siphon", async function() {
-  it("Emergency shutdown: lifecycle", async function() {
+  it("Post expiration siphon", async function() {
     // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
     // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.
     await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
@@ -1049,6 +1048,18 @@ contract("PricelessPositionManager", function(accounts) {
 
     // If the token holder tries to withdraw now they cant as it is post siphon.
     assert(await didContractThrow(pricelessPositionManager.settleExpired({ from: tokenHolder })));
+  });
+
+  it("Emergency shutdown: lifecycle", async function() {
+    // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
+    // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.
+    await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
+    const numTokens = toWei("100");
+    const amountCollateral = toWei("150");
+    await pricelessPositionManager.create({ rawValue: amountCollateral }, { rawValue: numTokens }, { from: sponsor });
+
+    // Transfer half the tokens from the sponsor to a tokenHolder. IRL this happens through the sponsor selling tokens.
+    const tokenHolderTokens = toWei("50");
     await tokenCurrency.transfer(tokenHolder, tokenHolderTokens, { from: sponsor });
 
     // Some time passes and the UMA token holders decide that Emergency shutdown needs to occur.

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -45,6 +45,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       isTest: true,
       expirationTimestamp: "12345678900",
       withdrawalLiveness: "1000",
+      siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,


### PR DESCRIPTION
This PR introduces the notion of a `siphon` function that enables excess collateral to be drained out of a contract if it has not been redeemed after a set maturity. All drained funds are sent to the store. 

The implementation in this PR was informed from a discussion we had during the week. If we choose to change how this siphon function works it's not a huge deal as this PR lays the foundation for this process. We can always introduce more logic to it as well as additional governance steps if we deem it appropriate.

Post `siphonDelay` all functionality is disabled except for the `siphon` function as the `onlyPostExpiration` modifier operates within the range from:

```
expiatory < t < expiry + siphonDelay
```

close #1001 