### PR TITLE
Discretize  expiration timestamps

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -9,7 +9,7 @@ import "./ExpiringMultiParty.sol";
 
 
 /**
-@title Expiring Multi Party Contract creator
+@title Expiring Multi Party Contract creator.
 @notice Factory contract to create and register new instances of expiring multiparty contracts. Responsible for
 constraining the parameters used to construct a new EMP.
 */
@@ -31,13 +31,13 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
     }
 
     /**
-    * @notice DEPLOYMENT CONFIGURATION CONSTRAINTS
-    * @dev: These constraints can evolve over time and are initially constrained to conservative values
-    * in this first iteration of an EMP creator. Technically there is nothing in the ExpiringMultiParty contract
-    * requiring these constraints. However, because "createExpiringMultiParty()"
-    * is intended to be the only way to create valid financial contracts that are **registered** with the DVM (via "_registerContract()"),
-    * we can enforce deployment configurations here.
-    **/
+     * @notice DEPLOYMENT CONFIGURATION CONSTRAINTS.
+     * @dev: These constraints can evolve over time and are initially constrained to conservative values
+     * in this first iteration of an EMP creator. Technically there is nothing in the ExpiringMultiParty contract
+     * requiring these constraints. However, because "createExpiringMultiParty()"
+     * is intended to be the only way to create valid financial contracts that are **registered** with the DVM (via "_registerContract()"),
+     * we can enforce deployment configurations here.
+     **/
 
     // - Whitelist allowed collateral currencies.
     AddressWhitelist public collateralTokenWhitelist;
@@ -102,9 +102,8 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         return address(derivative);
     }
 
-    //  Returns if timestamp is valid.
+    //  Returns if expiration timestamp is on hardcoded list.
     function _isValidTimestamp(uint timestamp) private view returns (bool) {
-        // Determine size of whitelist first
         for (uint i = 0; i < VALID_EXPIRATION_TIMESTAMPS.length; i++) {
             if (VALID_EXPIRATION_TIMESTAMPS[i] == timestamp) {
                 return true;
@@ -123,7 +122,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         constructorParams.isTest = isTest;
         constructorParams.finderAddress = finderAddress;
 
-        // Enforce configuration constrainments
+        // Enforce configuration constrainments.
         require(_isValidTimestamp(params.expirationTimestamp));
         require(params.disputeBondPct.isGreaterThan(MIN_DISPUTE_BOND_PCT));
         require(bytes(params.syntheticName).length != 0);
@@ -132,7 +131,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         constructorParams.liquidationLiveness = STRICT_LIQUIDATION_LIVENESS;
         require(collateralTokenWhitelist.isOnWhitelist(params.collateralAddress));
 
-        // Input from function call
+        // Input from function call.
         constructorParams.expirationTimestamp = params.expirationTimestamp;
         constructorParams.siphonDelay = params.siphonDelay;
         constructorParams.collateralAddress = params.collateralAddress;

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -58,12 +58,12 @@ contract("ExpiringMultiParty", function(accounts) {
     });
   });
 
-  it("Expiration timestamp must be one of the fifteen allowed month-start timestamps from April 2020 through June 2021", async function () {
+  it("Expiration timestamp must be one of the fifteen allowed month-start timestamps from April 2020 through June 2021", async function() {
     // Change only expiration timestamp.
     const validExpiration = await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(5);
     // Set to a valid expiry.
     constructorParams.expirationTimestamp = validExpiration.toString();
-    await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: contractCreator })
+    await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: contractCreator });
     // Set to an invalid expiry.
     constructorParams.expirationTimestamp = validExpiration.add(toBN("1")).toString();
     assert(
@@ -73,7 +73,7 @@ contract("ExpiringMultiParty", function(accounts) {
         })
       )
     );
-  })
+  });
 
   it("Cannot set dispute bond percentage below limit set by EMP creator", async function() {
     // Change only dispute bond %.

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -39,7 +39,7 @@ contract("ExpiringMultiParty", function(accounts) {
     await collateralTokenWhitelist.addToWhitelist(collateralToken.address, { from: contractCreator });
 
     constructorParams = {
-      expirationTimestamp: "1234567890",
+      expirationTimestamp: (await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(0)).toString(),
       siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       tokenFactoryAddress: TokenFactory.address,
@@ -58,10 +58,14 @@ contract("ExpiringMultiParty", function(accounts) {
     });
   });
 
-  it("Cannot set expiration timestamp above limit set by EMP creator", async function() {
+  it("Expiration timestamp must be one of the fifteen allowed month-start timestamps from April 2020 through June 2021", async function () {
     // Change only expiration timestamp.
-    const latestExpirationAllowed = await expiringMultiPartyCreator.LATEST_EXPIRATION_TIMESTAMP();
-    constructorParams.expirationTimestamp = latestExpirationAllowed.add(toBN("1")).toString();
+    const validExpiration = await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(5);
+    // Set to a valid expiry.
+    constructorParams.expirationTimestamp = validExpiration.toString();
+    await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: contractCreator })
+    // Set to an invalid expiry.
+    constructorParams.expirationTimestamp = validExpiration.add(toBN("1")).toString();
     assert(
       await didContractThrow(
         expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, {
@@ -69,7 +73,7 @@ contract("ExpiringMultiParty", function(accounts) {
         })
       )
     );
-  });
+  })
 
   it("Cannot set dispute bond percentage below limit set by EMP creator", async function() {
     // Change only dispute bond %.


### PR DESCRIPTION
Force expirations to be start of month, between April 2020 and June 2021. Removes the need to check for latest expiration timestamp because all timestamps must be on the hardcoded list.