### PR TITLE
Fix docs generation to work with Solidity 0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,9 @@ jobs:
       - run:
           name: Untar Pandoc
           command: sudo tar xvzf pandoc-2.7.3-linux.tar.gz --strip-components 1 -C /usr/local
-      # TODO(#977) Solc 0.6 not supported, skipping this test
       - run:
           name: Generate Docs
-          command: ./ci/false_positive.sh
+          command: ./scripts/build_docs_site.sh
       - store_artifacts:
           path: build/site
   slither:

--- a/ci/deploy_to_staging.sh
+++ b/ci/deploy_to_staging.sh
@@ -28,6 +28,5 @@ gsutil cp gs://staging-deployment-configuration/voter-app.yaml voter-dapp/app.ya
 ./scripts/deploy_dapp.sh voter-dapp voter-dapp/app.yaml -q
 
 # Deploy docs
-# TODO(#977) Solc 0.6 not supported, skipping this
-# ./scripts/deploy_docs.sh documentation/gae_app.yaml -q
+./scripts/deploy_docs.sh documentation/gae_app.yaml -q
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "winston-transport": "^4.3.0"
   },
   "optionalDependencies": {
-    "solidity-docgen": "github:UMAprotocol/solidity-docgen#fork-no-inheritance"
+    "solidity-docgen": "github:UMAprotocol/solidity-docgen#fork-updated"
   },
   "bin": {
     "uma": "./core/scripts/cli/cli_entry.sh"


### PR DESCRIPTION
This PR fixes our docs generation so it works with 0.6. To do this, I made some changes to our solidity-docgen fork and put them on the `fork-updated` branch.

These changes include:
- Updating to the latest open zeppelin commit.
- Removing some of our changes/commented code that are no longer necessary due to updates in the upstream repo.
- Fixing a minor 0.6 compatibility issue in the upstream repo.

This commit includes all changes that differ from HEAD of the upstream repository:
https://github.com/UMAprotocol/solidity-docgen/commit/8b918b387337615d4991f4eb3d4042810b0f0bdf

Fixes #977