### PR TITLE
Handle withdrawal requests that are greater than position's collateral

### DIFF
--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -202,9 +202,7 @@ contract Liquidatable is PricelessPositionManager {
         FixedPoint.Unsigned memory startCollateral = _getCollateral(positionToLiquidate.rawCollateral);
         FixedPoint.Unsigned memory startCollateralNetOfWithdrawal = FixedPoint.fromUnscaledUint(0);
         if (positionToLiquidate.withdrawalRequestAmount.isLessThanOrEqual(startCollateral)) {
-            startCollateralNetOfWithdrawal = startCollateral.sub(
-                positionToLiquidate.withdrawalRequestAmount
-            );
+            startCollateralNetOfWithdrawal = startCollateral.sub(positionToLiquidate.withdrawalRequestAmount);
         }
 
         FixedPoint.Unsigned memory startTokens = positionToLiquidate.tokensOutstanding;

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -198,10 +198,15 @@ contract Liquidatable is PricelessPositionManager {
         FixedPoint.Unsigned memory ratio = tokensToLiquidate.div(positionToLiquidate.tokensOutstanding);
 
         // Starting values for the Position being liquidated.
+        // If withdrawal request amount is > position's collateral, then set this to 0, otherwise set it to (startCollateral - withdrawal request amount).
         FixedPoint.Unsigned memory startCollateral = _getCollateral(positionToLiquidate.rawCollateral);
-        FixedPoint.Unsigned memory startCollateralNetOfWithdrawal = startCollateral.sub(
-            positionToLiquidate.withdrawalRequestAmount
-        );
+        FixedPoint.Unsigned memory startCollateralNetOfWithdrawal = FixedPoint.fromUnscaledUint(0);
+        if (positionToLiquidate.withdrawalRequestAmount.isLessThanOrEqual(startCollateral)) {
+            startCollateralNetOfWithdrawal = startCollateral.sub(
+                positionToLiquidate.withdrawalRequestAmount
+            );
+        }
+
         FixedPoint.Unsigned memory startTokens = positionToLiquidate.tokensOutstanding;
 
         // Check the max price constraint to ensure that the Position's collateralization ratio hasn't increased beyond

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -234,13 +234,19 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         PositionData storage positionData = _getPositionData(msg.sender);
         require(positionData.requestPassTimestamp < getCurrentTime());
 
-        _removeCollateral(positionData.rawCollateral, positionData.withdrawalRequestAmount);
-        _removeCollateral(rawTotalPositionCollateral, positionData.withdrawalRequestAmount);
+        // If withdrawal request amount is > position collateral, then withdraw the full collateral amount.
+        FixedPoint.Unsigned memory amountToWithdraw = positionData.withdrawalRequestAmount;
+        if (positionData.withdrawalRequestAmount.isGreaterThan(_getCollateral(positionData.rawCollateral))) {
+            amountToWithdraw = _getCollateral(positionData.rawCollateral);
+        }
+
+        _removeCollateral(positionData.rawCollateral, amountToWithdraw);
+        _removeCollateral(rawTotalPositionCollateral, amountToWithdraw);
 
         // Transfer approved withdrawal amount from the contract to the caller.
-        collateralCurrency.safeTransfer(msg.sender, positionData.withdrawalRequestAmount.rawValue);
+        collateralCurrency.safeTransfer(msg.sender, amountToWithdraw.rawValue);
 
-        emit RequestWithdrawalExecuted(msg.sender, positionData.withdrawalRequestAmount.rawValue);
+        emit RequestWithdrawalExecuted(msg.sender, amountToWithdraw.rawValue);
 
         // Reset withdrawal request
         positionData.withdrawalRequestAmount = FixedPoint.fromUnscaledUint(0);

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -1079,9 +1079,9 @@ contract("Liquidatable", function(accounts) {
       );
       // Request withdrawal amount > collateral
       await liquidationContract.requestWithdrawal(
-        { rawValue: amountOfCollateral.add(toBN("1")).toString()}, 
+        { rawValue: amountOfCollateral.add(toBN("1")).toString() },
         { from: sponsor }
-      )
+      );
       // Transfer synthetic tokens to a liquidator
       await syntheticToken.transfer(liquidator, amountOfSynthetic, { from: sponsor });
       // Liquidator believes the price of collateral per synthetic to be 1.5 and is liquidating the full token outstanding amount.
@@ -1124,8 +1124,8 @@ contract("Liquidatable", function(accounts) {
           // Once a dispute fails and the liquidator withdraws the struct is removed from state.
           ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED
         );
-      });      
-    })
+      });
+    });
   });
 
   describe("Emergency shutdown", () => {

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -1070,6 +1070,62 @@ contract("Liquidatable", function(accounts) {
       const expectedPaymentSponsor = amountOfCollateral.sub(settlementTRV).add(sponsorDisputeReward);
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), expectedPaymentSponsor.toString());
     });
