### PR TITLE
Added link to docs for 2 key contract in voter Dapp

### DIFF
--- a/voter-dapp/src/DesignatedVotingDeployment.js
+++ b/voter-dapp/src/DesignatedVotingDeployment.js
@@ -48,6 +48,12 @@ function DesignatedVotingDeployment({ votingAccount }) {
         Two key voting
       </Typography>
       You are not currently using a 2 key voting system. To deploy one, provide your cold key address.
+      <br />
+      To learn more about the 2 key voting system see this our{" "}
+      <a href="https://docs.umaproject.org/uma/oracle/voting_with_UMA_2-key_contract.html" target="_blank">
+        docs
+      </a>
+      .
       <div>
         <TextField
           helperText={errorText}

--- a/voter-dapp/src/DesignatedVotingDeployment.js
+++ b/voter-dapp/src/DesignatedVotingDeployment.js
@@ -49,7 +49,7 @@ function DesignatedVotingDeployment({ votingAccount }) {
       </Typography>
       You are not currently using a 2 key voting system. To deploy one, provide your cold key address.
       <br />
-      To learn more about the 2 key voting system see this our{" "}
+      To learn more about the 2 key voting system see our{" "}
       <a href="https://docs.umaproject.org/uma/oracle/voting_with_UMA_2-key_contract.html" target="_blank">
         docs
       </a>


### PR DESCRIPTION
Now that we have the docs to show how to set up the 2key contract, we should also have a link to it from the dapp. This quick PR implements this.

![image](https://user-images.githubusercontent.com/12886084/80595086-73887580-8a24-11ea-97d0-62e53c785cf9.png)


