### PR TITLE
Detect `it.only` in tests with eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     browser: true
   },
   extends: ["plugin:prettier/recommended"],
-  plugins: ["prettier"],
+  plugins: ["prettier", "mocha"],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -17,6 +17,10 @@ module.exports = {
     "linebreak-style": ["error", "unix"],
     quotes: ["error", "double", { avoidEscape: true }],
     semi: ["error", "always"],
-    "spaced-comment": ["error", "always", { exceptions: ["-", "+"] }]
+    "spaced-comment": ["error", "always", { exceptions: ["-", "+"] }],
+    "mocha/no-exclusive-tests": "error"
+  },
+  settings: {
+    "mocha/additionalTestFunctions": ["describeModule"]
   }
 };

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-mocha": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^4.2.3",
     "lint-staged": "^10.1.3",
-    "pretty-quick": "^2.0.1",
     "prettier": "1.19.1",
     "prettier-plugin-solidity": "^1.0.0-alpha.46",
+    "pretty-quick": "^2.0.1",
     "solidity-coverage": "^0.7.2",
     "truffle-deploy-registry": "^0.5.1"
   },


### PR DESCRIPTION
This PR adds the [eslint-plugin-mocha](https://github.com/lo1tuma/eslint-plugin-mocha) package to eslint to check for `it.only` or `describe.only`. Specifically, the [no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-exclusive-tests.md) rule is used to enable this. 

The screenshot below shows the output of ESLINT if an `it.only` is left in a test:
![image](https://user-images.githubusercontent.com/12886084/79645208-213a8f80-81ae-11ea-9baa-6e774daf0094.png)
