### PR TITLE
[P2-L02] Additional input validation

### DIFF
--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -98,6 +98,11 @@ abstract contract FeePayer is Testable {
             return totalPaid;
         }
 
+        // Exit early if fees were already paid during this block.
+        if (lastPaymentTime == getCurrentTime()) {
+            return totalPaid;
+        }
+
         (FixedPoint.Unsigned memory regularFee, FixedPoint.Unsigned memory latePenalty) = store.computeRegularFee(
             lastPaymentTime,
             time,

--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -99,7 +99,7 @@ abstract contract FeePayer is Testable {
         }
 
         // Exit early if fees were already paid during this block.
-        if (lastPaymentTime == getCurrentTime()) {
+        if (lastPaymentTime == time) {
             return totalPaid;
         }
 

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -149,14 +149,14 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         FixedPoint.Unsigned memory _minSponsorTokens,
         address _timerAddress
     ) public FeePayer(_collateralAddress, _finderAddress, _timerAddress) {
+        require(_expirationTimestamp > getCurrentTime());
+        require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier));
+
         expirationTimestamp = _expirationTimestamp;
         withdrawalLiveness = _withdrawalLiveness;
         TokenFactory tf = TokenFactory(_tokenFactoryAddress);
         tokenCurrency = tf.createToken(_syntheticName, _syntheticSymbol, 18);
         minSponsorTokens = _minSponsorTokens;
-
-        require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier));
-
         priceIdentifer = _priceIdentifier;
     }
 

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -214,10 +214,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     {
         PositionData storage positionData = _getPositionData(msg.sender);
         require(positionData.requestPassTimestamp == 0);
-        require(
-            collateralAmount.isGreaterThan(0) &&
-                collateralAmount.isLessThanOrEqual(_getCollateral(positionData.rawCollateral))
-        );
+        require(collateralAmount.isGreaterThan(0));
 
         _removeCollateral(positionData.rawCollateral, collateralAmount);
         require(_checkPositionCollateralization(positionData));

--- a/core/test/financial-templates/ExpiringMultiParty.js
+++ b/core/test/financial-templates/ExpiringMultiParty.js
@@ -15,7 +15,7 @@ contract("ExpiringMultiParty", function(accounts) {
     const collateralToken = await Token.new("UMA", "UMA", 18, { from: accounts[0] });
 
     const constructorParams = {
-      expirationTimestamp: "1234567890",
+      expirationTimestamp: (Math.round(Date.now() / 1000) + 1000).toString(),
       withdrawalLiveness: "1000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -1197,7 +1197,7 @@ contract("Liquidatable", function(accounts) {
       const expectedPaymentSponsor = amountOfCollateral.sub(settlementTRV).add(sponsorDisputeReward);
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), expectedPaymentSponsor.toString());
     });
