### PR TITLE
[P1-L02] Prevent EOAs from registering in the finder

### DIFF
--- a/core/contracts/oracle/implementation/Finder.sol
+++ b/core/contracts/oracle/implementation/Finder.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 
 import "../interfaces/FinderInterface.sol";
 
@@ -10,6 +11,8 @@ import "../interfaces/FinderInterface.sol";
  * @dev Examples of interfaces with implementations that Finder locates are the Oracle and Store interfaces.
  */
 contract Finder is FinderInterface, Ownable {
+    using Address for address;
+
     mapping(bytes32 => address) public interfacesImplemented;
 
     event InterfaceImplementationChanged(bytes32 indexed interfaceName, address indexed newImplementationAddress);
@@ -22,6 +25,7 @@ contract Finder is FinderInterface, Ownable {
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore
     function changeImplementationAddress(bytes32 interfaceName, address implementationAddress) external override onlyOwner {
+        require(implementationAddress.isContract(),"Can only change implementation to a contract");
         interfacesImplemented[interfaceName] = implementationAddress;
 
         emit InterfaceImplementationChanged(interfaceName, implementationAddress);

--- a/core/test/oracle/Finder.js
+++ b/core/test/oracle/Finder.js
@@ -7,20 +7,27 @@ const truffleAssert = require("truffle-assertions");
 contract("Finder", function(accounts) {
   const owner = accounts[0];
   const user = accounts[1];
+  const rando = accounts[3];
 
   it("General methods", async function() {
     const finder = await Finder.deployed();
 
     const interfaceName1 = web3.utils.hexToBytes(web3.utils.utf8ToHex("interface1"));
     const interfaceName2 = web3.utils.hexToBytes(web3.utils.utf8ToHex("interface2"));
-    const implementationAddress1 = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
-    const implementationAddress2 = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
-    const implementationAddress3 = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
+
+    // Create three contracts to use as dummy implementations to register in the finder.
+    // It does not matter what contracts these are as long as they are not EOAs.
+    const implementationAddress1 = (await Finder.new({ from: owner })).address;
+    const implementationAddress2 = (await Finder.new({ from: owner })).address;
+    const implementationAddress3 = (await Finder.new({ from: owner })).address;
 
     // Random users cannot change the implementation address.
     assert(
       await didContractThrow(finder.changeImplementationAddress(interfaceName1, implementationAddress1, { from: user }))
     );
+
+    // Cant set the implementation address to an EOA; only contracts addresses can be registered in the finder
+    assert(await didContractThrow(finder.changeImplementationAddress(interfaceName1, rando, { from: owner })));
 
     // Looking up unknown interfaces fails.
     assert(await didContractThrow(finder.getImplementationAddress(interfaceName1)));


### PR DESCRIPTION
The `Finder` should only allow implementation addresses to be contracts. This PR integrates with the OZ [Addresses.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.0-beta.0/contracts/utils/Address.sol#L24) library to enforce this.