### PR TITLE
Add Liquidator bot tests to CI, update dependency requirements, update tests

### DIFF
--- a/ci/run_truffle_tests.sh
+++ b/ci/run_truffle_tests.sh
@@ -48,6 +48,7 @@ run_tests $PROTOCOL_DIR/core
 # Hacky way of running truffle tests outside of core.
 cd $PROTOCOL_DIR/core
 $(npm bin)/truffle test ../financial-templates-lib/test/*.js --network ci
+$(npm bin)/truffle test ../liquidator/test/*.js --network ci
 
 # Check the Kovan deployment.
 check_deployment $PROTOCOL_DIR/core 4 rinkeby_mnemonic

--- a/financial-templates-lib/package.json
+++ b/financial-templates-lib/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "winston": "^3.2.1",
+    "winston-slack-webhook-transport": "^1.2.1",
     "winston-transport": "^4.3.0"
   }
 }

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -6,7 +6,7 @@ const { delay } = require("../financial-templates-lib/delay");
 const { Logger } = require("../financial-templates-lib/Logger");
 
 // JS libs
-const { Liquidator } = require("./Liquidator");
+const { Liquidator } = require("./liquidator");
 const { ExpiringMultiPartyClient } = require("../financial-templates-lib/ExpiringMultiPartyClient");
 
 // Truffle contracts

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -1,5 +1,5 @@
 const argv = require("minimist")(process.argv.slice(), { string: ["address"], integer: ["price"] });
-const { toWei, hexToUtf8, toBN } = web3.utils;
+const { toWei } = web3.utils;
 
 // Helpers
 const { delay } = require("../financial-templates-lib/delay");

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -13,12 +13,17 @@ const { ExpiringMultiPartyClient } = require("../financial-templates-lib/Expirin
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 
 // TODO: Figure out a good way to run this script, maybe with a wrapper shell script.
-// Currently, you can run it with `truffle exec ../liquidator/liquidator.js --address=<address>` *from the core
+// Currently, you can run it with `truffle exec ../liquidator/liquidator.js --address=<address> --price=<price>` *from the core
 // directory*.
 
 async function run() {
   if (!argv.address) {
     console.log("Bad input arg! Specify an `address` for the location of the expiring Multi Party.");
+    return;
+  }
+  // TODO: Remove this price flag once we have built the pricefeed module.
+  if (!argv.price) {
+    console.log("Bad input arg! Specify a `price` as the pricefeed.");
     return;
   }
   Logger.info({

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -2,7 +2,7 @@
 // wallet to run the liquidations. Future versions will deal with generating additional synthetic tokens from EMPs as the bot needs.
 
 const { Logger } = require("../financial-templates-lib/Logger");
-const { toBN, toWei } = web3.utils;
+const { toWei } = web3.utils;
 
 class Liquidator {
   constructor(expiringMultiPartyClient, account) {
@@ -61,7 +61,7 @@ class Liquidator {
           .createLiquidation(
             position.sponsor, 
             { rawValue: toWei(priceFeed) },
-            { rawValue: toWei(position.numTokens) }
+            { rawValue: position.numTokens }
           )
           .send({ from: this.account, gas: 1500000 })
       );

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -53,17 +53,15 @@ class Liquidator {
       });
 
       // Create the liquidation transaction to liquidate the entire position:
-      // - Maximum (Collateral/Synthetic) ratio to liquidate.
-      let liquidateCollateralPerToken = (parseFloat(position.amountCollateral) / parseFloat(position.numTokens));
-      // - Maximum amount of Synthetic tokens to liquidate.
-      let liquidateTokens = position.numTokens;
-
+      // - Price to liquidate at (`collateralPerToken`): Since you are determining which positions are under collateralized positions based on the priceFeed, 
+      // you also should be liquidating using that priceFeed.
+      // - Maximum amount of Synthetic tokens to liquidate: Liquidate the entire position.
       liquidationPromises.push(
         this.empContract.methods
           .createLiquidation(
             position.sponsor, 
-            { rawValue: toWei(liquidateCollateralPerToken.toString()) },
-            { rawValue: toWei(liquidateTokens) }
+            { rawValue: toWei(priceFeed) },
+            { rawValue: toWei(position.numTokens) }
           )
           .send({ from: this.account, gas: 1500000 })
       );

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -1,7 +1,7 @@
 const { toWei, hexToUtf8, toBN } = web3.utils;
 
 // Script to test
-const { Liquidator } = require("../Liquidator.js");
+const { Liquidator } = require("../liquidator.js");
 
 // Helper client script
 const { ExpiringMultiPartyClient } = require("../../financial-templates-lib/ExpiringMultiPartyClient");


### PR DESCRIPTION
While starting work on adding reward withdrawal logic to the Liquidator bot, I ran into build and test issues
- `winston-slack-transporter` was missing from `package.json` for `financial-templates-lib`
- `liquidator/test` was not up to date with latest NFCT contract code meaning that these changes were not getting caught in CI. I fixed the tests and added to CI similar to financial-templates-lib

Signed-off-by: Nick Pai <npai.nyc@gmail.com>