### PR TITLE
Add intrablock uniswap test and utility

### DIFF
--- a/common/SolidityTestUtils.js
+++ b/common/SolidityTestUtils.js
@@ -9,6 +9,98 @@ async function didContractThrow(promise) {
   return false;
 }
 
+async function minePendingTransactions(web3, time) {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [time],
+        id: new Date().getTime()
+      },
+      (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      }
+    );
+  });
+}
+
+async function stopMining(web3) {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "miner_stop",
+        params: [],
+        id: new Date().getTime()
+      },
+      (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      }
+    );
+  });
+}
+
+async function startMining(web3) {
+  return new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "miner_start",
+        params: [],
+        id: new Date().getTime()
+      },
+      (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      }
+    );
+  });
+}
+
+// This function will mine all transactions in `transactions` in the same block with block timestamp `time`.
+// The return value is an array of receipts corresponding to the transactions.
+// Each transaction in transactions should be a web3 transaction generated like:
+// let transaction = truffleContract.contract.methods.myMethodName(arg1, arg2);
+// or if already using a web3 contract object:
+// let transaction = web3Contract.methods.myMethodName(arg1, arg2);
+async function mineTransactionsAtTime(web3, transactions, time, sender) {
+  await stopMining(web3);
+
+  const receiptPromises = [];
+  for (const transaction of transactions) {
+    const result = transaction.send({ from: sender });
+
+    // Awaits the transactionHash, which signifies the transaction was sent, but not necessarily mined.
+    await new Promise((resolve, reject) => {
+      result.on("transactionHash", function() {
+        resolve();
+      });
+    });
+
+    // result, itself, is a promise that will resolve to the receipt.
+    receiptPromises.push(result);
+  }
+
+  await minePendingTransactions(web3, time);
+  const receipts = await Promise.all(receiptPromises);
+  await startMining(web3);
+
+  return receipts;
+}
+
 module.exports = {
-  didContractThrow
+  didContractThrow,
+  mineTransactionsAtTime
 };

--- a/financial-templates-lib/test/UniswapPriceFeed.js
+++ b/financial-templates-lib/test/UniswapPriceFeed.js
@@ -1,7 +1,7 @@
 const { toWei, toBN } = web3.utils;
 
 const { UniswapPriceFeed } = require("../UniswapPriceFeed");
-const { mineTransactionsAtTime, startMining, stopMining, minePendingTransactions } = require("../../common/SolidityTestUtils.js");
+const { mineTransactionsAtTime } = require("../../common/SolidityTestUtils.js");
 const { delay } = require("../delay.js");
 const { MAX_SAFE_JS_INT } = require("../../common/Constants");
 

--- a/financial-templates-lib/test/UniswapPriceFeed.js
+++ b/financial-templates-lib/test/UniswapPriceFeed.js
@@ -33,7 +33,7 @@ contract("UniswapPriceFeed.js", function(accounts) {
     assert.equal(uniswapPriceFeed.getCurrentPrice().toString(), toWei("0.25"));
   });
 
-  it.only("Selects most recent price in same block", async function() {
+  it("Selects most recent price in same block", async function() {
     // Just use current system time because the time doesn't matter.
     const time = Math.round(new Date().getTime() / 1000);
 


### PR DESCRIPTION
In the Uniswap price feed library, it's important that we handle multiple trades in the same block correctly. Since we don't control the contract we're subscribing to, we'll also have to use the block time to correctly compute TWAPs.

For these reasons, it was necessary to build a utility functions that can bunch transactions into the same block and control the block timestamp of that block.

Relevant to issue #1138.