### PR TITLE
Gas Estimator: Add unit tests, change getPrice to _getPrice

### DIFF
--- a/financial-templates-lib/GasEstimator.js
+++ b/financial-templates-lib/GasEstimator.js
@@ -48,8 +48,7 @@ class GasEstimator {
   };
 
   _update = async () => {
-    let returnedPrice = await this._getPrice(url);
-    this.lastFastPriceGwei = returnedPrice;
+    this.lastFastPriceGwei = await this._getPrice(url);
   };
 
   _getPrice = async url => {

--- a/financial-templates-lib/GasEstimator.js
+++ b/financial-templates-lib/GasEstimator.js
@@ -42,17 +42,17 @@ class GasEstimator {
     }
   };
 
-  _update = async () => {
-    let returnedPrice = await this.getPrice(url);
-    this.lastFastPriceGwei = returnedPrice;
-  };
-
   // Returns the current fast gas price in Wei, converted from the stored Gwei value.
   getCurrentFastPrice = () => {
     return this.lastFastPriceGwei * 1e9;
   };
 
-  getPrice = async url => {
+  _update = async () => {
+    let returnedPrice = await this._getPrice(url);
+    this.lastFastPriceGwei = returnedPrice;
+  };
+
+  _getPrice = async url => {
     try {
       const response = await fetch(url);
       const json = await response.json();

--- a/financial-templates-lib/test/GasEstimator.js
+++ b/financial-templates-lib/test/GasEstimator.js
@@ -1,0 +1,57 @@
+const { delay } = require('../delay');
+
+const { GasEstimator } = require("../GasEstimator");
+
+contract("GasEstimator.js", function() {
+
+  let gasEstimator;
+
+
+  describe("Construction with default config", () => {
+    beforeEach(() => {
+        gasEstimator = new GasEstimator();
+    })
+
+    it("Default parameters are set correctly", () => {
+        assert(gasEstimator.updateThreshold > 0);
+        assert(gasEstimator.defaultFastPriceGwei > 0);
+    });
+    it("Returns gas prices in wei before initial update", () => {
+        assert.equal(gasEstimator.defaultFastPriceGwei, gasEstimator.getCurrentFastPrice()/1e9);
+    });
+    it("Returns gas prices in wei after update", async () => {
+        await gasEstimator.update();
+        const latestFastGasPrice = gasEstimator.getCurrentFastPrice() / 1e9;
+        if (latestFastGasPrice === gasEstimator.defaultFastPriceGwei) {
+            console.log(`API Request to ethgasstation.info failed, using default gas price in Gwei: ${latestFastGasPrice}`);
+        } 
+        assert(latestFastGasPrice > 0);
+    });
+    it("Does not update if called before update threshold", async () => {
+        await gasEstimator.update();
+        const lastUpdateTimestamp = gasEstimator.lastUpdateTimestamp;
+        await delay(Number(1_000));
+        await gasEstimator.update();
+        assert.equal(lastUpdateTimestamp, gasEstimator.lastUpdateTimestamp);
+    });
+  });
+
+  describe("Construction with custom config", () => {
+    beforeEach(() => {
+        gasEstimator = new GasEstimator(updateThreshold=1.5, defaultFastPriceGwei=10);
+    });
+
+    it("Default parameters are set correctly", () => {
+        assert.equal(gasEstimator.updateThreshold, 1.5);
+        assert.equal(gasEstimator.defaultFastPriceGwei, 10);
+    });
+    it("Updates if called after update threshold", async () => {
+        await gasEstimator.update();
+        const lastUpdateTimestamp = gasEstimator.lastUpdateTimestamp;
+        await delay(Number(1_500));
+        await gasEstimator.update();
+        assert(lastUpdateTimestamp < gasEstimator.lastUpdateTimestamp);
+    });
+  });
+
+});


### PR DESCRIPTION
Resolves #1183 

`getPrice()` was only called internally by `_update()`, so I re-named to `_getPrice()` to better highlight that a client should be calling `getCurrentFastPrice()`.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>