### PR TITLE
[P1-H01] Require additional data in vote commit hash to prevent duplication of votes

### DIFF
--- a/common/EncryptionHelper.js
+++ b/common/EncryptionHelper.js
@@ -1,11 +1,25 @@
 const web3 = require("web3");
 
+// Web3's soliditySha3 will attempt to auto-detect the type of given input parameters,
+// but this won't produce expected behavior for certain types such as `bytes32` or `address`.
+// Therefore, these helper methods will explicitly set types.
+
 function computeTopicHash(request, roundId) {
-  // Explicitly set the type. Otherwise `identifier` is encoded as a string.
   return web3.utils.soliditySha3(
     { t: "bytes32", v: request.identifier },
     { t: "uint", v: request.time },
     { t: "uint", v: roundId }
+  );
+}
+
+function computeVoteHash(request) {
+  return web3.utils.soliditySha3(
+    { t: "int", v: request.price },
+    { t: "int", v: request.salt },
+    { t: "address", v: request.account },
+    { t: "uint", v: request.time },
+    { t: "uint", v: request.roundId },
+    { t: "bytes32", v: request.identifier }
   );
 }
 
@@ -14,4 +28,4 @@ function getKeyGenMessage(roundId) {
   return `UMA Protocol one time key for round: ${roundId.toString()}`;
 }
 
-module.exports = { computeTopicHash, getKeyGenMessage };
+module.exports = { computeTopicHash, computeVoteHash, getKeyGenMessage };

--- a/common/VotingUtils.js
+++ b/common/VotingUtils.js
@@ -4,7 +4,7 @@ const {
   deriveKeyPairFromSignatureTruffle,
   deriveKeyPairFromSignatureMetamask
 } = require("./Crypto");
-const { getKeyGenMessage, computeTopicHash } = require("./EncryptionHelper");
+const { getKeyGenMessage, computeTopicHash, computeVoteHash } = require("./EncryptionHelper");
 const { BATCH_MAX_COMMITS, BATCH_MAX_RETRIEVALS, BATCH_MAX_REVEALS } = require("./Constants");
 
 const argv = require("minimist")(process.argv.slice());
