### PR TITLE
[P2-L01] Enforce Check-Effects-Interactions pattern in withdrawPassedRequest

### DIFF
--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -276,14 +276,14 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         _removeCollateral(positionData.rawCollateral, amountToWithdraw);
         amountWithdrawn = _removeCollateral(rawTotalPositionCollateral, amountToWithdraw);
 
+        // Reset withdrawal request
+        positionData.withdrawalRequestAmount = FixedPoint.fromUnscaledUint(0);
+        positionData.requestPassTimestamp = 0;
+
         // Transfer approved withdrawal amount from the contract to the caller.
         collateralCurrency.safeTransfer(msg.sender, amountWithdrawn.rawValue);
 
         emit RequestWithdrawalExecuted(msg.sender, amountWithdrawn.rawValue);
-
-        // Reset withdrawal request
-        positionData.withdrawalRequestAmount = FixedPoint.fromUnscaledUint(0);
-        positionData.requestPassTimestamp = 0;
     }
 
     /**


### PR DESCRIPTION
This removes the pending withdraw data before executing the transfer of collateral.

I am still undecided if and how we should test re-entrancy for this change. I toyed with creating a contract `ReentrancyCheckerERC20` which inherits both `ReentrancyChecker` and `ExpandedERC20`. The idea is to override the `transfer` (or `safeTransfer`) method in the collateral contract such that when `withdrawPassedRequest()` calls `collateral.safeTransfer()` it triggers a pre-loaded reentrancy attack.

@mrice32 since you worked on the reentrancy fixes in the DVM, do you have any insight here if this would be a viable approach? Note that the `ReentrancyCheckerERC20` still needs to be a valid ERC20 that correctly excecutes methods like `safeTransferFrom` which is called by `create()` in order to get a test into the correct situation to test reentrancy of `withdrawPassedRequest`.
Signed-off-by: Nick Pai <npai.nyc@gmail.com>