### PR TITLE
[P1-N02] Remove TODOs

### DIFF
--- a/core/contracts/common/implementation/FixedPoint.sol
+++ b/core/contracts/common/implementation/FixedPoint.sol
@@ -201,8 +201,6 @@ library FixedPoint {
 
     /** @dev Raises an `Unsigned` to the power of an unscaled uint, reverting on overflow. E.g., `b=2` squares `a`. */
     function pow(Unsigned memory a, uint256 b) internal pure returns (Unsigned memory output) {
-        // TODO(ptare): Consider using the exponentiation by squaring technique instead:
-        // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
         output = fromUnscaledUint(1);
         for (uint256 i = 0; i < b; i = i.add(1)) {
             output = mul(output, a);

--- a/core/contracts/oracle/implementation/ContractCreator.sol
+++ b/core/contracts/oracle/implementation/ContractCreator.sol
@@ -4,7 +4,6 @@ import "../interfaces/FinderInterface.sol";
 import "./Registry.sol";
 
 
-// TODO(ptare): Make this (and all contracts) Withdrawable.
 /**
  * @title Base contract for all financial contract creators
  */

--- a/core/contracts/oracle/implementation/ResultComputation.sol
+++ b/core/contracts/oracle/implementation/ResultComputation.sol
@@ -62,7 +62,6 @@ library ResultComputation {
         view
         returns (bool isResolved, int256 price)
     {
-        // TODO(ptare): Figure out where this parameter is supposed to come from.
         FixedPoint.Unsigned memory modeThreshold = FixedPoint.fromUnscaledUint(50).div(100);
 
         if (


### PR DESCRIPTION
@ptare I think their suggestion to remove TODOs is a reasonable one. Do you think any of these should be tracked separately or are they not worth it?

For exponentiation-by-squaring one, we could just remove the TODO and just mention an alternative implementation?

I'm not super concerned about making everything withdrawable.

I think we've decided (by default) that we don't want to parameterize the "majority" threshold.

Thoughts?

