### PR TITLE
Fix explainer link

### DIFF
--- a/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
+++ b/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
@@ -125,7 +125,7 @@ await emp.deposit({rawValue: web3.utils.toWei("10")})
 ```
  
 2. For a token sponsor to withdraw collateral from his position, there are typically 2 ways to do this. 
-Read this [explainer](../explainers/synthetic_tokens.md) for more information. 
+Read this [explainer](../explainer.md) for more information. 
 In this scenario, because we are the only token sponsor, we will have to withdraw collateral the “slow” way. First, we need to request a withdrawal of 10 collateral tokens.
 ```js
 await emp.requestWithdrawal({rawValue: web3.utils.toWei("10")})


### PR DESCRIPTION
Fixing a small issue with a link in the synthetic token tutorial. 