### PR TITLE
Change "price feed" in Liquidator bot into a "price function" to standardize with Disputer bot

### DIFF
--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -48,7 +48,7 @@ async function run(price, address, shouldPoll) {
       // Acquire synthetic tokens somehow. v0: assume the bot holds on to them.
       // Liquidate any undercollateralized positions!
       // Withdraw money from any liquidations that are expired or DisputeFailed.
-      await liquidator.queryAndLiquidate(toWei(price.toString()));
+      await liquidator.queryAndLiquidate(() => toWei(price));
       await liquidator.queryAndWithdrawRewards();
     } catch (error) {
       Logger.error({

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -26,7 +26,7 @@ class Liquidator {
     Logger.debug({
       at: "Liquidator",
       message: "Checking for under collateralized positions",
-      price: priceFeed
+      inputPrice: priceFeed
     });
 
     // Update the client to get the latest position information.

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -19,11 +19,13 @@ class Liquidator {
   }
 
   // Queries underCollateralized positions and performs liquidations against any under collateralized positions.
-  queryAndLiquidate = async priceFeed => {
+  queryAndLiquidate = async priceFunction => {
+    const contractTime = await this.empContract.methods.getCurrentTime().call();
+    const priceFeed = priceFunction(contractTime);
+
     Logger.debug({
       at: "Liquidator",
-      message: "Checking for under collateralized positions",
-      inputPrice: priceFeed
+      message: "Checking for under collateralized positions"
     });
 
     // Update the client to get the latest position information.

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -25,7 +25,8 @@ class Liquidator {
 
     Logger.debug({
       at: "Liquidator",
-      message: "Checking for under collateralized positions"
+      message: "Checking for under collateralized positions",
+      price: priceFeed
     });
 
     // Update the client to get the latest position information.

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -112,7 +112,7 @@ contract("Liquidator.js", function(accounts) {
 
     // Start with a mocked price of 1 usd per token.
     // This puts both sponsors over collateralized so no liquidations should occur.
-    await liquidator.queryAndLiquidate(toWei("1"));
+    await liquidator.queryAndLiquidate(time => toWei("1"));
 
     // There should be no liquidations created from any sponsor account
     assert.deepStrictEqual(await emp.getLiquidations(sponsor1), []);
@@ -131,7 +131,7 @@ contract("Liquidator.js", function(accounts) {
     // Sponsor2: 100 * 1.3 * 1.2 > 150 [undercollateralized]
     // Sponsor2: 100 * 1.3 * 1.2 < 175 [sufficiently collateralized]
 
-    await liquidator.queryAndLiquidate(toWei("1.3"));
+    await liquidator.queryAndLiquidate(time => toWei("1.3"));
 
     // Sponsor1 should be in a liquidation state with the bot as the liquidator.
     assert.equal((await emp.getLiquidations(sponsor1))[0].sponsor, sponsor1);
@@ -166,7 +166,7 @@ contract("Liquidator.js", function(accounts) {
     // Next, the liquidator believes the price to be 1.3, which would make the position undercollateralized,
     // and liquidates the position.
     // Sponsor1: 100 * 1.3 * 1.2 > 125 [undercollateralized]
-    await liquidator.queryAndLiquidate(toWei("1.3"));
+    await liquidator.queryAndLiquidate(time => toWei("1.3"));
 
     // Advance the timer to the liquidation expiry.
     const liquidationTime = (await emp.getLiquidations(sponsor1))[0].liquidationTime;
@@ -201,7 +201,7 @@ contract("Liquidator.js", function(accounts) {
     // and liquidates the position.
     // Sponsor1: 100 * 1.3 * 1.2 > 125 [undercollateralized]
     const liquidationPrice = toWei("1.3");
-    await liquidator.queryAndLiquidate(liquidationPrice);
+    await liquidator.queryAndLiquidate(time => liquidationPrice);
 
     // Update the EMP client to detect new liquidations, and then
     // dispute the liquidation, which requires staking a dispute bond.
@@ -247,7 +247,7 @@ contract("Liquidator.js", function(accounts) {
     // and liquidates the position.
     // Sponsor1: 100 * 1.3 * 1.2 > 125 [undercollateralized]
     const liquidationPrice = toWei("1.3");
-    await liquidator.queryAndLiquidate(liquidationPrice);
+    await liquidator.queryAndLiquidate(time => liquidationPrice);
 
     // Update the EMP client to detect new liquidations, and then
     // dispute the liquidation, which requires staking a dispute bond.
@@ -289,7 +289,7 @@ contract("Liquidator.js", function(accounts) {
     const liquidationPrice = toWei("1.3");
 
     // No transaction should be sent, so this should not throw.
-    await liquidator.queryAndLiquidate(liquidationPrice);
+    await liquidator.queryAndLiquidate(time => liquidationPrice);
 
     // No liquidations should have gone through.
     assert.equal((await emp.getLiquidations(sponsor1)).length, 0);
@@ -298,7 +298,7 @@ contract("Liquidator.js", function(accounts) {
     await emp.create({ rawValue: toWei("1000") }, { rawValue: toWei("500") }, { from: liquidatorBot });
 
     // No transaction should be sent, so this should not throw.
-    await liquidator.queryAndLiquidate(liquidationPrice);
+    await liquidator.queryAndLiquidate(time => liquidationPrice);
 
     // The liquidation should have gone through.
     assert.equal((await emp.getLiquidations(sponsor1)).length, 1);


### PR DESCRIPTION
Resolves #1067 

I elected to make both bots take as input a callable `pricefunction(timestamp_seconds)` as this seems more powerful. 

Signed-off-by: Nick Pai <npai.nyc@gmail.com>