### PR TITLE
Move salt reuse warnings to `commitVote`, refine language

### DIFF
--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -311,6 +311,9 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
      * @notice Commit a vote for a price request for `identifier` at `time`.
      * @dev `identifier`, `time` must correspond to a price request that's currently in the commit phase.
      * Commits can be changed.
+     * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s expected behavior,
+     * voters should never reuse salts. If someone else is able to guess the voted price and knows that a salt will be reused, then
+     * they can determine the vote pre-reveal.
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
      * @param hash keccak256 hash of the `price`, `salt`, voter `address`, `time`, current `roundId`, and `identifier`.
@@ -358,9 +361,6 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
      * @notice Reveal a previously committed vote for `identifier` at `time`.
      * @dev The revealed `price`, `salt`, `time`, `address`, `roundId`, and `identifier`, must hash to the latest `hash`
      * that `commitVote()` was called with. Only the committer can reveal their vote.
-     * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s expected behavior,
-     * voters should never reuse salts. If someone else is able to predict the voted price or knows that a price will be reused, then
-     * they can easily reveal the vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
      * @param price voted on during the commit phase.

--- a/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -42,6 +42,9 @@ abstract contract VotingInterface {
      * @notice Commit a vote for a price request for `identifier` at `time`.
      * @dev `identifier`, `time` must correspond to a price request that's currently in the commit phase.
      * Commits can be changed.
+     * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s expected behavior,
+     * voters should never reuse salts. If someone else is able to guess the voted price and knows that a salt will be reused, then
+     * they can determine the vote pre-reveal.
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
      * @param hash keccak256 hash of the `price`, `salt`, voter `address`, `time`, current `roundId`, and `identifier`.
@@ -68,9 +71,6 @@ abstract contract VotingInterface {
      * @notice Reveal a previously committed vote for `identifier` at `time`.
      * @dev The revealed `price`, `salt`, `time`, `address`, `roundId`, and `identifier`, must hash to the latest `hash`
      * that `commitVote()` was called with. Only the committer can reveal their vote.
-     * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s expected behavior,
-     * voters should never reuse salts. If someone else is able to predict the voted price or knows that a price will be reused, then
-     * they can easily reveal the vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price is being voted on.
      * @param price voted on during the commit phase.

--- a/documentation/oracle/dvm_interfaces.md
+++ b/documentation/oracle/dvm_interfaces.md
@@ -137,8 +137,8 @@ It also takes the `hash` that the voter wishes to commit to. The `hash` is creat
 `keccak256(price, salt, time, address, roundId, identifier)`, where price is the `int256` price value that they wish to submit, `time` is the unix timestamp of the request being voted on, `address` is the voter's address (technically, the same one that will reveal the vote), `roundId` is the current voting round, `identifier` is the pricefeed identifier relevant to the price request, and `salt` is a random `int256` value. The voter must remember the inputs to the vote `hash` that they submitted so they can reveal their commit later - otherwise, the commit cannot be revealed and the vote won't be counted.
 
 Since transaction data is public, the salt will be revealed along with the vote. While this is the system’s expected behavior,
-voters should never reuse salts. If someone else is able to predict the voted price or knows that a price will be reused, then
-they can easily reveal the vote.
+voters should never reuse salts. If someone else is able to guess the voted price and knows that a salt will be reused, then
+they can determine the vote pre-reveal.
 
 A few notes:
 


### PR DESCRIPTION
Follow up to #1273
Signed-off-by: Nick Pai <npai.nyc@gmail.com>