### PR TITLE
[P1-L10] Replace transfer with sendValue

### DIFF
--- a/core/contracts/common/implementation/Withdrawable.sol
+++ b/core/contracts/common/implementation/Withdrawable.sol
@@ -4,8 +4,10 @@
 
 pragma solidity ^0.6.0;
 
+import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
 import "./MultiRole.sol";
 
 
@@ -21,7 +23,7 @@ abstract contract Withdrawable is MultiRole {
      * @notice Withdraws ETH from the contract.
      */
     function withdraw(uint amount) external onlyRoleHolder(_roleId) {
-        msg.sender.transfer(amount);
+        Address.sendValue(msg.sender, amount);
     }
 
     /**


### PR DESCRIPTION
This PR replaces the use of transfer with sendValue to enable sending ether to contracts with callback functions.