### PR TITLE
[P2-M03] EMP registers sponsors with financial contract party

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
     docker:
       - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -i 1234 -l 6720000
+        command: ganache-cli -i 1234 -l 9000000
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -149,7 +149,7 @@ jobs:
     docker:
       - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -i 1234 -l 6720000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+        command: ganache-cli -i 1234 -l 9000000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
     working_directory: ~/protocol
     steps:
       - restore_cache:

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -21,7 +21,7 @@ const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "
 
 // Default options
 const gasPx = 20000000000; // 20 gwei
-const gas = 6720000; // Conservative estimate of the block gas limit.
+const gas = 9000000; // Conservative estimate of the block gas limit.
 
 // Adds a public network.
 // Note: All public networks can be accessed using keys from GCS using the ManagedSecretProvider or using a mnemonic in the

--- a/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
@@ -5,5 +5,13 @@ import "./Liquidatable.sol";
 
 
 contract ExpiringMultiParty is Liquidatable {
+    /**
+     * @notice Note on party members of this registered financial contract.
+     * @dev Before creating a position, the ExpiringMultiParty contract must be registered with the Registry so that it can add and remove members to its party.
+     * Party members is the position sponsor if the position has a non-zero amount of un-liquidated collateral.
+     * The liquidator and disputer are never registered with the financial contract because they interact with liquidated collateral,
+     * which is conceptually not part of the position.
+     */
+
     constructor(ConstructorParams memory params) public Liquidatable(params) {}
 }

--- a/core/contracts/oracle/implementation/Registry.sol
+++ b/core/contracts/oracle/implementation/Registry.sol
@@ -191,6 +191,8 @@ contract Registry is RegistryInterface, MultiRole {
      ****************************************/
 
     function _addPartyToContract(address party, address contractAddress) internal {
+        // TODO: Instead of reverting, this method just return early if the `party` is already a member of the contract.
+        // Because of the revert, calling contracts need to perform an extra check that the `party` is not already registered.
         require(!isPartyMemberOfContract(party, contractAddress), "Can only register a party once");
         uint256 contractIndex = partyMap[party].contracts.length;
         partyMap[party].contracts.push(contractAddress);

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -1,4 +1,4 @@
-const { LiquidationStatesEnum } = require("../../common/Enums");
+const { LiquidationStatesEnum, RegistryRolesEnum } = require("../../common/Enums");
 const { interfaceName } = require("../../core/utils/Constants.js");
 
 const { toWei, toBN, utf8ToHex } = web3.utils;
@@ -18,6 +18,7 @@ const MockOracle = artifacts.require("MockOracle");
 const TokenFactory = artifacts.require("TokenFactory");
 const Token = artifacts.require("ExpandedERC20");
 const Timer = artifacts.require("Timer");
+const Registry = artifacts.require("Registry");
 
 contract("Disputer.js", function(accounts) {
   const disputeBot = accounts[0];
@@ -32,6 +33,7 @@ contract("Disputer.js", function(accounts) {
   let emp;
   let syntheticToken;
   let mockOracle;
+  let registry;
 
   const zeroAddress = "0x0000000000000000000000000000000000000000";
 
@@ -83,6 +85,12 @@ contract("Disputer.js", function(accounts) {
 
     // Deploy a new expiring multi party
     emp = await ExpiringMultiParty.new(constructorParams);
+    // Need to register the contract so that it can add/remove party members, even though
+    // registration is not required to make price requests specifically to the MockOracle
+    // (n.b. it is required to be registered to make price requests to the production Oracle).
+    registry = await Registry.deployed();
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, accounts[0]);
+    await registry.registerContract([accounts[0]], emp.address);
 
     await collateralToken.approve(emp.address, toWei("100000000"), { from: sponsor1 });
     await collateralToken.approve(emp.address, toWei("100000000"), { from: sponsor2 });


### PR DESCRIPTION
This PR is one proposal for how to synchronize the Registry's tracking of parties with the EMP. Currently, the EMPCreator registers the deployer of an EMP as the first and only member of the party. Therefore, this PR extends the notion of party membership, but the drawback is extra smart contract code and additional upfront setup costs on the client-side.

Since the "party" associated with each financial contract has no privileges that are enforced on-chain, I stuck to this set of rules when determining who should be in the "party":
```
- Party members is the position sponsor if the position has a non-zero amount of un-liquidated collateral.
- The liquidator and disputer are never registered with the financial contract because they interact with liquidated collateral, which is conceptually not part of the position.
```

Note the new requirement when setting up the `EMP`: 
- Before creating a position, the `EMP` contract must be registered with the `Registry `so that it can add and remove members to its party.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>