### PR TITLE
[P1-L13] Add onlyValidRole to setWithdrawRole

### DIFF
--- a/core/contracts/common/implementation/Withdrawable.sol
+++ b/core/contracts/common/implementation/Withdrawable.sol
@@ -44,8 +44,8 @@ abstract contract Withdrawable is MultiRole {
 
     /**
      * @notice Internal method that allows derived contracts to choose the role for withdrawal.
-     * @dev The role `roleId` must exist. Either this method or `createWithdrawRole` must be called by the derived class
-     * for this contract to function properly.
+     * @dev The role `roleId` must exist. Either this method or `createWithdrawRole` must be
+     * called by the derived class for this contract to function properly.
      */
     function setWithdrawRole(uint roleId) internal onlyValidRole(roleId) {
         _roleId = roleId;

--- a/core/contracts/common/implementation/Withdrawable.sol
+++ b/core/contracts/common/implementation/Withdrawable.sol
@@ -47,7 +47,7 @@ abstract contract Withdrawable is MultiRole {
      * @dev The role `roleId` must exist. Either this method or `createWithdrawRole` must be called by the derived class
      * for this contract to function properly.
      */
-    function setWithdrawRole(uint roleId) internal {
+    function setWithdrawRole(uint roleId) internal onlyValidRole(roleId) {
         _roleId = roleId;
     }
 }

--- a/core/contracts/common/test/WithdrawableTest.sol
+++ b/core/contracts/common/test/WithdrawableTest.sol
@@ -16,4 +16,8 @@ contract WithdrawableTest is Withdrawable {
     function pay() external payable {
         require(msg.value > 0);
     }
+
+    function setInternalWithdrawRole(uint roleId) public {
+        setWithdrawRole(roleId);
+    }
 }

--- a/core/test/common/Withdrawable.js
+++ b/core/test/common/Withdrawable.js
@@ -80,4 +80,17 @@ contract("Withdrawable", function(accounts) {
     endingBalance = web3.utils.toBN(await web3.eth.getBalance(withdrawable.address));
     assert.equal(endingBalance.toString(), "0");
   });
+
+  it("Can only set WithdrawRole to a valid role", async function() {
+    const withdrawable = await WithdrawableTest.new();
+
+    // can set to 0 (Owner)
+    await withdrawable.setInternalWithdrawRole(0);
+
+    // can set to 1 (Voter)
+    await withdrawable.setInternalWithdrawRole(1);
+
+    // cant set to anything other than 0 or 1
+    assert(await didContractThrow(withdrawable.setInternalWithdrawRole(2)));
+  });
 });


### PR DESCRIPTION
This PR ensures that only valid roles can be added to the Withdrawal contract via the `setWithdrawRole` function. This function is only ever called from the constructor of `DesignatedVoting.sol`, which calls `setWithdrawRole` in the constructor using the Roles enum. 