### PR TITLE
Update Propose.js

### DIFF
--- a/core/scripts/umip-3/Propose.js
+++ b/core/scripts/umip-3/Propose.js
@@ -10,6 +10,8 @@ const Umip3Upgrader = artifacts.require("Umip3Upgrader");
 
 const { RegistryRolesEnum } = require("../../../common/Enums.js");
 
+const tdr = require("truffle-deploy-registry");
+
 const proposerWallet = "0x2bAaA41d155ad8a4126184950B31F50A1513cE25";
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
@@ -101,7 +103,9 @@ async function runExport() {
 
   console.log("Deploying new Governor contract.");
 
-  const newGovernor = await Governor.new(finder.address, zeroAddress, { from: proposerWallet });
+  const startingId = 0;
+
+  const newGovernor = await Governor.new(finder.address, startingId, zeroAddress, { from: proposerWallet });
 
   /** ********************************************
    * 7) update permissions on all new contracts *
@@ -223,6 +227,15 @@ async function runExport() {
     ],
     { from: proposerWallet }
   );
+
+  console.log("Adding new contracts to the Registry");
+
+  await tdr.appendInstance(voting);
+  await tdr.appendInstance(registry);
+  await tdr.appendInstance(store);
+  await tdr.appendInstance(financialContractsAdmin);
+  await tdr.appendInstance(identifierWhitelist);
+  await tdr.appendInstance(newGovernor);
 
   console.log(`
 

--- a/core/scripts/umip-3/Propose.js
+++ b/core/scripts/umip-3/Propose.js
@@ -103,7 +103,8 @@ async function runExport() {
 
   console.log("Deploying new Governor contract.");
 
-  const startingId = 0;
+  // Add 1 to the existing proposal count to take into account the proposal that we're about to send.
+  const startingId = (await governor.numProposals()).addn(1).toString();
 
   const newGovernor = await Governor.new(finder.address, startingId, zeroAddress, { from: proposerWallet });
 


### PR DESCRIPTION
This just adds code to `Propose.js` that makes it write to the contract registry. This means that later calls to `apply-registry` will pull in the updated addresses.

It also changes the call to the governor constructor to take into account the old governor's proposals.