### PR TITLE
Add Uniswap interface and mock

### DIFF
--- a/core/contracts/common/interfaces/Uniswap.sol
+++ b/core/contracts/common/interfaces/Uniswap.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.6.0;
+
+
+/**
+ * @title Interface for Uniswap v2.
+ * @dev This only contains the methods/events that we use in our contracts or offchain infrastructure.
+ */
+abstract contract Uniswap {
+    // Called after every swap showing the new uniswap "price" for this token pair.
+    event Sync(uint112 reserve0, uint112 reserve1);
+}

--- a/core/contracts/common/test/UniswapMock.sol
+++ b/core/contracts/common/test/UniswapMock.sol
@@ -7,9 +7,6 @@ import "../interfaces/Uniswap.sol";
  * @title Uniswap v2 Mock that allows manual price injection.
  */
 contract UniswapMock is Uniswap {
-    // Called after every swap showing the new uniswap "price" for this token pair.
-    event Sync(uint112 reserve0, uint112 reserve1);
-
     function setPrice(uint112 reserve0, uint112 reserve1) external {
         emit Sync(reserve0, reserve1);
     }

--- a/core/contracts/common/test/UniswapMock.sol
+++ b/core/contracts/common/test/UniswapMock.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.6.0;
+
+import "../interfaces/Uniswap.sol";
+
+
+/**
+ * @title Uniswap v2 Mock that allows manual price injection.
+ */
+contract UniswapMock is Uniswap {
+    // Called after every swap showing the new uniswap "price" for this token pair.
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function setPrice(uint112 reserve0, uint112 reserve1) external {
+        emit Sync(reserve0, reserve1);
+    }
+}


### PR DESCRIPTION
This adds an interface and a mock for Uniswap V2. Note: I've only included the `Sync` event that we'll use to calculate the TWAP offchain. Since this isn't currently used in any of our other contracts, we're free to add to it as we see fit.

Note: for reference, here's this event in the uniswap v2 contract: https://github.com/Uniswap/uniswap-v2-core/blob/1f563ce23b6dbe972d667c79058d0299e6f10ff6/contracts/UniswapV2Pair.sol#L59