### PR TITLE
Add return values to createLiquidation and dispute

### DIFF
--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -205,7 +205,7 @@ contract("Liquidatable", function(accounts) {
       );
     });
     it("Returns correct ID", async () => {
-      const liquidationId = await liquidationContract.createLiquidation.call(
+      const { liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
@@ -266,7 +266,7 @@ contract("Liquidatable", function(accounts) {
       await syntheticToken.transfer(liquidator, amountOfSynthetic, { from: sponsor });
 
       // Create second liquidation
-      const liquidationId = await liquidationContract.createLiquidation.call(
+      const { liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
@@ -300,7 +300,7 @@ contract("Liquidatable", function(accounts) {
       const expectedRemainingWithdrawalRequest = withdrawalAmount.sub(withdrawalAmount.divn(5));
 
       // Create partial liquidation.
-      let liquidationId = await liquidationContract.createLiquidation.call(
+      let { liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
@@ -331,12 +331,12 @@ contract("Liquidatable", function(accounts) {
         { rawValue: amountOfSynthetic.divn(5).toString() },
         { from: liquidator }
       );
-      liquidationId = await liquidationContract.createLiquidation.call(
+      ({ liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
         { from: liquidator }
-      );
+      ));
       await liquidationContract.createLiquidation(
         sponsor,
         { rawValue: pricePerToken.toString() },
@@ -776,7 +776,7 @@ contract("Liquidatable", function(accounts) {
         await syntheticToken.transfer(liquidator, amountOfSynthetic, { from: sponsor });
 
         // Create another liquidation
-        const liquidationId = await liquidationContract.createLiquidation.call(
+        const { liquidationId } = await liquidationContract.createLiquidation.call(
           sponsor,
           { rawValue: pricePerToken.toString() },
           { rawValue: amountOfSynthetic.toString() },

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -219,6 +219,61 @@ contract("Liquidatable", function(accounts) {
       );
       assert.equal(liquidationId.toString(), liquidationParams.liquidationId.toString());
     });
+    it("Pulls correct token amount", async () => {
+      const { tokensLiquidated } = await liquidationContract.createLiquidation.call(
+        sponsor,
+        { rawValue: pricePerToken.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: liquidator }
+      );
+
+      // Should return the correct number of tokens.
+      assert.equal(tokensLiquidated.toString(), amountOfSynthetic.toString());
+
+      const intitialBalance = await syntheticToken.balanceOf(liquidator);
+      await liquidationContract.createLiquidation(
+        sponsor,
+        { rawValue: pricePerToken.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: liquidator }
+      );
+
+      // Synthetic balance decrease should equal amountOfSynthetic.
+      assert.equal(intitialBalance.sub(await syntheticToken.balanceOf(liquidator)), amountOfSynthetic.toString());
+    });
+    it("Liquidator pays final fee", async () => {
+      // Mint liquidator enough tokens to pay the final fee.
+      await collateralToken.mint(liquidator, finalFeeAmount, { from: contractDeployer });
+
+      // Set final fee.
+      await store.setFinalFee(collateralToken.address, { rawValue: finalFeeAmount.toString() });
+
+      const { finalFeeBond } = await liquidationContract.createLiquidation.call(
+        sponsor,
+        { rawValue: pricePerToken.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: liquidator }
+      );
+      // Should return the correct final fee amount.
+      assert.equal(finalFeeBond.toString(), finalFeeAmount.toString());
+
+      const intitialBalance = await collateralToken.balanceOf(liquidator);
+      await liquidationContract.createLiquidation(
+        sponsor,
+        { rawValue: pricePerToken.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: liquidator }
+      );
+
+      // Collateral balance change should equal the final fee.
+      assert.equal(
+        intitialBalance.sub(await collateralToken.balanceOf(liquidator)).toString(),
+        finalFeeAmount.toString()
+      );
+
+      // Reset final fee to 0.
+      await store.setFinalFee(collateralToken.address, { rawValue: "0" });
+    });
     it("Emits an event", async () => {
       const createLiquidationResult = await liquidationContract.createLiquidation(
         sponsor,
@@ -300,7 +355,7 @@ contract("Liquidatable", function(accounts) {
       const expectedRemainingWithdrawalRequest = withdrawalAmount.sub(withdrawalAmount.divn(5));
 
       // Create partial liquidation.
-      let { liquidationId } = await liquidationContract.createLiquidation.call(
+      let { liquidationId, tokensLiquidated } = await liquidationContract.createLiquidation.call(
         sponsor,
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
@@ -322,6 +377,7 @@ contract("Liquidatable", function(accounts) {
       );
       assert.equal(expectedLiquidatedTokens.toString(), liquidation.tokensOutstanding.toString());
       assert.equal(expectedLockedCollateral.toString(), liquidation.lockedCollateral.toString());
+      assert.equal(expectedLiquidatedTokens.toString(), tokensLiquidated.toString());
 
       // A independent and identical liquidation can be created.
       await liquidationContract.createLiquidation(
@@ -491,6 +547,12 @@ contract("Liquidatable", function(accounts) {
       it("Dispute pays a final fee", async () => {
         // Mint final fee amount to disputer
         await collateralToken.mint(disputer, finalFeeAmount, { from: contractDeployer });
+
+        // Returns correct total bond.
+        const totalPaid = await liquidationContract.dispute.call(liquidationParams.liquidationId, sponsor, {
+          from: disputer
+        });
+        assert.equal(totalPaid.toString(), disputeBond.add(finalFeeAmount).toString());
 
         // Check that store's collateral balance increases
         const storeInitialBalance = toBN(await collateralToken.balanceOf(store.address));


### PR DESCRIPTION
This PR adds return values to createLiquidation and dispute to allow the caller to compute the tokens and/or collateral that will be pulled from their accounts when called.