### PR TITLE
Added slack integration to liquidator

### DIFF
--- a/core/.env_sample
+++ b/core/.env_sample
@@ -1,1 +1,2 @@
 MNEMONIC="your mnemonic here"
+SLACK_WEBHOOK="web hook for your slack app here"

--- a/financial-templates-lib/Logger.js
+++ b/financial-templates-lib/Logger.js
@@ -38,7 +38,26 @@ const transports = [
 if (process.env.SLACK_WEBHOOK) {
   transports.push(
     new SlackHook({
-      webhookUrl: process.env.SLACK_WEBHOOK
+      webhookUrl: process.env.SLACK_WEBHOOK,
+      formatter: info => {
+        return {
+          text: `${info.level}: ${info.message}`,
+          attachments: [
+            {
+              text: `${JSON.stringify(info)}`
+            }
+          ],
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "plain_text",
+                text: `${info.level}`
+              }
+            }
+          ]
+        };
+      }
     })
   );
 }

--- a/financial-templates-lib/Logger.js
+++ b/financial-templates-lib/Logger.js
@@ -66,6 +66,7 @@ transports.push(
   new winston.transports.Console({
     level: "debug",
     handleExceptions: true
+    // TODO improve the formatter as defined in issue #1041
     // format: alignedWithColorsAndTime
   })
 );

--- a/financial-templates-lib/Logger.js
+++ b/financial-templates-lib/Logger.js
@@ -1,5 +1,7 @@
 const winston = require("winston");
 const Transport = require("winston-transport");
+const SlackHook = require("winston-slack-webhook-transport");
+require("dotenv").config();
 
 class StackTransport extends Transport {
   log(info, callback) {
@@ -33,11 +35,19 @@ const transports = [
   })
 ];
 
+if (process.env.SLACK_WEBHOOK) {
+  transports.push(
+    new SlackHook({
+      webhookUrl: process.env.SLACK_WEBHOOK
+    })
+  );
+}
+
 transports.push(
   new winston.transports.Console({
     level: "debug",
-    handleExceptions: true,
-    format: alignedWithColorsAndTime
+    handleExceptions: true
+    // format: alignedWithColorsAndTime
   })
 );
 

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -18,7 +18,8 @@ class Liquidator {
   queryAndLiquidate = async priceFeed => {
     Logger.info({
       at: "liquidator",
-      message: "Checking for under collateralized positions"
+      message: "Checking for under collateralized positions",
+      inputPrice: priceFeed
     });
 
     // Update the client to get the latest position information.

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -171,17 +171,4 @@ contract("Liquidator.js", function(accounts) {
     assert.deepStrictEqual(await emp.getLiquidations(sponsor3), []);
     assert.equal((await emp.getCollateral(sponsor3)).rawValue, toWei("175"));
   });
-
-  it.only("set up positions", async function() {
-    console.log("seeding emp @", emp.address);
-    for (let i = 1; i < 6; i++) {
-      console.log("Creating position for account", accounts[i]);
-      await collateralToken.mint(accounts[i], toWei("100000"), { from: contractCreator });
-      await collateralToken.approve(emp.address, toWei("1000000"), { from: accounts[i] });
-      await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[i] });
-    }
-
-    // liquidatorBot creates a position to have synthetic tokens to pay off debt upon liquidation.
-    await emp.create({ rawValue: toWei("100000") }, { rawValue: toWei("50000") }, { from: liquidatorBot });
-  });
 });

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -171,4 +171,17 @@ contract("Liquidator.js", function(accounts) {
     assert.deepStrictEqual(await emp.getLiquidations(sponsor3), []);
     assert.equal((await emp.getCollateral(sponsor3)).rawValue, toWei("175"));
   });
+
+  it.only("set up positions", async function() {
+    console.log("seeding emp @", emp.address);
+    for (let i = 1; i < 6; i++) {
+      console.log("Creating position for account", accounts[i]);
+      await collateralToken.mint(accounts[i], toWei("100000"), { from: contractCreator });
+      await collateralToken.approve(emp.address, toWei("1000000"), { from: accounts[i] });
+      await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[i] });
+    }
+
+    // liquidatorBot creates a position to have synthetic tokens to pay off debt upon liquidation.
+    await emp.create({ rawValue: toWei("100000") }, { rawValue: toWei("50000") }, { from: liquidatorBot });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "web3-eth-abi": "^1.2.4",
     "web3-utils": "^1.2.4",
     "winston": "^3.2.1",
+    "winston-slack-webhook-transport": "^1.2.1",
     "winston-transport": "^4.3.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This PR adds basic slack integration to the liquidator bot to close #1030 . Additional refinement is require to improve the output styling and formatting of the slack message, as detailed in issue #1031 . 

The screenshots below shows the current slack output for a few basic operations in liquidating 5 positions

![image](https://user-images.githubusercontent.com/12886084/76256316-60dd9580-6258-11ea-826c-a7fa5410cd2b.png)

![image](https://user-images.githubusercontent.com/12886084/76256409-91bdca80-6258-11ea-917d-57694dea59fb.png)


This output is currently the same as generated in the console. Issue #1031 will add a custom formatter to create nice looking markdown logs in Slack.

Information on creating webhooks can be found here: https://slack.com/intl/en-za/help/articles/115005265063-Incoming-Webhooks-for-Slack