### PR TITLE
Minor refactor of liquidation bot

### DIFF
--- a/financial-templates-lib/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/ExpiringMultiPartyClient.js
@@ -132,6 +132,7 @@ class ExpiringMultiPartyClient {
           numTokens: liquidation.tokensOutstanding.toString(),
           amountCollateral: liquidation.liquidatedCollateral.toString(),
           liquidationTime: liquidation.liquidationTime,
+          liquidator: liquidation.liquidator,
           disputer: liquidation.disputer
         };
 

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -289,6 +289,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
           amountCollateral: toWei("150"),
+          liquidator: liquidator,
           disputer: zeroAddress
         }
       ],
@@ -312,6 +313,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
           amountCollateral: toWei("150"),
+          liquidator: liquidator,
           disputer: zeroAddress
         }
       ],
@@ -365,6 +367,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
           amountCollateral: toWei("150"),
+          liquidator: liquidator,
           disputer: sponsor1
         }
       ], 

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -168,6 +168,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         numTokens: toWei("45"),
         amountCollateral: toWei("100"),
         liquidationTime: (await emp.getCurrentTime()).toString(),
+        liquidator: sponsor1,
         disputer: zeroAddress
       }
     ];

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -52,7 +52,7 @@ class Liquidator {
         message: "liquidating sponsor🔥",
         address: position.sponsor,
         gasPrice: this.gasEstimator.getCurrentFastPrice(),
-        underCollateralizedPosition: underCollateralizedPosition
+        position: position
       });
 
       // Create the liquidation transaction to liquidate the entire position:
