### PR TITLE
[P02-N10] Use single-line comments rather than natspec for internal methods

### DIFF
--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -126,12 +126,9 @@ abstract contract FeePayer is Testable {
         }
     }
 
-    /**
-     * @notice Pays UMA DVM final fees to the Store contract.
-     * @dev This is a flat fee charged for each price request.
-     * @param payer address of who is paying the fees.
-     * @param amount the amount of collateral to send as the final fee.
-     */
+    // Pays UMA Oracle final fees of `amount` in `collateralCurrency` to the Store contract. Final fee is a flat fee charged for each price request.
+    // If payer is the contract, adjusts internal bookkeeping variables. If payer is not the contract, pulls in `amount`
+    // of collateral currency.
     function _payFinalFees(address payer, FixedPoint.Unsigned memory amount) internal {
         if (amount.isEqual(0)) {
             return;

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -496,11 +496,9 @@ contract Liquidatable is PricelessPositionManager {
         return liquidation.liquidationTime.add(liquidationLiveness);
     }
 
-    /**
-     * @dev These internal functions are supposed to act identically to modifiers, but re-used modifiers
-     * unnecessarily increase contract bytecode size.
-     * source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
-     */
+    // These internal functions are supposed to act identically to modifiers, but re-used modifiers
+    // unnecessarily increase contract bytecode size.
+    // source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
     function _disputable(uint256 liquidationId, address sponsor) internal view {
         LiquidationData storage liquidation = _getLiquidationData(sponsor, liquidationId);
         require((getCurrentTime() < _getLiquidationExpiry(liquidation)) && (liquidation.state == Status.PreDispute));

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -706,11 +706,9 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         return uint256(value);
     }
 
-    /**
-     * @dev These internal functions are supposed to act identically to modifiers, but re-used modifiers
-     * unnecessarily increase contract bytecode size.
-     * source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
-     */
+    // These internal functions are supposed to act identically to modifiers, but re-used modifiers
+    // unnecessarily increase contract bytecode size.
+    // source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
     function _onlyOpenState() internal view {
         require(contractState == ContractState.Open);
     }


### PR DESCRIPTION
We use natspec only for the public methods.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>