### PR TITLE
[P1-L19] Explicitly pass in amount of ERC20 to pay as fees

### DIFF
--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -103,7 +103,7 @@ abstract contract FeePayer is Testable {
 
         if (regularFee.isGreaterThan(0)) {
             collateralCurrency.safeIncreaseAllowance(address(store), regularFee.rawValue);
-            store.payOracleFeesErc20(address(collateralCurrency));
+            store.payOracleFeesErc20(address(collateralCurrency), regularFee);
         }
 
         if (latePenalty.isGreaterThan(0)) {
@@ -147,7 +147,7 @@ abstract contract FeePayer is Testable {
 
         StoreInterface store = _getStore();
         collateralCurrency.safeIncreaseAllowance(address(store), amount.rawValue);
-        store.payOracleFeesErc20(address(collateralCurrency));
+        store.payOracleFeesErc20(address(collateralCurrency), amount);
     }
 
     /**

--- a/core/contracts/oracle/implementation/Store.sol
+++ b/core/contracts/oracle/implementation/Store.sol
@@ -65,16 +65,15 @@ contract Store is StoreInterface, Withdrawable, Testable {
     /**
      * @notice Pays oracle fees in the margin currency, erc20Address, to the store.
      * @dev To be used if the margin currency is an ERC20 token rather than ETH.
-     * All approved tokens are transferred.
      * @param erc20Address address of the ERC20 token used to pay the fee.
+     * @param amount number of tokens to transfer. An approval for at least this amount must exist.
      */
     // TODO(#969) Remove once prettier-plugin-solidity can handle the "override" keyword
     // prettier-ignore
-    function payOracleFeesErc20(address erc20Address) external override {
+    function payOracleFeesErc20(address erc20Address, FixedPoint.Unsigned calldata amount) external override {
         IERC20 erc20 = IERC20(erc20Address);
-        uint256 authorizedAmount = erc20.allowance(msg.sender, address(this));
-        require(authorizedAmount > 0);
-        erc20.safeTransferFrom(msg.sender, address(this), authorizedAmount);
+        require(amount.isGreaterThan(0));
+        erc20.safeTransferFrom(msg.sender, address(this), amount.rawValue);
     }
 
     /**

--- a/core/contracts/oracle/interfaces/StoreInterface.sol
+++ b/core/contracts/oracle/interfaces/StoreInterface.sol
@@ -18,10 +18,10 @@ interface StoreInterface {
     /**
      * @notice Pays oracle fees in the margin currency, erc20Address, to the store.
      * @dev To be used if the margin currency is an ERC20 token rather than ETH.
-     * All approved tokens are transferred.
      * @param erc20Address address of the ERC20 token used to pay the fee.
+     * @param amount number of tokens to transfer. An approval for at least this amount must exist.
      */
-    function payOracleFeesErc20(address erc20Address) external;
+    function payOracleFeesErc20(address erc20Address, FixedPoint.Unsigned calldata amount) external;
 
     /**
      * @notice Computes the regular oracle fees that a contract should pay for a period.

--- a/core/contracts/tokenized-derivative/TokenizedDerivative.sol
+++ b/core/contracts/tokenized-derivative/TokenizedDerivative.sol
@@ -825,7 +825,7 @@ library TokenizedDerivativeUtils {
             store.payOracleFees.value(feeAmount)();
         } else {
             require(s.externalAddresses.marginCurrency.approve(address(store), feeAmount));
-            store.payOracleFeesErc20(address(s.externalAddresses.marginCurrency));
+            store.payOracleFeesErc20(address(s.externalAddresses.marginCurrency), FixedPoint.Unsigned(feeAmount));
         }
     }
 

--- a/core/test/oracle/Store.js
+++ b/core/test/oracle/Store.js
@@ -157,16 +157,18 @@ contract("Store", function(accounts) {
     assert.equal(secondTokenBalanceInDerivative, web3.utils.toWei("100", "ether"));
 
     // Pay 10 of the first margin token to the store and verify balances.
-    await firstMarginToken.approve(store.address, web3.utils.toWei("10", "ether"), { from: derivative });
-    await store.payOracleFeesErc20(firstMarginToken.address, { from: derivative });
+    let feeAmount = web3.utils.toWei("10", "ether");
+    await firstMarginToken.approve(store.address, feeAmount, { from: derivative });
+    await store.payOracleFeesErc20(firstMarginToken.address, { rawValue: feeAmount }, { from: derivative });
     firstTokenBalanceInStore = await firstMarginToken.balanceOf(store.address);
     firstTokenBalanceInDerivative = await firstMarginToken.balanceOf(derivative);
     assert.equal(firstTokenBalanceInStore.toString(), web3.utils.toWei("10", "ether"));
     assert.equal(firstTokenBalanceInDerivative.toString(), web3.utils.toWei("90", "ether"));
 
     // Pay 20 of the second margin token to the store and verify balances.
-    await secondMarginToken.approve(store.address, web3.utils.toWei("20", "ether"), { from: derivative });
-    await store.payOracleFeesErc20(secondMarginToken.address, { from: derivative });
+    feeAmount = web3.utils.toWei("20", "ether");
+    await secondMarginToken.approve(store.address, feeAmount, { from: derivative });
+    await store.payOracleFeesErc20(secondMarginToken.address, { rawValue: feeAmount }, { from: derivative });
     secondTokenBalanceInStore = await secondMarginToken.balanceOf(store.address);
     secondTokenBalanceInDerivative = await secondMarginToken.balanceOf(derivative);
     assert.equal(secondTokenBalanceInStore.toString(), web3.utils.toWei("20", "ether"));


### PR DESCRIPTION
The previous implementation transferred all the approved tokens, which
is suboptimal because allowances are not considered payments. Note that
this PR doesn't change functionality because the only callers to
`payOracleFeesErc20` were other contracts.

We prefer to have an explicit function rather than the callers simply
transferring tokens because while this implementation of Store.sol
doesn't do anything in this function, we want the StoreInterface to have
an explicit function we can plug in to later.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>