@@ -21,7 +21,14 @@ const argv = require("minimist")(process.argv.slice());
 const constructCommitment = async (request, roundId, web3, price, account) => {
   const priceWei = web3.utils.toWei(price.toString());
   const salt = web3.utils.toBN(web3.utils.randomHex(32));
-  const hash = web3.utils.soliditySha3(priceWei, salt, account);
+  const hash = computeVoteHash({
+    price: priceWei,
+    salt,
+    account,
+    time: request.time,
+    roundId,
+    identifier: request.identifier
+  });
 
   const vote = { price: priceWei, salt };
   let publicKey;

--- a/common/VotingUtils.js
+++ b/common/VotingUtils.js
@@ -21,7 +21,7 @@ const argv = require("minimist")(process.argv.slice());
 const constructCommitment = async (request, roundId, web3, price, account) => {
   const priceWei = web3.utils.toWei(price.toString());
   const salt = web3.utils.toBN(web3.utils.randomHex(32));
-  const hash = web3.utils.soliditySha3(priceWei, salt);
+  const hash = web3.utils.soliditySha3(priceWei, salt, account);
 
   const vote = { price: priceWei, salt };
   let publicKey;

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -129,6 +129,7 @@ contract Governor is MultiRole, Testable {
         );
         require(transaction.to != address(0), "Transaction has already been executed");
         require(price != 0, "Cannot execute, proposal was voted down");
+        require(msg.value == transaction.value, "Must send the exact amount of ETH to execute transaction");
         require(_executeCall(transaction.to, transaction.value, transaction.data), "Transaction execution failed");
 
         // Delete the transaction.

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -68,6 +68,7 @@ contract Governor is MultiRole, Testable {
 
     /**
      * @notice Proposes a new governance action. Can only be called by the holder of the Proposer role.
+     * Caller is expected to deposit ETH to execute all payable transactions.
      * @param transactions the list of transactions that are being proposed.
      * @dev You can create the data portion of each transaction by doing the following:
      * ```
@@ -78,9 +79,10 @@ contract Governor is MultiRole, Testable {
      * disallows structs arrays to be passed to external functions.
      * @param transactions array of `Transaction` which can be voted on.
      */
-    function propose(Transaction[] memory transactions) public onlyRoleHolder(uint(Roles.Proposer)) {
+    function propose(Transaction[] memory transactions) public payable onlyRoleHolder(uint(Roles.Proposer)) {
         uint id = proposals.length;
         uint time = getCurrentTime();
+        uint amountOfEthRequired = 0;
 
         // Note: doing all of this array manipulation manually is necessary because directly setting an array of
         // structs in storage to an an array of structs in memory is currently not implemented in solidity :/.
@@ -95,8 +97,14 @@ contract Governor is MultiRole, Testable {
         // Initialize the transaction array.
         for (uint i = 0; i < transactions.length; i++) {
             require(transactions[i].to != address(0), "The to address cannot be 0x0");
+            if (transactions[i].value > 0) {
+                amountOfEthRequired += transactions[i].value;
+            }
             proposal.transactions.push(transactions[i]);
         }
+
+        // Check that the caller sent enough ETH.
+        require(msg.value >= amountOfEthRequired, "Caller did not send enough ETH to execute all payable proposals");
 
         bytes32 identifier = _constructIdentifier(id);
 

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -340,7 +340,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.
-     * @dev The revealed `address`, `price`, `salt`, `time`, `roundId`, and `identifier`, must hash to the latest `hash` that `commitVote()` was called with.
+     * @dev The revealed `price`, `salt`, `time`, `address`, `roundId`, and `identifier`, must hash to the latest `hash` that `commitVote()` was called with.
      * Only the committer can reveal their vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -311,7 +311,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      * @dev `identifier`, `time` must correspond to a price request that's currently in the commit phase.
      * Commits can be changed.
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
-     * @param time unix timestamp of the price is being voted on.
+     * @param time unix timestamp of the price being voted on.
      * @param hash keccak256 hash of the price you want to vote for, your address, and a `int salt`.
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -364,7 +364,14 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         // Cannot reveal an uncommitted or previously revealed hash
         require(voteSubmission.commit != bytes32(0), "Invalid hash reveal");
         // Committed hash doesn't match revealed voter address, price and salt
-        require(keccak256(abi.encodePacked(price, salt, msg.sender)) == voteSubmission.commit, "Invalid commit hash, address & salt");
+        require(keccak256(abi.encodePacked(
+            price,
+            salt,
+            msg.sender,
+            time,
+            roundId,
+            identifier
+        )) == voteSubmission.commit, "Commit hash must match px, salt, address, timestamp, round, and identifier");
         delete voteSubmission.commit;
 
         // Lock in round variables including snapshotId and inflation rate

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -370,7 +370,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
             time,
             roundId,
             identifier
-        )) == voteSubmission.commit, "Commit hash must match px, salt, address, timestamp, round, and identifier");
+        )) == voteSubmission.commit, "Revealed data != commit hash");
         delete voteSubmission.commit;
 
         // Lock in round variables including snapshotId and inflation rate

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -312,7 +312,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      * Commits can be changed.
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
-     * @param hash keccak256 hash of the price, salt, voter address, `time`, current round ID, and `identifier`.
+     * @param hash keccak256 hash of the `price`, `salt`, voter `address`, `time`, current `roundId`, and `identifier`.
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -363,7 +363,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         // 0 hashes are disallowed in the commit phase, so they indicate a different error.
         // Cannot reveal an uncommitted or previously revealed hash
         require(voteSubmission.commit != bytes32(0), "Invalid hash reveal");
