### PR TITLE
Locks OZ version used in the NFCT

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@awaitjs/express": "^0.3.0",
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/storage": "^2.4.2",
-    "@openzeppelin/contracts": "^3.0.0-beta.0",
+    "@openzeppelin/contracts": "3.0.0-beta.0",
     "@sendgrid/mail": "^6.4.0",
     "@truffle/contract": "^4.1.0",
     "@truffle/hdwallet-provider": "^1.0.25",


### PR DESCRIPTION
OZ released a number of breaking changes. If the `^` is included then compilation will fail as the current OZ versions include some changes to directory structure (`ownable.sol` and `ERC20Snapshot.sol` move) and some implementation changes.