### PR TITLE
Removed siphon from EMP

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -18,7 +18,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
 
     struct Params {
         uint expirationTimestamp;
-        uint siphonDelay;
         address collateralAddress;
         address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
@@ -104,7 +103,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
 
         // Input from function call
         constructorParams.expirationTimestamp = params.expirationTimestamp;
-        constructorParams.siphonDelay = params.siphonDelay;
         constructorParams.collateralAddress = params.collateralAddress;
         constructorParams.tokenFactoryAddress = params.tokenFactoryAddress;
         constructorParams.priceFeedIdentifier = params.priceFeedIdentifier;

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -124,7 +124,6 @@ contract Liquidatable is PricelessPositionManager {
         bool isTest;
         uint expirationTimestamp;
         uint withdrawalLiveness;
-        uint siphonDelay;
         address collateralAddress;
         address finderAddress;
         address tokenFactoryAddress;
@@ -145,7 +144,6 @@ contract Liquidatable is PricelessPositionManager {
             params.isTest,
             params.expirationTimestamp,
             params.withdrawalLiveness,
-            params.siphonDelay,
             params.collateralAddress,
             params.finderAddress,
             params.priceFeedIdentifier,

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -60,10 +60,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     uint public expirationTimestamp;
     // Time that has to elapse for a withdrawal request to be considered passed, if no liquidations occur.
     uint public withdrawalLiveness;
-    // Time that has to elapse for the contract to be siphoned. This occurs if `siphonDelay`
-    // seconds have past after the expiration timestamp and there is remaining unclaimed
-    // collateral in the contract.
-    uint public siphonDelay;
 
     // The expiry price pulled from the DVM.
     FixedPoint.Unsigned public expiryPrice;
@@ -92,7 +88,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     modifier onlyPostExpiration() {
         _onlyPostExpiration();
-        _onlyPreSiphon();
         _;
     }
 
@@ -112,7 +107,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         bool _isTest,
         uint _expirationTimestamp,
         uint _withdrawalLiveness,
-        uint _siphonDelay,
         address _collateralAddress,
         address _finderAddress,
         bytes32 _priceIdentifier,
@@ -122,7 +116,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     ) public FeePayer(_collateralAddress, _finderAddress, _isTest) {
         expirationTimestamp = _expirationTimestamp;
         withdrawalLiveness = _withdrawalLiveness;
-        siphonDelay = _siphonDelay;
         TokenFactory tf = TokenFactory(_tokenFactoryAddress);
         tokenCurrency = tf.createToken(_syntheticName, _syntheticSymbol, 18);
 
@@ -388,18 +381,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     }
 
     /**
-     * @notice If token holders or sponsors do not redeem their positions for underlying collateral within
-     * a pre-defined `siphonDelay`, all underlying collateral is sent to the Store. This delay
-     * should be set to be sufficiently long such that token holders have a reasonable
-     * period of time to withdrawal.
-     */
-    function siphonContractCollateral() external {
-        require(getCurrentTime() > expirationTimestamp.add(siphonDelay));
-        uint contractCollateralBalance = collateralCurrency.balanceOf(address(this));
-        collateralCurrency.safeTransfer(_getStoreAddress(), contractCollateralBalance);
-    }
-
-    /**
      * @notice Premature contract settlement under emergency circumstances.
      * @dev Only the governor can call this function as they are permissioned within the `FinancialContractAdmin`.
      * Upon emergency shutdown, the contract settlement time is set to the shutdown time. This enables withdrawal
@@ -554,10 +535,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     function _onlyPostExpiration() internal view {
         require(getCurrentTime() >= expirationTimestamp);
-    }
-
-    function _onlyPreSiphon() internal view {
-        require(getCurrentTime() < expirationTimestamp.add(siphonDelay));
     }
 
     function _onlyCollateralizedPosition(address sponsor) internal view {

--- a/core/test/financial-templates/ExpiringMultiParty.js
+++ b/core/test/financial-templates/ExpiringMultiParty.js
@@ -17,7 +17,6 @@ contract("ExpiringMultiParty", function(accounts) {
       isTest: true,
       expirationTimestamp: "1234567890",
       withdrawalLiveness: "1000",
-      siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -40,7 +40,6 @@ contract("ExpiringMultiParty", function(accounts) {
 
     constructorParams = {
       expirationTimestamp: "1234567890",
-      siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -55,7 +55,6 @@ contract("Liquidatable", function(accounts) {
   const expirationTimestamp = toBN(startTime)
     .add(positionLiveness)
     .toString();
-  const siphonDelay = "100000";
   const withdrawalLiveness = toBN(60)
     .muln(60)
     .muln(1);
@@ -118,7 +117,6 @@ contract("Liquidatable", function(accounts) {
       isTest: true,
       expirationTimestamp: expirationTimestamp,
       withdrawalLiveness: withdrawalLiveness.toString(),
-      siphonDelay: siphonDelay,
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -38,7 +38,6 @@ contract("PricelessPositionManager", function(accounts) {
   const syntheticSymbol = "UMATEST";
   const withdrawalLiveness = 1000;
   const expirationTimestamp = Math.floor(Date.now() / 1000) + 10000;
-  const siphonDelay = 100000;
   const priceTrackingIdentifier = web3.utils.utf8ToHex("UMATEST");
 
   // Contract state
@@ -99,7 +98,6 @@ contract("PricelessPositionManager", function(accounts) {
       true, // _isTest
       expirationTimestamp, // _expirationTimestamp
       withdrawalLiveness, // _withdrawalLiveness
-      siphonDelay, // __siphonDelay
       collateral.address, // _collateralAddress
       Finder.address, // _finderAddress
       priceTrackingIdentifier, // _priceFeedIdentifier
@@ -984,70 +982,6 @@ contract("PricelessPositionManager", function(accounts) {
     await pricelessPositionManager.settleExpired({ from: other });
     collateralPaid = (await collateral.balanceOf(other)).sub(initialCollateral);
     assert.equal(collateralPaid, toWei("120"));
-  });
-
-  it("Post expiration siphon", async function() {
-    // Create one position with 100 synthetic tokens to mint with 150 tokens of collateral. For this test say the
-    // collateral is Dai with a value of 1USD and the synthetic is some fictional stock or commodity.
-    await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
-    const numTokens = toWei("100");
-    const amountCollateral = toWei("150");
-    await pricelessPositionManager.create({ rawValue: amountCollateral }, { rawValue: numTokens }, { from: sponsor });
-
-    // Transfer half the tokens from the sponsor to a tokenHolder. IRL this happens through the sponsor selling tokens.
-    const tokenHolderTokens = toWei("50");
-    await tokenCurrency.transfer(tokenHolder, tokenHolderTokens, {
-      from: sponsor
-    });
-
-    // Siphon should revert if before the siphon delay.
-    assert(await didContractThrow(pricelessPositionManager.siphonContractCollateral({ from: other })));
-
-    // Advance time until after expiration. Token holders and sponsors should now be able to to settle.
-    const expirationTime = await pricelessPositionManager.expirationTimestamp();
-    await pricelessPositionManager.setCurrentTime(expirationTime.toNumber() + 1);
-
-    // To settle positions the DVM needs to be to be queried to get the price at the settlement time.
-    await pricelessPositionManager.expire({ from: other });
-
-    // Push a settlement price into the mock oracle to simulate a DVM vote. Say settlement occurs at 1.2 Stock/USD for the price.
-    await mockOracle.pushPrice(priceTrackingIdentifier, expirationTime.toNumber(), toWei("1.2"));
-
-    // At this point, as it is post expiry,  token sponsor and token holder should be able to redeem their tokens.
-    // Let the token sponsor withdraw their expected collateral however the token holder never redeems their tokens.
-    await tokenCurrency.approve(pricelessPositionManager.address, amountCollateral, {
-      from: sponsor
-    });
-    await pricelessPositionManager.settleExpired({ from: sponsor });
-
-    // Siphon should revert if after the expired, but before the siphon delay.
-    assert(await didContractThrow(pricelessPositionManager.siphonContractCollateral({ from: other })));
-
-    // Advance time to after the siphon delay. Siphon should now work.
-    await pricelessPositionManager.setCurrentTime(expirationTime.toNumber() + siphonDelay + 1);
-
-    // The pricelessPositionManager should have the original collateral (150) - the amount withdrawn by the sponsor.
-    // The net of this is that the pricelessPositionManager should have exactly the value unclaimed tokens from the token holder
-    // denominated in collateral. The tokenHolder has 50 unclaimed tokens, valued at 1.2 Dai per token should yield: 50 * 1.2 = 60
-    const ppmCollateralBefore = await collateral.balanceOf(pricelessPositionManager.address);
-    assert.equal(ppmCollateralBefore.toString(), toWei("60"));
-
-    // Grab the store balance from before. This is non-zero as fees have been accrued in previous tests.
-    const storeCollateralBefore = await collateral.balanceOf(store.address);
-
-    // Execute the siphon action. Anyone can call this
-    await pricelessPositionManager.siphonContractCollateral({ from: other });
-
-    // After the siphon is done the pricelessPositionManager should have 0 collateral left in it.
-    const ppmCollateralAfter = await collateral.balanceOf(pricelessPositionManager.address);
-    assert.equal(ppmCollateralAfter.toString(), 0);
-
-    // The store should gain all of the pricelessPositionManager's collateral that was present before the siphon
-    const storeCollateralAfter = await collateral.balanceOf(store.address);
-    assert.equal(storeCollateralAfter.sub(storeCollateralBefore).toString(), ppmCollateralBefore.toString());
-
-    // If the token holder tries to withdraw now they cant as it is post siphon.
-    assert(await didContractThrow(pricelessPositionManager.settleExpired({ from: tokenHolder })));
   });
 
   it("Emergency shutdown: lifecycle", async function() {

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -45,7 +45,6 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       isTest: true,
       expirationTimestamp: "12345678900",
       withdrawalLiveness: "1000",
-      siphonDelay: "100000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -73,7 +73,6 @@ contract("Liquidator.js", function(accounts) {
       isTest: true,
       expirationTimestamp: "12345678900",
       withdrawalLiveness: "1000",
-      siphonDelay: "10000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,


### PR DESCRIPTION
This PR removes the sipon functionality added to the contracts in #1002. In doing so, this PR will close #1027