-        // Committed hash doesn't match revealed voter address, price and salt
         require(keccak256(abi.encodePacked(
             price,
             salt,

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -709,7 +709,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         }
 
         // Grab the snapshotted supply from the voting token. It's already scaled by 10**18, so we can directly
-            // initialize the Unsigned value with the returned uint.
+        // initialize the Unsigned value with the returned uint.
         FixedPoint.Unsigned memory snapshottedSupply = FixedPoint.Unsigned(votingToken.totalSupplyAt(snapshotId));
 
         // Multiply the total supply at the snapshot by the gatPercentage to get the GAT in number of tokens.

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -312,7 +312,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      * Commits can be changed.
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
      * @param time unix timestamp of the price is being voted on.
-     * @param hash keccak256 hash of the price you want to vote for and a `int salt`.
+     * @param hash keccak256 hash of the price you want to vote for, your address, and a `int salt`.
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore
@@ -340,7 +340,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.
-     * @dev The revealed `price` and `salt` must match the latest `hash` that `commitVote()` was called with.
+     * @dev The revealed `address`, `price` and `salt` must match the latest `hash` that `commitVote()` was called with.
      * Only the committer can reveal their vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price is being voted on.
@@ -363,8 +363,8 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
         // 0 hashes are disallowed in the commit phase, so they indicate a different error.
         // Cannot reveal an uncommitted or previously revealed hash
         require(voteSubmission.commit != bytes32(0), "Invalid hash reveal");
-        // Committed hash doesn't match revealed price and salt
-        require(keccak256(abi.encode(price, salt)) == voteSubmission.commit, "Invalid commit hash & salt");
+        // Committed hash doesn't match revealed voter address, price and salt
+        require(keccak256(abi.encodePacked(price, salt, msg.sender)) == voteSubmission.commit, "Invalid commit hash, address & salt");
         delete voteSubmission.commit;
 
         // Lock in round variables including snapshotId and inflation rate

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -312,7 +312,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
      * Commits can be changed.
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
-     * @param hash keccak256 hash of the price you want to vote for, your address, and a `int salt`.
+     * @param hash keccak256 hash of the price, salt, voter address, `time`, current round ID, and `identifier`.
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -340,7 +340,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface, Encrypte
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.
-     * @dev The revealed `address`, `price` and `salt` must match the latest `hash` that `commitVote()` was called with.
+     * @dev The revealed `address`, `price`, `salt`, `time`, `roundId`, and `identifier`, must hash to the latest `hash` that `commitVote()` was called with.
      * Only the committer can reveal their vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.

--- a/core/scripts/local/BatchGasEstimation.js
+++ b/core/scripts/local/BatchGasEstimation.js
@@ -126,7 +126,7 @@ const cycleCommit = async (voting, identifier, time, requestNum, registeredContr
   // Create the batch of commitments.
   for (var i = 0; i < requestNum; i++) {
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt);
+    const hash = web3.utils.soliditySha3(price, salt, voter);
     salts[i] = salt;
 
     // Generate encrypted vote to store on chain.
@@ -158,7 +158,7 @@ const cycleReveal = async (voting, identifier, time, requestNum, registeredContr
   // Generate Commitments. We will use single commit so no upper bound from the previous test
   for (var i = 0; i < requestNum; i++) {
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt);
+    const hash = web3.utils.soliditySha3(price, salt, voter);
     await voting.commitVote(identifier, time + i, hash, { from: voter });
     salts[i] = salt;
   }
@@ -189,7 +189,7 @@ const cycleClaim = async (voting, identifier, time, requestNum, registeredContra
 
   for (var i = 0; i < requestNum; i++) {
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt);
+    const hash = web3.utils.soliditySha3(price, salt, voter);
     await voting.commitVote(identifier, time + i, hash, { from: voter });
     salts[i] = salt;
   }

--- a/core/scripts/local/BatchGasEstimation.js
+++ b/core/scripts/local/BatchGasEstimation.js
@@ -10,7 +10,7 @@
 const { RegistryRolesEnum } = require("../../../common/Enums.js");
 const { getRandomSignedInt, getRandomUnsignedInt } = require("../../../common/Random.js");
 const { encryptMessage, deriveKeyPairFromSignatureTruffle } = require("../../../common/Crypto.js");
-const { getKeyGenMessage } = require("../../../common/EncryptionHelper");
+const { getKeyGenMessage, computeVoteHash } = require("../../../common/EncryptionHelper");
 const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
 
 const Registry = artifacts.require("Registry");
@@ -118,6 +118,7 @@ const cycleCommit = async (voting, identifier, time, requestNum, registeredContr
 
   // Advance to commit phase
   await moveToNextRound(voting);
+  const roundId = await voting.getCurrentRoundId();
 
   const salts = [];
   const price = getRandomSignedInt();
@@ -126,12 +127,18 @@ const cycleCommit = async (voting, identifier, time, requestNum, registeredContr
   // Create the batch of commitments.
   for (var i = 0; i < requestNum; i++) {
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt, voter);
+    const hash = computeVoteHash({
+      price,
+      salt,
+      account: voter,
+      time: time + i,
+      roundId,
+      identifier
+    });
     salts[i] = salt;
 
     // Generate encrypted vote to store on chain.
     const vote = { price, salt };
-    const roundId = await voting.getCurrentRoundId();
     const { publicKey } = await deriveKeyPairFromSignatureTruffle(web3, getKeyGenMessage(roundId), voter);
     const encryptedVote = await encryptMessage(publicKey, JSON.stringify(vote));
 
@@ -151,6 +158,7 @@ const cycleReveal = async (voting, identifier, time, requestNum, registeredContr
   await generatePriceRequests(requestNum, voting, identifier, time, registeredContract);
 
   await moveToNextRound(voting);
+  const roundId = await voting.getCurrentRoundId();
 
   const salts = [];
   const price = getRandomSignedInt();
@@ -158,7 +166,14 @@ const cycleReveal = async (voting, identifier, time, requestNum, registeredContr
   // Generate Commitments. We will use single commit so no upper bound from the previous test
   for (var i = 0; i < requestNum; i++) {
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt, voter);
+    const hash = computeVoteHash({
+      price,
+      salt,
+      account: voter,
+      time: time + i,
+      roundId,
+      identifier
+    });
     await voting.commitVote(identifier, time + i, hash, { from: voter });
     salts[i] = salt;
   }
@@ -183,13 +198,21 @@ const cycleClaim = async (voting, identifier, time, requestNum, registeredContra
   await generatePriceRequests(requestNum, voting, identifier, time, registeredContract);
 
   await moveToNextRound(voting);
+  let roundId = await voting.getCurrentRoundId();
 
   const salts = [];
   const price = getRandomSignedInt();
 
   for (var i = 0; i < requestNum; i++) {
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt, voter);
+    const hash = computeVoteHash({
+      price,
+      salt,
+      account: voter,
+      time: time + i,
+      roundId,
+      identifier
+    });
     await voting.commitVote(identifier, time + i, hash, { from: voter });
     salts[i] = salt;
   }
@@ -202,7 +225,7 @@ const cycleClaim = async (voting, identifier, time, requestNum, registeredContra
   }
 
   // Finally generate the batch rewards to retrieve
-  const roundId = await voting.getCurrentRoundId();
+  roundId = await voting.getCurrentRoundId();
 
   await moveToNextRound(voting);
 

--- a/core/scripts/local/VoteGasEstimation.js
+++ b/core/scripts/local/VoteGasEstimation.js
@@ -106,9 +106,8 @@ const cycleRound = async (voting, votingToken, identifier, time, accounts) => {
 
     for (var j = 0; j < numVoters; j++) {
       const salt = getRandomUnsignedInt();
-      const hash = web3.utils.soliditySha3(price, salt);
-
       const voter = getVoter(accounts, j);
+      const hash = web3.utils.soliditySha3(price, salt, voter);
 
       const result = await voting.commitVote(identifier, time + i, hash, { from: voter });
       const gasUsed = result.receipt.gasUsed;

--- a/core/test/oracle/DesignatedVoting.js
+++ b/core/test/oracle/DesignatedVoting.js
@@ -92,7 +92,9 @@ contract("DesignatedVoting", function(accounts) {
 
     const price = getRandomSignedInt();
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt);
+    // Note: the "voter" address for this vote must be the designated voting contract since its the one that will ultimately
+    // "reveal" the vote. Only the voter can call reveal through the designated voting contract.
+    const hash = web3.utils.soliditySha3(price, salt, designatedVoting.address);
 
     // Only the voter can commit a vote.
     await designatedVoting.commitVote(identifier, time, hash, { from: voter });
@@ -106,9 +108,9 @@ contract("DesignatedVoting", function(accounts) {
     await moveToNextPhase(voting);
 
     // Only the voter can reveal a vote.
-    await designatedVoting.revealVote(identifier, time, price, salt, { from: voter });
     assert(await didContractThrow(designatedVoting.revealVote(identifier, time, price, salt, { from: tokenOwner })));
     assert(await didContractThrow(designatedVoting.revealVote(identifier, time, price, salt, { from: umaAdmin })));
+    await designatedVoting.revealVote(identifier, time, price, salt, { from: voter });
 
     // Check the resolved price.
     const roundId = await voting.getCurrentRoundId();
@@ -154,12 +156,12 @@ contract("DesignatedVoting", function(accounts) {
 
     const price1 = getRandomSignedInt();
     const salt1 = getRandomUnsignedInt();
-    const hash1 = web3.utils.soliditySha3(price1, salt1);
+    const hash1 = web3.utils.soliditySha3(price1, salt1, designatedVoting.address);
     const message1 = web3.utils.randomHex(4);
 
     const price2 = getRandomSignedInt();
     const salt2 = getRandomUnsignedInt();
-    const hash2 = web3.utils.soliditySha3(price2, salt2);
+    const hash2 = web3.utils.soliditySha3(price2, salt2, designatedVoting.address);
     const message2 = web3.utils.randomHex(4);
 
     // Batch commit.

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -236,7 +236,7 @@ contract("Governor", function(accounts) {
     );
   });
 
-  it("Proposer did not send enough ETH to execute payable transaction", async function() {
+  it("Proposer did not send exact amount of ETH to execute payable transaction", async function() {
     const amountToDeposit = toWei("1");
 
     // Send the proposal to send ETH to account2.
@@ -262,9 +262,11 @@ contract("Governor", function(accounts) {
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
-    // Execute the proposal but do not send enough ETH to pay for the transaction
     const startingBalance = await web3.eth.getBalance(account2);
-    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("0.1") })));
+    // Sent too little ETH.
+    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("0.9") })));
+    // Sent too much ETH.
+    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("1.1") })));
     assert.equal(await web3.eth.getBalance(account2), startingBalance);
   });
 

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -152,7 +152,7 @@ contract("Governor", function(accounts) {
     // Execute the proposals to clean up.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request1.identifier, request1.time, hash);
     await voting.commitVote(request2.identifier, request2.time, hash);
     await moveToNextPhase(voting);
@@ -186,7 +186,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -221,7 +221,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -259,7 +259,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -303,7 +303,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -337,7 +337,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -373,7 +373,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -410,7 +410,7 @@ contract("Governor", function(accounts) {
     // Vote down the proposal.
     const vote = "0";
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -445,8 +445,8 @@ contract("Governor", function(accounts) {
     // Vote on the proposal, but don't reach the GAT.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
-    await voting.commitVote(request.identifier, request.time, hash, { from: account2 });
+    const hash2 = web3.utils.soliditySha3(vote, salt, account2);
+    await voting.commitVote(request.identifier, request.time, hash2, { from: account2 });
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt, { from: account2 });
     await moveToNextRound(voting);
@@ -457,7 +457,8 @@ contract("Governor", function(accounts) {
     assert.equal((await testToken.balanceOf(proposer)).toString(), startingBalance.toString());
 
     // Resolve the vote to clean up.
-    await voting.commitVote(request.identifier, request.time, hash);
+    const hash1 = web3.utils.soliditySha3(vote, salt, proposer);
+    await voting.commitVote(request.identifier, request.time, hash1);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
@@ -483,7 +484,7 @@ contract("Governor", function(accounts) {
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -524,7 +525,7 @@ contract("Governor", function(accounts) {
     const request = pendingRequests[0];
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -192,6 +192,9 @@ contract("Governor", function(accounts) {
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
+    // Cannot send ETH to execute a transaction that requires 0 ETH.
+    assert(await didContractThrow(governor.executeProposal(id, 0, { value: toWei("1") })));
+
     // Check to make sure that the tokens get transferred at the time of execution.
     const startingBalance = await testToken.balanceOf(proposer);
     await governor.executeProposal(id, 0);

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -563,7 +563,7 @@ contract("Governor", function(accounts) {
     const request = pendingRequests[0];
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt);
+    const hash = web3.utils.soliditySha3(vote, salt, proposer);
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -1,6 +1,7 @@
 const { didContractThrow } = require("../../../common/SolidityTestUtils.js");
 const { getRandomUnsignedInt } = require("../../../common/Random.js");
 const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
+const { computeVoteHash } = require("../../../common/EncryptionHelper");
 const truffleAssert = require("truffle-assertions");
 
 const Governor = artifacts.require("Governor");
@@ -141,6 +142,7 @@ contract("Governor", function(accounts) {
 
     // The proposals should show up in the pending requests in the *next* round.
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
 
     // Check that the proposals shows up and that the identifiers are constructed correctly.
@@ -153,9 +155,24 @@ contract("Governor", function(accounts) {
     // Execute the proposals to clean up.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
-    await voting.commitVote(request1.identifier, request1.time, hash);
-    await voting.commitVote(request2.identifier, request2.time, hash);
+    const hash1 = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request1.time,
+      roundId,
+      identifier: request1.identifier
+    });
+    const hash2 = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request2.time,
+      roundId,
+      identifier: request2.identifier
+    });
+    await voting.commitVote(request1.identifier, request1.time, hash1);
+    await voting.commitVote(request2.identifier, request2.time, hash2);
     await moveToNextPhase(voting);
     await voting.revealVote(request1.identifier, request1.time, vote, salt);
     await voting.revealVote(request2.identifier, request2.time, vote, salt);
@@ -181,13 +198,21 @@ contract("Governor", function(accounts) {
       }
     ]);
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -216,13 +241,21 @@ contract("Governor", function(accounts) {
     ]);
 
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -254,13 +287,21 @@ contract("Governor", function(accounts) {
     ]);
 
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -298,13 +339,21 @@ contract("Governor", function(accounts) {
     ]);
 
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -332,13 +381,21 @@ contract("Governor", function(accounts) {
       }
     ]);
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -368,13 +425,21 @@ contract("Governor", function(accounts) {
       }
     ]);
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -405,13 +470,21 @@ contract("Governor", function(accounts) {
       }
     ]);
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote down the proposal.
     const vote = "0";
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -440,13 +513,21 @@ contract("Governor", function(accounts) {
       }
     ]);
     await moveToNextRound(voting);
+    let roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote on the proposal, but don't reach the GAT.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash2 = web3.utils.soliditySha3(vote, salt, account2);
+    const hash2 = computeVoteHash({
+      price: vote,
+      salt,
+      account: account2,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash2, { from: account2 });
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt, { from: account2 });
@@ -458,7 +539,15 @@ contract("Governor", function(accounts) {
     assert.equal((await testToken.balanceOf(proposer)).toString(), startingBalance.toString());
 
     // Resolve the vote to clean up.
-    const hash1 = web3.utils.soliditySha3(vote, salt, proposer);
+    roundId = await voting.getCurrentRoundId();
+    const hash1 = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash1);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -479,13 +568,21 @@ contract("Governor", function(accounts) {
       }
     ]);
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
 
     // Vote the proposal through.
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -522,11 +619,19 @@ contract("Governor", function(accounts) {
 
     // Vote the proposal through.
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);
@@ -559,11 +664,19 @@ contract("Governor", function(accounts) {
 
     // Vote the proposal through.
     await moveToNextRound(voting);
+    const roundId = await voting.getCurrentRoundId();
     const pendingRequests = await voting.getPendingRequests();
     const request = pendingRequests[0];
     const vote = toWei("1");
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(vote, salt, proposer);
+    const hash = computeVoteHash({
+      price: vote,
+      salt,
+      account: proposer,
+      time: request.time,
+      roundId,
+      identifier: request.identifier
+    });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
     await voting.revealVote(request.identifier, request.time, vote, salt);

--- a/core/test/oracle/Voting.js
+++ b/core/test/oracle/Voting.js
@@ -115,7 +115,11 @@ contract("Voting", function(accounts) {
     // Voters can alter their commits.
     const newPrice = getRandomSignedInt();
     const newSalt = getRandomUnsignedInt();
-    const newHash = web3.utils.soliditySha3(newPrice, newSalt, account1);
+    const newHash = web3.utils.soliditySha3(
+      { t: 'int', v: newPrice }, 
+      { t: 'int', v: newSalt }, 
+      { t: 'address', v: account1 }
+    );
 
     // Can alter a committed hash.
     await voting.commitVote(identifier, time, newHash);
@@ -1375,7 +1379,7 @@ contract("Voting", function(accounts) {
     // Commit vote.
     const price = getRandomSignedInt();
     const salt = getRandomUnsignedInt();
-    const hash = web3.utils.soliditySha3(price, salt);
+    const hash = web3.utils.soliditySha3(price, salt, account1);
     await votingTest.commitVote(identifier, time, hash);
 
     // Reveal phase.

--- a/core/test/oracle/Voting.js
+++ b/core/test/oracle/Voting.js
@@ -116,9 +116,9 @@ contract("Voting", function(accounts) {
     const newPrice = getRandomSignedInt();
     const newSalt = getRandomUnsignedInt();
     const newHash = web3.utils.soliditySha3(
-      { t: 'int', v: newPrice }, 
-      { t: 'int', v: newSalt }, 
-      { t: 'address', v: account1 }
+      { t: "int", v: newPrice },
+      { t: "int", v: newSalt },
+      { t: "address", v: account1 }
     );
 
     // Can alter a committed hash.

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -230,7 +230,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
       commits.push({
         identifier: pendingRequests[index].identifier,
         time: pendingRequests[index].time,
-        hash: web3.utils.soliditySha3(price, salt),
+        hash: web3.utils.soliditySha3(price, salt, account),
         encryptedVote
       });
       indicesCommitted.push(index);

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -17,7 +17,7 @@ import { formatDate, formatWei } from "./common/FormattingUtils.js";
 import { VotePhasesEnum } from "./common/Enums.js";
 import { decryptMessage, deriveKeyPairFromSignatureMetamask, encryptMessage } from "./common/Crypto.js";
 import { useTableStyles } from "./Styles.js";
-import { getKeyGenMessage } from "./common/EncryptionHelper.js";
+import { getKeyGenMessage, computeVoteHash, computeTopicHash } from "./common/EncryptionHelper.js";
 import { getRandomUnsignedInt } from "./common/Random.js";
 import { BATCH_MAX_COMMITS, BATCH_MAX_REVEALS } from "./common/Constants.js";
 import { getAdminRequestId, isAdminRequest, decodeTransaction } from "./common/AdminUtils.js";
@@ -112,7 +112,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         "Voting",
         "getMessage",
         votingAccount,
-        web3.utils.soliditySha3(request.identifier, request.time, currentRoundId)
+        computeTopicHash({ identifier: request.identifier, time: request.time }, currentRoundId)
       )
     }));
   });
@@ -230,7 +230,14 @@ function ActiveRequests({ votingAccount, votingGateway }) {
       commits.push({
         identifier: pendingRequests[index].identifier,
         time: pendingRequests[index].time,
-        hash: web3.utils.soliditySha3(price, salt, account),
+        hash: computeVoteHash({
+          price,
+          salt,
+          account,
+          time: pendingRequests[index].time,
+          roundId: currentRoundId,
+          identifier: pendingRequests[index].identifier
+        }),
         encryptedVote
       });
       indicesCommitted.push(index);


### PR DESCRIPTION
Resolves #1216 
Resolves #1219 

Caller now must include an address, price request timestamp, round ID, and pricefeed identifier with their vote hash. The hash is enforced in `revealVote`.

This includes fixes for the voting-cli and the voter-dapp as well.