### PR TITLE
Add PriceFeedInterface

### DIFF
--- a/ci/run_truffle_tests.sh
+++ b/ci/run_truffle_tests.sh
@@ -49,9 +49,9 @@ run_tests $PROTOCOL_DIR/core
 cd $PROTOCOL_DIR/core
 
 $(npm bin)/truffle test $(find ../financial-templates-lib/test -name '*.js') --network ci
-$(npm bin)/truffle test ../liquidator/test/*.js --network ci
-$(npm bin)/truffle test ../disputer/test/*.js --network ci
-$(npm bin)/truffle test ../monitors/test/*.js --network ci
+$(npm bin)/truffle test $(find ../liquidator/test -name '*.js') --network ci
+$(npm bin)/truffle test $(find ../disputer/test -name '*.js') --network ci
+$(npm bin)/truffle test $(find ../monitors/test -name '*.js') --network ci
 
 # Check the Kovan deployment.
 check_deployment $PROTOCOL_DIR/core 4 rinkeby_mnemonic

--- a/ci/run_truffle_tests.sh
+++ b/ci/run_truffle_tests.sh
@@ -47,7 +47,8 @@ run_tests $PROTOCOL_DIR/core
 
 # Hacky way of running truffle tests outside of core.
 cd $PROTOCOL_DIR/core
-$(npm bin)/truffle test ../financial-templates-lib/test/*.js --network ci
+
+$(npm bin)/truffle test $(find ../financial-templates-lib/test -name '*.js') --network ci
 $(npm bin)/truffle test ../liquidator/test/*.js --network ci
 $(npm bin)/truffle test ../disputer/test/*.js --network ci
 $(npm bin)/truffle test ../monitors/test/*.js --network ci

--- a/financial-templates-lib/price-feed/PriceFeedInterface.js
+++ b/financial-templates-lib/price-feed/PriceFeedInterface.js
@@ -1,0 +1,41 @@
+// Price feed interface -- all price feed implementations should override all functions (except for _abstractFunctionCalled).
+class PriceFeedInterface {
+  // Updates the internal state of the price feed. Should pull in any async data so the get*Price methods can be called.
+  // Note: derived classes *must* override this method.
+  async update() {
+    this._abstractFunctionCalled();
+  }
+
+  // Gets the current price (as a BN) for this feed synchronously from the in-memory state of this price feed object.
+  // This price should be up-to-date as of the last time `update()` was called. If `update()` has never been called,
+  // this should return `undefined`. If no price could be retrieved, it should return `null`.
+  // Note: derived classes *must* override this method.
+  getCurrentPrice() {
+    this._abstractFunctionCalled();
+  }
+
+  // Gets the price (as a BN) for the time specified. Similar to `getCurrentPrice()`, the price is derived from the
+  // in-memory state of the price feed object, so this method is syncrhonous. This price should be up-to-date as of the
+  // last time `update()` was called. If `update()` has never been called, this should return `undefined`. If the time
+  // is before the pre-determined historical lookback window of this PriceFeed object, then this method should return
+  // `null`. If the historical price could not be computed for any other reason, this method should return `null`.
+  // Note: derived classes *must* override this method.
+  getHistoricalPrice(time) {
+    this._abstractFunctionCalled();
+  }
+
+  // This returns the last time that the `update()` method was called. If it hasn't been calle
+  // Note: derived classes *must* override this method.
+  getLastUpdateTime() {
+    this._abstractFunctionCalled();
+  }
+
+  // Common function to throw an error if an interface method is called.
+  _abstractFunctionCalled() {
+    throw "Abstract function called -- derived class should implement this function";
+  }
+}
+
+module.exports = {
+  PriceFeedInterface
+};


### PR DESCRIPTION
This adds a simple interface that all price feeds should implement.

This PR also includes changes to force the UniswapPriceFeed to conform to this interface, and it moves the price feeds to their own directory.