### PR TITLE
Update docs site to not change `.md` extensions for external links

### DIFF
--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -23,7 +23,7 @@ md_to_adoc() {
     sed -i.bak 's/^##/#/' $tmpfile
 
     # Changes markdown file interlink extensions to .html so they continue to work when the site is rendered.
-    sed -i.bak 's/\.md\([)#]\)/.html\1/g' $tmpfile
+    sed -i.bak 's/\((\.\{0,2\}[^).]*\)\.md\([)#]\)/\1.html\2/g' $tmpfile
 
     # Changes all dashes to underscores inside the anchors.
     sed -i.bak -e ':loop' -e 's/\(\]([^)]*#[^)]*\)-\([^)]*)\)/\1_\2/g' -e 't loop' $tmpfile

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -23,7 +23,7 @@ md_to_adoc() {
     sed -i.bak 's/^##/#/' $tmpfile
 
     # Changes markdown file interlink extensions to .html so they continue to work when the site is rendered.
-    sed -i.bak 's/\((\.\{0,2\}[^).]*\)\.md\([)#]\)/\1.html\2/g' $tmpfile
+    sed -i.bak 's/\(\](\.\{0,2\}[^).]*\)\.md\([)#]\)/\1.html\2/g' $tmpfile
 
     # Changes all dashes to underscores inside the anchors.
     sed -i.bak -e ':loop' -e 's/\(\]([^)]*#[^)]*\)-\([^)]*)\)/\1_\2/g' -e 't loop' $tmpfile


### PR DESCRIPTION
Previously:
```
[link here](www.example.com/example.md)
```
was being changed to:
```
[link here](www.example.com/example.html)
```
However, we want external sites to retain their extension.

The only links we want to change are ones to `.md` files that are within the site. For example:
```
[link here](./internal_file.md)
```
should be changed to:
```
[link here](./internal_file.html)
```

This PR updates the sed to distinguish.

cc @rcai1 this should fix the link issue you were seeing.