@@ -114,7 +114,7 @@ class Liquidator {
     const disputedLiquidations = this.empClient.getDisputedLiquidations();
     const potentialWithdrawableLiquidations = expiredLiquidations
       .concat(disputedLiquidations)
-      .filter(liquidation => liquidation.liquidation === this.account);
+      .filter(liquidation => liquidation.liquidator === this.account);
 
     if (potentialWithdrawableLiquidations.length === 0) {
       Logger.debug({

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -49,7 +49,7 @@ class Liquidator {
       // TODO: add additional information about this liquidation event to the log.
       Logger.info({
         at: "liquidator",
-        message: "liquidating sponsor 🔥",
+        message: "liquidating sponsor🔥",
         address: position.sponsor,
         gasPrice: this.gasEstimator.getCurrentFastPrice(),
         underCollateralizedPosition: underCollateralizedPosition
@@ -126,7 +126,7 @@ class Liquidator {
 
     Logger.debug({
       at: "liquidator",
-      message: "potential withdrawable liquidations detected!💰",
+      message: "potential withdrawable liquidations detected",
       number: potentialWithdrawableLiquidations.length,
       potentialWithdrawableLiquidations: potentialWithdrawableLiquidations
     });
@@ -136,7 +136,7 @@ class Liquidator {
     for (const liquidation of potentialWithdrawableLiquidations) {
       Logger.debug({
         at: "liquidator",
-        message: "attempting to withdraw rewards from liquidations💪",
+        message: "attempting to withdraw rewards from liquidations",
         address: liquidation.sponsor,
         id: liquidation.id
       });
@@ -159,7 +159,7 @@ class Liquidator {
 
       Logger.info({
         at: "liquidator",
-        message: `Will attempt to withdraw.`,
+        message: `Will attempt to withdraw🤑`,
         address: liquidation.sponsor,
         id: liquidation.id,
         amount: this.web3.utils.fromWei(withdrawAmount.rawValue)

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -36,19 +36,12 @@ class Liquidator {
     // Get the latest undercollateralized positions from the client.
     const underCollateralizedPositions = this.empClient.getUnderCollateralizedPositions(priceFeed);
 
-    if (underCollateralizedPositions.length > 0) {
-      for (const underCollateralizedPosition of underCollateralizedPositions) {
-        Logger.info({
-          at: "liquidator",
-          message: "undercollateralized positions detected 🚨",
-          underCollateralizedPosition: underCollateralizedPosition
-        });
-      }
-    } else {
+    if (underCollateralizedPositions.length === 0) {
       Logger.debug({
         at: "liquidator",
         message: "No undercollateralized position"
       });
+      return;
     }
 
     let liquidationPromises = []; // store all promises to resolve in parallel later on.
@@ -58,7 +51,8 @@ class Liquidator {
         at: "liquidator",
         message: "liquidating sponsor 🔥",
         address: position.sponsor,
-        gasPrice: this.gasEstimator.getCurrentFastPrice()
+        gasPrice: this.gasEstimator.getCurrentFastPrice(),
+        underCollateralizedPosition: underCollateralizedPosition
       });
 
       // Create the liquidation transaction to liquidate the entire position:
@@ -118,70 +112,82 @@ class Liquidator {
     // expired and disputed liquidations.
     const expiredLiquidations = this.empClient.getExpiredLiquidations();
     const disputedLiquidations = this.empClient.getDisputedLiquidations();
-    const potentialWithdrawableLiquidations = expiredLiquidations.concat(disputedLiquidations);
+    const potentialWithdrawableLiquidations = expiredLiquidations
+      .concat(disputedLiquidations)
+      .filter(liquidation => liquidation.liquidation === this.account);
 
-    if (potentialWithdrawableLiquidations.length > 0) {
-      Logger.info({
+    if (potentialWithdrawableLiquidations.length === 0) {
+      Logger.debug({
         at: "liquidator",
-        message: "potential withdrawable liquidations detected!💰",
-        number: potentialWithdrawableLiquidations.length,
-        potentialWithdrawableLiquidations: potentialWithdrawableLiquidations
+        message: "No withdrawable liquidations"
+      });
+      return;
+    }
+
+    Logger.debug({
+      at: "liquidator",
+      message: "potential withdrawable liquidations detected!💰",
+      number: potentialWithdrawableLiquidations.length,
+      potentialWithdrawableLiquidations: potentialWithdrawableLiquidations
+    });
+
+    // Save all withdraw promises to resolve in parallel later on.
+    const withdrawPromises = [];
+    for (const liquidation of potentialWithdrawableLiquidations) {
+      Logger.debug({
+        at: "liquidator",
+        message: "attempting to withdraw rewards from liquidations💪",
+        address: liquidation.sponsor,
+        id: liquidation.id
       });
 
-      // Save all withdraw promises to resolve in parallel later on.
-      const withdrawPromises = [];
-      for (const liquidation of potentialWithdrawableLiquidations) {
-        Logger.info({
+      // Confirm that liquidation has eligible rewards to be withdrawn.
+      const withdraw = this.empContract.methods.withdrawLiquidation(liquidation.id, liquidation.sponsor);
+      let withdrawAmount;
+      try {
+        withdrawAmount = await withdraw.call({ from: this.account });
+      } catch (error) {
+        Logger.debug({
           at: "liquidator",
-          message: "attempting to withdraw rewards from liquidations💪",
+          message: "Liquidation failed or not ready for withdrawal",
           address: liquidation.sponsor,
           id: liquidation.id
         });
 
-        // Confirm that liquidation has eligible rewards to be withdrawn.
-        try {
-          let withdraw = this.empContract.methods.withdrawLiquidation(liquidation.id, liquidation.sponsor);
-          let withdrawAmount = await withdraw.call({ from: this.account });
-          if (this.web3.utils.toBN(withdrawAmount.rawValue).gt("0")) {
-            withdrawPromises.push(
-              withdraw.send({
-                from: this.account,
-                gas: 1500000,
-                gasPrice: this.gasEstimator.getCurrentFastPrice()
-              })
-            );
-          }
-        } catch (err) {
-          Logger.error({
-            at: "liquidator",
-            message: "failed to withdraw rewards from liquidation🤕",
-            address: liquidation.sponsor,
-            id: liquidation.id
-          });
-          continue;
-        }
+        continue;
       }
 
-      // Resolve all promises in parallel.
-      let promiseResponse = await Promise.all(withdrawPromises);
-
-      for (const response of promiseResponse) {
-        const logResult = {
-          tx: response.transactionHash,
-          caller: response.events.LiquidationWithdrawn.returnValues.caller,
-          withdrawalAmount: response.events.LiquidationWithdrawn.returnValues.withdrawalAmount,
-          liquidationStatus: response.events.LiquidationWithdrawn.returnValues.liquidationStatus
-        };
-        Logger.info({
-          at: "liquidator",
-          message: "withdraw tx result📄",
-          liquidationResult: logResult
-        });
-      }
-    } else {
-      Logger.debug({
+      Logger.info({
         at: "liquidator",
-        message: "No withdrawable liquidations"
+        message: `Will attempt to withdraw.`,
+        address: liquidation.sponsor,
+        id: liquidation.id,
+        amount: this.web3.utils.fromWei(withdrawAmount.rawValue)
+      });
+
+      withdrawPromises.push(
+        withdraw.send({
+          from: this.account,
+          gas: 1500000,
+          gasPrice: this.gasEstimator.getCurrentFastPrice()
+        })
+      );
+    }
+
+    // Resolve all promises in parallel.
+    let promiseResponse = await Promise.all(withdrawPromises);
+
+    for (const response of promiseResponse) {
+      const logResult = {
+        tx: response.transactionHash,
+        caller: response.events.LiquidationWithdrawn.returnValues.caller,
+        withdrawalAmount: response.events.LiquidationWithdrawn.returnValues.withdrawalAmount,
+        liquidationStatus: response.events.LiquidationWithdrawn.returnValues.liquidationStatus
+      };
+      Logger.info({
+        at: "liquidator",
+        message: "withdraw tx result📄",
+        liquidationResult: logResult
       });
     }
   };

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -136,7 +136,7 @@ class Liquidator {
     for (const liquidation of potentialWithdrawableLiquidations) {
       Logger.debug({
         at: "liquidator",
-        message: "attempting to withdraw rewards from liquidations",
+        message: "attempting to withdraw reward from liquidation",
         address: liquidation.sponsor,
         id: liquidation.id
       });
@@ -159,7 +159,7 @@ class Liquidator {
 
       Logger.info({
         at: "liquidator",
-        message: `Will attempt to withdraw🤑`,
+        message: "Will withdraw liquidation🤑",
         address: liquidation.sponsor,
         id: liquidation.id,
         amount: this.web3.utils.fromWei(withdrawAmount.rawValue)


### PR DESCRIPTION
This PR is kinda a mismash of refactors on the liquidator. I combined them because some of the log changes were due to the changes in structure and logic. Happy to try to decompose if it's difficult to review.

This PR does a few things:
- Slightly simplifies the structure of the liquidation bot by returning early in a few places.
- Updates log message positioning and level so there are no `info` messages that get sent on every iteration. `info` should now only be used if a transaction is sent since that's the only case where the state is likely to change before the next iteration.
- Adds filtering to the liquidation withdrawals, so withdraw isn't even attempted if `this.account` wasn't the liquidator.
- Removed the check for a withdrawal amount of 0, since the `.call` will revert in that case. This will need to be updated in the dispute bot as well.