### PR TITLE
Flatten docs site links

### DIFF
--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -49,6 +49,12 @@ md_to_adoc() {
     # This sed takes links that look like "(./)deeper_dir/file.html" and transforms them to "file.html".
     sed -i.bak 's/\]([.]\{0,1\}[^.][^).]*\/\([[:alnum:]_-]*.html\)/](\1/g' $tmpfile
 
+    # If the file is in the ROOT directory, then we need to remove all of the leading "../" from links.
+    if [[ $infile = *ROOT* ]]
+    then
+        sed -i.bak 's/\](\.\.\//](/g' $tmpfile
+    fi
+
     # Use pandoc to do the remainder of the conversion and output to the destination.
     pandoc --atx-headers --verbose --wrap=none --toc --reference-links -f gfm -s -o $outfile -t asciidoc $tmpfile
 }

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -41,6 +41,14 @@ md_to_adoc() {
         sed -i.bak 's/(\.\.\//(/' $tmpfile
     done
 
+    # Because the antora directory structure is flattened, we need to strip directories deeper than the module level.
+    # This sed takes links that look like "../module/deeper_dir/file.html" and transforms them to "../module/file.html".
+    sed -i.bak 's/\(\](\.\.\/[[:alnum:]_-]*\/\)[^.)]*\/\([[:alnum:]_-]*.html\)/\1\2/g' $tmpfile
+
+    # Similar to the last sed except that it handles links that don't start with "../".
+    # This sed takes links that look like "(./)deeper_dir/file.html" and transforms them to "file.html".
+    sed -i.bak 's/\]([.]\{0,1\}[^.][^).]*\/\([[:alnum:]_-]*.html\)/](\1/g' $tmpfile
+
     # Use pandoc to do the remainder of the conversion and output to the destination.
     pandoc --atx-headers --verbose --wrap=none --toc --reference-links -f gfm -s -o $outfile -t asciidoc $tmpfile
 }


### PR DESCRIPTION
The nested structure of our docs cannot be replicated in antora since their concept of modules (as far as I'm aware) cannot be nested. So essentially all docs sit at the module level. The github repo structure does not mirror this, so we have to massage the links to flatten them into the antora structure. I've added two more preprocessing `sed` commands to flatten these links.

cc @rcai1 @hlambur

Issue #1055.