### PR TITLE
Add Olympics 2020 expiration timestamp and July 2021 

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -42,7 +42,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
     // - Address of TokenFactory to pass into newly constructed ExpiringMultiParty contracts
     address public tokenFactoryAddress;
     // - Discretize expirations such that they must expire on the first of each month.
-    uint[15] public VALID_EXPIRATION_TIMESTAMPS = [
+    uint[17] public VALID_EXPIRATION_TIMESTAMPS = [
         1585699200, // 2020-04-01T00:00:00.000Z
         1588291200, // 2020-05-01T00:00:00.000Z
         1590969600, // 2020-06-01T00:00:00.000Z
@@ -57,7 +57,9 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         1614556800, // 2021-03-01T00:00:00.000Z
         1617235200, // 2021-04-01T00:00:00.000Z
         1619827200, // 2021-05-01T00:00:00.000Z
-        1622505600 // 2021-06-01T00:00:00.000Z
+        1622505600, // 2021-06-01T00:00:00.000Z
+        1625097600, // 2021-07-01T00:00:00.000Z
+        1597017600 // 2020-08-10T00:00:00.000Z (Note: This is a special expiration that marks the end of the Tokyo Olympics 2020)
     ];
     // - Time for pending withdrawal to be disputed: 60 minutes. Lower liveness increases sponsor usability. However, this parameter is a reflection of how long we expect it to take for
     // liquidators to identify that a sponsor is undercollateralized and acquire the tokens needed to liquidate them.

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -60,7 +60,7 @@ contract("ExpiringMultiParty", function(accounts) {
     assert.equal(await expiringMultiPartyCreator.tokenFactoryAddress(), (await TokenFactory.deployed()).address);
   });
 
-  it("Expiration timestamp must be one of the allowed month-start timestamps", async function() {
+  it("Expiration timestamp must be one of the allowed timestamps", async function() {
     // Change only expiration timestamp.
     const validExpiration = await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(5);
     // Set to a valid expiry.

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -60,7 +60,7 @@ contract("ExpiringMultiParty", function(accounts) {
     assert.equal(await expiringMultiPartyCreator.tokenFactoryAddress(), (await TokenFactory.deployed()).address);
   });
 
-  it("Expiration timestamp must be one of the fifteen allowed month-start timestamps from April 2020 through June 2021", async function() {
+  it("Expiration timestamp must be one of the allowed month-start timestamps", async function() {
     // Change only expiration timestamp.
     const validExpiration = await expiringMultiPartyCreator.VALID_EXPIRATION_TIMESTAMPS(5);
     // Set to a valid expiry.


### PR DESCRIPTION
Regarding the addition of July 2021, I realize that if we want the last expiration to be June 30 2021, then we need an additional timestamp: July 2021. The previous latest timestamp was June 2021.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>