### PR TITLE
[P1-M04] Refactor registry to prevent multiple address registration during inital contract registration

### DIFF
--- a/core/contracts/oracle/implementation/Registry.sol
+++ b/core/contracts/oracle/implementation/Registry.sol
@@ -94,9 +94,7 @@ contract Registry is RegistryInterface, MultiRole {
         // For all parties in the array add them to the contract's parties.
         financialContract.valid = Validity.Valid;
         for (uint i = 0; i < parties.length; i = i.add(1)) {
-            partyMap[parties[i]].contracts.push(contractAddress);
-            uint newLength = partyMap[parties[i]].contracts.length;
-            partyMap[parties[i]].contractIndex[contractAddress] = newLength - 1;
+            _addPartyToContract(parties[i], contractAddress);
         }
 
         emit NewContractRegistered(contractAddress, msg.sender, parties);
@@ -115,12 +113,7 @@ contract Registry is RegistryInterface, MultiRole {
         require(contractMap[contractAddress].valid == Validity.Valid, "Can only add to valid contract");
         require(!isPartyMemberOfContract(party, contractAddress), "Can only register a party once");
 
-        // Push the contract address and store the index.
-        uint contractIndex = partyMap[party].contracts.length;
-        partyMap[party].contracts.push(contractAddress);
-        partyMap[party].contractIndex[contractAddress] = contractIndex;
-
-        emit PartyAdded(contractAddress, party);
+        _addPartyToContract(party, contractAddress);
     }
 
     /**
@@ -206,5 +199,18 @@ contract Registry is RegistryInterface, MultiRole {
     function isPartyMemberOfContract(address party, address contractAddress) public override view returns (bool) {
         uint index = partyMap[party].contractIndex[contractAddress];
         return partyMap[party].contracts.length > index && partyMap[party].contracts[index] == contractAddress;
+    }
+
+    /****************************************
+     *           INTERNAL FUNCTIONS         *
+     ****************************************/
+
+    function _addPartyToContract(address party, address contractAddress) internal {
+        require(!isPartyMemberOfContract(party, contractAddress), "Can only register a party once");
+        uint contractIndex = partyMap[party].contracts.length;
+        partyMap[party].contracts.push(contractAddress);
+        partyMap[party].contractIndex[contractAddress] = contractIndex;
+
+        emit PartyAdded(contractAddress, party);
     }
 }

--- a/core/contracts/oracle/implementation/Registry.sol
+++ b/core/contracts/oracle/implementation/Registry.sol
@@ -111,7 +111,6 @@ contract Registry is RegistryInterface, MultiRole {
         address contractAddress = msg.sender;
 
         require(contractMap[contractAddress].valid == Validity.Valid, "Can only add to valid contract");
-        require(!isPartyMemberOfContract(party, contractAddress), "Can only register a party once");
 
         _addPartyToContract(party, contractAddress);
     }


### PR DESCRIPTION
This PR prevents one address being registered multiple times in the `Registry` upon calling `registerContract`. This change prevents the `Registry` from ending in an inconsistent state as a result of one address being registered multiple times as a party for one contract address.

The `registerContract` function now behaves more like `addPartyToContract` which previously enforced this check that an address cant be added multiple times.

close #1195