### PR TITLE
[P1-L11] Correct element deletion in pendingPriceRequests array

### DIFF
--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -95,7 +95,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
     // Price request ids for price requests that haven't yet been marked as resolved.
     // These requests may be for future rounds.
-    bytes32[] private pendingPriceRequests;
+    bytes32[] internal pendingPriceRequests;
 
     VoteTiming.Data public voteTiming;
 
@@ -695,7 +695,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         PriceRequest storage lastPriceRequest = priceRequests[pendingPriceRequests[lastIndex]];
         lastPriceRequest.index = priceRequest.index;
         pendingPriceRequests[priceRequest.index] = pendingPriceRequests[lastIndex];
-        delete pendingPriceRequests[lastIndex];
+        pendingPriceRequests.pop();
 
         priceRequest.index = UINT_MAX;
         emit PriceResolved(priceRequest.lastVotingRound, priceRequest.identifier, priceRequest.time, resolvedPrice);

--- a/core/contracts/oracle/implementation/test/VotingTest.sol
+++ b/core/contracts/oracle/implementation/test/VotingTest.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.6.0;
+
+pragma experimental ABIEncoderV2;
+
+import "../Voting.sol";
+import "../../../common/implementation/FixedPoint.sol";
+
+
+// Test contract used to access internal variables in the Voting contract.
+contract VotingTest is Voting {
+    constructor(
+        uint _phaseLength,
+        FixedPoint.Unsigned memory _gatPercentage,
+        FixedPoint.Unsigned memory _inflationRate,
+        uint _rewardsExpirationTimeout,
+        address _votingToken,
+        address _identifierWhitelist,
+        address _finder,
+        bool _isTest
+    )
+        public
+        Voting(
+            _phaseLength,
+            _gatPercentage,
+            _inflationRate,
+            _rewardsExpirationTimeout,
+            _votingToken,
+            _identifierWhitelist,
+            _finder,
+            _isTest
+        )
+    {}
+
+    function getPendingPriceRequestsArray() external view returns (bytes32[] memory) {
+        return pendingPriceRequests;
+    }
+}

--- a/core/test/oracle/Voting.js
+++ b/core/test/oracle/Voting.js
@@ -11,6 +11,7 @@ const Registry = artifacts.require("Registry");
 const Voting = artifacts.require("Voting");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const VotingToken = artifacts.require("VotingToken");
+const VotingTest = artifacts.require("VotingTest");
 
 contract("Voting", function(accounts) {
   let voting;
@@ -1326,5 +1327,62 @@ contract("Voting", function(accounts) {
     assert(await voting.hasPrice(identifier, time1, { from: migratedVoting }));
     assert(await didContractThrow(voting.hasPrice(identifier, time1, { from: registeredContract })));
     assert(await didContractThrow(voting.commitVote(identifier, time2, hash, { from: account1 })));
+  });
+
+  it("pendingPriceRequests array length", async function() {
+    // Use a test derived contract to expose the internal array (and its length).
+    const votingTest = await VotingTest.new(
+      "86400", // 1 day phase length
+      { rawValue: web3.utils.toWei("0.05") }, // 5% GAT
+      { rawValue: "0" }, // No inflation
+      "1209600", // 2 week reward expiration
+      votingToken.address,
+      supportedIdentifiers.address,
+      Finder.address,
+      true
+    );
+
+    await moveToNextRound(votingTest);
+
+    const startingTime = await votingTest.getCurrentTime();
+    const identifier = web3.utils.utf8ToHex("array-size");
+    const time = "1000";
+    const startingLength = (await votingTest.getPendingPriceRequestsArray()).length;
+
+    // pendingPriceRequests should start with no elements.
+    assert.equal(startingLength, 0);
+
+    // Make the Oracle support the identifier.
+    await supportedIdentifiers.addSupportedIdentifier(identifier);
+
+    // Request a price.
+    await votingTest.requestPrice(identifier, time, { from: registeredContract });
+
+    // There should be one element in the array after the first price request.
+    assert.equal((await votingTest.getPendingPriceRequestsArray()).length, 1);
+
+    // Move to voting round.
+    await moveToNextRound(votingTest);
+    const votingRound = await votingTest.getCurrentRoundId();
+
+    // Commit vote.
+    const price = getRandomSignedInt();
+    const salt = getRandomUnsignedInt();
+    const hash = web3.utils.soliditySha3(price, salt);
+    await votingTest.commitVote(identifier, time, hash);
+
+    // Reveal phase.
+    await moveToNextPhase(votingTest);
+
+    // Reveal vote.
+    await votingTest.revealVote(identifier, time, price, salt);
+
+    // Pending requests should be empty after the voting round ends and the price is resolved.
+    await moveToNextRound(votingTest);
+
+    await votingTest.retrieveRewards(account1, votingRound, [{ identifier, time }]);
+
+    // After retrieval, the length should be decreased back to 0 since the element added in this test is now deleted.
+    assert.equal((await votingTest.getPendingPriceRequestsArray()).length, 0);
   });
 });


### PR DESCRIPTION
This PR corrects an issue where the length of `pendingPriceRequests` in `Voting.sol` was not being decreased when the last element was deleted.

To ensure this behavior remains correct, I added a unit test to verify the raw array's length.

Note: to access its length, one would need to add a custom method rather than just making the array a public variable. Rather than adding a new public method on the `Voting` contract that would only be used for testing, a derived `TestVoting` contract was added to access this variable. Definitely open to doing this a different way, but, to me, this seemed like the cleanest solution.