### PR TITLE
Add starting id to governor constructor

### DIFF
--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -57,22 +57,23 @@ contract Governor is MultiRole, Testable {
     /**
      * @notice Construct the Governor contract.
      * @param _finderAddress keeps track of all contracts within the system based on their interfaceName.
+     * @param _startingId the initial proposal id that the contract will begin incrementing from.
      * @param _timerAddress Contract that stores the current time in a testing environment.
      * Must be set to 0x0 for production environments that use live time.
      */
-    constructor(address _finderAddress, uint startingId, address _timerAddress) public Testable(_timerAddress) {
+    constructor(address _finderAddress, uint _startingId, address _timerAddress) public Testable(_timerAddress) {
         finder = FinderInterface(_finderAddress);
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
         _createExclusiveRole(uint(Roles.Proposer), uint(Roles.Owner), msg.sender);
 
         // Ensure the startingId is not set unreasonably high to avoid overwriting other storage slots.
         uint maxStartingId = 10**18;
-        require(startingId <= maxStartingId, "Cannot set startingId larger than 10^18");
+        require(_startingId <= maxStartingId, "Cannot set startingId larger than 10^18");
 
         // This just sets the initial length of the array to the startingId since modifying length directly has been
         // disallowed in solidity 0.6.
         assembly {
-            sstore(proposals_slot, startingId)
+            sstore(proposals_slot, _startingId)
         }
     }
 

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -60,10 +60,20 @@ contract Governor is MultiRole, Testable {
      * @param _timerAddress Contract that stores the current time in a testing environment.
      * Must be set to 0x0 for production environments that use live time.
      */
-    constructor(address _finderAddress, address _timerAddress) public Testable(_timerAddress) {
+    constructor(address _finderAddress, uint startingId, address _timerAddress) public Testable(_timerAddress) {
         finder = FinderInterface(_finderAddress);
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
         _createExclusiveRole(uint(Roles.Proposer), uint(Roles.Owner), msg.sender);
+
+        // Ensure the startingId is not set unreasonably high to avoid overwriting other storage slots.
+        uint maxStartingId = 10**18;
+        require(startingId <= maxStartingId, "Cannot set startingId larger than 10^18");
+
+        // This just sets the initial length of the array to the startingId since modifying length directly has been
+        // disallowed in solidity 0.6.
+        assembly {
+            sstore(proposals_slot, startingId)
+        }
     }
 
     /****************************************

--- a/core/contracts/oracle/implementation/Governor.sol
+++ b/core/contracts/oracle/implementation/Governor.sol
@@ -66,7 +66,8 @@ contract Governor is MultiRole, Testable {
         _createExclusiveRole(uint(Roles.Owner), uint(Roles.Owner), msg.sender);
         _createExclusiveRole(uint(Roles.Proposer), uint(Roles.Owner), msg.sender);
 
-        // Ensure the startingId is not set unreasonably high to avoid overwriting other storage slots.
+        // Ensure the startingId is not set unreasonably high to avoid it being set such that new proposals overwrite
+        // other storage slots in the contract.
         uint maxStartingId = 10**18;
         require(_startingId <= maxStartingId, "Cannot set startingId larger than 10^18");
 

--- a/core/contracts/oracle/implementation/test/GovernorTest.sol
+++ b/core/contracts/oracle/implementation/test/GovernorTest.sol
@@ -7,7 +7,7 @@ import "../Governor.sol";
 
 // GovernorTest exposes internal methods in the Governor for testing.
 contract GovernorTest is Governor {
-    constructor(address _timerAddress) public Governor(address(0), _timerAddress) {}
+    constructor(address _timerAddress) public Governor(address(0), 0, _timerAddress) {}
 
     function addPrefix(bytes32 input, bytes32 prefix, uint256 prefixLength) external pure returns (bytes32) {
         return _addPrefix(input, prefix, prefixLength);

--- a/core/migrations/9_deploy_governor.js
+++ b/core/migrations/9_deploy_governor.js
@@ -8,12 +8,14 @@ const { RegistryRolesEnum } = require("../../common/Enums.js");
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
   const controllableTiming = enableControllableTiming(network);
+  const startingId = "0";
 
   const { contract: governor } = await deploy(
     deployer,
     network,
     Governor,
     Finder.address,
+    startingId,
     controllableTiming ? Timer.address : "0x0000000000000000000000000000000000000000",
     {
       from: keys.deployer


### PR DESCRIPTION
This adds a line to the governor constructor that starts the proposal ids at an arbitrary number. This means we'll be able to ensure that when the Governor is upgraded, the proposal ids can continue to be unique. Note: this uniqueness is not absolutely necessary for the Governor to function correctly, but it does help the voters differentiate the proposals without having to use the timestamp.

It does involve inline assembly to directly modify the length of the array (modifying `length` was disallowed starting in Solidity 0.6).

