### PR TITLE
Add basic inventory management to the dispute bot

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -73,6 +73,14 @@ class Disputer {
           id: disputeableLiquidation.id,
           sponsor: disputeableLiquidation.sponsor
         });
+
+        Logger.debug({
+          at: "Disputer",
+          message: "Dispute call error message",
+          id: disputeableLiquidation.id,
+          sponsor: disputeableLiquidation.sponsor,
+          error: error
+        });
         continue;
       }
 

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -67,7 +67,7 @@ class Disputer {
       try {
         await dispute.call({ from: this.account });
       } catch (error) {
-        Logger.warn({
+        Logger.error({
           at: "Disputer",
           message: "Cannot dispute liquidation: not enough collateral (or large enough approval) to initiate dispute.",
           id: disputeableLiquidation.id,

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -65,7 +65,7 @@ class Disputer {
 
       // Simple version of inventory management: simulate the transaction and assume that if it fails, the caller didn't have enough collateral.
       try {
-        await dispute.call({ from: this.account, gasPrice: this.gasEstimator.getCurrentFastPrice()});
+        await dispute.call({ from: this.account, gasPrice: this.gasEstimator.getCurrentFastPrice() });
       } catch (error) {
         Logger.error({
           at: "Disputer",

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -66,7 +66,7 @@ class Disputer {
       try {
         await dispute.call({ from: this.account });
       } catch (error) {
-        Logger.error({
+        Logger.warn({
           at: "Disputer",
           message: "Cannot dispute liquidation: not enough collateral (or large enough approval) to initiate dispute.",
           id: disputeableLiquidation.id,

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -60,12 +60,24 @@ class Disputer {
       });
 
       // Create the liquidation transaction
+      const dispute = await this.empContract.methods
+        .dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor);
 
-      // TODO: compute the amount of collateral required to dispute and ensure the bot has enough to perform it.
+      // Simple version of inventory management: simulate the transaction and assume that if it fails, the caller didn't have enough collateral.
+      try {
+        await dispute.call({ from: this.account });
+      } catch (error) {
+        Logger.error({
+          at: "Disputer",
+          message: "Cannot dispute liquidation: not enough collateral (or large enough approval) to initiate dispute.",
+          id: disputeableLiquidation.id,
+          sponsor: disputeableLiquidation.sponsor
+        });
+        continue;
+      }
 
       // TODO: handle transaction failures.
-      const receipt = await this.empContract.methods
-        .dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor)
+      const receipt = await dispute
         .send({ from: this.account, gas: 1500000, gasPrice: this.gasEstimator.getCurrentFastPrice() });
 
       const disputeResult = {

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -65,7 +65,7 @@ class Disputer {
 
       // Simple version of inventory management: simulate the transaction and assume that if it fails, the caller didn't have enough collateral.
       try {
-        await dispute.call({ from: this.account });
+        await dispute.call({ from: this.account, gasPrice: this.gasEstimator.getCurrentFastPrice()});
       } catch (error) {
         Logger.error({
           at: "Disputer",

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -61,7 +61,7 @@ class Disputer {
       });
 
       // Create the liquidation transaction
-      const dispute = await this.empContract.methods.dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor);
+      const dispute = this.empContract.methods.dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor);
 
       // Simple version of inventory management: simulate the transaction and assume that if it fails, the caller didn't have enough collateral.
       try {

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -60,8 +60,7 @@ class Disputer {
       });
 
       // Create the liquidation transaction
-      const dispute = await this.empContract.methods
-        .dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor);
+      const dispute = await this.empContract.methods.dispute(disputeableLiquidation.id, disputeableLiquidation.sponsor);
 
       // Simple version of inventory management: simulate the transaction and assume that if it fails, the caller didn't have enough collateral.
       try {
@@ -77,8 +76,11 @@ class Disputer {
       }
 
       // TODO: handle transaction failures.
-      const receipt = await dispute
-        .send({ from: this.account, gas: 1500000, gasPrice: this.gasEstimator.getCurrentFastPrice() });
+      const receipt = await dispute.send({
+        from: this.account,
+        gas: 1500000,
+        gasPrice: this.gasEstimator.getCurrentFastPrice()
+      });
 
       const disputeResult = {
         tx: receipt.transactionHash,

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -6,6 +6,7 @@ const { Disputer } = require("../disputer.js");
 // Helper client script
 const { ExpiringMultiPartyClient } = require("../../financial-templates-lib/ExpiringMultiPartyClient");
 const { GasEstimator } = require("../../financial-templates-lib/GasEstimator");
+const { LiquidationStatesEnum } = require("../../common/Enums");
 
 // Contracts and helpers
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
@@ -146,17 +147,17 @@ contract("Disputer.js", function(accounts) {
     await disputer.queryAndDispute(time => toWei("1.75"));
 
     // There should be no liquidations created from any sponsor account
-    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PRE_DISPUTE);
-    assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.PRE_DISPUTE);
-    assert.equal((await emp.getLiquidations(sponsor3))[0].state, STATES.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor2))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor3))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
 
     // With a price of 1.1, two sponsors should be correctly collateralized, so disputes should be issued against sponsor2 and sponsor3's liquidations.
     await disputer.queryAndDispute(time => toWei("1.1"));
 
     // Sponsor2 and sponsor3 should be disputed.
-    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PRE_DISPUTE);
-    assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.PENDING_DISPUTE);
-    assert.equal((await emp.getLiquidations(sponsor3))[0].state, STATES.PENDING_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor2))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor3))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
 
     // The disputeBot should be the disputer in sponsor2 and sponsor3's liquidations.
     assert.equal((await emp.getLiquidations(sponsor2))[0].disputer, disputeBot);
@@ -198,11 +199,11 @@ contract("Disputer.js", function(accounts) {
 
     // sponsor1's dipsute was unsuccessful, so the disputeBot should not have called the withdraw method.
     assert.equal((await emp.getLiquidations(sponsor1))[0].disputer, disputeBot);
-    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PENDING_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
 
     // sponsor2's dispute was successful, so the disputeBot should've called the withdraw method.
     assert.equal((await emp.getLiquidations(sponsor2))[0].disputer, zeroAddress);
-    assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.DISPUTE_SUCCEEDED);
+    assert.equal((await emp.getLiquidations(sponsor2))[0].state, LiquidationStatesEnum.DISPUTE_SUCCEEDED);
   });
 
   it("Too little collateral", async function() {
@@ -232,14 +233,14 @@ contract("Disputer.js", function(accounts) {
     await disputer.queryAndDispute(time => toWei("1.1"));
 
     // Only sponsor2 should be disputed.
-    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PRE_DISPUTE);
-    assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.PENDING_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor2))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
 
     // Transfer balance back, and the dispute should go through.
     await collateralToken.transfer(disputeBot, transferAmount, { from: rando });
     await disputer.queryAndDispute(time => toWei("1.1"));
 
     // sponsor1 should now be disputed.
-    assert.equal((await emp.getLiquidations(sponsor1))[0].state, STATES.PENDING_DISPUTE);
+    assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
   });
 });

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -205,7 +205,7 @@ contract("Disputer.js", function(accounts) {
     assert.equal((await emp.getLiquidations(sponsor2))[0].state, STATES.DISPUTE_SUCCEEDED);
   });
 
-  it.only("Too little collateral", async function() {
+  it("Too little collateral", async function() {
     // sponsor1 creates a position with 150 units of collateral, creating 100 synthetic tokens.
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: sponsor1 });
 

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -177,12 +177,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: toWei("100") },
       { from: liquidator }
     );
-    await emp.createLiquidation(
-      sponsor2,
-      { rawValue: toWei("1.75") },
-      { rawValue: toWei("1") },
-      { from: liquidator }
-    );
+    await emp.createLiquidation(sponsor2, { rawValue: toWei("1.75") }, { rawValue: toWei("1") }, { from: liquidator });
 
     // Send most of the user's balance elsewhere leaving only enough to dispute sponsor1's position.
     const transferAmount = (await collateralToken.balanceOf(disputeBot)).sub(toBN(toWei("1")));


### PR DESCRIPTION
This just adds a quick simulation of the txn before sending that should catch an insufficient balance. There are more sophisticated implementation of inventory management that give more detailed descriptions of what went wrong, but that seems unnecessarily complex at this point.

Fixes #1092.