### PR TITLE
Refactored and added methods to ExpiringMultiPartyClient to support the Liquidator withdrawing rewards

### DIFF
--- a/financial-templates-lib/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/ExpiringMultiPartyClient.js
@@ -86,17 +86,17 @@ class ExpiringMultiPartyClient {
       );
   };
 
-  _isExpired = async (liquidation) => {
+  _isExpired = async liquidation => {
     const currentTime = await this.emp.methods.getCurrentTime().call();
-    return (Number(liquidation.liquidationTime) + this.liquidationLiveness <= currentTime)
-  }
+    return Number(liquidation.liquidationTime) + this.liquidationLiveness <= currentTime;
+  };
 
-  _isLiquidationPreDispute = (liquidation) => {
-    // @dev: Liquidation's can't have state == 0 (Uninitialized), 
+  _isLiquidationPreDispute = liquidation => {
+    // @dev: Liquidation's can't have state == 0 (Uninitialized),
     // and disputed liquidations have state > 1
     const predisputeState = "1";
-    return (liquidation.state === predisputeState)
-  }
+    return liquidation.state === predisputeState;
+  };
 
   _update = async () => {
     this.collateralRequirement = this.web3.utils.toBN(
@@ -134,12 +134,12 @@ class ExpiringMultiPartyClient {
         if (this._isLiquidationPreDispute(liquidation)) {
           // Determine whether liquidation has expired.
           if (!(await this._isExpired(liquidation))) {
-            undisputedLiquidations.push(liquidationData);  
+            undisputedLiquidations.push(liquidationData);
           } else {
             expiredLiquidations.push(liquidationData);
           }
         } else {
-          disputedLiquidations.push(liquidationData)
+          disputedLiquidations.push(liquidationData);
         }
       }
     }

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -73,7 +73,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     await syntheticToken.approve(emp.address, toWei("100000000"), { from: accounts[1] });
   });
 
-  it("All Positions", async function() {
+  it("Returns all positions", async function() {
     // Create a position and check that it is detected correctly from the client.
     await emp.create({ rawValue: toWei("10") }, { rawValue: toWei("50") }, { from: accounts[0] });
     await updateAndVerify(
@@ -133,7 +133,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       ]
     );
 
-    // If a position is liquidated it should be removed from the clients state.
+    // If a position is liquidated it should be removed from the list of positions and added to the undisputed liquidations.
     const id = await emp.createLiquidation.call(
       accounts[1],
       { rawValue: toWei("99999") },
@@ -172,31 +172,6 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     ];
     assert.deepStrictEqual(expectedLiquidations.sort(), client.getUndisputedLiquidations().sort());
 
-    // Expire the liquidation by manipulating Date.now to be just after the liquidation's expiry.
-    const expiryTime = (await emp.liquidations(accounts[1], id.toString())).expiry;
-    let oldNow = Date.now;
-    Date.now = () => {
-      return Number(expiryTime) * 1000 + 1;
-    };
-
-    await updateAndVerify(
-      client,
-      [accounts[0], accounts[1]],
-      [
-        {
-          sponsor: accounts[0],
-          numTokens: toWei("100"),
-          amountCollateral: toWei("20"),
-          hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
-          withdrawalRequestAmount: "0"
-        }
-      ]
-    );
-    assert.deepStrictEqual([], client.getUndisputedLiquidations().sort());
-
-    Date.now = oldNow;
-
     // Pending withdrawals state should be correctly identified.
     await emp.requestWithdrawal({ rawValue: toWei("10") }, { from: accounts[0] });
     await client._update();
@@ -222,7 +197,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     // assert.deepStrictEqual([], client.getPendingWithdrawals());
   });
 
-  it("Undercollateralized", async function() {
+  it("Returns undercollateralized positions", async function() {
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[0] });
     await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("100") }, { from: accounts[1] });
 
@@ -243,6 +218,11 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       ],
       client.getUnderCollateralizedPositions(toWei("1.00000000000000001"))
     );
