### PR TITLE
[P1-H02] Add ability for Governor to execute payable proposed transactions

### DIFF
--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -129,6 +129,7 @@ contract Governor is MultiRole, Testable {
         );
         require(transaction.to != address(0), "Transaction has already been executed");
         require(price != 0, "Cannot execute, proposal was voted down");
+        require(msg.value == transaction.value, "Must send the exact amount of ETH to execute transaction");
         require(_executeCall(transaction.to, transaction.value, transaction.data), "Transaction execution failed");
 
         // Delete the transaction.

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -68,6 +68,7 @@ contract Governor is MultiRole, Testable {
 
     /**
      * @notice Proposes a new governance action. Can only be called by the holder of the Proposer role.
+     * Caller is expected to deposit ETH to execute all payable transactions.
      * @param transactions the list of transactions that are being proposed.
      * @dev You can create the data portion of each transaction by doing the following:
      * ```
@@ -78,9 +79,10 @@ contract Governor is MultiRole, Testable {
      * disallows structs arrays to be passed to external functions.
      * @param transactions array of `Transaction` which can be voted on.
      */
-    function propose(Transaction[] memory transactions) public onlyRoleHolder(uint(Roles.Proposer)) {
+    function propose(Transaction[] memory transactions) public payable onlyRoleHolder(uint(Roles.Proposer)) {
         uint id = proposals.length;
         uint time = getCurrentTime();
+        uint amountOfEthRequired = 0;
 
         // Note: doing all of this array manipulation manually is necessary because directly setting an array of
         // structs in storage to an an array of structs in memory is currently not implemented in solidity :/.
@@ -95,8 +97,14 @@ contract Governor is MultiRole, Testable {
         // Initialize the transaction array.
         for (uint i = 0; i < transactions.length; i++) {
             require(transactions[i].to != address(0), "The to address cannot be 0x0");
+            if (transactions[i].value > 0) {
+                amountOfEthRequired += transactions[i].value;
+            }
             proposal.transactions.push(transactions[i]);
         }
+
+        // Check that the caller sent enough ETH.
+        require(msg.value >= amountOfEthRequired, "Caller did not send enough ETH to execute all payable proposals");
 
         bytes32 identifier = _constructIdentifier(id);
 

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -236,7 +236,7 @@ contract("Governor", function(accounts) {
     );
   });
 
-  it("Proposer did not send enough ETH to execute payable transaction", async function() {
+  it("Proposer did not send exact amount of ETH to execute payable transaction", async function() {
     const amountToDeposit = toWei("1");
 
     // Send the proposal to send ETH to account2.
@@ -262,9 +262,11 @@ contract("Governor", function(accounts) {
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
-    // Execute the proposal but do not send enough ETH to pay for the transaction
     const startingBalance = await web3.eth.getBalance(account2);
-    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("0.1") })));
+    // Sent too little ETH.
+    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("0.9") })));
+    // Sent too much ETH.
+    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("1.1") })));
     assert.equal(await web3.eth.getBalance(account2), startingBalance);
   });
 

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -192,6 +192,9 @@ contract("Governor", function(accounts) {
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
+    // Cannot send ETH to execute a transaction that requires 0 ETH.
+    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("1") })));
+
     // Check to make sure that the tokens get transferred at the time of execution.
     const startingBalance = await testToken.balanceOf(proposer);
     await governor.executeProposal(id, 0);


### PR DESCRIPTION
Resolves #1190 

Make `propose()` a payable function and check that the caller deposits enough ETH to cover all payable transactions (i.e. In which the `Transaction` struct has `value > 0`.

One design decision I made that I'm not 100% sure on: I could have made `propose()` or `executeProposal()` payable. I chose to make the "upfront" action payable so that voters would not vote through a proposal that ultimately can't execute because the contract doesn't have enough ETH to execute payable transactions.