### PR TITLE
Clarify copy in Voting.revealVote

### DIFF
--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -358,7 +358,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.
-     * @dev The revealed `price`, `salt`, `time`, `address`, `roundId`, and `identifier`, must hash to the latest `hash`
+     * @dev The revealed `price`, `salt`, `address`, `time`, `roundId`, and `identifier`, must hash to the latest `hash`
      * that `commitVote()` was called with. Only the committer can reveal their vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
@@ -386,7 +386,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
         require(voteSubmission.commit != bytes32(0), "Invalid hash reveal");
         require(
             keccak256(abi.encodePacked(price, salt, msg.sender, time, roundId, identifier)) == voteSubmission.commit,
-            "Revealed data != commit hash"
+            "Revealed data does not match commit hash"
         );
         delete voteSubmission.commit;
 

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -386,7 +386,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
         require(voteSubmission.commit != bytes32(0), "Invalid hash reveal");
         require(
             keccak256(abi.encodePacked(price, salt, msg.sender, time, roundId, identifier)) == voteSubmission.commit,
-            "Revealed data does not match commit hash"
+            "Revealed data does not match commit hash contents"
         );
         delete voteSubmission.commit;
 

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -386,7 +386,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
         require(voteSubmission.commit != bytes32(0), "Invalid hash reveal");
         require(
             keccak256(abi.encodePacked(price, salt, msg.sender, time, roundId, identifier)) == voteSubmission.commit,
-            "Revealed data does not match commit hash contents"
+            "Revealed data != commit hash"
         );
         delete voteSubmission.commit;
 

--- a/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -73,7 +73,7 @@ abstract contract VotingInterface {
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.
-     * @dev The revealed `price`, `salt`, `time`, `address`, `roundId`, and `identifier`, must hash to the latest `hash`
+     * @dev The revealed `price`, `salt`, `address`, `time`, `roundId`, and `identifier`, must hash to the latest `hash`
      * that `commitVote()` was called with. Only the committer can reveal their vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price is being voted on.


### PR DESCRIPTION
Follow up to #1217 

- @dev comment in `revealVote` lists hash contents in incorrect order. This should match the order in `commitVote` and more importantly the order that data is listed in `abi.encodePacked()`
- Error message "Revealed data != commit hash" might be shown to an end user that's not familiar with the "!=" idiom. I made this more readable.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>