+  });
+
+  it("Returns undisputed liquidations", async function () {
+    await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[0] });
+    await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("100") }, { from: accounts[1] });
 
     // Create a new liquidation for account[0]'s position.
     const id = await emp.createLiquidation.call(
@@ -271,7 +251,64 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     await emp.dispute(id.toString(), accounts[0], { from: accounts[0] });
     await client._update();
 
-    // The disputed liquidation should longer show up as undisputed.
+    // The disputed liquidation should no longer show up as undisputed.
     assert.deepStrictEqual([], client.getUndisputedLiquidations().sort());
+  });
+
+  it("Returns expired liquidations", async function () {
+    await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[0] });
+    await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("100") }, { from: accounts[1] });
+
+    // Create a new liquidation for account[0]'s position.
+    await emp.createLiquidation.call(
+      accounts[0],
+      { rawValue: toWei("9999999") },
+      { rawValue: toWei("150") },
+      { from: accounts[1] }
+    );
+    await emp.createLiquidation(
+      accounts[0],
+      { rawValue: toWei("9999999") },
+      { rawValue: toWei("150") },
+      { from: accounts[1] }
+    );
+    await client._update();
+
+    const liquidations = client.getUndisputedLiquidations();
+    const liquidationTime = liquidations[0].liquidationTime;
+    assert.deepStrictEqual(
+      [
+        {
+          sponsor: accounts[0],
+          id: "0",
+          liquidationTime: liquidationTime,
+          numTokens: toWei("100"),
+          amountCollateral: toWei("150")
+        }
+      ],
+      liquidations
+    );
+    assert.deepStrictEqual([], client.getExpiredLiquidations().sort());
+
+    // Move EMP time to the liquidation's expiry.
+    const liquidationLiveness = 1000;
+    await emp.setCurrentTime(Number(liquidationTime) + liquidationLiveness);
+    await client._update();
+
+    // The liquidation is registered by the EMP client as expired.
+    assert.deepStrictEqual([], client.getUndisputedLiquidations().sort());
+    const expiredLiquidations = client.getExpiredLiquidations();
+    assert.deepStrictEqual(
+      [
+        {
+          sponsor: accounts[0],
+          id: "0",
+          liquidationTime: liquidationTime,
+          numTokens: toWei("100"),
+          amountCollateral: toWei("150")
+        }
+      ],
+      expiredLiquidations
+    );
   });
 });

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -222,19 +222,19 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
 
   it("Returns undisputed liquidations", async function () {
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[0] });
-    await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("100") }, { from: accounts[1] });
+    await syntheticToken.transfer(accounts[1], toWei("100"), { from: accounts[0] })
 
     // Create a new liquidation for account[0]'s position.
     const id = await emp.createLiquidation.call(
       accounts[0],
       { rawValue: toWei("9999999") },
-      { rawValue: toWei("150") },
+      { rawValue: toWei("100") },
       { from: accounts[1] }
     );
     await emp.createLiquidation(
       accounts[0],
       { rawValue: toWei("9999999") },
-      { rawValue: toWei("150") },
+      { rawValue: toWei("100") },
       { from: accounts[1] }
     );
     await client._update();
@@ -257,19 +257,19 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
 
   it("Returns expired liquidations", async function () {
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[0] });
-    await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("100") }, { from: accounts[1] });
+    await syntheticToken.transfer(accounts[1], toWei("100"), { from: accounts[0] });
 
     // Create a new liquidation for account[0]'s position.
     await emp.createLiquidation.call(
       accounts[0],
       { rawValue: toWei("9999999") },
-      { rawValue: toWei("150") },
+      { rawValue: toWei("100") },
       { from: accounts[1] }
     );
     await emp.createLiquidation(
       accounts[0],
       { rawValue: toWei("9999999") },
-      { rawValue: toWei("150") },
+      { rawValue: toWei("100") },
       { from: accounts[1] }
     );
     await client._update();
