### PR TITLE
[P1-L18] Pin @openzeppelin dependency to fixed version: v3.0.0-rc.1

### DIFF
--- a/core/contracts/common/implementation/AddressWhitelist.sol
+++ b/core/contracts/common/implementation/AddressWhitelist.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 
 /**

--- a/core/contracts/common/implementation/ExpandedERC20.sol
+++ b/core/contracts/common/implementation/ExpandedERC20.sol
@@ -19,7 +19,17 @@ contract ExpandedERC20 is ExpandedIERC20, ERC20, MultiRole {
         Burner
     }
 
-    constructor() public {
+    /**
+     * @notice Constructs the ExpandedERC20.
+     * @param tokenName The name which describes the new token.
+     * @param tokenSymbol The ticker abbreviation of the name. Ideally < 5 chars.
+     * @param tokenDecimals The number of decimals to define token precision.
+     */
+    constructor(string memory tokenName, string memory tokenSymbol, uint8 tokenDecimals)
+        public
+        ERC20(tokenName, tokenSymbol)
+    {
+        _setupDecimals(tokenDecimals);
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
         _createSharedRole(uint(Roles.Minter), uint(Roles.Owner), new address[](0));
         _createSharedRole(uint(Roles.Burner), uint(Roles.Owner), new address[](0));

--- a/core/contracts/common/implementation/TestnetERC20.sol
+++ b/core/contracts/common/implementation/TestnetERC20.sol
@@ -9,14 +9,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
  * this token should never be used to store real value since it allows permissionless minting.
  */
 contract TestnetERC20 is ERC20 {
-    string public name;
-    string public symbol;
-    uint8 public decimals;
-
-    constructor(string memory _name, string memory _symbol, uint8 _decimals) public {
-        name = _name; // solhint-disable-line const-name-snakecase
-        symbol = _symbol; // solhint-disable-line const-name-snakecase
-        decimals = _decimals; // solhint-disable-line const-name-snakecase
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) public ERC20(_name, _symbol) {
+        _setupDecimals(_decimals);
     }
 
     // Sample token information.

--- a/core/contracts/financial-templates/implementation/SyntheticToken.sol
+++ b/core/contracts/financial-templates/implementation/SyntheticToken.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.6.0;
-import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
 import "../../common/implementation/ExpandedERC20.sol";
 
 
@@ -9,7 +8,7 @@ import "../../common/implementation/ExpandedERC20.sol";
  * is capable of adding new roles.
  */
 
-contract SyntheticToken is ExpandedERC20, ERC20Detailed {
+contract SyntheticToken is ExpandedERC20 {
     /**
      * @notice Constructs the SyntheticToken.
      * @param tokenName The name which describes the new token.
@@ -18,7 +17,7 @@ contract SyntheticToken is ExpandedERC20, ERC20Detailed {
      */
     constructor(string memory tokenName, string memory tokenSymbol, uint8 tokenDecimals)
         public
-        ERC20Detailed(tokenName, tokenSymbol, tokenDecimals)
+        ExpandedERC20(tokenName, tokenSymbol, tokenDecimals)
     {}
 
     /**

--- a/core/contracts/oracle/implementation/FinancialContractsAdmin.sol
+++ b/core/contracts/oracle/implementation/FinancialContractsAdmin.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "../interfaces/AdministrateeInterface.sol";
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 
 /**

--- a/core/contracts/oracle/implementation/Finder.sol
+++ b/core/contracts/oracle/implementation/Finder.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
 import "../interfaces/FinderInterface.sol";

--- a/core/contracts/oracle/implementation/IdentifierWhitelist.sol
+++ b/core/contracts/oracle/implementation/IdentifierWhitelist.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "../interfaces/IdentifierWhitelistInterface.sol";
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 
 /**

--- a/core/contracts/oracle/implementation/TokenMigrator.sol
+++ b/core/contracts/oracle/implementation/TokenMigrator.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../common/implementation/FixedPoint.sol";
 import "../../common/interfaces/ExpandedIERC20.sol";
-import "@openzeppelin/contracts/drafts/ERC20Snapshot.sol";
+import "./VotingToken.sol";
 
 
 /**
@@ -18,7 +18,7 @@ contract TokenMigrator {
      *    INTERNAL VARIABLES AND STORAGE    *
      ****************************************/
 
-    ERC20Snapshot public oldToken;
+    VotingToken public oldToken;
     ExpandedIERC20 public newToken;
 
     uint256 public snapshotId;
@@ -39,7 +39,7 @@ contract TokenMigrator {
         require(_rate.isGreaterThan(0));
         rate = _rate;
         newToken = ExpandedIERC20(_newToken);
-        oldToken = ERC20Snapshot(_oldToken);
+        oldToken = VotingToken(_oldToken);
         snapshotId = oldToken.snapshot();
     }
 

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -14,7 +14,7 @@ import "./VoteTiming.sol";
 import "./VotingToken.sol";
 import "./Constants.sol";
 
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
 

--- a/core/contracts/oracle/implementation/VotingToken.sol
+++ b/core/contracts/oracle/implementation/VotingToken.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "../../common/implementation/ExpandedERC20.sol";
-import "@openzeppelin/contracts/drafts/ERC20Snapshot.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Snapshot.sol";
 
 
 /**
@@ -9,10 +9,18 @@ import "@openzeppelin/contracts/drafts/ERC20Snapshot.sol";
  * @dev Supports snapshotting and allows the Oracle to mint new tokens as rewards.
  */
 contract VotingToken is ExpandedERC20, ERC20Snapshot {
-    // Standard ERC20 metadata.
-    string public constant name = "UMA Voting Token v1"; // solhint-disable-line const-name-snakecase
-    string public constant symbol = "UMA"; // solhint-disable-line const-name-snakecase
-    uint8 public constant decimals = 18; // solhint-disable-line const-name-snakecase
+    /**
+     * @notice Constructs the VotingToken.
+     */
+    constructor() public ExpandedERC20("UMA Voting Token v1", "UMA", 18) {}
+
+    /**
+     * @notice Creates a new snapshot ID.
+     * @return uint256 Thew new snapshot ID.
+     */
+    function snapshot() external returns (uint256) {
+        return _snapshot();
+    }
 
     // _transfer, _mint and _burn are ERC20 internal methods that are overridden by ERC20Snapshot,
     // therefore the compiler will complain that VotingToken must override these methods

--- a/core/contracts/tokenized-derivative/LeveragedReturnCalculator.sol
+++ b/core/contracts/tokenized-derivative/LeveragedReturnCalculator.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.6.0;
 
 import "./ReturnCalculatorInterface.sol";
 import "../common/implementation/Withdrawable.sol";
-import "@openzeppelin/contracts/drafts/SignedSafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 
 
 /**

--- a/core/contracts/tokenized-derivative/ManualPriceFeed.sol
+++ b/core/contracts/tokenized-derivative/ManualPriceFeed.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "../common/implementation/Testable.sol";
 import "../common/implementation/Withdrawable.sol";
 import "./PriceFeedInterface.sol";

--- a/core/contracts/tokenized-derivative/TokenizedDerivative.sol
+++ b/core/contracts/tokenized-derivative/TokenizedDerivative.sol
@@ -14,7 +14,7 @@ import "./PriceFeedInterface.sol";
 import "./ReturnCalculatorInterface.sol";
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/drafts/SignedSafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -1144,11 +1144,6 @@ library TokenizedDerivativeUtils {
 contract TokenizedDerivative is ERC20, AdministrateeInterface, ExpandedIERC20 {
     using TokenizedDerivativeUtils for TDS.Storage;
 
-    // Note: these variables are to give ERC20 consumers information about the token.
-    string public name;
-    string public symbol;
-    uint8 public constant decimals = 18; // solhint-disable-line const-name-snakecase
-
     TDS.Storage public derivativeStorage;
 
     // These events are actually emitted by TokenizedDerivativeUtils, but we unfortunately have to define the events
@@ -1166,11 +1161,8 @@ contract TokenizedDerivative is ERC20, AdministrateeInterface, ExpandedIERC20 {
 
     constructor(TokenizedDerivativeParams.ConstructorParams memory params, string memory _name, string memory _symbol)
         public
+        ERC20(_name, _symbol)
     {
-        // Set token properties.
-        name = _name;
-        symbol = _symbol;
-
         // Initialize the contract.
         derivativeStorage._initialize(params, _symbol);
     }

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -58,7 +58,7 @@ contract("IntegrationTest", function(accounts) {
   const timeOffsetBetweenTests = toBN(60 * 60); // timestep advance between loop iterations (1 hour)
 
   beforeEach(async () => {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
     await collateralToken.addMember(1, contractCreator, {
       from: contractCreator
     });

--- a/core/scripts/PrecisionErrors.js
+++ b/core/scripts/PrecisionErrors.js
@@ -69,7 +69,7 @@ async function createTestEnvironment() {
   const disputerDisputeRewardPct = toWei("0.1");
 
   // Create and mint collateral token.
-  collateral = await MarginToken.new();
+  collateral = await MarginToken.new("UMA", "UMA", 18);
   await collateral.addMember(1, contractDeployer, { from: contractDeployer });
   await collateral.mint(sponsor, toWei("1000000"), { from: contractDeployer });
   await collateral.mint(other, toWei("1000000"), { from: contractDeployer });

--- a/core/scripts/local/CreateMarginToken.js
+++ b/core/scripts/local/CreateMarginToken.js
@@ -7,7 +7,7 @@ const createMarginToken = async function(callback) {
     const deployer = (await web3.eth.getAccounts())[0];
 
     // Deploy the token.
-    const marginToken = await Token.new({ from: deployer });
+    const marginToken = await Token.new("UMA", "UMA", 18, { from: deployer });
 
     // Mint deployer 1 million tokens.
     await marginToken.addMember(1, deployer, { from: deployer });

--- a/core/scripts/local/InitializeSystem.js
+++ b/core/scripts/local/InitializeSystem.js
@@ -51,7 +51,7 @@ const initializeSystem = async function(callback) {
     }
 
     // Create and register a margin currency.
-    const marginToken = await Token.new({ from: sponsor });
+    const marginToken = await Token.new("UMA", "UMA", 18, { from: sponsor });
     await marginToken.addMember(1, sponsor, { from: sponsor });
     await marginToken.mint(sponsor, web3.utils.toWei("100", "ether"), { from: sponsor });
     const marginCurrencyWhitelist = await AddressWhitelist.at(

--- a/core/test/common/Withdrawable.js
+++ b/core/test/common/Withdrawable.js
@@ -13,7 +13,7 @@ contract("Withdrawable", function(accounts) {
 
   before(async function() {
     // Create token contract and mint tokens for use by rando.
-    token = await Token.new({ from: owner });
+    token = await Token.new("UMA", "UMA", 18, { from: owner });
     await token.addMember(1, owner, { from: owner });
     await token.mint(rando, web3.utils.toWei("100", "ether"), { from: owner });
   });

--- a/core/test/financial-templates/ExpiringMultiParty.js
+++ b/core/test/financial-templates/ExpiringMultiParty.js
@@ -12,7 +12,7 @@ const Timer = artifacts.require("Timer");
 
 contract("ExpiringMultiParty", function(accounts) {
   it("Can deploy", async function() {
-    const collateralToken = await Token.new({ from: accounts[0] });
+    const collateralToken = await Token.new("UMA", "UMA", 18, { from: accounts[0] });
 
     const constructorParams = {
       expirationTimestamp: "1234567890",

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -28,7 +28,7 @@ contract("ExpiringMultiParty", function(accounts) {
   let constructorParams;
 
   beforeEach(async () => {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
     registry = await Registry.deployed();
     expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
     await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, expiringMultiPartyCreator.address, {
@@ -106,7 +106,7 @@ contract("ExpiringMultiParty", function(accounts) {
 
   it("Collateral token must be whitelisted", async function() {
     // Change only the collateral token address
-    constructorParams.collateralAddress = await Token.new({ from: contractCreator }).address;
+    constructorParams.collateralAddress = await Token.new("UMA", "UMA", 18, { from: contractCreator }).address;
     assert(
       await didContractThrow(
         expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, {

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -96,7 +96,7 @@ contract("Liquidatable", function(accounts) {
     await timer.setCurrentTime(startTime);
 
     // Create Collateral and Synthetic ERC20's
-    collateralToken = await Token.new({ from: contractDeployer });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractDeployer });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -70,7 +70,7 @@ contract("PricelessPositionManager", function(accounts) {
 
   before(async function() {
     // Represents DAI or some other token that the sponsor and contracts don't control.
-    collateral = await MarginToken.new({ from: collateralOwner });
+    collateral = await MarginToken.new("UMA", "UMA", 18, { from: collateralOwner });
     await collateral.addMember(1, collateralOwner, { from: collateralOwner });
     await collateral.mint(sponsor, toWei("1000000"), { from: collateralOwner });
     await collateral.mint(other, toWei("1000000"), { from: collateralOwner });

--- a/core/test/oracle/Store.js
+++ b/core/test/oracle/Store.js
@@ -138,8 +138,8 @@ contract("Store", function(accounts) {
   });
 
   it("Pay fees in ERC20 token", async function() {
-    const firstMarginToken = await Token.new({ from: erc20TokenOwner });
-    const secondMarginToken = await Token.new({ from: erc20TokenOwner });
+    const firstMarginToken = await Token.new("UMA", "UMA", 18, { from: erc20TokenOwner });
+    const secondMarginToken = await Token.new("UMA2", "UMA2", 18, { from: erc20TokenOwner });
 
     // Mint 100 tokens of each to the contract and verify balances.
     await firstMarginToken.addMember(1, erc20TokenOwner, { from: erc20TokenOwner });

--- a/core/test/tokenized-derivative/TokenizedDerivative.js
+++ b/core/test/tokenized-derivative/TokenizedDerivative.js
@@ -72,7 +72,7 @@ contract("TokenizedDerivative", function(accounts) {
     await deployedFinder.changeImplementationAddress(oracleInterfaceName, mockOracle.address);
 
     // Create an arbitrary ERC20 margin token.
-    marginToken = await Token.new({ from: sponsor });
+    marginToken = await Token.new("UMA", "UMA", 18, { from: sponsor });
     await marginToken.addMember(1, sponsor, { from: sponsor });
     await marginToken.mint(sponsor, web3.utils.toWei("100", "ether"), { from: sponsor });
     await marginToken.mint(apDelegate, web3.utils.toWei("100", "ether"), { from: sponsor });
@@ -2595,7 +2595,7 @@ contract("TokenizedDerivative", function(accounts) {
       );
 
       // Unapproved margin currency.
-      const unapprovedCurrency = await Token.new({ from: sponsor });
+      const unapprovedCurrency = await Token.new("UMA", "UMA", 18, { from: sponsor });
       const unapprovedCurrencyParams = { ...defaultConstructorParams, marginCurrency: unapprovedCurrency.address };
       assert(
         await didContractThrow(

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -36,7 +36,7 @@ contract("Disputer.js", function(accounts) {
   const zeroAddress = "0x0000000000000000000000000000000000000000";
 
   before(async function() {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
     await collateralToken.addMember(1, contractCreator, {
       from: contractCreator
     });

--- a/disputer/test/index.js
+++ b/disputer/test/index.js
@@ -18,7 +18,7 @@ contract("index.js", function(accounts) {
   let collateralToken;
 
   before(async function() {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();
@@ -26,7 +26,7 @@ contract("index.js", function(accounts) {
   });
 
   beforeEach(async function() {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
 
     const constructorParams = {
       expirationTimestamp: "12345678900",

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -34,7 +34,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
   };
 
   before(async function() {
-    collateralToken = await Token.new({ from: sponsor1 });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: sponsor1 });
     await collateralToken.addMember(1, sponsor1, { from: sponsor1 });
     await collateralToken.mint(sponsor1, toWei("100000"), { from: sponsor1 });
     await collateralToken.mint(sponsor2, toWei("100000"), { from: sponsor1 });

--- a/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
@@ -36,7 +36,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
   let constructorParams;
 
   before(async function() {
-    collateralToken = await Token.new({ from: tokenSponsor });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: tokenSponsor });
     await collateralToken.addMember(1, tokenSponsor, { from: tokenSponsor });
     await collateralToken.mint(liquidator, toWei("100000"), { from: tokenSponsor });
     await collateralToken.mint(sponsor1, toWei("100000"), { from: tokenSponsor });

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -34,7 +34,7 @@ contract("Liquidator.js", function(accounts) {
   let mockOracle;
 
   before(async function() {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
     await collateralToken.addMember(1, contractCreator, {
       from: contractCreator
     });
@@ -307,18 +307,5 @@ contract("Liquidator.js", function(accounts) {
 
     // The liquidation should have gone through.
     assert.equal((await emp.getLiquidations(sponsor1)).length, 1);
-  });
-
-  it.only("set up positions", async function() {
-    console.log("seeding emp @", emp.address);
-    for (let i = 1; i < 6; i++) {
-      console.log("Creating position for account", accounts[i]);
-      await collateralToken.mint(accounts[i], toWei("100000"), { from: contractCreator });
-      await collateralToken.approve(emp.address, toWei("1000000"), { from: accounts[i] });
-      await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: accounts[i] });
-    }
-
-    // liquidatorBot creates a position to have synthetic tokens to pay off debt upon liquidation.
-    await emp.create({ rawValue: toWei("100000") }, { rawValue: toWei("50000") }, { from: liquidatorBot });
   });
 });

--- a/liquidator/test/index.js
+++ b/liquidator/test/index.js
@@ -18,7 +18,7 @@ contract("index.js", function(accounts) {
   let emp;
 
   before(async function() {
-    collateralToken = await Token.new({ from: contractCreator });
+    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@awaitjs/express": "^0.3.0",
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/storage": "^2.4.2",
-    "@openzeppelin/contracts": "3.0.0-beta.0",
+    "@openzeppelin/contracts": "^3.0.0-rc.1",
     "@sendgrid/mail": "^6.4.0",
     "@truffle/contract": "^4.1.0",
     "@truffle/hdwallet-provider": "^1.0.25",


### PR DESCRIPTION
The `v3-rc` version contains breaking changes from the `v3-beta` version that we were previously using. But the soon-to-be released stable v3 release should not have major breaking changes from the latest `rc` so this change will make transitioning to v3 smoother.

Contract interface changes to look at carefully:
- `ERC20` constructor now takes in `string name` and `string symbol`, replacing functionality that was previously imported via `ERC20Detailed`. (It can set decimals by calling a new internal method `_setupDecimals`.) I decided to add `(name, symbol, decimals)` as input parameters into the constructor of `ExpandedERC20` so that `ExpandedERC20` now implicitly assumes the functionality of the now-deprecated `ERC20Detailed`. The downside to this change was that I had to update a ton of tests that constructed new `ExpandedERC20`'s.
- `ERC20Snapshot` `snapshot()` method is replaced with an internal `_snapshot()` method. Therefore, `TokenMigrator` can no longer cast the `oldToken` to an `ERC20Snapshot` and call `snapshot()`. I saw two reasonable solutions: (1) create a new token that is an `ERC20Snapshot` and exposes a `snapshot()` method, or (2) add a `snapshot` method to `VotingToken`, which already is an `ERC20Snapshot`. Regardless, the ABI of `VotingToken` will change if we upgrade to these OpenZeppelin contracts because its `snapshot()` method will no longer exist. So, even though I wanted to avoid changing the `VotingToken` interface, I believe it will inevitably have to change.

Minor breaking changes:
- `Ownable.sol` changed directories from `ownership` to `access`
- `SignedSafeMath` changed directories from `drafts` to `math`

Signed-off-by: Nick Pai <npai.nyc@gmail.com>