### PR TITLE
Fix anchors in docs site links

### DIFF
--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -23,7 +23,7 @@ md_to_adoc() {
     sed -i.bak 's/^##/#/' $tmpfile
 
     # Changes markdown file interlink extensions to .html so they continue to work when the site is rendered.
-    sed -i.bak 's/\.md[)#]/.html[)#]/g' $tmpfile
+    sed -i.bak 's/\.md\([)#]\)/.html\1/g' $tmpfile
 
     # Changes all dashes to underscores inside the anchors.
     sed -i.bak -e ':loop' -e 's/\(\]([^)]*#[^)]*\)-\([^)]*)\)/\1_\2/g' -e 't loop' $tmpfile

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -23,7 +23,16 @@ md_to_adoc() {
     sed -i.bak 's/^##/#/' $tmpfile
 
     # Changes markdown file interlink extensions to .html so they continue to work when the site is rendered.
-    sed -i.bak 's/\.md)/.html)/' $tmpfile
+    sed -i.bak 's/\.md[)#]/.html[)#]/g' $tmpfile
+
+    # Changes all dashes to underscores inside the anchors.
+    sed -i.bak -e ':loop' -e 's/\(\]([^)]*#[^)]*\)-\([^)]*)\)/\1_\2/g' -e 't loop' $tmpfile
+
+    # Adds a leading underscore to same-file anchors.
+    sed -i.bak 's/\](#/\](#_/g' $tmpfile
+
+    # Adds a leading underscore to outside-file anchors.
+    sed -i.bak 's/\.html#/.html#_/g' $tmpfile
 
     # For each level of depth below the module level, we need to remove one "../" from file references. This is because
     # subdirectories effectively get flattened into the modules general file list.

--- a/scripts/gen-nav.js
+++ b/scripts/gen-nav.js
@@ -38,7 +38,7 @@ const lines = require('fs').readFileSync(mapFile, 'utf-8')
 const moduleIndex = lines.findIndex(line => line.startsWith(`* ${moduleName}`));
 
 if (moduleIndex === -1) {
-    throw "Could not find module in mapFile (argument 1)";
+    throw `Could not find ${moduleName} module in mapFile`;
 }
 
 for (let i = moduleIndex + 1; i < lines.length; i++) {


### PR DESCRIPTION
Github anchors are generated based on the section title. The html site generates them in a different style. This PR adds preprocessing to correct for this difference.
- It adds an underscore at the beginning of the anchor.
- It adds a leading underscore to all anchors.
- It corrects a previous error where links that had anchors were not being correctly converted from `.md` to `.html`.

I also included a minor, unrelated error message change to improve debuggability of the site generation.

Issue #1055.