@@ -314,19 +314,19 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
 
   it("Returns disputed liquidations", async function () {
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[0] });
-    await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("100") }, { from: accounts[1] });
+    await syntheticToken.transfer(accounts[1], toWei("100"), { from: accounts[0] });
 
     // Create a new liquidation for account[0]'s position.
     const id = await emp.createLiquidation.call(
       accounts[0],
       { rawValue: toWei("9999999") },
-      { rawValue: toWei("150") },
+      { rawValue: toWei("100") },
       { from: accounts[1] }
     );
     await emp.createLiquidation(
       accounts[0],
       { rawValue: toWei("9999999") },
-      { rawValue: toWei("150") },
+      { rawValue: toWei("100") },
       { from: accounts[1] }
     );
     await client._update();

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -101,11 +101,16 @@ class Liquidator {
     // TODO: Just showing an example of how I want to use the client:
     // Get expired liquidations from the client.
     const expiredLiquidations = this.empClient.getExpiredLiquidations();
-    // TODO: Withdraw rewards
-    
+    // TODO: 
+    // - Withdraw rewards
+    // - Check that amount of rewards was correct.
+
+
     // Get disputed liquidations from the client.
     const disputedLiquidations = this.empClient.getDisputedLiquidations();
-    // TODO: Withdraw rewards
+    // TODO: 
+    // - Withdraw rewards
+    // - Check whether it was a successful or failed dispute and double check that the reward amount was correct
   }
 }
 

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -86,6 +86,50 @@ class Liquidator {
       });
     }
   };
+
+  // Queries ongoing liquidations and attempts to withdraw rewards from both expired and disputed liquidations.
+  queryAndWithdrawRewards = async () => {
+    Logger.info({
+      at: "liquidator",
+      message: "Checking for liquidations",
+      inputPrice: priceFeed
+    });
+
+    // Update the client to get the latest information.
+    await this.empClient._update();
+
+    // Get expired liquidations from the client.
+    const expiredLiquidations = this.empClient.getExpiredLiquidations();
+    if (expiredLiquidations.length > 0) {
+      Logger.info({
+        at: "liquidator",
+        message: "Expired liquidations detected!",
+        number: expiredLiquidations.length,
+        expiredLiquidations: expiredLiquidations
+      });
+    } else {
+      Logger.info({
+        at: "liquidator",
+        message: "No expired liquidations"
+      });
+    }
+
+    // Get disputed liquidations from the client.
+    const disputedLiquidations = this.empClient.getDisputedLiquidations();
+    if (disputedLiquidations.length > 0) {
+      Logger.info({
+        at: "liquidator",
+        message: "Disputed liquidations detected!",
+        number: disputedLiquidations.length,
+        disputedLiquidations: disputedLiquidations
+      });
+    } else {
+      Logger.info({
+        at: "liquidator",
+        message: "No disputed liquidations"
+      });
+    }
+  }
 }
 
 module.exports = {

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -105,7 +105,6 @@ class Liquidator {
     // - Withdraw rewards
     // - Check that amount of rewards was correct.
 
-
     // Get disputed liquidations from the client.
     const disputedLiquidations = this.empClient.getDisputedLiquidations();
     // TODO: 

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -98,37 +98,14 @@ class Liquidator {
     // Update the client to get the latest information.
     await this.empClient._update();
 
+    // TODO: Just showing an example of how I want to use the client:
     // Get expired liquidations from the client.
     const expiredLiquidations = this.empClient.getExpiredLiquidations();
-    if (expiredLiquidations.length > 0) {
-      Logger.info({
-        at: "liquidator",
-        message: "Expired liquidations detected!",
-        number: expiredLiquidations.length,
-        expiredLiquidations: expiredLiquidations
-      });
-    } else {
-      Logger.info({
-        at: "liquidator",
-        message: "No expired liquidations"
-      });
-    }
-
+    // TODO: Withdraw rewards
+    
     // Get disputed liquidations from the client.
     const disputedLiquidations = this.empClient.getDisputedLiquidations();
-    if (disputedLiquidations.length > 0) {
-      Logger.info({
-        at: "liquidator",
-        message: "Disputed liquidations detected!",
-        number: disputedLiquidations.length,
-        disputedLiquidations: disputedLiquidations
-      });
-    } else {
-      Logger.info({
-        at: "liquidator",
-        message: "No disputed liquidations"
-      });
-    }
+    // TODO: Withdraw rewards
   }
 }
 


### PR DESCRIPTION
- added methods to return (1) expired liquidations and (2) disputed liquidations. Instead of creating these two arrays, I could have instead consolidated them into one `withdrawableLiquidations` but I thought it might be useful specifically for the Disputer bot to get just the disputed liquidations because the disputer cannot withdraw from an expired liquidation.
- Throughout the course of adding the above methods, I found various parts we could refactor in the main `_update()` method in the EMP Client
- Added to and reorganized some of the EMP Client unit tests

In a follow-up pull request, I will add logic to `liquidator/liquidator.js` to actually withdraw rewards, but for now I've left placeholder TODO's.