### PR TITLE
Change `derivative` to `contract` in the DVM

### DIFF
--- a/ci/deploy_to_staging.sh
+++ b/ci/deploy_to_staging.sh
@@ -27,12 +27,6 @@ gsutil cp gs://staging-deployment-configuration/voter-app.yaml voter-dapp/app.ya
 # Deploy voter dapp
 ./scripts/deploy_dapp.sh voter-dapp voter-dapp/app.yaml -q
 
-# Copy the staging config into the sponsor-dapp-v2 dir
-gsutil cp gs://staging-deployment-configuration/sponsor-v2-app.yaml sponsor-dapp-v2/app.yaml
-
-# Deploy sponsor-dapp-v2
-./scripts/deploy_dapp.sh sponsor-dapp-v2 sponsor-dapp-v2/app.yaml -q
-
 # Deploy docs
 # TODO(#977) Solc 0.6 not supported, skipping this
 # ./scripts/deploy_docs.sh documentation/gae_app.yaml -q

--- a/common/Enums.js
+++ b/common/Enums.js
@@ -1,7 +1,7 @@
 // Corresponds to Registry.Roles.
 const RegistryRolesEnum = {
   OWNER: "0",
-  DERIVATIVE_CREATOR: "1"
+  CONTRACT_CREATOR: "1"
 };
 
 // Corresponds to VoteTiming.Phase.

--- a/core/contracts/oracle/implementation/ContractCreator.sol
+++ b/core/contracts/oracle/implementation/ContractCreator.sol
@@ -19,6 +19,6 @@ contract ContractCreator {
         FinderInterface finder = FinderInterface(finderAddress);
         bytes32 registryInterface = "Registry";
         Registry registry = Registry(finder.getImplementationAddress(registryInterface));
-        registry.registerDerivative(parties, contractToRegister);
+        registry.registerContract(parties, contractToRegister);
     }
 }

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -189,12 +189,12 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
                     MODIFIERS
     ****************************************/
 
