### PR TITLE
Change parameter names in Voting events for consistency

### DIFF
--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -156,9 +156,9 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
         uint256 numTokens
     );
 
-    event PriceRequestAdded(uint256 indexed votingRoundId, bytes32 indexed identifier, uint256 time);
+    event PriceRequestAdded(uint256 indexed roundId, bytes32 indexed identifier, uint256 time);
 
-    event PriceResolved(uint256 indexed resolutionRoundId, bytes32 indexed identifier, uint256 time, int256 price);
+    event PriceResolved(uint256 indexed roundId, bytes32 indexed identifier, uint256 time, int256 price);
 
     /**
      * @notice Construct the Voting contract.

--- a/core/test/oracle/Voting.js
+++ b/core/test/oracle/Voting.js
@@ -1123,7 +1123,7 @@ contract("Voting", function(accounts) {
     const result = await voting.retrieveRewards(account1, roundId, req);
     truffleAssert.eventEmitted(result, "PriceResolved", ev => {
       return (
-        ev.resolutionRoundId.toString() == roundId.toString() &&
+        ev.roundId.toString() == roundId.toString() &&
         web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier) &&
         ev.time == time &&
         ev.price.toString() == winningPrice.toString()
@@ -1291,7 +1291,7 @@ contract("Voting", function(accounts) {
     truffleAssert.eventEmitted(result, "PriceRequestAdded", ev => {
       return (
         // The vote is added to the next round, so we have to add 1 to the current round id.
-        ev.votingRoundId.toString() == currentRoundId.addn(1).toString() &&
+        ev.roundId.toString() == currentRoundId.addn(1).toString() &&
         web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier) &&
         ev.time.toString() == time.toString()
       );
@@ -1375,7 +1375,7 @@ contract("Voting", function(accounts) {
     result = await voting.retrieveRewards(account1, roundId, [{ identifier, time }]);
     truffleAssert.eventEmitted(result, "PriceResolved", ev => {
       return (
-        ev.resolutionRoundId.toString() == currentRoundId.toString() &&
+        ev.roundId.toString() == currentRoundId.toString() &&
         web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier) &&
         ev.time == time &&
         ev.price.toString() == price.toString()


### PR DESCRIPTION
This just changes the name of the various roundId parameters so they are all the same. Namely, this will allow us to take advantage of the `getLatestEvent` (offchain) function for all the Voting events.