### PR TITLE
[P2-N08] Removed unused repeated function in EMP

### DIFF
--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -580,10 +580,6 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         return OracleInterface(finder.getImplementationAddress(OracleInterfaces.Oracle));
     }
 
-    function _getStoreAddress() internal view returns (address) {
-        return finder.getImplementationAddress(OracleInterfaces.Store);
-    }
-
     function _getFinancialContractsAdminAddress() internal view returns (address) {
         return finder.getImplementationAddress(OracleInterfaces.FinancialContractsAdmin);
     }


### PR DESCRIPTION
The `_getStoreAddress` function is implemented in the `PricelessPositionManager`, however it is never used. This PR removes this function.