### PR TITLE
basic adversarial integration tests

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -131,6 +131,10 @@ module.exports = {
   // for more about customizing your Truffle configuration!
   networks: networks,
   plugins: ["solidity-coverage"],
+  mocha: {
+    enableTimeouts: false,
+    before_timeout: 1800000
+  },
   compilers: {
     solc: {
       version: "0.6.4",

--- a/core/contracts/financial-templates/implementation/SyntheticToken.sol
+++ b/core/contracts/financial-templates/implementation/SyntheticToken.sol
@@ -40,7 +40,7 @@ contract SyntheticToken is ExpandedERC20, ERC20Detailed {
         return holdsRole(uint(Roles.Minter), account);
     }
 
-    /**
+    /**\
      * @dev Add burner role to account
      *
      * Requirements:

--- a/core/contracts/financial-templates/implementation/SyntheticToken.sol
+++ b/core/contracts/financial-templates/implementation/SyntheticToken.sol
@@ -40,7 +40,7 @@ contract SyntheticToken is ExpandedERC20, ERC20Detailed {
         return holdsRole(uint(Roles.Minter), account);
     }
 
-    /**\
+    /**
      * @dev Add burner role to account
      *
      * Requirements:

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -342,8 +342,10 @@ contract("IntegrationTest", function(accounts) {
     assert.equal((await collateralToken.balanceOf(expiringMultiParty.address)).toString(), "0");
   });
 
-  it("Iterative full life cycle test with unfriendly numbers", async function() {
-    // This test follows the exact same pattern as before except the input parames are less friendly
+  it("Iterative full life cycle test with unfriendly numbers and seeded liquidator", async function() {
+    // This test follows the exact same pattern as before except the input params are less friendly.
+    // As before the liquidator is seeded with one large oversize position which is used to execute
+    // liquidations.
 
     // Test settings
     const numIterations = 10; // number of times the simulation loop is run
@@ -368,15 +370,16 @@ contract("IntegrationTest", function(accounts) {
     let depositsMade = 0;
     let redemptionsMade = 0;
     let liquidationsObject = [];
+    let maxCollateralLocked = 0;
 
     // STEP: 0.a) set the oracle fee
     await store.setFixedOracleFeePerSecond({ rawValue: dvmRegularFee.toString() }, { from: contractCreator });
 
-    // STEP: 0.b): seed liquidator
+    // STEP: 0.b): seed one over sized position
     console.log("Seeding liquidator");
     await expiringMultiParty.create(
-      { rawValue: baseCollateralAmount.mul(toBN("100000")).toString() },
-      { rawValue: baseNumTokens.mul(toBN("100000")).toString() },
+      { rawValue: baseCollateralAmount.mul(toBN("1000000")).toString() },
+      { rawValue: baseNumTokens.mul(toBN("1000000")).toString() },
       { from: liquidator }
     );
 
@@ -472,6 +475,9 @@ contract("IntegrationTest", function(accounts) {
       }
     } // exit iteration loop
 
+    maxCollateralLocked = await expiringMultiParty.rawTotalPositionCollateral();
+    console.log("max", maxCollateralLocked.toString());
+
     console.log(
       "\nPosition creation done!\nAdvancing time and withdrawing winnings/losses for sponsor, disputer and liquidator from liquidations and disputes"
     );
@@ -528,6 +534,9 @@ contract("IntegrationTest", function(accounts) {
       assert.equal(await syntheticToken.balanceOf(sponsor), "0");
     }
 
+    const finalBalanceDrift = await collateralToken.balanceOf(expiringMultiParty.address);
+    const finalBalanceDriftFrac = finalBalanceDrift.mul(toBN(toWei("100"))).div(maxCollateralLocked);
+
     console.log("All accounts have been able to withdraw without revert!");
     console.table({
       iterations: numIterations,
@@ -537,7 +546,236 @@ contract("IntegrationTest", function(accounts) {
       redemptionsMade: redemptionsMade,
       liquidations: liquidationsObject.length,
       disputedLiquidations: liquidationsObject.filter(liquidation => liquidation.disputed).length,
-      finalBalanceDrift: (await collateralToken.balanceOf(expiringMultiParty.address)).toNumber()
+      finalBalanceDrift: finalBalanceDrift.toNumber(),
+      driftAsFracOfTotalDeposit: finalBalanceDriftFrac.toString() + " e-18 %"
+    });
+
+    // STEP 11): ensure all funds were taken from the contract.
+    // However due to drift from the unfriendly numbers we cant assert this! print the error in the output table.
+  });
+
+  it("Iterative full life cycle test with unfriendly numbers and efficient liquidator seeding", async function() {
+    // This test follows the exact same pattern as before except the input params are less friendly
+    // and the liquidator is not seeded before hand. Rather, the liquidator creates a position right
+    // before creating the liquidation. In this way all positions within the contract hold similar size
+    // without one massive sponsor soaking up all the errors.
+
+    // Test settings
+    const numIterations = 100; // number of times the simulation loop is run
+    const runLiquidations = true; // if liquidations should occur in the loop
+    const runDisputes = true; // if disputes should occur in the loop
+    const runExtraDeposits = true; // if the sponsor should have a chance to add more
+    const runRedeemTokens = true; // if the sponsor should have a chance to redeem some of their tokens
+
+    // Tunable parameters
+    const baseCollateralAmount = toBN(toWei("150.333333333333333333")); // starting amount of collateral deposited by sponsor
+    const baseNumTokens = toBN(toWei("99.333333333333333333")); // starting number of tokens created by sponsor
+    const settlementPrice = toBN(toWei("1.000000000000000001")); // Price the contract resolves to
+    const liquidationPrice = toBN(toWei("1.5")); // Price a liquidator will liquidate at
+    const disputePrice = toBN(toWei("0.999999999999999999")); // Price a dispute will resolve to
+    const depositAmount = toBN(toWei("9.999999999999999999")); // Amount of additional collateral to add to a position
+    const redeemAmount = toBN(toWei("0.999999999999999999")); // The number of synthetic tokens to redeem for collateral
+    const dvmRegularFee = toBN(toWei("0.05")).divn(60 * 60 * 24 * 365); // DVM fee charged per second
+
+    // Counter variables
+    let positionsCreated = 0;
+    let tokenTransfers = 0;
+    let depositsMade = 0;
+    let redemptionsMade = 0;
+    let liquidationsObject = [];
+    let maxCollateralLocked = 0;
+
+    // STEP: 0.a) set the oracle fee
+    await store.setFixedOracleFeePerSecond({ rawValue: dvmRegularFee.toString() }, { from: contractCreator });
+
+    let sponsor;
+    let tokenHolder;
+    console.log("Creating positions, liquidations and disputes iteratively\nIteration counter:");
+    for (let i = 0; i < numIterations; i++) {
+      process.stdout.write(i.toString() + ", ");
+      // pick the sponsor and token holder from their arrays
+      sponsor = sponsors[i % sponsors.length];
+      tokenHolder = tokenHolders[i % tokenHolders.length];
+
+      // STEP 1: creating position
+      const tokensOutstanding = await expiringMultiParty.totalTokensOutstanding();
+      const rawCollateral = await expiringMultiParty.rawTotalPositionCollateral();
+
+      let GCR;
+      if (tokensOutstanding.toString() == "0" || rawCollateral.toString() == "0") {
+        console.log("defaultGCR");
+        GCR = toBN(toWei("150"));
+      } else {
+        GCR = rawCollateral.mul(toBN(toWei("1"))).div(tokensOutstanding);
+      }
+
+      const collateralNeeded = baseNumTokens
+        .mul(GCR)
+        .div(toBN(toWei("1")))
+        .add(toBN("100000"));
+
+      await expiringMultiParty.create(
+        { rawValue: collateralNeeded.toString() },
+        { rawValue: baseNumTokens.toString() },
+        { from: sponsor }
+      );
+      positionsCreated++;
+
+      // STEP 2: transferring tokens to the token holder
+      if (i % 2 == 1) {
+        await syntheticToken.transfer(tokenHolder, baseNumTokens.toString(), {
+          from: sponsor
+        });
+        tokenTransfers++;
+      }
+
+      // STEP 3: advancing time
+      const currentTime = await expiringMultiParty.getCurrentTime();
+      await expiringMultiParty.setCurrentTime(currentTime.add(timeOffsetBetweenTests));
+      await mockOracle.setCurrentTime(currentTime.add(timeOffsetBetweenTests));
+
+      // STEP 4.a: chance to liquidate position. 1 in 3 will get liquidated
+      if (i % 3 == 1 && runLiquidations) {
+        const positionTokensOutstanding = toBN(
+          (await expiringMultiParty.positions(sponsor)).tokensOutstanding.rawValue
+        );
+
+        // STEP: 0.b): seed liquidator with the exact amount that they require to create the liquidation
+        let liquidatorSeedCollateral = positionTokensOutstanding
+          .mul(GCR)
+          .div(toBN(toWei("1")))
+          .add(toBN("100000"));
+        await expiringMultiParty.create(
+          {
+            rawValue: liquidatorSeedCollateral.toString()
+          },
+          { rawValue: positionTokensOutstanding.toString() },
+          { from: liquidator }
+        );
+
+        await expiringMultiParty.createLiquidation(
+          sponsor,
+          { rawValue: GCR.toString() },
+          { rawValue: positionTokensOutstanding.toString() },
+          { from: liquidator }
+        );
+
+        // get the liquidation info from the event. Used later on to withdraw by accounts.
+        const liquidationEvents = await expiringMultiParty.getPastEvents("LiquidationCreated");
+        const liquidationEvent = liquidationEvents[liquidationEvents.length - 1].args;
+
+        liquidationsObject.push({
+          sponsor: liquidationEvent.sponsor,
+          id: liquidationEvent.liquidationId.toString(),
+          disputed: false
+        });
+
+        // STEP 4.b) Chance to dispute the liquidation. 1 in 2 liquidations will get disputed
+        if (i % 2 == 1 && runDisputes) {
+          // Create the dispute request for the liquidation
+          await expiringMultiParty.dispute(liquidationEvent.liquidationId.toString(), liquidationEvent.sponsor, {
+            from: disputer
+          });
+
+          // Push a price into the oracle. This will enable resolution later on when the disputer
+          // calls `withdrawLiquidation` to extract their winnings.
+          const liquidationTime = await expiringMultiParty.getCurrentTime();
+          await mockOracle.pushPrice(constructorParams.priceFeedIdentifier, liquidationTime, disputePrice);
+
+          liquidationsObject[liquidationsObject.length - 1].disputed = true;
+        }
+      }
+      else {
+      // STEP 5): chance for the token sponsor to deposit more collateral
+      if (i % 2 == 0 && runExtraDeposits) {
+        // Wrap the deposit attempt in a try/catch to deal with a liquidated position reverting deposit
+
+        await expiringMultiParty.deposit({ rawValue: depositAmount.toString() }, { from: sponsor });
+        depositsMade++;
+      }
+      // STEP 6): chance for the token sponsor to redeem some collateral
+      if (i % 2 == 1 && runRedeemTokens) {
+        // Wrap the deposit attempt in a try/catch to deal with a liquidated position reverting deposit
+
+        await expiringMultiParty.redeem({ rawValue: redeemAmount.toString() }, { from: sponsor });
+        redemptionsMade++;
+        }
+      }
+    } // exit iteration loop
+
+    maxCollateralLocked = await expiringMultiParty.rawTotalPositionCollateral();
+    console.log("max", maxCollateralLocked.toString());
+
+    console.log(
+      "\nPosition creation done!\nAdvancing time and withdrawing winnings/losses for sponsor, disputer and liquidator from liquidations and disputes"
+    );
+    // STEP 8): Before settling the contract the liquidator, disruptor and token sponsors need to withdraw from all
+    // liquidation events that occurred. To do this we iterate over all liquidations that happened and attempt to withdraw
+    // from the liquidation from all three users(sponsor, disputer and liquidator).
+    if (runLiquidations) {
+      for (const liquidation of liquidationsObject) {
+        if (liquidation.disputed) {
+          // sponsor and disputer should only withdraw if the liquidation was disputed
+
+          await expiringMultiParty.withdrawLiquidation(liquidation.id, liquidation.sponsor, {
+            from: liquidation.sponsor
+          });
+
+          await expiringMultiParty.withdrawLiquidation(liquidation.id, liquidation.sponsor, { from: disputer });
+        }
+
+        // the liquidator should always try withdraw, even if disputed
+        await expiringMultiParty.withdrawLiquidation(liquidation.id, liquidation.sponsor, { from: liquidator });
+      }
+    }
+
+    // STEP 9): expire the contract and settle positions
+    console.log("Advancing time and settling contract");
+    await expiringMultiParty.setCurrentTime(expirationTime.toNumber() + 1);
+    await mockOracle.setCurrentTime(expirationTime.toNumber() + 1);
+
+    await expiringMultiParty.expire();
+
+    // After expiration the oracle needs to settle the price. Push a price of 1 usd per collateral means that each
+    // token is redeemable for 1 unit of underlying.
+    const oracleTime = await expiringMultiParty.getCurrentTime();
+    await mockOracle.pushPrice(constructorParams.priceFeedIdentifier, oracleTime.subn(1).toString(), settlementPrice);
+
+    // STEP 10): all users withdraw their funds
+    // Settle the liquidator
+    await expiringMultiParty.settleExpired({ from: liquidator });
+    assert.equal(await syntheticToken.balanceOf(liquidator), "0");
+
+    // Settle the disputer
+    await expiringMultiParty.settleExpired({ from: disputer });
+    assert.equal(await syntheticToken.balanceOf(disputer), "0");
+
+    // Settle token holders
+    for (const tokenHolder of tokenHolders) {
+      await expiringMultiParty.settleExpired({ from: tokenHolder });
+      assert.equal(await syntheticToken.balanceOf(tokenHolder), "0");
+    }
+
+    // Settle token sponsors
+    for (const sponsor of sponsors) {
+      await expiringMultiParty.settleExpired({ from: sponsor });
+      assert.equal(await syntheticToken.balanceOf(sponsor), "0");
+    }
+
+    const finalBalanceDrift = await collateralToken.balanceOf(expiringMultiParty.address);
+    const finalBalanceDriftFrac = finalBalanceDrift.mul(toBN(toWei("100"))).div(maxCollateralLocked);
+
+    console.log("All accounts have been able to withdraw without revert!");
+    console.table({
+      iterations: numIterations,
+      positionsCreated: positionsCreated,
+      tokensTransferred: tokenTransfers,
+      additionalDepositsMade: depositsMade,
+      redemptionsMade: redemptionsMade,
+      liquidations: liquidationsObject.length,
+      disputedLiquidations: liquidationsObject.filter(liquidation => liquidation.disputed).length,
+      finalBalanceDrift: finalBalanceDrift.toNumber(),
+      driftAsFracOfTotalDeposit: finalBalanceDriftFrac.toString() + " e-18 %"
     });
 
     // STEP 11): ensure all funds were taken from the contract.

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -561,7 +561,7 @@ contract("IntegrationTest", function(accounts) {
     // without one massive sponsor soaking up all the errors.
 
     // Test settings
-    const numIterations = 100; // number of times the simulation loop is run
+    const numIterations = 10; // number of times the simulation loop is run
     const runLiquidations = true; // if liquidations should occur in the loop
     const runDisputes = true; // if disputes should occur in the loop
     const runExtraDeposits = true; // if the sponsor should have a chance to add more

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -684,21 +684,20 @@ contract("IntegrationTest", function(accounts) {
 
           liquidationsObject[liquidationsObject.length - 1].disputed = true;
         }
-      }
-      else {
-      // STEP 5): chance for the token sponsor to deposit more collateral
-      if (i % 2 == 0 && runExtraDeposits) {
-        // Wrap the deposit attempt in a try/catch to deal with a liquidated position reverting deposit
+      } else {
+        // STEP 5): chance for the token sponsor to deposit more collateral
+        if (i % 2 == 0 && runExtraDeposits) {
+          // Wrap the deposit attempt in a try/catch to deal with a liquidated position reverting deposit
 
-        await expiringMultiParty.deposit({ rawValue: depositAmount.toString() }, { from: sponsor });
-        depositsMade++;
-      }
-      // STEP 6): chance for the token sponsor to redeem some collateral
-      if (i % 2 == 1 && runRedeemTokens) {
-        // Wrap the deposit attempt in a try/catch to deal with a liquidated position reverting deposit
+          await expiringMultiParty.deposit({ rawValue: depositAmount.toString() }, { from: sponsor });
+          depositsMade++;
+        }
+        // STEP 6): chance for the token sponsor to redeem some collateral
+        if (i % 2 == 1 && runRedeemTokens) {
+          // Wrap the deposit attempt in a try/catch to deal with a liquidated position reverting deposit
 
-        await expiringMultiParty.redeem({ rawValue: redeemAmount.toString() }, { from: sponsor });
-        redemptionsMade++;
+          await expiringMultiParty.redeem({ rawValue: redeemAmount.toString() }, { from: sponsor });
+          redemptionsMade++;
         }
       }
     } // exit iteration loop

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -342,7 +342,7 @@ contract("IntegrationTest", function(accounts) {
     assert.equal((await collateralToken.balanceOf(expiringMultiParty.address)).toString(), "0");
   });
 
-  it.only("Iterative full life cycle test with unfriendly numbers", async function() {
+  it("Iterative full life cycle test with unfriendly numbers", async function() {
     // This test follows the exact same pattern as before except the input parames are less friendly
 
     // Test settings

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -52,8 +52,8 @@ contract("IntegrationTest", function(accounts) {
   let startingTime;
   let expirationTime;
 
-  const mintAndApprove = toBN(toWei("10000000")); // number of tokens minted and approved by each account
-  const timeOffsetBetweenTests = toBN("10000"); // timestep advance between loop iterations
+  const mintAndApprove = toBN(toWei("100000000000000")); // number of tokens minted and approved by each account
+  const timeOffsetBetweenTests = toBN(60 * 60); // timestep advance between loop iterations (1 hour)
 
   beforeEach(async () => {
     collateralToken = await Token.new({ from: contractCreator });
@@ -72,7 +72,7 @@ contract("IntegrationTest", function(accounts) {
     });
 
     startingTime = await expiringMultiPartyCreator.getCurrentTime();
-    expirationTime = startingTime.add(toBN(60 * 60 * 24 * 30)); // One month in the future
+    expirationTime = startingTime.add(toBN(60 * 60 * 24 * 30 * 3)); // Three month in the future
     constructorParams = {
       isTest: true,
       expirationTimestamp: expirationTime.toString(),
@@ -346,7 +346,7 @@ contract("IntegrationTest", function(accounts) {
     // This test follows the exact same pattern as before except the input parames are less friendly
 
     // Test settings
-    const numIterations = 100; // number of times the simulation loop is run
+    const numIterations = 10; // number of times the simulation loop is run
     const runLiquidations = true; // if liquidations should occur in the loop
     const runDisputes = true; // if disputes should occur in the loop
     const runExtraDeposits = true; // if the sponsor should have a chance to add more
@@ -375,8 +375,8 @@ contract("IntegrationTest", function(accounts) {
     // STEP: 0.b): seed liquidator
     console.log("Seeding liquidator");
     await expiringMultiParty.create(
-      { rawValue: baseCollateralAmount.mul(toBN("100")).toString() },
-      { rawValue: baseNumTokens.mul(toBN("100")).toString() },
+      { rawValue: baseCollateralAmount.mul(toBN("100000")).toString() },
+      { rawValue: baseNumTokens.mul(toBN("100000")).toString() },
       { from: liquidator }
     );
 
@@ -425,7 +425,7 @@ contract("IntegrationTest", function(accounts) {
         const positionTokensOutstanding = (await expiringMultiParty.positions(sponsor)).tokensOutstanding;
         await expiringMultiParty.createLiquidation(
           sponsor,
-          { rawValue: GCR.add(toBN("100000")).toString() },
+          { rawValue: GCR.toString() },
           { rawValue: positionTokensOutstanding.toString() },
           { from: liquidator }
         );


### PR DESCRIPTION
This PR adds two an addition integration test (which follows the same pattern as before by iteratively calling `create`, `createLiquidation`, `deposit`, `redeem`, `withdrawLiquidation` and `settleExpired`) but uses unfriendly numbers **and** a regular fee. 

**TLDR:** Contract drift is directly proportional to the total collateral locked and the number of iterations performed. This relationship places a reasonable bound on how much _dust_ can be lost in a contract at expiry and quantifies how much is lost from interactions. From the iterative experiments an average of ~ 1Wei is lost per 1 unit of collateral (1e18) which is shown to scale linearly with collateral added. Under no configuration is the contract locked.

In order for these tests to pass up to 1000 iterations the contract duration for the EMP was extended to run over a 3 month duration with a time step of 1 hour between each iteration. Additionally the truffle config time out was extended.

To quantify the drift the final amount of collateral left within the contract  after all interactions is measured. This value is compared to the total collateral locked within the contract over it's life to find a relative percentage size of the drift.

**Two main experiments were conducted were:**
1) The first experiments follows the standard integration test flow with one small change: **the liquidator is not seeded before hand. Rather, the liquidator creates a new token position of required liquidation size right before creating the liquidation**. The goal of this is to not unbalance the contract with any disproportionately large positions but rather keep the system more "flat" with equal token distribution between accounts. In doing so one user will not soak up all the rounding errors.
2) The second experiment follows the opposite approach by **creating one oversized position held by the liquidator** (1000000x larger than the token holders positions) and then proceeds with the standard integration test flow.  This large position should dominate the majority of the rounding errors. 

Common between all tests is the size of the trader positions created, number of liquidations, disputes, redeems and deposits over different iteration counts.
 In both experiments the goal is to find the correlation between error drift and the total locked collateral.

# Results
The tables below show the output after 10, 100 and 1000 iterations of the for _experiment 1_ where the liquidator was seeded effectively and all positions sizes are approximately equal(including liquidator & disputor):

```
┌───────────────────────────┬──────────────┐
│          (index)          │    Values    │
├───────────────────────────┼──────────────┤
│        iterations         │      10      │
│     positionsCreated      │      10      │
│     tokensTransferred     │      5       │
│  additionalDepositsMade   │      4       │
│      redemptionsMade      │      3       │
│       liquidations        │      3       │
│   disputedLiquidations    │      2       │
│     finalBalanceDrift     │    712793    │
│ driftAsFracOfTotalDeposit │  479 e-18 %  │
└───────────────────────────┴──────────────┘
┌───────────────────────────┬───────────────┐
│          (index)          │    Values     │
├───────────────────────────┼───────────────┤
│        iterations         │      100      │
│     positionsCreated      │      100      │
│     tokensTransferred     │      50       │
│  additionalDepositsMade   │      34       │
│      redemptionsMade      │      33       │
│       liquidations        │      33       │
│   disputedLiquidations    │      17       │
│     finalBalanceDrift     │   51041800    │
│ driftAsFracOfTotalDeposit │  3429 e-18 %  │
└───────────────────────────┴───────────────┘
┌───────────────────────────┬────────────────┐
│          (index)          │     Values     │
├───────────────────────────┼────────────────┤
│        iterations         │      1000      │
│     positionsCreated      │      1000      │
│     tokensTransferred     │      500       │
│  additionalDepositsMade   │      334       │
│      redemptionsMade      │      333       │
│       liquidations        │      333       │
│   disputedLiquidations    │      167       │
│     finalBalanceDrift     │   5182768266   │
│ driftAsFracOfTotalDeposit │  34630 e-18 %  │
└───────────────────────────┴────────────────┘
```
From these results we can see that the error scales linearly with the number of iterations. Importantly between 100 and 1000 iterations there is an almost exact 10x increase in drift which implies that over more iterations than tested (say 10k) the drift will not increase too drastically past this linear relationship. 

The takeaway here is that when the system is balanced, with no single whale holding a majority stake, the errors average out to ~ `0.34630*10^-18` per unit of collateral. As some interactions only occurs 1 in 3 iterations (deposits, redemptions and liquidations) so it is possible that this drift occurs fully when these interactions occur and no drift happens on the other iterations. If this is the case then expect to see a 3x increase if all interactions happen every iteration and so we can assume that in the average case the drift is ~= 1 Wei of drift per unit collateral per executed transaction. This result is imprecise and for a more exact numerical description of this specific rounding the `PrecisionErrors.js` script should be consulted. 

However this result does have a valuable take away which corroborates the results of the Precision Error work done by @nicholaspai in that the precision errors, while apparent, do not result in any meaningful loss of value within the system. For every unit of collateral currency deposited (1e18 as an assumed base) 1 Wei worth is lost. This is not enough to warrant any kind of worry.

Next, _experiment 2_ is preformed over 10, 100 and 1000 iterations. In this experiment the liquidator holds one oversized position of 10000x the size of the other accounts.

```
┌───────────────────────────┬──────────────┐
│          (index)          │    Values    │
├───────────────────────────┼──────────────┤
│        iterations         │      10      │
│     positionsCreated      │      10      │
│     tokensTransferred     │      5       │
│  additionalDepositsMade   │      4       │
│      redemptionsMade      │      3       │
│       liquidations        │      3       │
│   disputedLiquidations    │      2       │
│     finalBalanceDrift     │  826619684   │
│ driftAsFracOfTotalDeposit │  549 e-18 %  │
└───────────────────────────┴──────────────┘
┌───────────────────────────┬───────────────┐
│          (index)          │    Values     │
├───────────────────────────┼───────────────┤
│        iterations         │      100      │
│     positionsCreated      │      100      │
│     tokensTransferred     │      50       │
│  additionalDepositsMade   │      34       │
│      redemptionsMade      │      33       │
│       liquidations        │      33       │
│   disputedLiquidations    │      17       │
│     finalBalanceDrift     │  7460983423   │
│ driftAsFracOfTotalDeposit │  4962 e-18 %  │
└───────────────────────────┴───────────────┘
┌───────────────────────────┬────────────────┐
│          (index)          │     Values     │
├───────────────────────────┼────────────────┤
│        iterations         │      1000      │
│     positionsCreated      │      1000      │
│     tokensTransferred     │      500       │
│  additionalDepositsMade   │      334       │
│      redemptionsMade      │      333       │
│       liquidations        │      333       │
│   disputedLiquidations    │      167       │
│     finalBalanceDrift     │  76105691377   │
│ driftAsFracOfTotalDeposit │  50589 e-18 %  │
└───────────────────────────┴────────────────┘
```

Firstly the total drift amount has gone up considerably when compared to the first experiment. This is expected as the total collateral has also increased by a large amount (10000x due to the liquidators position). However, despite this increase, the relative size of the drift as a fraction of the total collateral has not increased too drastically. A value of ~ `0.50589*10^-18` units of drift per unit of collateral was observed. As with the previous test this falls within a reasonable bound for drift for each unit of collateral.

Note that an additional setup was also constructed where a separate wallet (not a sponsor, holder, liquidator or disruptor) created the "whale" position and then iterative tests were preformed. These yielded the same results as shown above.

Experiment 2 shows that even with one large token holder position the drift scales proportionally to the total collateral locked.

# Conclusions
- All token sponsors, holders, liquidators and disputers were able to withdraw, with no contract lockup under all tests, irrespective of the size of the drift. The only impact of the drift is that the final withdrawal action results in slightly less collateral being released than expected.
- Observed drift is directly proportional to the total collateral locked within the contract and the number of iterations executed against a "drifting" function.
- Having one over sized position vs positions of approximately equal size yields similar cumulative drift which further supports that drift is proportional to total collateral locked.