### PR TITLE
[P1-H03] Prevent re-entrancy on Governor executeProposal

### DIFF
--- a/core/contracts/common/test/ReentrancyChecker.sol
+++ b/core/contracts/common/test/ReentrancyChecker.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.6.0;
+
+
+// The Reentrancy Checker causes failures if it is successfully able to re-enter a contract.
+// How to use:
+// 1. Call setTransactionData with the transaction data you want the Reentrancy Checker to reenter the calling
+//    contract with.
+// 2. Get the calling contract to call into the reentrancy checker with any call. The fallback function will receive
+//    this call and reenter the contract with the transaction data provided in 1. If that reentrancy call does not
+//    revert, then the reentrancy checker reverts the initial call, likely causeing the entire transaction to revert.
+//
+// Note: the reentrancy checker has a guard to prevent an infinite cycle of reentrancy. Inifinite cycles will run out
+// of gas in all cases, potentially causing a revert when the contract is adequately protected from reentrancy.
+contract ReentrancyChecker {
+    bytes public txnData;
+    bool hasBeenCalled;
+
+    // Used to prevent infinite cycles where the reentrancy is cycled forever.
+    modifier skipIfReentered {
+        if (hasBeenCalled) {
+            return;
+        }
+        hasBeenCalled = true;
+        _;
+        hasBeenCalled = false;
+    }
+
+    function setTransactionData(bytes memory _txnData) public {
+        txnData = _txnData;
+    }
+
+    function _executeCall(address to, uint256 value, bytes memory data) private returns (bool success) {
+        // Mostly copied from:
+        // solhint-disable-next-line max-line-length
+        // https://github.com/gnosis/safe-contracts/blob/59cfdaebcd8b87a0a32f87b50fead092c10d3a05/contracts/base/Executor.sol#L23-L31
+        // solhint-disable-next-line no-inline-assembly
+
+        assembly {
+            let inputData := add(data, 0x20)
+            let inputDataSize := mload(data)
+            success := call(gas(), to, value, inputData, inputDataSize, 0, 0)
+        }
+    }
+
+    fallback() external skipIfReentered {
+        // Attampt to re-enter with the set txnData.
+        bool success = _executeCall(msg.sender, 0, txnData);
+
+        // Fail if the call succeeds because that means the re-entrancy was successful.
+        require(!success, "Re-entrancy was successful");
+    }
+}

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -9,6 +9,7 @@ const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const Voting = artifacts.require("Voting");
 const VotingToken = artifacts.require("VotingToken");
 const TestnetERC20 = artifacts.require("TestnetERC20");
+const ReentrancyChecker = artifacts.require("ReentrancyChecker");
 
 // Extract web3 functions into primary namespace.
 const { toBN, toWei, toChecksumAddress } = web3.utils;
@@ -461,5 +462,39 @@ contract("Governor", function(accounts) {
     truffleAssert.eventEmitted(receipt, "ProposalExecuted", ev => {
       return ev.id.toString() === id.toString() && ev.transactionIndex.toString() === "0";
     });
+  });
+
+  it("No re-entrant execution", async function() {
+    // Send the proposal and verify that an event is produced.
+    const id = await governor.numProposals();
+
+    // Construct the transaction that we want to re-enter and pass the txn data to the ReentrancyChecker.
+    const txnData = governor.contract.methods.executeProposal(id.toString(), "0").encodeABI();
+    const reentrancyChecker = await ReentrancyChecker.new();
+    await reentrancyChecker.setTransactionData(txnData);
+
+    // Propose the reentrant transaction.
+    await governor.propose([
+      {
+        to: reentrancyChecker.address,
+        value: 0,
+        data: constructTransferTransaction(account1, toWei("0")) // Data doesn't since it will hit the fallback regardless.
+      }
+    ]);
+
+    // Vote the proposal through.
+    await moveToNextRound(voting);
+    const pendingRequests = await voting.getPendingRequests();
+    const request = pendingRequests[0];
+    const vote = toWei("1");
+    const salt = getRandomUnsignedInt();
+    const hash = web3.utils.soliditySha3(vote, salt);
+    await voting.commitVote(request.identifier, request.time, hash);
+    await moveToNextPhase(voting);
+    await voting.revealVote(request.identifier, request.time, vote, salt);
+    await moveToNextRound(voting);
+
+    // Since we're using the reentrancy checker, this transaction should FAIL if the reentrancy is successful.
+    await governor.executeProposal(id, 0);
   });
 });

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -552,7 +552,7 @@ contract("Governor", function(accounts) {
       {
         to: reentrancyChecker.address,
         value: 0,
-        data: constructTransferTransaction(account1, toWei("0")) // Data doesn't since it will hit the fallback regardless.
+        data: constructTransferTransaction(account2, toWei("0")) // Data doesn't since it will hit the fallback regardless.
       }
     ]);
 


### PR DESCRIPTION
This PR prevents a re-entrancy attack where a proposal execution re-enters and attempts to execute itself again.

It's prevented by deleting the proposal before the execution rather than after.

This PR also adds a test contract, called `ReentrancyChecker` that can be used to check for re-entrancy protection.