### PR TITLE
[P2-N01] Check whether regular fees owed is less than the available collateral

### DIFF
--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -116,8 +116,17 @@ abstract contract FeePayer is Testable {
         if (totalPaid.isEqual(0)) {
             return totalPaid;
         }
-        // The amount of fees paid must be < pfc or the fee will be larger than 100%.
-        require(_pfc.isGreaterThan(totalPaid));
+        // If the effective fees paid as a % of the pfc is > 100%, then reduce it to 100%. The amount that `totalPaid` is greater than `_pfc` is
+        // reduced from the greater component of (regularFees, latePenalty).
+        if (totalPaid.isGreaterThan(_pfc)) {
+            if (regularFee.isGreaterThan(latePenalty)) {
+                regularFee = regularFee.sub((totalPaid.sub(_pfc)));
+            } else {
+                latePenalty = latePenalty.sub((totalPaid.sub(_pfc)));
+            }
+
+            totalPaid = regularFee.add(latePenalty);
+        }
 
         emit RegularFeesPaid(regularFee.rawValue, latePenalty.rawValue);
 

--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -110,9 +110,15 @@ abstract contract FeePayer is Testable {
         );
         lastPaymentTime = time;
 
+        totalPaid = regularFee.add(latePenalty);
+        if (totalPaid.isEqual(0)) {
+            return totalPaid;
+        }
+        // The amount of fees paid must be < pfc or the fee will be larger than 100%.
+        require(_pfc.isGreaterThan(totalPaid));
+
         emit RegularFeesPaid(regularFee.rawValue, latePenalty.rawValue);
 
-        totalPaid = regularFee.add(latePenalty);
         FixedPoint.Unsigned memory effectiveFee = totalPaid.divCeil(_pfc);
         cumulativeFeeMultiplier = cumulativeFeeMultiplier.mul(FixedPoint.fromUnscaledUint(1).sub(effectiveFee));
 

--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -86,7 +86,9 @@ abstract contract FeePayer is Testable {
      * @notice Pays UMA DVM regular fees to the Store contract.
      * @dev These must be paid periodically for the life of the contract. If the contract has not paid its
      * regular fee in a week or more then a late penalty is applied which is sent to the caller.
+     * This will revert if the amount of fees owed are greater than the pfc. An event is only fired if the fees charged are greater than 0.
      * @return totalPaid Amount of collateral that the contract paid (sum of the amount paid to the Store and caller).
+     * This will return 0 and exit early if there is no pfc, fees were already paid during the current block, or the fee rate is 0.
      */
     function payFees() public returns (FixedPoint.Unsigned memory totalPaid) {
         StoreInterface store = _getStore();
@@ -134,9 +136,10 @@ abstract contract FeePayer is Testable {
 
     /**
      * @notice Pays UMA DVM final fees to the Store contract.
-     * @dev This is a flat fee charged for each price request.
+     * @dev This is a flat fee charged for each price request to the original caller of the price request.
+     * This will revert if `amount` is greater than the pfc. An event is only fired if the fees charged are greater than 0.
      * @param payer address of who is paying the fees.
-     * @param amount the amount of collateral to send as the final fee.
+     * @param amount the amount of collateral to send as the final fee. This will exit early if `amount` is zero.
      */
     function _payFinalFees(address payer, FixedPoint.Unsigned memory amount) internal {
         if (amount.isEqual(0)) {

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -903,8 +903,23 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal((await collateral.balanceOf(sponsor)).toString(), expectedSponsorBalance.toString());
     assert.equal((await pricelessPositionManager.getCollateral(sponsor)).toString(), toWei("98.99"));
 
+    // Ensure that pay fees reverts if the total fee paid is > 100% of the PfC. Advance 100 seconds from the last payment time to attempt to
+    // pay 100% fees on the PfC.
+    const pfc = await pricelessPositionManager.pfc();
+    const feesOwed = (
+      await store.computeRegularFee(startTime.addn(1), startTime.addn(101), { rawValue: pfc.toString() })
+    ).regularFee;
+    assert.equal(pfc.toString(), feesOwed.toString());
+    await pricelessPositionManager.setCurrentTime(startTime.addn(101));
+    assert(await didContractThrow(pricelessPositionManager.payFees()));
+
     // Set the store fees back to 0 to prevent it from affecting other tests.
     await store.setFixedOracleFeePerSecondPerPfc({ rawValue: "0" });
+
+    // Check that no event is fired if the fees owed are 0.
+    await pricelessPositionManager.setCurrentTime(startTime.addn(102));
+    const payZeroFeesResult = await payFees();
+    truffleAssert.eventNotEmitted(payZeroFeesResult, "RegularFeesPaid");
   });
 
   it("Final fees", async function() {


### PR DESCRIPTION
If `pfc` is not greater than `totalPaid`, then `payFees()` will revert. I chose to enforce `PfC > totalPaid` as opposed to `>=` to be consistent with `_payFinalFees()`, which would prevent the `cumulativeFeeMultiplier` from ever getting set to 0.

Additionally, `payFees()` now exits early without emitting an event if `totalPaid == 0`.