### PR TITLE
remove TokenFactory address from EMP config

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -17,7 +17,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         uint withdrawalLiveness;
         uint siphonDelay;
         address collateralAddress;
-        address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
         string syntheticName;
         string syntheticSymbol;
@@ -65,7 +64,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         constructorParams.withdrawalLiveness = params.withdrawalLiveness;
         constructorParams.siphonDelay = params.siphonDelay;
         constructorParams.collateralAddress = params.collateralAddress;
-        constructorParams.tokenFactoryAddress = params.tokenFactoryAddress;
         constructorParams.priceFeedIdentifier = params.priceFeedIdentifier;
         constructorParams.syntheticName = params.syntheticName;
         constructorParams.syntheticSymbol = params.syntheticSymbol;

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -127,7 +127,6 @@ contract Liquidatable is PricelessPositionManager {
         uint siphonDelay;
         address collateralAddress;
         address finderAddress;
-        address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
         string syntheticName;
         string syntheticSymbol;
@@ -150,8 +149,7 @@ contract Liquidatable is PricelessPositionManager {
             params.finderAddress,
             params.priceFeedIdentifier,
             params.syntheticName,
-            params.syntheticSymbol,
-            params.tokenFactoryAddress
+            params.syntheticSymbol
         )
     {
         require(params.collateralRequirement.isGreaterThan(1));

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -117,13 +117,12 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         address _finderAddress,
         bytes32 _priceIdentifier,
         string memory _syntheticName,
-        string memory _syntheticSymbol,
-        address _tokenFactoryAddress
+        string memory _syntheticSymbol
     ) public FeePayer(_collateralAddress, _finderAddress, _isTest) {
         expirationTimestamp = _expirationTimestamp;
         withdrawalLiveness = _withdrawalLiveness;
         siphonDelay = _siphonDelay;
-        TokenFactory tf = TokenFactory(_tokenFactoryAddress);
+        TokenFactory tf = _getTokenFactory();
         tokenCurrency = tf.createToken(_syntheticName, _syntheticSymbol, 18);
 
         require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier));
@@ -480,6 +479,11 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     function _getOracle() internal view returns (OracleInterface) {
         bytes32 oracleInterface = "Oracle";
         return OracleInterface(finder.getImplementationAddress(oracleInterface));
+    }
+
+    function _getTokenFactory() internal view returns (TokenFactory) {
+        bytes32 tf = "TokenFactory";
+        return TokenFactory(finder.getImplementationAddress(tf));
     }
 
     function _getStoreAddress() internal view returns (address) {

--- a/core/migrations/17_deploy_tokenfactory.js
+++ b/core/migrations/17_deploy_tokenfactory.js
@@ -1,8 +1,15 @@
+const Finder = artifacts.require("Finder");
 const TokenFactory = artifacts.require("TokenFactory");
 const { getKeysForNetwork, deploy } = require("../../common/MigrationUtils.js");
+const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  await deploy(deployer, network, TokenFactory, { from: keys.deployer });
+  const { contract: tf } = await deploy(deployer, network, TokenFactory, { from: keys.deployer });
+
+  const finder = await Finder.deployed();
+  await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.TokenFactory), tf.address, {
+    from: keys.deployer
+  });
 };

--- a/core/test/financial-templates/ExpiringMultiParty.js
+++ b/core/test/financial-templates/ExpiringMultiParty.js
@@ -6,7 +6,6 @@ const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 // Helper Contracts
 const Finder = artifacts.require("Finder");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
-const TokenFactory = artifacts.require("TokenFactory");
 const Token = artifacts.require("ExpandedERC20");
 
 contract("ExpiringMultiParty", function(accounts) {
@@ -20,7 +19,6 @@ contract("ExpiringMultiParty", function(accounts) {
       siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
-      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMATEST",

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -7,9 +7,7 @@ const { RegistryRolesEnum } = require("../../../common/Enums.js");
 const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
 
 // Helper Contracts
-const Finder = artifacts.require("Finder");
 const Token = artifacts.require("ExpandedERC20");
-const TokenFactory = artifacts.require("TokenFactory");
 const Registry = artifacts.require("Registry");
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
@@ -39,7 +37,6 @@ contract("ExpiringMultiParty", function(accounts) {
       withdrawalLiveness: "1000",
       siphonDelay: "100000",
       collateralAddress: collateralToken.address,
-      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMATEST",

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -14,7 +14,6 @@ const Store = artifacts.require("Store");
 const Finder = artifacts.require("Finder");
 const MockOracle = artifacts.require("MockOracle");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
-const TokenFactory = artifacts.require("TokenFactory");
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 
 contract("Liquidatable", function(accounts) {
@@ -24,7 +23,6 @@ contract("Liquidatable", function(accounts) {
   const liquidator = accounts[2];
   const disputer = accounts[3];
   const rando = accounts[4];
-  const mockGovernor = accounts[5];
   const zeroAddress = "0x0000000000000000000000000000000000000000";
 
   // Amount of tokens to mint for test
@@ -121,7 +119,6 @@ contract("Liquidatable", function(accounts) {
       siphonDelay: siphonDelay,
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
-      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: priceTrackingIdentifier,
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMAETH",

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -12,7 +12,6 @@ const MockOracle = artifacts.require("MockOracle");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const MarginToken = artifacts.require("ExpandedERC20");
 const SyntheticToken = artifacts.require("SyntheticToken");
-const TokenFactory = artifacts.require("TokenFactory");
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 
 contract("PricelessPositionManager", function(accounts) {
@@ -105,7 +104,6 @@ contract("PricelessPositionManager", function(accounts) {
       priceTrackingIdentifier, // _priceFeedIdentifier
       syntheticName, // _syntheticName
       syntheticSymbol, // _syntheticSymbol
-      TokenFactory.address, // _tokenFactoryAddress
       { from: contractDeployer }
     );
     tokenCurrency = await SyntheticToken.at(await pricelessPositionManager.tokenCurrency());

--- a/core/utils/Constants.js
+++ b/core/utils/Constants.js
@@ -4,7 +4,8 @@ const interfaceName = {
   Oracle: "Oracle",
   Registry: "Registry",
   Store: "Store",
-  IdentifierWhitelist: "IdentifierWhitelist"
+  IdentifierWhitelist: "IdentifierWhitelist",
+  TokenFactory: "TokenFactory"
 };
 
 module.exports = {


### PR DESCRIPTION
There is no reason for an EMP deployer to pass in a TF address, I instead register the contract with the Finder and grab it there.

I could see a counter argument if we want to enable multiple implementations of TF--thoughts?

Signed-off-by: Nick Pai <npai.nyc@gmail.com>