### PR TITLE
[P1-N15] removed import

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
-import "../../common/implementation/FixedPoint.sol";
 import "./Liquidatable.sol";
 
 


### PR DESCRIPTION
This PR removes a redundant import within the EMP. Originally the OZ audit found another 2 redundant end points but these were removed when we upgraded the timable implementation, in this [PR](https://github.com/UMAprotocol/protocol/pull/1236). As a result this PR is tiny 🍹