### PR TITLE
Add dispute bot implementation

### DIFF
--- a/ci/run_truffle_tests.sh
+++ b/ci/run_truffle_tests.sh
@@ -48,6 +48,7 @@ run_tests $PROTOCOL_DIR/core
 # Hacky way of running truffle tests outside of core.
 cd $PROTOCOL_DIR/core
 $(npm bin)/truffle test ../financial-templates-lib/test/*.js --network ci
+$(npm bin)/truffle test ../disputer/test/*.js --network ci
 
 # Check the Kovan deployment.
 check_deployment $PROTOCOL_DIR/core 4 rinkeby_mnemonic

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -1,0 +1,81 @@
+const { Logger } = require("../financial-templates-lib/Logger");
+
+class Disputer {
+  constructor(expiringMultiPartyClient, account) {
+    this.account = account;
+
+    // Expiring multiparty contract to read contract state
+    this.empClient = expiringMultiPartyClient;
+
+    // Instance of the expiring multiparty to perform on-chain liquidations
+    this.empContract = this.empClient.emp;
+  }
+
+  // Queries disputable liquidations and disputes any that were incorrectly liquidated.
+  queryAndDispute = async priceFunction => {
+    Logger.debug({
+      at: "Disputer",
+      message: "Checking for any disputable liquidations"
+    });
+
+    // Update the client to get the latest liquidation information.
+    await this.empClient._update();
+
+    // Get the latest disputable liquidations from the client.
+    const undisputedLiquidations = this.empClient.getUndisputedLiquidations();
+    const disputeableLiquidations = undisputedLiquidations.filter(liquidation => this.empClient.isDisputable(liquidation, priceFunction(liquidation.liquidationTime)));
+
+    if (disputeableLiquidations.length === 0) {
+      Logger.debug({
+        at: "liquidator",
+        message: "No disputable liquidations"
+      });
+
+      // Nothing left to do, so return.
+      return;
+    }
+
+
+    Logger.info({
+      at: "Disputer",
+      message: "Disputable liquidation(s) detected!",
+      number: disputeableLiquidations.length,
+      underCollateralizedPositions: disputeableLiquidations
+    });
+
+    for (const disputeableLiquidation of disputeableLiquidations) {
+      Logger.info({
+        at: "Disputer",
+        message: "Disputing liquidation",
+        address: disputeableLiquidation.sponsor,
+        inputPrice: priceFunction(disputeableLiquidation.liquidationTime)
+      });
+
+      // Create the liquidation transaction
+
+      // TODO: compute the amount of collateral required to dispute and ensure the bot has enough to perform it.
+
+      // TODO: handle transaction failures.
+      const receipt = await this.empContract.methods.dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor).send({ from: this.account, gas: 1500000 });
+
+      const disputeResult = {
+        tx: receipt.transactionHash,
+        sponsor: receipt.events.LiquidationDisputed.returnValues.sponsor,
+        liquidator: receipt.events.LiquidationDisputed.returnValues.liquidator,
+        id: receipt.events.LiquidationDisputed.returnValues.disputeId,
+        disputeBondPaid: receipt.events.LiquidationDisputed.returnValues.disputeBondAmount
+      };
+      Logger.info({
+        at: "Disputer",
+        message: "Dispute tx result",
+        disputeResult: disputeResult
+      });
+
+      // TODO: query any resolved disputes that this address participated in and attempt to withdraw.
+    }
+  };
+}
+
+module.exports = {
+  Disputer
+};

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -23,7 +23,9 @@ class Disputer {
 
     // Get the latest disputable liquidations from the client.
     const undisputedLiquidations = this.empClient.getUndisputedLiquidations();
-    const disputeableLiquidations = undisputedLiquidations.filter(liquidation => this.empClient.isDisputable(liquidation, priceFunction(liquidation.liquidationTime)));
+    const disputeableLiquidations = undisputedLiquidations.filter(liquidation =>
+      this.empClient.isDisputable(liquidation, priceFunction(liquidation.liquidationTime))
+    );
 
     if (disputeableLiquidations.length === 0) {
       Logger.debug({
@@ -34,7 +36,6 @@ class Disputer {
       // Nothing left to do, so return.
       return;
     }
-
 
     Logger.info({
       at: "Disputer",
@@ -56,7 +57,9 @@ class Disputer {
       // TODO: compute the amount of collateral required to dispute and ensure the bot has enough to perform it.
 
       // TODO: handle transaction failures.
-      const receipt = await this.empContract.methods.dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor).send({ from: this.account, gas: 1500000 });
+      const receipt = await this.empContract.methods
+        .dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor)
+        .send({ from: this.account, gas: 1500000 });
 
       const disputeResult = {
         tx: receipt.transactionHash,

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -7,7 +7,7 @@ class Disputer {
     // Expiring multiparty contract to read contract state
     this.empClient = expiringMultiPartyClient;
 
-    // Instance of the expiring multiparty to perform on-chain liquidations
+    // Instance of the expiring multiparty to perform on-chain disputes
     this.empContract = this.empClient.emp;
   }
 
@@ -41,7 +41,7 @@ class Disputer {
       at: "Disputer",
       message: "Disputable liquidation(s) detected!",
       number: disputeableLiquidations.length,
-      underCollateralizedPositions: disputeableLiquidations
+      disputeableLiquidations: disputeableLiquidations
     });
 
     for (const disputeableLiquidation of disputeableLiquidations) {

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -1,4 +1,4 @@
-const argv = require("minimist")(process.argv.slice(), { string: ["address", "price"]});
+const argv = require("minimist")(process.argv.slice(), { string: ["address", "price"] });
 const { toWei, hexToUtf8, toBN } = web3.utils;
 
 // Helpers

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -1,0 +1,56 @@
+const argv = require("minimist")(process.argv.slice(), { string: ["address", "price"]});
+const { toWei, hexToUtf8, toBN } = web3.utils;
+
+// Helpers
+const { delay } = require("../financial-templates-lib/delay");
+const { Logger } = require("../financial-templates-lib/Logger");
+
+// JS libs
+const { Disputer } = require("./Liquidator");
+const { ExpiringMultiPartyClient } = require("../financial-templates-lib/ExpiringMultiPartyClient");
+
+// Truffle contracts
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+
+async function run() {
+  if (!argv.address || !argv.price) {
+    throw "Must provide --address and --price arguments";
+  }
+  Logger.info({
+    at: "liquidator#index",
+    message: "liquidator started",
+    empAddress: argv.address,
+    currentPrice: argv.price
+  });
+
+  // Setup web3 accounts an contract instance
+  const accounts = await web3.eth.getAccounts();
+  const emp = await ExpiringMultiParty.at(argv.address);
+
+  // Client and dispute bot
+  const empClient = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
+  const disputer = new Disputer(empClient, accounts[0]);
+
+  while (true) {
+    try {
+      await disputer.queryAndDispute(toWei(argv.price));
+    } catch (error) {
+      Logger.error({
+        at: "Disputer#index",
+        message: "Disputer error",
+        error: error
+      });
+    }
+    await delay(Number(10_000));
+  }
+}
+
+module.exports = async function(callback) {
+  try {
+    await run();
+  } catch (err) {
+    console.error(err);
+    callback(err);
+  }
+  callback();
+};

--- a/disputer/package.json
+++ b/disputer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "disputer",
+  "version": "0.1.0",
+  "description": "UMA Disputer",
+  "private": true,
+  "dependencies": {
+    "winston": "^3.2.1",
+    "winston-transport": "^4.3.0"
+  }
+}

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -1,0 +1,146 @@
+const { toWei, utf8ToHex } = web3.utils;
+
+// Script to test
+const { Disputer } = require("../disputer.js");
+
+// Helper client script
+const { ExpiringMultiPartyClient } = require("../../financial-templates-lib/ExpiringMultiPartyClient");
+
+// Contracts and helpers
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const Finder = artifacts.require("Finder");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const MockOracle = artifacts.require("MockOracle");
+const TokenFactory = artifacts.require("TokenFactory");
+const Token = artifacts.require("ExpandedERC20");
+
+contract("Disputer.js", function(accounts) {
+  const disputeBot = accounts[0];
+  const sponsor1 = accounts[1];
+  const sponsor2 = accounts[2];
+  const sponsor3 = accounts[3];
+  const liquidator = accounts[4];
+  const contractCreator = accounts[5];
+
+  let collateralToken;
+  let emp;
+  let syntheticToken;
+  let mockOracle;
+
+  // States for Liquidation to be in
+  const STATES = {
+    UNINITIALIZED: "0",
+    PRE_DISPUTE: "1",
+    PENDING_DISPUTE: "2",
+    DISPUTE_SUCCEEDED: "3",
+    DISPUTE_FAILED: "4"
+  };
+
+  before(async function() {
+    collateralToken = await Token.new({ from: contractCreator });
+    await collateralToken.addMember(1, contractCreator, {
+      from: contractCreator
+    });
+
+    // Seed the accounts.
+    await collateralToken.mint(sponsor1, toWei("100000"), { from: contractCreator });
+    await collateralToken.mint(sponsor2, toWei("100000"), { from: contractCreator });
+    await collateralToken.mint(sponsor3, toWei("100000"), { from: contractCreator });
+    await collateralToken.mint(liquidator, toWei("100000"), { from: contractCreator });
+    await collateralToken.mint(disputeBot, toWei("100000"), { from: contractCreator });
+
+    // Create a mockOracle and finder. Register the mockMoracle with the finder.
+    mockOracle = await MockOracle.new(IdentifierWhitelist.address, {
+      from: contractCreator
+    });
+    finder = await Finder.deployed();
+    const mockOracleInterfaceName = web3.utils.utf8ToHex("Oracle");
+    await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
+  });
+
+  beforeEach(async function() {
+    const constructorParams = {
+      isTest: true,
+      expirationTimestamp: "12345678900",
+      withdrawalLiveness: "1000",
+      collateralAddress: collateralToken.address,
+      finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
+      priceFeedIdentifier: utf8ToHex("UMATEST"),
+      syntheticName: "Test UMA Token",
+      syntheticSymbol: "UMATEST",
+      liquidationLiveness: "1000",
+      collateralRequirement: { rawValue: toWei("1.2") },
+      disputeBondPct: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPct: { rawValue: toWei("0.1") }
+    };
+
+    identifierWhitelist = await IdentifierWhitelist.deployed();
+    await identifierWhitelist.addSupportedIdentifier(constructorParams.priceFeedIdentifier, {
+      from: accounts[0]
+    });
+
+    // Deploy a new expiring multi party
+    emp = await ExpiringMultiParty.new(constructorParams);
+
+    await collateralToken.approve(emp.address, toWei("100000000"), { from: sponsor1 });
+    await collateralToken.approve(emp.address, toWei("100000000"), { from: sponsor2 });
+    await collateralToken.approve(emp.address, toWei("100000000"), { from: sponsor3 });
+    await collateralToken.approve(emp.address, toWei("100000000"), { from: liquidator });
+    await collateralToken.approve(emp.address, toWei("100000000"), { from: disputeBot });
+
+    syntheticToken = await Token.at(await emp.tokenCurrency());
+    await syntheticToken.approve(emp.address, toWei("100000000"), { from: sponsor1 });
+    await syntheticToken.approve(emp.address, toWei("100000000"), { from: sponsor2 });
+    await syntheticToken.approve(emp.address, toWei("100000000"), { from: sponsor3 });
+    await syntheticToken.approve(emp.address, toWei("100000000"), { from: liquidator });
+    await syntheticToken.approve(emp.address, toWei("100000000"), { from: disputeBot });
+
+    // Create a new instance of the ExpiringMultiPartyClient to construct the disputer
+    empClient = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
+
+    // Create a new instance of the disputer to test
+    disputer = new Disputer(empClient, accounts[0]);
+  });
+
+  it("Detect disputable positions and send dipsutes", async function() {
+    // sponsor1 creates a position with 125 units of collateral, creating 100 synthetic tokens.
+    await emp.create({ rawValue: toWei("125") }, { rawValue: toWei("100") }, { from: sponsor1 });
+
+    // sponsor2 creates a position with 150 units of collateral, creating 100 synthetic tokens.
+    await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: sponsor2 });
+
+    // sponsor3 creates a position with 175 units of collateral, creating 100 synthetic tokens.
+    await emp.create({ rawValue: toWei("175") }, { rawValue: toWei("100") }, { from: sponsor3 });
+
+    // The liquidator creates a position to have synthetic tokens.
+    await emp.create({ rawValue: toWei("1000") }, { rawValue: toWei("500") }, { from: liquidator });
+
+    await emp.createLiquidation(sponsor1, { rawValue: toWei("1.75") }, { rawValue: toWei("100") }, { from: liquidator });
+    await emp.createLiquidation(sponsor2, { rawValue: toWei("1.75") }, { rawValue: toWei("100") }, { from: liquidator });
+    await emp.createLiquidation(sponsor3, { rawValue: toWei("1.75") }, { rawValue: toWei("100") }, { from: liquidator });
+
+    // Start with a mocked price of 1.75 usd per token.
+    // This makes all sponsors undercollateralized, meaning no disputes are issued.
+    await disputer.queryAndDispute(time => toWei("1.75"));
+
+    // There should be no liquidations created from any sponsor account
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor3))[0].state, STATES.PRE_DISPUTE);
+
+
+    // With a price of 1.1, two sponsors should be correctly collateralized, so disputes should be issued against sponsor2 and sponsor3's liquidations.
+    await disputer.queryAndDispute(time => toWei("1.1"));
+
+    // Sponsor2 and sponsor3 should be disputed.
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.PENDING_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor3))[0].state, STATES.PENDING_DISPUTE);
+
+    // The disputeBot should be the disputer in sponsor2 and sponsor3's liquidations.
+    assert.equal((await emp.getLiquidations(sponsor2))[0].disputer, disputeBot);
+    assert.equal((await emp.getLiquidations(sponsor3))[0].disputer, disputeBot);
+  });
+});

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -117,9 +117,24 @@ contract("Disputer.js", function(accounts) {
     // The liquidator creates a position to have synthetic tokens.
     await emp.create({ rawValue: toWei("1000") }, { rawValue: toWei("500") }, { from: liquidator });
 
-    await emp.createLiquidation(sponsor1, { rawValue: toWei("1.75") }, { rawValue: toWei("100") }, { from: liquidator });
-    await emp.createLiquidation(sponsor2, { rawValue: toWei("1.75") }, { rawValue: toWei("100") }, { from: liquidator });
-    await emp.createLiquidation(sponsor3, { rawValue: toWei("1.75") }, { rawValue: toWei("100") }, { from: liquidator });
+    await emp.createLiquidation(
+      sponsor1,
+      { rawValue: toWei("1.75") },
+      { rawValue: toWei("100") },
+      { from: liquidator }
+    );
+    await emp.createLiquidation(
+      sponsor2,
+      { rawValue: toWei("1.75") },
+      { rawValue: toWei("100") },
+      { from: liquidator }
+    );
+    await emp.createLiquidation(
+      sponsor3,
+      { rawValue: toWei("1.75") },
+      { rawValue: toWei("100") },
+      { from: liquidator }
+    );
 
     // Start with a mocked price of 1.75 usd per token.
     // This makes all sponsors undercollateralized, meaning no disputes are issued.
@@ -129,7 +144,6 @@ contract("Disputer.js", function(accounts) {
     assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PRE_DISPUTE);
     assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.PRE_DISPUTE);
     assert.equal((await emp.getLiquidations(sponsor3))[0].state, STATES.PRE_DISPUTE);
-
 
     // With a price of 1.1, two sponsors should be correctly collateralized, so disputes should be issued against sponsor2 and sponsor3's liquidations.
     await disputer.queryAndDispute(time => toWei("1.1"));

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint_vanilla": "eslint 'core/**/*.js'",
     "prettier": "npm run prettier_vanilla -- --write",
     "prettier_check": "npm run prettier_vanilla -- --check",
-    "prettier_vanilla": "prettier --bracket-spacing 'core/**/*.js' 'common/**/*.js' '*.js' 'voter-dapp/src/**/*.js' 'sponsor-dapp-v2/src/**/*.js' 'core/contracts/**/*.sol' 'financial-templates-lib/*.js'"
+    "prettier_vanilla": "prettier --bracket-spacing 'core/**/*.js' 'common/**/*.js' '*.js' 'voter-dapp/src/**/*.js' 'sponsor-dapp-v2/src/**/*.js' 'core/contracts/**/*.sol' 'financial-templates-lib/*.js' 'disputer/**/*.js'"
   },
   "author": "UMA Team",
   "license": "AGPL-3.0",


### PR DESCRIPTION
This follows the general template established by the liquidation bot.

Two TODOs left in the code:
- Managing collateral inventory.
- Withdrawing collateral after the dispute is completed.

Pertains to #1011.