-    it("Requested withdrawal amount is greater than total position collateral, liquidated collateral should be 0", async () => {
+    it("Requested withdrawal amount is equal to the total position collateral, liquidated collateral should be 0", async () => {
       // Create position.
       await liquidationContract.create(
         { rawValue: amountOfCollateral.toString() },
@@ -1205,10 +1205,7 @@ contract("Liquidatable", function(accounts) {
         { from: sponsor }
       );
       // Request withdrawal amount > collateral
-      await liquidationContract.requestWithdrawal(
-        { rawValue: amountOfCollateral.add(toBN("1")).toString() },
-        { from: sponsor }
-      );
+      await liquidationContract.requestWithdrawal({ rawValue: amountOfCollateral.toString() }, { from: sponsor });
       // Transfer synthetic tokens to a liquidator
       await syntheticToken.transfer(liquidator, amountOfSynthetic, { from: sponsor });
       // Liquidator believes the price of collateral per synthetic to be 1.5 and is liquidating the full token outstanding amount.

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -833,6 +833,12 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(collateralAmount.rawValue.toString(), toWei("0.99"));
     assert.equal((await collateral.balanceOf(store.address)).toString(), expectedStoreBalance.toString());
 
+    // Calling `payFees()` more than once in the same block does not emit a RegularFeesPaid event.
+    const feesPaidRepeat = await payFees.call();
+    assert.equal(feesPaidRepeat.toString(), "0");
+    const payFeesRepeatResult = await payFees();
+    truffleAssert.eventNotEmitted(payFeesRepeatResult, "RegularFeesPaid");
+
     // Ensure that fees are not applied to new collateral.
     // TODO: value chosen specifically to avoid rounding errors -- see #873.
     await pricelessPositionManager.deposit({ rawValue: toWei("99") }, { from: sponsor });

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -273,6 +273,8 @@ contract("PricelessPositionManager", function(accounts) {
       await didContractThrow(pricelessPositionManager.deposit({ rawValue: depositCollateral }, { from: sponsor }))
     );
     await collateral.approve(pricelessPositionManager.address, depositCollateral, { from: sponsor });
+    // Cannot deposit 0 collateral.
+    assert(await didContractThrow(pricelessPositionManager.deposit({ rawValue: "0" }, { from: sponsor })));
     await pricelessPositionManager.deposit({ rawValue: depositCollateral }, { from: sponsor });
     await checkBalances(expectedSponsorTokens, expectedSponsorCollateral);
 
@@ -280,6 +282,10 @@ contract("PricelessPositionManager", function(accounts) {
     const withdrawCollateral = toWei("20");
     expectedSponsorCollateral = expectedSponsorCollateral.sub(toBN(withdrawCollateral));
     let sponsorInitialBalance = await collateral.balanceOf(sponsor);
+    // Cannot withdraw 0 collateral.
+    assert(await didContractThrow(pricelessPositionManager.withdraw({ rawValue: "0" }, { from: sponsor })));
+    // Cannot withdraw more than balance. (The position currently has 150 + 50 collateral).
+    assert(await didContractThrow(pricelessPositionManager.withdraw({ rawValue: toWei("201") }, { from: sponsor })));
     await pricelessPositionManager.withdraw({ rawValue: withdrawCollateral }, { from: sponsor });
     let sponsorFinalBalance = await collateral.balanceOf(sponsor);
     assert.equal(sponsorFinalBalance.sub(sponsorInitialBalance).toString(), withdrawCollateral);
@@ -396,6 +402,15 @@ contract("PricelessPositionManager", function(accounts) {
       { from: sponsor }
     );
 
+    // Must request greater than 0 and less than full position's collateral.
+    assert(await didContractThrow(pricelessPositionManager.requestWithdrawal({ rawValue: "0" }, { from: sponsor })));
+    assert(
+      await didContractThrow(pricelessPositionManager.requestWithdrawal({ rawValue: toWei("151") }, { from: sponsor }))
+    );
+
+    // Cannot execute withdrawal request before a request is made.
+    assert(await didContractThrow(pricelessPositionManager.withdrawPassedRequest({ from: sponsor })));
+
     // Request withdrawal. Check event is emitted
     const resultRequestWithdrawal = await pricelessPositionManager.requestWithdrawal(
       { rawValue: toWei("100") },
@@ -479,26 +494,30 @@ contract("PricelessPositionManager", function(accounts) {
     // Can't cancel if no withdrawals pending.
     assert(await didContractThrow(pricelessPositionManager.cancelWithdrawal({ from: sponsor })));
 
-    // Request to withdraw more than remaining collateral should result in the amount getting capped to the remaining collateral.
+    // Request to withdraw remaining collateral. Post-fees, this amount should get reduced to the remaining collateral.
     await pricelessPositionManager.requestWithdrawal(
       {
-        rawValue: toBN(toWei("125"))
-          .add(toBN("1"))
-          .toString()
+        rawValue: toWei("125")
       },
       { from: sponsor }
     );
+    // Setting fees to 0.00001 per second will charge (0.00001 * 1000) = 0.01 or 1 % of the collateral.
+    await store.setFixedOracleFeePerSecondPerPfc({ rawValue: toWei("0.00001") });
     await pricelessPositionManager.setCurrentTime(
       (await pricelessPositionManager.getCurrentTime()).toNumber() + withdrawalLiveness
     );
     resultWithdrawPassedRequest = await pricelessPositionManager.withdrawPassedRequest({ from: sponsor });
     truffleAssert.eventEmitted(resultWithdrawPassedRequest, "RequestWithdrawalExecuted", ev => {
-      return ev.sponsor == sponsor && ev.collateralAmount == toWei("125").toString();
+      return ev.sponsor == sponsor && ev.collateralAmount == toWei("123.75").toString();
     });
-    await checkBalances(toBN(initialSponsorTokens), toBN("0"));
+    // @dev: Can't easily call `checkBalances(initialSponsorTokens, 0)` here because of the fee charged, which is also
+    // charged on the lowly-collateralized collateral (whose sponsor is `other`).
 
     // Contract state should not have changed.
     assert.equal(await pricelessPositionManager.contractState(), PositionStatesEnum.OPEN);
+
+    // Reset store state.
+    await store.setFixedOracleFeePerSecondPerPfc({ rawValue: "0" });
   });
 
   it("Global collateralization ratio checks", async function() {


### PR DESCRIPTION
This PR makes several changes that validate function input:

`PricelessPositionManager.sol`:
- constructor requires `_expirationTimestamp` to be greater than the current contract block timestamp.
- `deposit` requires `collateralAmount` to be greater than 0.
- `withdraw` and `requestWithdrawal` requires `collateralAmount` to be greater than 0 and less than the sponsor's position size. If charged fees cause the requested withdrawal amount to be greater than the collateral (net of fees), then the withdrawal amount gets set to collateral net of fees. @ptare This might require tweaking the Sponsor CLI if the CLI currently allows a user to withdraw/request a withdrawal greater than their position. Before it would get reduced to their full position, now it reverts.
- `withdrawPassedRequest` checks that there is a pending withdrawal request, by checking if the request timestamp is not 0.

`FeePayer.sol`:
- `payFees` checks if the `lastPaymentTime` is the current block timestamp, if so, then it will exit early (without throwing an error) and not emit the `RegularFeesPaid` event. This will make accounting cleaner.

`ExpiringMultiPartyCreator.sol`:
- `VALID_EXPIRATION_TIMESTAMPS` array length was fixed to 16 (the exact amount of initialized elements) from 17 in [this PR](https://github.com/UMAprotocol/protocol/pull/1308).