### PR TITLE
[P1-N11] Remove hard-coded condition statement in require

### DIFF
--- a/core/contracts/common/implementation/MultiRole.sol
+++ b/core/contracts/common/implementation/MultiRole.sol
@@ -111,7 +111,7 @@ abstract contract MultiRole {
         } else if (role.roleType == RoleType.Shared) {
             return role.sharedRoleMembership.isMember(memberToCheck);
         }
-        require(false, "Invalid roleId");
+        revert("Invalid roleId");
     }
 
     /**


### PR DESCRIPTION
This PR removes the use of a hardcoded `false` within `require` statement within `MultiRole.sol` in favour of a direct `revert` call.