### PR TITLE
Revert commit that adds TF to Finder

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -19,6 +19,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
     struct Params {
         uint expirationTimestamp;
         address collateralAddress;
+        address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
         string syntheticName;
         string syntheticSymbol;
@@ -132,6 +133,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         // Input from function call.
         constructorParams.expirationTimestamp = params.expirationTimestamp;
         constructorParams.collateralAddress = params.collateralAddress;
+        constructorParams.tokenFactoryAddress = params.tokenFactoryAddress;
         constructorParams.priceFeedIdentifier = params.priceFeedIdentifier;
         constructorParams.syntheticName = params.syntheticName;
         constructorParams.syntheticSymbol = params.syntheticSymbol;

--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -19,7 +19,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
     struct Params {
         uint expirationTimestamp;
         address collateralAddress;
-        address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
         string syntheticName;
         string syntheticSymbol;
@@ -40,6 +39,8 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
 
     // - Whitelist allowed collateral currencies.
     AddressWhitelist public collateralTokenWhitelist;
+    // - Address of TokenFactory to pass into newly constructed ExpiringMultiParty contracts
+    address public tokenFactoryAddress;
     // - Discretize expirations such that they must expire on the first of each month.
     uint[15] public VALID_EXPIRATION_TIMESTAMPS = [
         1585699200, // 2020-04-01T00:00:00.000Z
@@ -75,12 +76,13 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
 
     event CreatedExpiringMultiParty(address expiringMultiPartyAddress, address partyMemberAddress);
 
-    constructor(bool _isTest, address _finderAddress, address _collateralTokenWhitelist)
+    constructor(bool _isTest, address _finderAddress, address _collateralTokenWhitelist, address _tokenFactoryAddress)
         public
         ContractCreator(_finderAddress)
         Testable(_isTest)
     {
         collateralTokenWhitelist = AddressWhitelist(_collateralTokenWhitelist);
+        tokenFactoryAddress = _tokenFactoryAddress;
     }
 
     /**
@@ -120,6 +122,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         // Known from creator deployment.
         constructorParams.isTest = isTest;
         constructorParams.finderAddress = finderAddress;
+        constructorParams.tokenFactoryAddress = tokenFactoryAddress;
 
         // Enforce configuration constrainments.
         require(_isValidTimestamp(params.expirationTimestamp));
@@ -133,7 +136,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         // Input from function call.
         constructorParams.expirationTimestamp = params.expirationTimestamp;
         constructorParams.collateralAddress = params.collateralAddress;
-        constructorParams.tokenFactoryAddress = params.tokenFactoryAddress;
         constructorParams.priceFeedIdentifier = params.priceFeedIdentifier;
         constructorParams.syntheticName = params.syntheticName;
         constructorParams.syntheticSymbol = params.syntheticSymbol;

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -126,6 +126,7 @@ contract Liquidatable is PricelessPositionManager {
         uint withdrawalLiveness;
         address collateralAddress;
         address finderAddress;
+        address tokenFactoryAddress;
         bytes32 priceFeedIdentifier;
         string syntheticName;
         string syntheticSymbol;
@@ -147,7 +148,8 @@ contract Liquidatable is PricelessPositionManager {
             params.finderAddress,
             params.priceFeedIdentifier,
             params.syntheticName,
-            params.syntheticSymbol
+            params.syntheticSymbol,
+            params.tokenFactoryAddress
         )
     {
         require(params.collateralRequirement.isGreaterThan(1));

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -110,11 +110,12 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         address _finderAddress,
         bytes32 _priceIdentifier,
         string memory _syntheticName,
-        string memory _syntheticSymbol
+        string memory _syntheticSymbol,
+        address _tokenFactoryAddress
     ) public FeePayer(_collateralAddress, _finderAddress, _isTest) {
         expirationTimestamp = _expirationTimestamp;
         withdrawalLiveness = _withdrawalLiveness;
-        TokenFactory tf = _getTokenFactory();
+        TokenFactory tf = TokenFactory(_tokenFactoryAddress);
         tokenCurrency = tf.createToken(_syntheticName, _syntheticSymbol, 18);
 
         require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier));
@@ -469,11 +470,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     function _getOracle() internal view returns (OracleInterface) {
         bytes32 oracleInterface = "Oracle";
         return OracleInterface(finder.getImplementationAddress(oracleInterface));
-    }
-
-    function _getTokenFactory() internal view returns (TokenFactory) {
-        bytes32 tf = "TokenFactory";
-        return TokenFactory(finder.getImplementationAddress(tf));
     }
 
     function _getStoreAddress() internal view returns (address) {

--- a/core/migrations/17_deploy_tokenfactory.js
+++ b/core/migrations/17_deploy_tokenfactory.js
@@ -1,15 +1,8 @@
-const Finder = artifacts.require("Finder");
 const TokenFactory = artifacts.require("TokenFactory");
 const { getKeysForNetwork, deploy } = require("../../common/MigrationUtils.js");
-const { interfaceName } = require("../utils/Constants.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
 
-  const { contract: tf } = await deploy(deployer, network, TokenFactory, { from: keys.deployer });
-
-  const finder = await Finder.deployed();
-  await finder.changeImplementationAddress(web3.utils.utf8ToHex(interfaceName.TokenFactory), tf.address, {
-    from: keys.deployer
-  });
+  await deploy(deployer, network, TokenFactory, { from: keys.deployer });
 };

--- a/core/migrations/18_deploy_expiring_multi_party_creator.js
+++ b/core/migrations/18_deploy_expiring_multi_party_creator.js
@@ -1,6 +1,7 @@
 const Finder = artifacts.require("Finder");
 const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
+const TokenFactory = artifacts.require("TokenFactory");
 const { getKeysForNetwork, deploy, enableControllableTiming } = require("../../common/MigrationUtils.js");
 
 module.exports = async function(deployer, network, accounts) {
@@ -13,6 +14,7 @@ module.exports = async function(deployer, network, accounts) {
   });
 
   const finder = await Finder.deployed();
+  const tokenFactory = await TokenFactory.deployed();
 
   await deploy(
     deployer,
@@ -21,6 +23,7 @@ module.exports = async function(deployer, network, accounts) {
     controllableTiming,
     finder.address,
     collateralCurrencyWhitelist.address,
+    tokenFactory.address,
     { from: keys.deployer }
   );
 };

--- a/core/test/financial-templates/ExpiringMultiParty.js
+++ b/core/test/financial-templates/ExpiringMultiParty.js
@@ -6,6 +6,7 @@ const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 // Helper Contracts
 const Finder = artifacts.require("Finder");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const TokenFactory = artifacts.require("TokenFactory");
 const Token = artifacts.require("ExpandedERC20");
 
 contract("ExpiringMultiParty", function(accounts) {
@@ -18,6 +19,7 @@ contract("ExpiringMultiParty", function(accounts) {
       withdrawalLiveness: "1000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMATEST",

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -41,7 +41,6 @@ contract("ExpiringMultiParty", function(accounts) {
     constructorParams = {
       expirationTimestamp: (await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(0)).toString(),
       collateralAddress: collateralToken.address,
-      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMATEST",
@@ -55,6 +54,10 @@ contract("ExpiringMultiParty", function(accounts) {
     await identifierWhitelist.addSupportedIdentifier(constructorParams.priceFeedIdentifier, {
       from: contractCreator
     });
+  });
+
+  it("TokenFactory address should be set on construction", async function() {
+    assert.equal(await expiringMultiPartyCreator.tokenFactoryAddress(), (await TokenFactory.deployed()).address);
   });
 
   it("Expiration timestamp must be one of the fifteen allowed month-start timestamps from April 2020 through June 2021", async function() {

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -8,6 +8,7 @@ const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator")
 
 // Helper Contracts
 const Token = artifacts.require("ExpandedERC20");
+const TokenFactory = artifacts.require("TokenFactory");
 const Registry = artifacts.require("Registry");
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
@@ -40,6 +41,7 @@ contract("ExpiringMultiParty", function(accounts) {
     constructorParams = {
       expirationTimestamp: (await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(0)).toString(),
       collateralAddress: collateralToken.address,
+      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMATEST",

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -14,6 +14,7 @@ const Store = artifacts.require("Store");
 const Finder = artifacts.require("Finder");
 const MockOracle = artifacts.require("MockOracle");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const TokenFactory = artifacts.require("TokenFactory");
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 
 contract("Liquidatable", function(accounts) {
@@ -118,6 +119,7 @@ contract("Liquidatable", function(accounts) {
       withdrawalLiveness: withdrawalLiveness.toString(),
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
       priceFeedIdentifier: priceTrackingIdentifier,
       syntheticName: "Test UMA Token",
       syntheticSymbol: "UMAETH",

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -12,6 +12,7 @@ const MockOracle = artifacts.require("MockOracle");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const MarginToken = artifacts.require("ExpandedERC20");
 const SyntheticToken = artifacts.require("SyntheticToken");
+const TokenFactory = artifacts.require("TokenFactory");
 const FinancialContractsAdmin = artifacts.require("FinancialContractsAdmin");
 
 contract("PricelessPositionManager", function(accounts) {
@@ -102,6 +103,7 @@ contract("PricelessPositionManager", function(accounts) {
       priceTrackingIdentifier, // _priceFeedIdentifier
       syntheticName, // _syntheticName
       syntheticSymbol, // _syntheticSymbol
+      TokenFactory.address, // _tokenFactoryAddress
       { from: contractDeployer }
     );
     tokenCurrency = await SyntheticToken.at(await pricelessPositionManager.tokenCurrency());

--- a/core/utils/Constants.js
+++ b/core/utils/Constants.js
@@ -4,8 +4,7 @@ const interfaceName = {
   Oracle: "Oracle",
   Registry: "Registry",
   Store: "Store",
-  IdentifierWhitelist: "IdentifierWhitelist",
-  TokenFactory: "TokenFactory"
+  IdentifierWhitelist: "IdentifierWhitelist"
 };
 
 module.exports = {


### PR DESCRIPTION
Originally, I registered `TokenFactory` with the `Finder` thinking that it is a singleton contract referenced by other contracts and therefore should be added to the Finder for smoother upgradeability.

However, I didn't realize that `Finder` is explicitly made a DVM contract, designed to be owned by the DVM's governor. This can be seen in [`/scripts/TransferPermissions`](https://github.com/UMAprotocol/protocol/blob/master/core/scripts/TransferPermissions.js).

However, I still don't think it is clean to have original implementation of `ExpiringMultiPartyCreator.createExpiringMultiparty()` take in a `TokenFactory` address. I think that the deployer of a financial template should not be responsible for determining which TF to set. Therefore, I have made one small change and ask that the deployer of `ExpiringMultiPartyCreator` pass in a TF address by construction. EMPCreator will then save the TF address and pass it into `ExpiringMultiParty`'s constructor on each call to `create...()`.

This is similar to having the deployer of EMPCreator pass in the `Finder's` address and not ask the deployer of EMP, calling `EMPCreator.createEMP()`, to pass in the Finder address.

This deprecates #1034 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>