### PR TITLE
Sponsor CLI: confirms withdrawal amount for redeem and withdraw before unwrapping WETH collateral

### DIFF
--- a/core/scripts/cli/sponsor/redeem.js
+++ b/core/scripts/cli/sponsor/redeem.js
@@ -36,7 +36,7 @@ const redeem = async (web3, artifacts, emp) => {
 
   const tokensToRedeem = toBN(toWei(input["numTokens"]));
   const expectedCollateral = collateralPerToken.mul(toBN(tokensToRedeem)).div(scalingFactor);
-  console.log("You'll receive", fromWei(expectedCollateral), requiredCollateralSymbol);
+  console.log("You'll receive approximately", fromWei(expectedCollateral), requiredCollateralSymbol);
   const confirmation = await inquirer.prompt({
     type: "confirm",
     message: "Continue?",
@@ -53,6 +53,9 @@ const redeem = async (web3, artifacts, emp) => {
       totalTransactions
     );
     transactionNum++;
+
+    // Simulate redemption to confirm exactly how much collateral you will receive back.
+    const exactCollateral = await emp.redeem.call({ rawValue: tokensToRedeem.toString() });
     await submitTransaction(
       web3,
       async () => await emp.redeem({ rawValue: tokensToRedeem.toString() }),
@@ -62,7 +65,7 @@ const redeem = async (web3, artifacts, emp) => {
     );
     transactionNum++;
     if (isWeth) {
-      await unwrapToEth(web3, artifacts, emp, expectedCollateral, transactionNum, totalTransactions);
+      await unwrapToEth(web3, artifacts, emp, exactCollateral, transactionNum, totalTransactions);
     }
   }
 };

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -15,7 +15,6 @@ const Finder = artifacts.require("Finder");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const MockOracle = artifacts.require("MockOracle");
 const Token = artifacts.require("ExpandedERC20");
-const AddressWhitelist = artifacts.require("AddressWhitelist");
 const Registry = artifacts.require("Registry");
 const WETH9 = artifacts.require("WETH9");
 
@@ -25,7 +24,6 @@ let emp;
 let syntheticToken;
 let mockOracle;
 let identifierWhitelist;
-let collateralTokenWhitelist;
 let registry;
 let expiringMultiPartyCreator;
 


### PR DESCRIPTION
Fixed a bug where user received less collateral than they were expecting and therefore failed to unwrap the expected amount of WETH. 

Can re-create the situation by creating a position with 3 tokens (4.5 ETH collateral), and redeeming 1 token. This should redeem 1/3 of the collateral, 1.5 ETH, but due to rounding returns slightly less than that.

Resolves #1173 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>