### PR TITLE
Add .jpg and .png file extensions to docs site

### DIFF
--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -46,9 +46,9 @@ mkdir -p $START_DIR/modules/explainers/pages
 mkdir -p $START_DIR/modules/explainers/assets/images
 mkdir -p $START_DIR/modules/contracts/pages
 
-cp $START_DIR/documentation/explainers/*.jpeg $START_DIR/modules/explainers/assets/images/
-cp $START_DIR/documentation/explainers/*.jpg $START_DIR/modules/explainers/assets/images/
-cp $START_DIR/documentation/explainers/*.png $START_DIR/modules/explainers/assets/images/
+cp $START_DIR/documentation/explainers/*.jpeg $START_DIR/modules/explainers/assets/images/ || echo "No .jpegs found"
+cp $START_DIR/documentation/explainers/*.jpg $START_DIR/modules/explainers/assets/images/ || echo "No .jpgs found"
+cp $START_DIR/documentation/explainers/*.png $START_DIR/modules/explainers/assets/images/ || echo "No .pngs found"
 
 $START_DIR/ci/docgen.sh
 find $START_DIR/docs -name "*.adoc" -exec cp '{}' $START_DIR/modules/contracts/pages/ \;

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -47,6 +47,8 @@ mkdir -p $START_DIR/modules/explainers/assets/images
 mkdir -p $START_DIR/modules/contracts/pages
 
 cp $START_DIR/documentation/explainers/*.jpeg $START_DIR/modules/explainers/assets/images/
+cp $START_DIR/documentation/explainers/*.jpg $START_DIR/modules/explainers/assets/images/
+cp $START_DIR/documentation/explainers/*.png $START_DIR/modules/explainers/assets/images/
 
 $START_DIR/ci/docgen.sh
 find $START_DIR/docs -name "*.adoc" -exec cp '{}' $START_DIR/modules/contracts/pages/ \;


### PR DESCRIPTION
@rcai1 wants to use `.png`s on the docs site, so I figured it would make sense to go ahead and add them along with `.jpg`s to our `build_docs_site.sh` script.