+    it("Requested withdrawal amount is greater than total position collateral, liquidated collateral should be 0", async () => {
+      // Create position.
+      await liquidationContract.create(
+        { rawValue: amountOfCollateral.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: sponsor }
+      );
+      // Request withdrawal amount > collateral
+      await liquidationContract.requestWithdrawal(
+        { rawValue: amountOfCollateral.add(toBN("1")).toString()}, 
+        { from: sponsor }
+      )
+      // Transfer synthetic tokens to a liquidator
+      await syntheticToken.transfer(liquidator, amountOfSynthetic, { from: sponsor });
+      // Liquidator believes the price of collateral per synthetic to be 1.5 and is liquidating the full token outstanding amount.
+      // Therefore, they are intending to liquidate all 150 collateral,
+      // however due to the pending withdrawal amount, the liquidated collateral gets reduced to 0.
+      const createLiquidationResult = await liquidationContract.createLiquidation(
+        sponsor,
+        { rawValue: pricePerToken.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: liquidator }
+      );
+      truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
+        return (
+          ev.sponsor == sponsor,
+          ev.liquidator == liquidator,
+          ev.liquidationId == 0,
+          ev.tokensOutstanding == amountOfSynthetic.toString(),
+          ev.lockedCollateral == amountOfCollateral.toString(),
+          ev.liquidatedCollateral == "0"
+        );
+      });
+      // Since the liquidated collateral:synthetic ratio is 0, even the lowest price (amount of collateral each synthetic is worth)
+      // above 0 should result in a failed dispute because the liquidator was correct: there is not enough collateral backing the tokens.
+      await liquidationContract.dispute(liquidationParams.liquidationId, sponsor, { from: disputer });
+      const liquidationTime = await liquidationContract.getCurrentTime();
+      const disputePrice = "1";
+      await mockOracle.pushPrice(priceFeedIdentifier, liquidationTime, disputePrice);
+      const withdrawLiquidationResult = await liquidationContract.withdrawLiquidation(
+        liquidationParams.liquidationId,
+        sponsor,
+        { from: liquidator }
+      );
+      // Liquidator should get the full locked collateral.
+      const expectedPayment = amountOfCollateral.add(disputeBond);
+      truffleAssert.eventEmitted(withdrawLiquidationResult, "LiquidationWithdrawn", ev => {
+        return (
+          ev.caller == liquidator &&
+          ev.withdrawalAmount.toString() == expectedPayment.toString() &&
+          // State should be uninitialized as the struct has been deleted as a result of the withdrawal.
+          // Once a dispute fails and the liquidator withdraws the struct is removed from state.
+          ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED
+        );
+      });      
+    })
   });
 
   describe("Emergency shutdown", () => {

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -264,7 +264,9 @@ contract("PricelessPositionManager", function(accounts) {
     );
 
     // Cannot withdraw full collateral because the GCR check will always fail.
-    assert(await didContractThrow(pricelessPositionManager.withdraw({ rawValue: createCollateral }, { from: sponsor })));
+    assert(
+      await didContractThrow(pricelessPositionManager.withdraw({ rawValue: createCollateral }, { from: sponsor }))
+    );
   });
 
   it("Withdrawal request", async function() {

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -370,7 +370,7 @@ contract("PricelessPositionManager", function(accounts) {
     assert(await didContractThrow(pricelessPositionManager.cancelWithdrawal({ from: sponsor })));
 
     // Request to withdraw more than remaining collateral should result in the amount getting capped to the remaining collateral.
-    await pricelessPositionManager.requestWithdrawal({ rawValue: toWei("125.000000000000000001") }, { from: sponsor });
+    await pricelessPositionManager.requestWithdrawal({ rawValue: toBN(toWei("125")).add(toBN("1")).toString() }, { from: sponsor });
     await pricelessPositionManager.setCurrentTime(
       (await pricelessPositionManager.getCurrentTime()).toNumber() + withdrawalLiveness + 1
     );

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -370,7 +370,14 @@ contract("PricelessPositionManager", function(accounts) {
     assert(await didContractThrow(pricelessPositionManager.cancelWithdrawal({ from: sponsor })));
 
     // Request to withdraw more than remaining collateral should result in the amount getting capped to the remaining collateral.
-    await pricelessPositionManager.requestWithdrawal({ rawValue: toBN(toWei("125")).add(toBN("1")).toString() }, { from: sponsor });
+    await pricelessPositionManager.requestWithdrawal(
+      {
+        rawValue: toBN(toWei("125"))
+          .add(toBN("1"))
+          .toString()
+      },
+      { from: sponsor }
+    );
     await pricelessPositionManager.setCurrentTime(
       (await pricelessPositionManager.getCurrentTime()).toNumber() + withdrawalLiveness + 1
     );


### PR DESCRIPTION
Resolves #1049 

There are two situations where we need to handle `(withdrawalRequestAmount > _getCollateral(sponsor)`:

1.  `withdrawPassedRequest()`: Requested withdrawal amount might be greater than position's collateral (due to regular fees accrued, or user just requested too much), so we instead withdraw the full collateral available
2. `createLiquidation()`: Pending withdrawal amount is greater than position's collateral, so calculating `startCollateralNetWithdrawal = startCollateral.sub(withdrawalRequestAmount)` could revert. Here, if `withdrawalRequestAmount > startCollateral` then I set `startCollateralNetWithdrawal = 0`.

I also added a test to `PricelessPositionManager.js` that shows that it is impossible to withdraw instantly (via `withdraw()`) the full position collateral. 