### PR TITLE
[P1-L14] Add events to store state fee update

### DIFF
--- a/core/contracts/oracle/implementation/Store.sol
+++ b/core/contracts/oracle/implementation/Store.sol
@@ -33,6 +33,8 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
      ****************************************/
 
     event NewFixedOracleFeePerSecond(FixedPoint.Unsigned newOracleFee);
+    event NewWeeklyDelayFee(FixedPoint.Unsigned newWeeklyDelayFee);
+    event NewFinalFee(FixedPoint.Unsigned newFinalFee);
 
     /**
      * @notice Construct the Store contract.
@@ -133,17 +135,19 @@ contract Store is StoreInterface, MultiRole, Withdrawable {
      */
     function setWeeklyDelayFee(FixedPoint.Unsigned memory newWeeklyDelayFee) public onlyRoleHolder(uint(Roles.Owner)) {
         weeklyDelayFee = newWeeklyDelayFee;
+        emit NewWeeklyDelayFee(newWeeklyDelayFee);
     }
 
     /**
      * @notice Sets a new final fee for a particular currency.
      * @param currency defines the token currency used to pay the final fee.
-     * @param finalFee final fee amount.
+     * @param newFinalFee final fee amount.
      */
-    function setFinalFee(address currency, FixedPoint.Unsigned memory finalFee)
+    function setFinalFee(address currency, FixedPoint.Unsigned memory newFinalFee)
         public
         onlyRoleHolder(uint(Roles.Owner))
     {
-        finalFees[currency] = finalFee;
+        finalFees[currency] = newFinalFee;
+        emit NewFinalFee(newFinalFee);
     }
 }

--- a/core/test/oracle/Store.js
+++ b/core/test/oracle/Store.js
@@ -1,4 +1,5 @@
 const { didContractThrow } = require("../../../common/SolidityTestUtils.js");
+const truffleAssert = require("truffle-assertions");
 
 const Token = artifacts.require("ExpandedERC20");
 const Store = artifacts.require("Store");
@@ -64,11 +65,28 @@ contract("Store", function(accounts) {
     // TODO Check that only permitted role can change the fee
   });
 
-  it("Final fees", async function() {
+  it.only("Final fees", async function() {
     // Add final fee and confirm
-    await store.setFinalFee(arbitraryTokenAddr, { rawValue: web3.utils.toWei("5", "ether") }, { from: owner });
+    const result = await store.setFinalFee(
+      arbitraryTokenAddr,
+      { rawValue: web3.utils.toWei("5", "ether") },
+      { from: owner }
+    );
+
+    truffleAssert.eventEmitted(result, "NewFinalFee", ev => {
+      return ev.newFinalFee.rawValue === web3.utils.toWei("5", "ether");
+    });
     const fee = await store.computeFinalFee(arbitraryTokenAddr);
     assert.equal(fee.rawValue, web3.utils.toWei("5", "ether"));
+  });
+
+  it.only("Weekly delay fees", async function() {
+    // Add final fee and confirm
+    const result = await store.setWeeklyDelayFee({ rawValue: web3.utils.toWei("0.5", "ether") }, { from: owner });
+
+    truffleAssert.eventEmitted(result, "NewWeeklyDelayFee", ev => {
+      return ev.newWeeklyDelayFee.rawValue === web3.utils.toWei("0.5", "ether");
+    });
   });
 
   it("Pay fees in Ether", async function() {

--- a/core/test/oracle/Store.js
+++ b/core/test/oracle/Store.js
@@ -65,7 +65,7 @@ contract("Store", function(accounts) {
     // TODO Check that only permitted role can change the fee
   });
 
-  it.only("Final fees", async function() {
+  it("Final fees", async function() {
     // Add final fee and confirm
     const result = await store.setFinalFee(
       arbitraryTokenAddr,
@@ -80,7 +80,7 @@ contract("Store", function(accounts) {
     assert.equal(fee.rawValue, web3.utils.toWei("5", "ether"));
   });
 
-  it.only("Weekly delay fees", async function() {
+  it("Weekly delay fees", async function() {
     // Add final fee and confirm
     const result = await store.setWeeklyDelayFee({ rawValue: web3.utils.toWei("0.5", "ether") }, { from: owner });
 


### PR DESCRIPTION
Right now the store does not emit events after fees being updated. This PR adds them and associated tests.

Open question: I dont really see enough test coverage for weekly delay fees. This should be expanded.