### PR TITLE
Liquidator pays final fee bond

### DIFF
--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -396,7 +396,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         contractState = ContractState.ExpiredPriceRequested;
 
         // The final fee for this request is paid out of the contract rather than by the caller.
-        _payFinalFees(address(this));
+        _payFinalFees(address(this), _computeFinalFees());
         _requestOraclePrice(expirationTimestamp);
 
         emit ContractExpired(msg.sender);


### PR DESCRIPTION
This PR adds functionality to force the liquidator to post the final fee as a "bond". If the liquidator wins the liquidation, then they receive this bond back. If not, it goes to pay the final fee.