### PR TITLE
Add withdraw functionality to dispute bot

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -12,6 +12,7 @@ class Disputer {
 
     // Instance of the expiring multiparty to perform on-chain disputes
     this.empContract = this.empClient.emp;
+    this.web3 = this.empClient.web3;
   }
 
   // Queries disputable liquidations and disputes any that were incorrectly liquidated.
@@ -80,8 +81,90 @@ class Disputer {
         message: "Dispute tx result",
         disputeResult: disputeResult
       });
+    }
+  };
 
-      // TODO: query any resolved disputes that this address participated in and attempt to withdraw.
+  // Queries ongoing disputes and attempts to withdraw any pending rewards from them.
+  queryAndWithdrawRewards = async () => {
+    Logger.info({
+      at: "Disputer",
+      message: "Checking for disputed liquidations that may have resolved"
+    });
+
+    // Update the client to get the latest information.
+    await this.empClient._update();
+
+    // Update the gasEstimator to get the latest gas price data.
+    // If the client has a data point in the last 60 seconds returns immediately.
+    await this.gasEstimator._update();
+
+    // Can only derive rewards from disputed liquidations that this account disputed.
+    const disputedLiquidations = this.empClient
+      .getDisputedLiquidations()
+      .filter(liquidation => liquidation.disputer === this.account);
+
+    if (disputedLiquidations.length === 0) {
+      Logger.info({
+        at: "Disputer",
+        message: "No withdrawable liquidations"
+      });
+      return;
+    }
+
+    for (const liquidation of disputedLiquidations) {
+      Logger.info({
+        at: "Disputer",
+        message: "Attempting to withdraw from previous dispute.",
+        address: liquidation.sponsor,
+        id: liquidation.id
+      });
+
+      const withdraw = this.empContract.methods.withdrawLiquidation(liquidation.id, liquidation.sponsor);
+
+      // Attempt to compute the withdraw amount. If the dispute has not been resolved (DVM has not returned a price), this should fail.
+      // In that case, just continue because there is nothing left to do.
+      let withdrawAmount;
+      try {
+        withdrawAmount = await withdraw.call({ from: this.account });
+      } catch (error) {
+        Logger.info({
+          at: "Disputer",
+          message: "Withdraw not ready.",
+          address: liquidation.sponsor,
+          id: liquidation.id
+        });
+        continue;
+      }
+
+      // If there is nothing to withdraw, the dispute failed and there's nothing to do.
+      if (this.web3.utils.toBN(withdrawAmount.rawValue).isZero()) {
+        Logger.info({
+          at: "Disputer",
+          message: "Dispute failed.",
+          address: liquidation.sponsor,
+          id: liquidation.id
+        });
+        continue;
+      }
+
+      // TODO: handle transaction failure.
+      const receipt = await withdraw.send({
+        from: this.account,
+        gas: 1500000,
+        gasPrice: this.gasEstimator.getCurrentFastPrice()
+      });
+
+      const logResult = {
+        tx: receipt.transactionHash,
+        caller: receipt.events.LiquidationWithdrawn.returnValues.caller,
+        withdrawalAmount: receipt.events.LiquidationWithdrawn.returnValues.withdrawalAmount,
+        liquidationStatus: receipt.events.LiquidationWithdrawn.returnValues.liquidationStatus
+      };
+      Logger.info({
+        at: "Disputer",
+        message: "Withdraw tx result",
+        liquidationResult: logResult
+      });
     }
   };
 }

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -36,6 +36,7 @@ async function run() {
   while (true) {
     try {
       await disputer.queryAndDispute(toWei(argv.price));
+      await disputer.queryAndWithdrawRewards();
     } catch (error) {
       Logger.error({
         at: "Disputer#index",

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -162,7 +162,7 @@ contract("Disputer.js", function(accounts) {
     assert.equal((await emp.getLiquidations(sponsor3))[0].disputer, disputeBot);
   });
 
-  it.only("Withdraw from successful disputes", async function() {
+  it("Withdraw from successful disputes", async function() {
     // sponsor1 creates a position with 150 units of collateral, creating 100 synthetic tokens.
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: sponsor1 });
 

--- a/financial-templates-lib/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/ExpiringMultiPartyClient.js
@@ -133,7 +133,8 @@ class ExpiringMultiPartyClient {
           id: id.toString(),
           numTokens: liquidation.tokensOutstanding.toString(),
           amountCollateral: liquidation.liquidatedCollateral.toString(),
-          liquidationTime: liquidation.liquidationTime
+          liquidationTime: liquidation.liquidationTime,
+          disputer: liquidation.disputer
         };
 
         // Get all undisputed liquidations.

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -13,6 +13,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
   const sponsor1 = accounts[0]
   const sponsor2 = accounts[1]
 
+  const zeroAddress = "0x0000000000000000000000000000000000000000";
+
   let collateralToken;
   let emp;
   let client;
@@ -170,7 +172,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         id: id.toString(),
         numTokens: toWei("45"),
         amountCollateral: toWei("100"),
-        liquidationTime: (await emp.getCurrentTime()).toString()
+        liquidationTime: (await emp.getCurrentTime()).toString(),
+        disputer: zeroAddress
       }
     ];
     assert.deepStrictEqual(expectedLiquidations.sort(), client.getUndisputedLiquidations().sort());
@@ -290,7 +293,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           id: "0",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
-          amountCollateral: toWei("150")
+          amountCollateral: toWei("150"),
+          disputer: zeroAddress
         }
       ],
       liquidations
@@ -312,7 +316,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           id: "0",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
-          amountCollateral: toWei("150")
+          amountCollateral: toWei("150"),
+          disputer: zeroAddress
         }
       ],
       expiredLiquidations
@@ -364,7 +369,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           id: "0",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
-          amountCollateral: toWei("150")
+          amountCollateral: toWei("150"),
+          disputer: sponsor1
         }
       ], 
       client.getDisputedLiquidations().sort()


### PR DESCRIPTION
Adds `queryAndWithdrawRewards` (like in the liquidation bot) to the dispute bot. This is a fairly straightforward change.

Outside of the dispute bot, this change required a slight addition to the liquidation object that the EMP returns to make it easier to determine the liquidations that are eligible for withdrawal.

Fixes  #1092.