-    modifier onlyRegisteredDerivative() {
+    modifier onlyRegisteredContract() {
         if (migratedAddress != address(0)) {
             require(msg.sender == migratedAddress);
         } else {
             Registry registry = Registry(finder.getImplementationAddress("Registry"));
-            require(registry.isDerivativeRegistered(msg.sender));
+            require(registry.isContractRegistered(msg.sender));
         }
         _;
     }
@@ -216,7 +216,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore
-    function requestPrice(bytes32 identifier, uint time) external override onlyRegisteredDerivative() {
+    function requestPrice(bytes32 identifier, uint time) external override onlyRegisteredContract() {
         uint blockTime = getCurrentTime();
         require(time <= blockTime, "Can only request in past");
         require(identifierWhitelist.isIdentifierSupported(identifier), "Unsupported identifier request");
@@ -252,7 +252,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore
-    function hasPrice(bytes32 identifier, uint time) external override view onlyRegisteredDerivative() returns (bool _hasPrice) {
+    function hasPrice(bytes32 identifier, uint time) external override view onlyRegisteredContract() returns (bool _hasPrice) {
         (_hasPrice, , ) = _getPriceOrError(identifier, time);
     }
 
@@ -265,7 +265,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore
-    function getPrice(bytes32 identifier, uint time) external override view onlyRegisteredDerivative() returns (int) {
+    function getPrice(bytes32 identifier, uint time) external override view onlyRegisteredContract() returns (int) {
         (bool _hasPrice, int price, string memory message) = _getPriceOrError(identifier, time);
 
         // If the price wasn't available, revert with the provided message.

--- a/core/contracts/oracle/interfaces/AdministrateeInterface.sol
+++ b/core/contracts/oracle/interfaces/AdministrateeInterface.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.6.0;
 
 
 /**
- * @title Interface that all derivative contracts expose to the admin.
+ * @title Interface that all financial contracts expose to the admin.
  */
 interface AdministrateeInterface {
     /**

--- a/core/contracts/oracle/interfaces/RegistryInterface.sol
+++ b/core/contracts/oracle/interfaces/RegistryInterface.sol
@@ -4,57 +4,57 @@ pragma experimental ABIEncoderV2;
 
 
 /**
- * @title Interface for a registry of derivatives and derivative creators.
+ * @title Interface for a registry of contracts and contract creators.
  */
 interface RegistryInterface {
     /**
-     * @notice Registers a new derivative.
-     * @dev Only authorized derivative creators can call this method.
-     * @param parties an array of addresses who become party members to a derivative.
-     * @param derivativeAddress defines the address of the deployed derivative.
+     * @notice Registers a new contract.
+     * @dev Only authorized contract creators can call this method.
+     * @param parties an array of addresses who become parties in the contract.
+     * @param contractAddress defines the address of the deployed contract.
      */
-    function registerDerivative(address[] calldata parties, address derivativeAddress) external;
+    function registerContract(address[] calldata parties, address contractAddress) external;
 
     /**
-     * @notice Returns whether the derivative has been registered with the registry.
+     * @notice Returns whether the contract has been registered with the registry.
      * @dev If it is registered, it is an authorized participant in the UMA system.
-     * @param derivative address of the derivative contract.
-     * @return bool indicates whether the derivative is registered.
+     * @param contractAddress address of the contract.
+     * @return bool indicates whether the contract is registered.
      */
-    function isDerivativeRegistered(address derivative) external view returns (bool);
+    function isContractRegistered(address contractAddress) external view returns (bool);
 
     /**
-     * @notice Returns a list of all derivatives that are associated with a particular party.
+     * @notice Returns a list of all contracts that are associated with a particular party.
      * @param party address of the party.
-     * @return an array of the derivatives the party is registered to.
+     * @return an array of the contracts the party is registered to.
      */
-    function getRegisteredDerivatives(address party) external view returns (address[] memory);
+    function getRegisteredContracts(address party) external view returns (address[] memory);
 
     /**
-     * @notice Returns all registered derivatives.
-     * @return all registered derivative addresses within the system.
+     * @notice Returns all registered contracts.
+     * @return all registered contract addresses within the system.
      */
-    function getAllRegisteredDerivatives() external view returns (address[] memory);
+    function getAllRegisteredContracts() external view returns (address[] memory);
 
     /**
-     * @notice Adds a party member to the calling derivative.
-     * @dev msg.sender must be the derivative contract to which the party member is added.
-     * @param party address to be added to the derivatives.
+     * @notice Adds a party to the calling contract.
+     * @dev msg.sender must be the contract to which the party member is added.
+     * @param party address to be added to the contract.
      */
-    function addPartyToDerivative(address party) external;
+    function addPartyToContract(address party) external;
 
     /**
-     * @notice Removes a party member to the calling derivative.
-     * @dev msg.sender must be the derivative contract to which the party member is added.
-     * @param party address to be removed to the derivatives.
+     * @notice Removes a party member to the calling contract.
+     * @dev msg.sender must be the contract to which the party member is added.
+     * @param party address to be removed from the contract.
      */
-    function removePartyFromDerivative(address party) external;
+    function removePartyFromContract(address party) external;
 
     /**
-     * @notice checks if a party member is part of a derivative.
+     * @notice checks if an address is a party in a contract.
      * @param party party to check.
-     * @param derivativeAddress address to check against the party.
-     * @return bool indicating if the address is a party of the derivative.
+     * @param contractAddress address to check against the party.
+     * @return bool indicating if the address is a party of the contract.
      */
-    function isPartyMemberOfDerivative(address party, address derivativeAddress) external view returns (bool);
+    function isPartyMemberOfContract(address party, address contractAddress) external view returns (bool);
 }

--- a/core/contracts/oracle/interfaces/StoreInterface.sol
+++ b/core/contracts/oracle/interfaces/StoreInterface.sol
@@ -6,7 +6,7 @@ import "../../common/implementation/FixedPoint.sol";
 
 
 /**
- * @title Interface that allows derivative contracts to pay oracle fees for their use of the system.
+ * @title Interface that allows financial contracts to pay oracle fees for their use of the system.
  */
 interface StoreInterface {
     /**

--- a/core/migrations/14_deploy_register_creator.js
+++ b/core/migrations/14_deploy_register_creator.js
@@ -10,7 +10,7 @@ module.exports = async function(deployer, network, accounts) {
   const tokenizedDerivativeCreator = await TokenizedDerivativeCreator.deployed();
 
   // Add creator contract to the registry.
-  await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, tokenizedDerivativeCreator.address, {
+  await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, tokenizedDerivativeCreator.address, {
     from: keys.deployer
   });
 };

--- a/core/migrations/8_deploy_governor.js
+++ b/core/migrations/8_deploy_governor.js
@@ -14,9 +14,9 @@ module.exports = async function(deployer, network, accounts) {
 
   // Add governor to registry so it can send price requests.
   const registry = await Registry.deployed();
-  await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, keys.deployer, { from: keys.deployer });
-  await registry.registerDerivative([], governor.address, { from: keys.deployer });
-  await registry.removeMember(RegistryRolesEnum.DERIVATIVE_CREATOR, keys.deployer, { from: keys.deployer });
+  await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, keys.deployer, { from: keys.deployer });
+  await registry.registerContract([], governor.address, { from: keys.deployer });
+  await registry.removeMember(RegistryRolesEnum.CONTRACT_CREATOR, keys.deployer, { from: keys.deployer });
 
   // TODO: make the governor the owner of the Registry, Finder, FinancialContractsAdmin, Store, Voting, and
   // VotingToken for prod deployments.

--- a/core/scripts/CheckDeploymentValidity.js
+++ b/core/scripts/CheckDeploymentValidity.js
@@ -17,7 +17,7 @@ const checkDeploymentValidity = async function(callback) {
     const registryImplementationAddress = await finder.getImplementationAddress(
       web3.utils.utf8ToHex(interfaceName.Registry)
     );
-    if (registryImplementationAddress != registry.address) {
+    if (registryImplementationAddress != Registry.address) {
       throw "Incorrect implementation address for Registry";
     }
 

--- a/core/scripts/CheckDeploymentValidity.js
+++ b/core/scripts/CheckDeploymentValidity.js
@@ -14,7 +14,7 @@ const checkDeploymentValidity = async function(callback) {
 
     // Registry
     const registry = await Registry.deployed();
-    await registry.getAllRegisteredDerivatives();
+    await registry.getAllRegisteredContracts();
 
     // Finder
     const finder = await Finder.deployed();

--- a/core/scripts/CheckDeploymentValidity.js
+++ b/core/scripts/CheckDeploymentValidity.js
@@ -12,10 +12,6 @@ const checkDeploymentValidity = async function(callback) {
     const migrations = await Migrations.deployed();
     await migrations.last_completed_migration();
 
-    // Registry
-    const registry = await Registry.deployed();
-    await registry.getAllRegisteredContracts();
-
     // Finder
     const finder = await Finder.deployed();
     const registryImplementationAddress = await finder.getImplementationAddress(

--- a/core/scripts/local/InitializeSystem.js
+++ b/core/scripts/local/InitializeSystem.js
@@ -60,7 +60,7 @@ const initializeSystem = async function(callback) {
     await marginCurrencyWhitelist.addToWhitelist(marginToken.address);
     console.log("Registered margin address:", marginToken.address);
 
-    await deployedRegistry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, tokenizedDerivativeCreator.address);
+    await deployedRegistry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, tokenizedDerivativeCreator.address);
 
     // NOTE: Pass arguments through the command line and assign them here
     // in order to customize the instantiated TokenizedDerivative.

--- a/core/scripts/local/RequestOraclePrice.js
+++ b/core/scripts/local/RequestOraclePrice.js
@@ -13,18 +13,18 @@ async function getDeployAddress() {
   return accounts[0];
 }
 
-async function registerDerivative(registry) {
+async function registerContract(registry) {
   const deployAddress = await getDeployAddress();
 
-  if (!(await registry.holdsRole(RegistryRolesEnum.DERIVATIVE_CREATOR, deployAddress))) {
+  if (!(await registry.holdsRole(RegistryRolesEnum.CONTRACT_CREATOR, deployAddress))) {
     // Wrapping with an if isn't strictly necessary, but saves gas when script is used regularly.
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, deployAddress);
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, deployAddress);
     console.log("Creator Added:", deployAddress);
   }
 
-  if (!(await registry.isDerivativeRegistered(deployAddress))) {
-    await registry.registerDerivative([], deployAddress);
-    console.log("Registered derivative:", deployAddress);
+  if (!(await registry.isContractRegistered(deployAddress))) {
+    await registry.registerContract([], deployAddress);
+    console.log("Registered contract:", deployAddress);
   }
 }
 
@@ -40,7 +40,7 @@ async function run(deployedFinder, identifier, timeString) {
     const deployedRegistry = await Registry.at(
       await deployedFinder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.Registry))
     );
-    await registerDerivative(deployedRegistry);
+    await registerContract(deployedRegistry);
 
     const identifierInBytes = web3.utils.fromAscii(identifier);
 

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -12,7 +12,7 @@ const numPriceRequests = 2;
 const numVoters = 2;
 
 const getVoter = (accounts, id) => {
-  // Offset by 2, because owner == accounts[0] and registeredDerivative == accounts[1]
+  // Offset by 2, because owner == accounts[0] and registeredContract == accounts[1]
   return accounts[id + 2];
 };
 
@@ -25,13 +25,13 @@ async function run() {
 
   const accounts = await web3.eth.getAccounts();
   const owner = accounts[0];
-  const registeredDerivative = accounts[1];
+  const registeredContract = accounts[1];
 
   await voting.setInflationRate({ rawValue: web3.utils.toWei("0.01", "ether") });
-  await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, owner);
+  await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, owner);
 
-  if (!(await registry.isDerivativeRegistered(registeredDerivative))) {
-    await registry.registerDerivative([], registeredDerivative, { from: owner });
+  if (!(await registry.isContractRegistered(registeredContract))) {
+    await registry.registerContract([], registeredContract, { from: owner });
   }
 
   const identifier = web3.utils.utf8ToHex("test-identifier");

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -97,7 +97,7 @@ contract("ExpiringMultiParty", function(accounts) {
       expiringMultiPartyAddress = ev.expiringMultiPartyAddress;
       return ev.expiringMultiPartyAddress != 0 && ev.partyMemberAddress == contractCreator;
     });
-    assert.isTrue(await registry.isDerivativeRegistered(expiringMultiPartyAddress));
-    assert.isTrue(await registry.isPartyMemberOfDerivative(contractCreator, expiringMultiPartyAddress));
+    assert.isTrue(await registry.isContractRegistered(expiringMultiPartyAddress));
+    assert.isTrue(await registry.isPartyMemberOfContract(contractCreator, expiringMultiPartyAddress));
   });
 });

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -30,7 +30,7 @@ contract("ExpiringMultiParty", function(accounts) {
     registry = await Registry.deployed();
     expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
 
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, expiringMultiPartyCreator.address, {
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, expiringMultiPartyCreator.address, {
       from: contractCreator
     });
 

--- a/core/test/oracle/DesignatedVoting.js
+++ b/core/test/oracle/DesignatedVoting.js
@@ -15,7 +15,7 @@ contract("DesignatedVoting", function(accounts) {
   const umaAdmin = accounts[0];
   const tokenOwner = accounts[1];
   const voter = accounts[2];
-  const registeredDerivative = accounts[3];
+  const registeredContract = accounts[3];
 
   let voting;
   let votingToken;
@@ -39,8 +39,8 @@ contract("DesignatedVoting", function(accounts) {
     await votingToken.transfer(tokenOwner, tokenBalance, { from: umaAdmin });
 
     const registry = await Registry.deployed();
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, umaAdmin);
-    await registry.registerDerivative([], registeredDerivative, { from: umaAdmin });
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, umaAdmin);
+    await registry.registerContract([], registeredContract, { from: umaAdmin });
   });
 
   it("Deposit and withdraw", async function() {
@@ -87,7 +87,7 @@ contract("DesignatedVoting", function(accounts) {
     const identifier = web3.utils.utf8ToHex("one-voter");
     const time = "1000";
     await supportedIdentifiers.addSupportedIdentifier(identifier);
-    await voting.requestPrice(identifier, time, { from: registeredDerivative });
+    await voting.requestPrice(identifier, time, { from: registeredContract });
     await moveToNextRound(voting);
 
     const price = getRandomSignedInt();
@@ -113,7 +113,7 @@ contract("DesignatedVoting", function(accounts) {
     // Check the resolved price.
     const roundId = await voting.getCurrentRoundId();
     await moveToNextRound(voting);
-    assert.equal((await voting.getPrice(identifier, time, { from: registeredDerivative })).toString(), price);
+    assert.equal((await voting.getPrice(identifier, time, { from: registeredContract })).toString(), price);
 
     // Retrieve rewards and check that rewards accrued to the `designatedVoting` contract.
     await designatedVoting.retrieveRewards(roundId, [{ identifier, time }], { from: voter });
@@ -146,8 +146,8 @@ contract("DesignatedVoting", function(accounts) {
     const time1 = "1000";
     const time2 = "2000";
     await supportedIdentifiers.addSupportedIdentifier(identifier);
-    await voting.requestPrice(identifier, time1, { from: registeredDerivative });
-    await voting.requestPrice(identifier, time2, { from: registeredDerivative });
+    await voting.requestPrice(identifier, time1, { from: registeredContract });
+    await voting.requestPrice(identifier, time2, { from: registeredContract });
     await moveToNextRound(voting);
 
     const roundId = await voting.getCurrentRoundId();
@@ -193,8 +193,8 @@ contract("DesignatedVoting", function(accounts) {
 
     // Check the resolved price.
     await moveToNextRound(voting);
-    assert.equal((await voting.getPrice(identifier, time1, { from: registeredDerivative })).toString(), price1);
-    assert.equal((await voting.getPrice(identifier, time2, { from: registeredDerivative })).toString(), price2);
+    assert.equal((await voting.getPrice(identifier, time1, { from: registeredContract })).toString(), price1);
+    assert.equal((await voting.getPrice(identifier, time2, { from: registeredContract })).toString(), price2);
 
     // Reset the state.
     await designatedVoting.withdrawErc20(votingToken.address, tokenBalance, { from: tokenOwner });

--- a/core/test/oracle/Registry.js
+++ b/core/test/oracle/Registry.js
@@ -14,11 +14,11 @@ contract("Registry", function(accounts) {
   const creator2 = accounts[2];
   const rando1 = accounts[3];
 
-  // The addition and removal of party members after a derivative is created can only be done
-  // by the derivative contract its self. These two addresses act to simulate calls from a
-  // registered derivative to tests these post creation addition and removal actions.
-  const derivativeContract1 = accounts[4];
-  const derivativeContract2 = accounts[5];
+  // The addition and removal of parties after a contract is created can only be done
+  // by the contract itself. These two addresses act to simulate calls from a
+  // registered contract to tests these post creation addition and removal actions.
+  const contract1 = accounts[4];
+  const contract2 = accounts[5];
 
   beforeEach(async function() {
     registry = await Registry.new();
@@ -28,202 +28,200 @@ contract("Registry", function(accounts) {
     return address1.toLowerCase() === address2.toLowerCase();
   };
 
-  it("Derivative creation", async function() {
+  it("Contract creation", async function() {
     // No creators should be registered initially.
-    assert.isNotTrue(await registry.holdsRole(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1));
+    assert.isNotTrue(await registry.holdsRole(RegistryRolesEnum.CONTRACT_CREATOR, creator1));
 
-    // Only the owner should be able to add derivative creators.
-    assert(
-      await didContractThrow(registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: rando1 }))
-    );
+    // Only the owner should be able to add contract creators.
+    assert(await didContractThrow(registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: rando1 })));
 
     // Register creator1, but not creator2.
-    let result = await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
-    assert.isTrue(await registry.holdsRole(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1));
-    assert.isFalse(await registry.holdsRole(RegistryRolesEnum.DERIVATIVE_CREATOR, creator2));
+    let result = await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
+    assert.isTrue(await registry.holdsRole(RegistryRolesEnum.CONTRACT_CREATOR, creator1));
+    assert.isFalse(await registry.holdsRole(RegistryRolesEnum.CONTRACT_CREATOR, creator2));
 
     // Add it a second time.
-    result = await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
+    result = await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
 
     // Try to register an arbitrary contract.
     const arbitraryContract = web3.utils.randomHex(20);
     const parties = [web3.utils.randomHex(20), web3.utils.randomHex(20)];
 
     // Only approved creators can register contracts.
-    assert(await didContractThrow(registry.registerDerivative(parties, arbitraryContract, { from: creator2 })));
+    assert(await didContractThrow(registry.registerContract(parties, arbitraryContract, { from: creator2 })));
 
     // creator1 should be able to register a new contract.
-    result = await registry.registerDerivative(parties, arbitraryContract, { from: creator1 });
-    assert.isTrue(await registry.isDerivativeRegistered(arbitraryContract));
+    result = await registry.registerContract(parties, arbitraryContract, { from: creator1 });
+    assert.isTrue(await registry.isContractRegistered(arbitraryContract));
 
-    // Make sure a NewDerivativeRegistered event is emitted.
-    truffleAssert.eventEmitted(result, "NewDerivativeRegistered", ev => {
+    // Make sure a NewContractRegistered event is emitted.
+    truffleAssert.eventEmitted(result, "NewContractRegistered", ev => {
       return (
-        web3.utils.toChecksumAddress(ev.derivativeAddress) === web3.utils.toChecksumAddress(arbitraryContract) &&
+        web3.utils.toChecksumAddress(ev.contractAddress) === web3.utils.toChecksumAddress(arbitraryContract) &&
         web3.utils.toChecksumAddress(ev.creator) === web3.utils.toChecksumAddress(creator1)
       );
     });
 
-    // Remove the derivative creator.
-    result = await registry.removeMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
-    assert.isFalse(await registry.holdsRole(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1));
+    // Remove the contract creator.
+    result = await registry.removeMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
+    assert.isFalse(await registry.holdsRole(RegistryRolesEnum.CONTRACT_CREATOR, creator1));
 
     // Creation should fail since creator1 is no longer approved.
     const secondContract = web3.utils.randomHex(20);
-    assert(await didContractThrow(registry.registerDerivative(parties, secondContract, { from: creator1 })));
+    assert(await didContractThrow(registry.registerContract(parties, secondContract, { from: creator1 })));
 
     // A second removal should still work.
-    result = await registry.removeMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
+    result = await registry.removeMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
 
     // Remove the owner.
     await registry.resetMember(RegistryRolesEnum.OWNER, rando1, { from: owner });
 
-    // The owner can no longer add or remove derivative creators.
-    assert(await didContractThrow(registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner })));
+    // The owner can no longer add or remove contract creators.
+    assert(await didContractThrow(registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner })));
     assert(
-      await didContractThrow(registry.removeMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner }))
+      await didContractThrow(registry.removeMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner }))
     );
   });
 
-  it("Register and query derivatives", async function() {
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator2, { from: owner });
+  it("Register and query contracts", async function() {
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator2, { from: owner });
 
-    // Register an arbitrary derivative.
-    const derivative1 = web3.utils.randomHex(20);
-    const derivative2 = web3.utils.randomHex(20);
-    const derivative3 = web3.utils.randomHex(20);
+    // Register arbitrary financial contracts.
+    const fc1 = web3.utils.randomHex(20);
+    const fc2 = web3.utils.randomHex(20);
+    const fc3 = web3.utils.randomHex(20);
     const party1 = web3.utils.randomHex(20);
     const party2 = web3.utils.randomHex(20);
     const party3 = web3.utils.randomHex(20);
 
     // Register three derivatives with partially overlapping parties
-    await registry.registerDerivative([party1, party2], derivative1, { from: creator1 });
-    await registry.registerDerivative([party2, party3], derivative2, { from: creator2 });
-    await registry.registerDerivative([], derivative3, { from: creator1 });
+    await registry.registerContract([party1, party2], fc1, { from: creator1 });
+    await registry.registerContract([party2, party3], fc2, { from: creator2 });
+    await registry.registerContract([], fc3, { from: creator1 });
 
-    // Query that derivative by party and ensure all parties see their correct derivatives.
-    const party1Derivatives = await registry.getRegisteredDerivatives(party1);
-    assert.equal(party1Derivatives.length, 1);
-    assert.isTrue(areAddressesEqual(party1Derivatives[0], derivative1));
+    // Query that contract by party and ensure all parties see their correct contracts.
+    const party1Contracts = await registry.getRegisteredContracts(party1);
+    assert.equal(party1Contracts.length, 1);
+    assert.isTrue(areAddressesEqual(party1Contracts[0], fc1));
 
-    const party2Derivatives = await registry.getRegisteredDerivatives(party2);
-    assert.equal(party2Derivatives.length, 2);
-    assert.isTrue(areAddressesEqual(party2Derivatives[0], derivative1));
-    assert.isTrue(areAddressesEqual(party2Derivatives[1], derivative2));
+    const party2Contracts = await registry.getRegisteredContracts(party2);
+    assert.equal(party2Contracts.length, 2);
+    assert.isTrue(areAddressesEqual(party2Contracts[0], fc1));
+    assert.isTrue(areAddressesEqual(party2Contracts[1], fc2));
 
-    const party3Derivatives = await registry.getRegisteredDerivatives(party3);
-    assert.equal(party3Derivatives.length, 1);
-    assert.isTrue(areAddressesEqual(party3Derivatives[0], derivative2));
+    const party3Contracts = await registry.getRegisteredContracts(party3);
+    assert.equal(party3Contracts.length, 1);
+    assert.isTrue(areAddressesEqual(party3Contracts[0], fc2));
 
-    const allDerivatives = await registry.getAllRegisteredDerivatives();
-    assert.equal(allDerivatives.length, 3);
-    assert.isTrue(areAddressesEqual(allDerivatives[0], derivative1));
-    assert.isTrue(areAddressesEqual(allDerivatives[1], derivative2));
-    assert.isTrue(areAddressesEqual(allDerivatives[2], derivative3));
+    const allContracts = await registry.getAllRegisteredContracts();
+    assert.equal(allContracts.length, 3);
+    assert.isTrue(areAddressesEqual(allContracts[0], fc1));
+    assert.isTrue(areAddressesEqual(allContracts[1], fc2));
+    assert.isTrue(areAddressesEqual(allContracts[2], fc3));
 
-    // Check derivative information.
-    const derivativeStruct = await registry.derivativeMap(derivative1);
-    assert.equal(derivativeStruct.valid.toNumber(), 1);
-    assert.equal(derivativeStruct.index.toNumber(), 0);
+    // Check contract information.
+    const financialContractStruct = await registry.contractMap(fc1);
+    assert.equal(financialContractStruct.valid.toNumber(), 1);
+    assert.equal(financialContractStruct.index.toNumber(), 0);
 
-    // Check party is correctly added to derivative.
-    assert.isTrue(await registry.isPartyMemberOfDerivative(party2, derivative1));
-    assert.isFalse(await registry.isPartyMemberOfDerivative(rando1, derivative1));
+    // Check party is correctly added to contract.
+    assert.isTrue(await registry.isPartyMemberOfContract(party2, fc1));
+    assert.isFalse(await registry.isPartyMemberOfContract(rando1, fc1));
   });
 
-  it("Double-register derivative", async function() {
+  it("Double-register contract", async function() {
     // Approve creator.
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
 
-    // Register derivative.
-    const derivative1 = web3.utils.randomHex(20);
-    await registry.registerDerivative([], derivative1, { from: creator1 });
+    // Register contract.
+    const fc1 = web3.utils.randomHex(20);
+    await registry.registerContract([], fc1, { from: creator1 });
 
-    // Cannot register a derivative that is already registered.
-    assert(await didContractThrow(registry.registerDerivative([], derivative1, { from: creator1 })));
+    // Cannot register a contract that is already registered.
+    assert(await didContractThrow(registry.registerContract([], fc1, { from: creator1 })));
   });
 
-  it("Adding party members to derivatives", async function() {
-    // Approve creator and register derivative.
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
-    await registry.registerDerivative([], derivativeContract1, { from: creator1 });
+  it("Adding parties to contracts", async function() {
+    // Approve creator and register contract.
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
+    await registry.registerContract([], contract1, { from: creator1 });
 
     // Adding party member.
-    let result = await registry.addPartyToDerivative(creator2, { from: derivativeContract1 });
+    let result = await registry.addPartyToContract(creator2, { from: contract1 });
 
     // Make sure a PartyMemberAdded event is emitted.
-    truffleAssert.eventEmitted(result, "PartyMemberAdded", ev => {
+    truffleAssert.eventEmitted(result, "PartyAdded", ev => {
       return (
-        web3.utils.toChecksumAddress(ev.derivativeAddress) === web3.utils.toChecksumAddress(derivativeContract1) &&
+        web3.utils.toChecksumAddress(ev.contractAddress) === web3.utils.toChecksumAddress(contract1) &&
         web3.utils.toChecksumAddress(ev.party) === web3.utils.toChecksumAddress(creator2)
       );
     });
 
     // Check the party member was added to state.
-    assert.isTrue(await registry.isPartyMemberOfDerivative(creator2, derivativeContract1));
-    assert.isFalse(await registry.isPartyMemberOfDerivative(rando1, derivativeContract1));
-    assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 1);
-    assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract1);
+    assert.isTrue(await registry.isPartyMemberOfContract(creator2, contract1));
+    assert.isFalse(await registry.isPartyMemberOfContract(rando1, contract1));
+    assert.equal((await registry.getRegisteredContracts(creator2)).length, 1);
+    assert.equal((await registry.getRegisteredContracts(creator2))[0], contract1);
 
     // Cant add a member to a party more than once.
-    assert(await didContractThrow(registry.addPartyToDerivative(creator2, { from: derivativeContract1 })));
+    assert(await didContractThrow(registry.addPartyToContract(creator2, { from: contract1 })));
 
-    // Cant add a member to an invalid derivative.
-    assert(await didContractThrow(registry.addPartyToDerivative(creator2, { from: rando1 })));
+    // Cant add a member to an invalid contract.
+    assert(await didContractThrow(registry.addPartyToContract(creator2, { from: rando1 })));
 
-    // Create a second derivative and add it to the same user. Check that they are party of two.
-    await registry.registerDerivative([], derivativeContract2, { from: creator1 });
-    await registry.addPartyToDerivative(creator2, { from: derivativeContract2 });
+    // Create a second contract and add it to the same user. Check that they are party of two.
+    await registry.registerContract([], contract2, { from: creator1 });
+    await registry.addPartyToContract(creator2, { from: contract2 });
 
-    // Check that creator2 is part of two derivatives.
-    assert.isTrue(await registry.isPartyMemberOfDerivative(creator2, derivativeContract2));
-    assert.isFalse(await registry.isPartyMemberOfDerivative(rando1, derivativeContract2));
-    assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 2);
-    assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract1);
-    assert.equal((await registry.getRegisteredDerivatives(creator2))[1], derivativeContract2);
+    // Check that creator2 is part of two contracts.
+    assert.isTrue(await registry.isPartyMemberOfContract(creator2, contract2));
+    assert.isFalse(await registry.isPartyMemberOfContract(rando1, contract2));
+    assert.equal((await registry.getRegisteredContracts(creator2)).length, 2);
+    assert.equal((await registry.getRegisteredContracts(creator2))[0], contract1);
+    assert.equal((await registry.getRegisteredContracts(creator2))[1], contract2);
   });
 
-  it("Removing party members from derivatives", async function() {
-    // Approve creator and register two derivative.
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator1, { from: owner });
-    await registry.registerDerivative([], derivativeContract1, { from: creator1 });
-    await registry.registerDerivative([], derivativeContract2, { from: creator1 });
+  it("Removing parties from contracts", async function() {
+    // Approve creator and register two contract.
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator1, { from: owner });
+    await registry.registerContract([], contract1, { from: creator1 });
+    await registry.registerContract([], contract2, { from: creator1 });
 
-    // Adding party member to both derivatives.
-    await registry.addPartyToDerivative(creator2, { from: derivativeContract1 });
-    await registry.addPartyToDerivative(creator2, { from: derivativeContract2 });
-    assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 2);
+    // Adding party member to both contracts.
+    await registry.addPartyToContract(creator2, { from: contract1 });
+    await registry.addPartyToContract(creator2, { from: contract2 });
+    assert.equal((await registry.getRegisteredContracts(creator2)).length, 2);
 
-    // Remove party member from the first derivative and check they are part of only the second derivative.
-    let result = await registry.removePartyFromDerivative(creator2, { from: derivativeContract1 });
+    // Remove party member from the first contract and check they are part of only the second contract.
+    let result = await registry.removePartyFromContract(creator2, { from: contract1 });
 
-    truffleAssert.eventEmitted(result, "PartyMemberRemoved", ev => {
+    truffleAssert.eventEmitted(result, "PartyRemoved", ev => {
       return (
-        web3.utils.toChecksumAddress(ev.derivativeAddress) === web3.utils.toChecksumAddress(derivativeContract1) &&
+        web3.utils.toChecksumAddress(ev.contractAddress) === web3.utils.toChecksumAddress(contract1) &&
         web3.utils.toChecksumAddress(ev.party) === web3.utils.toChecksumAddress(creator2)
       );
     });
 
     // Check party member has been removed from state.
-    assert.isFalse(await registry.isPartyMemberOfDerivative(creator2, derivativeContract1));
-    assert.isTrue(await registry.isPartyMemberOfDerivative(creator2, derivativeContract2));
-    assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 1);
-    assert.equal((await registry.getRegisteredDerivatives(creator2))[0], derivativeContract2);
+    assert.isFalse(await registry.isPartyMemberOfContract(creator2, contract1));
+    assert.isTrue(await registry.isPartyMemberOfContract(creator2, contract2));
+    assert.equal((await registry.getRegisteredContracts(creator2)).length, 1);
+    assert.equal((await registry.getRegisteredContracts(creator2))[0], contract2);
 
-    // Cant remove a party from derivative multiple times.
-    assert(await didContractThrow(registry.removePartyFromDerivative(creator2, { from: derivativeContract1 })));
+    // Cant remove a party from contract multiple times.
+    assert(await didContractThrow(registry.removePartyFromContract(creator2, { from: contract1 })));
 
-    // Cant remove a member to an invalid derivative.
-    assert(await didContractThrow(registry.removePartyFromDerivative(creator2, { from: rando1 })));
+    // Cant remove a member to an invalid contract.
+    assert(await didContractThrow(registry.removePartyFromContract(creator2, { from: rando1 })));
 
-    // Remove party remember from second derivative and check that they are part of none.
-    await registry.removePartyFromDerivative(creator2, { from: derivativeContract2 });
-    assert.equal((await registry.getRegisteredDerivatives(creator2)).length, 0);
-    assert.isFalse(await registry.isPartyMemberOfDerivative(creator2, derivativeContract1));
-    assert.isFalse(await registry.isPartyMemberOfDerivative(creator2, derivativeContract2));
+    // Remove party remember from second contract and check that they are part of none.
+    await registry.removePartyFromContract(creator2, { from: contract2 });
+    assert.equal((await registry.getRegisteredContracts(creator2)).length, 0);
+    assert.isFalse(await registry.isPartyMemberOfContract(creator2, contract1));
+    assert.isFalse(await registry.isPartyMemberOfContract(creator2, contract2));
 
-    // Cant remove a derivative if there is none left for the party.
-    assert(await didContractThrow(registry.removePartyFromDerivative(creator2, { from: derivativeContract1 })));
+    // Cant remove a contract if there is none left for the party.
+    assert(await didContractThrow(registry.removePartyFromContract(creator2, { from: contract1 })));
   });
 });

--- a/core/test/scripts/DecodeTransactionData.js
+++ b/core/test/scripts/DecodeTransactionData.js
@@ -5,17 +5,17 @@ const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
 
 contract("scripts/DecodeTransactionData.js", function(accounts) {
-  it("Decode registerDerivative", async function() {
-    const derivativeAddress = web3.utils.randomHex(20);
+  it("Decode registerContract", async function() {
+    const contractAddress = web3.utils.randomHex(20);
 
     const registry = await Registry.deployed();
-    const txnData = registry.contract.methods.registerDerivative([], derivativeAddress).encodeABI();
+    const txnData = registry.contract.methods.registerContract([], contractAddress).encodeABI();
 
     const expectedObject = {
-      name: "registerDerivative",
+      name: "registerContract",
       params: {
         parties: [],
-        derivativeAddress: derivativeAddress
+        contractAddress: contractAddress
       }
     };
 

--- a/core/test/scripts/EmergencyShutdown.js
+++ b/core/test/scripts/EmergencyShutdown.js
@@ -19,7 +19,7 @@ contract("scripts/EmergencyShutdown.js", function(accounts) {
   let voting;
   let leverage;
   let priceFeed;
-  let derivativeContract;
+  let contract;
   let identifierBytes;
   const deployer = accounts[0];
   const sponsor = accounts[1];
@@ -50,7 +50,7 @@ contract("scripts/EmergencyShutdown.js", function(accounts) {
     // request created by emergency shutdown is in the past.
     await voting.setCurrentTime(latestTime + 700);
 
-    // Create derivative
+    // Create contract
     const params = {
       sponsor: sponsor,
       priceFeedAddress: priceFeed.address,
@@ -71,20 +71,20 @@ contract("scripts/EmergencyShutdown.js", function(accounts) {
     };
     await creator.createTokenizedDerivative(params, { from: sponsor });
 
-    // Retrieve the derivative we just created
-    const derivatives = await registry.getRegisteredDerivatives(sponsor);
-    const derivativeAddress = derivatives[derivatives.length - 1];
-    derivativeContract = await TokenizedDerivative.at(derivativeAddress);
+    // Retrieve the contract we just created
+    const contracts = await registry.getRegisteredContracts(sponsor);
+    const contractAddress = contracts[contracts.length - 1];
+    contract = await TokenizedDerivative.at(contractAddress);
   });
 
   it("Requests a price", async function() {
-    // Assert that the derivative is live
-    assert.equal((await derivativeContract.derivativeStorage()).state.toString(), "0");
+    // Assert that the contract is live
+    assert.equal((await contract.derivativeStorage()).state.toString(), "0");
 
     // Call emergency shutdown
-    await EmergencyShutdown.run(deployer, derivativeContract.address);
+    await EmergencyShutdown.run(deployer, contract.address);
 
     // Derivative is in Emergency state
-    assert.equal((await derivativeContract.derivativeStorage()).state.toString(), "4");
+    assert.equal((await contract.derivativeStorage()).state.toString(), "4");
   });
 });

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -76,8 +76,8 @@ contract("scripts/Voting.js", function(accounts) {
     registry = await Registry.deployed();
 
     // Register "derivative" with Registry, so we can make price requests in this test.
-    await registry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, account1);
-    await registry.registerDerivative([], account1);
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, account1);
+    await registry.registerContract([], account1);
 
     // Give voter all of the tokens.
     const initialSupply = await votingToken.balanceOf(account1);

--- a/core/test/tokenized-derivative/TokenizedDerivative.js
+++ b/core/test/tokenized-derivative/TokenizedDerivative.js
@@ -90,8 +90,8 @@ contract("TokenizedDerivative", function(accounts) {
 
     // Add the owner to the list of registered derivatives so it's allowed to query oracle prices.
     let creator = accounts[5];
-    await deployedRegistry.addMember(RegistryRolesEnum.DERIVATIVE_CREATOR, creator);
-    await deployedRegistry.registerDerivative([], owner, { from: creator });
+    await deployedRegistry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, creator);
+    await deployedRegistry.registerContract([], owner, { from: creator });
   });
 
   const computeNewNav = (previousNav, priceReturn, fees) => {
@@ -184,7 +184,7 @@ contract("TokenizedDerivative", function(accounts) {
 
       await tokenizedDerivativeCreator.createTokenizedDerivative(constructorParams, { from: sponsor });
 
-      const derivativeArray = await deployedRegistry.getRegisteredDerivatives(sponsor);
+      const derivativeArray = await deployedRegistry.getRegisteredContracts(sponsor);
       const derivativeAddress = derivativeArray[derivativeArray.length - 1];
       derivativeContract = await TokenizedDerivative.at(derivativeAddress);
 

--- a/sponsor-dapp-v2/src/lib/custom-hooks.js
+++ b/sponsor-dapp-v2/src/lib/custom-hooks.js
@@ -41,7 +41,7 @@ export function useNumRegisteredContracts() {
     return drizzleState.accounts[0];
   });
 
-  const registeredContracts = useCacheCall("Registry", "getRegisteredDerivatives", account);
+  const registeredContracts = useCacheCall("Registry", "getRegisteredContracts", account);
 
   if (account && registeredContracts) {
     return registeredContracts.length;

--- a/sponsor-dapp-v2/src/views/ViewPositions.js
+++ b/sponsor-dapp-v2/src/views/ViewPositions.js
@@ -28,7 +28,7 @@ function usePositionList() {
     }
   });
 
-  const registeredContracts = useCacheCallPromise("Registry", "getRegisteredDerivatives", account);
+  const registeredContracts = useCacheCallPromise("Registry", "getRegisteredContracts", account);
 
   const finishedAddingContracts = drizzleReactHooks.useDrizzleStatePromise(
     (drizzleState, resolvePromise, registeredContractsResolved) => {


### PR DESCRIPTION
This is a mostly mechanical change to go from `derivative` language to using the generic term `contract` (or `financialContract` in a small number of places).

Since this involved many changes in the Registry, I went ahead and modified a few of the comments in that file to make them clearer.

Fixes #975.