### PR TITLE
DVM clients should filter on "roundId" instead of "resolutionRoundId"

### DIFF
--- a/core/scripts/cli/voting/getResolvedVotesByRoundId.js
+++ b/core/scripts/cli/voting/getResolvedVotesByRoundId.js
@@ -37,12 +37,12 @@ const getResolvedVotesByRound = async (web3, votingContract, account) => {
   // Now filter resolved prices by the voter participation
   if (Object.keys(roundIds).length > 0) {
     const resolvedPrices = await votingContract.getPastEvents("PriceResolved", {
-      filter: { resolutionRoundId: Object.keys(roundIds) },
+      filter: { roundId: Object.keys(roundIds) },
       fromBlock: 0
     });
 
     resolvedPrices.forEach(price => {
-      const roundId = price.args.resolutionRoundId;
+      const roundId = price.args.roundId;
       const resolvedPrice = {
         roundId: roundId.toString(),
         identifier: web3.utils.hexToUtf8(price.args.identifier),

--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -28,7 +28,7 @@ function ResolvedRequests({ votingAccount }) {
       useMemo(() => {
         const indexRoundId = currentRoundId == null ? MAX_UINT_VAL : currentRoundId - 1;
         // If all resolved requests are being shown, don't filter by round id.
-        return { filter: { resolutionRoundId: showAllResolvedRequests ? undefined : indexRoundId }, fromBlock: 0 };
+        return { filter: { roundId: showAllResolvedRequests ? undefined : indexRoundId }, fromBlock: 0 };
       }, [currentRoundId, showAllResolvedRequests])
     ) || [];
 
@@ -40,7 +40,7 @@ function ResolvedRequests({ votingAccount }) {
         const indexRoundId = currentRoundId == null ? MAX_UINT_VAL : currentRoundId - 1;
         // If all resolved requests are being shown, don't filter by round id.
         return {
-          filter: { resolutionRoundId: showAllResolvedRequests ? undefined : indexRoundId, voter: votingAccount },
+          filter: { roundId: showAllResolvedRequests ? undefined : indexRoundId, voter: votingAccount },
           fromBlock: 0
         };
       }, [currentRoundId, votingAccount, showAllResolvedRequests])
@@ -57,8 +57,8 @@ function ResolvedRequests({ votingAccount }) {
   // TODO: add a resolved timestamp to the table so the sorting makes more sense to the user.
   // Sort the resolved requests such that they are organized from most recent to least recent round.
   const resolvedEventsSorted = resolvedEvents.sort((a, b) => {
-    const aRoundId = web3.utils.toBN(a.returnValues.resolutionRoundId);
-    const bRoundId = web3.utils.toBN(b.returnValues.resolutionRoundId);
+    const aRoundId = web3.utils.toBN(a.returnValues.roundId);
+    const bRoundId = web3.utils.toBN(b.returnValues.roundId);
     return bRoundId.cmp(aRoundId);
   });
 

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -46,7 +46,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
     for (const event of priceResolvedEvents) {
       const voteState = getVoteState(event.returnValues.identifier, event.returnValues.time);
 
-      voteState.priceResolutionRound = event.returnValues.resolutionRoundId.toString();
+      voteState.priceResolutionRound = event.returnValues.roundId.toString();
     }
 
     // Since this loop is the last one, we can use the state to determine if this identifer, time, roundId combo
@@ -142,7 +142,7 @@ function RetrieveRewards({ votingAccount }) {
     "Voting",
     "PriceResolved",
     useMemo(() => {
-      return { filter: { resolutionRoundId: roundIds }, fromBlock: 0 };
+      return { filter: { roundId: roundIds }, fromBlock: 0 };
     }, [roundIds])
   );
 


### PR DESCRIPTION
#1275 changed the event argument name for `PriceResolved` from `resolutionRoundId` to `roundId`. This PR fixes the Voting CLI and Voter-dApp by filtering on this changed argument name.

I discovered this bug while testing the Voting CLI to see if I could display the pending Admin proposals.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>