### PR TITLE
Add CryptoWatchPriceFeed

### DIFF
--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -1,0 +1,136 @@
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+
+// An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
+class CryptoWatchPriceFeed extends PriceFeedInterface {
+  // Constructs the CryptoWatchPriceFeed.
+  // apiKey the CW API key. Note: these API keys are rate-limited.
+  // exchange a string identifier for the echange to pull prices from. This should be the identifier used to
+  //          identify the exchange in CW's REST API.
+  // pair a string representation of the pair the price feed is tracking. This pair should be available on the
+  //      provided exchange. The string should be the representation used by CW to identify this pair.
+  // lookback how far in the past the historical prices will be available using the getHistoricalPrice function.
+  // networker networker object used to send the API requests.
+  // getTime function to return the current time.
+  // minTimeBetweenUpdates min number of seconds between updates. If update() is called again before this number of
+  // seconds has passed, it will be a no-op.
+  constructor(web3, apiKey, exchange, pair, lookback, networker, getTime, minTimeBetweenUpdates) {
+    super();
+    this.web3 = web3;
+    this.apiKey = apiKey;
+    this.exchange = exchange;
+    this.pair = pair;
+    this.lookback = lookback;
+    this.networker = networker;
+    this.getTime = getTime;
+    this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+
+    // Use CryptoWatch's most granular option, one minute.
+    this.ohlcPeriod = 60;
+  }
+
+  getCurrentPrice() {
+    return this.currentPrice;
+  }
+
+  getHistoricalPrice(time) {
+    if (this.lastUpdateTime === undefined) {
+      return undefined;
+    }
+
+    // If the time is before the first piece of data in the set, return null because the price is before the lookback
+    // window.
+    if (time < this.historicalPricePeriods[0].openTime) {
+      return null;
+    }
+
+    // historicalPricePeriods are ordered from oldest to newest.
+    // This finds the first pricePeriod whose closeTime is after the provided time.
+    const match = this.historicalPricePeriods.find(pricePeriod => {
+      return time < pricePeriod.closeTime;
+    });
+
+    // If there is no match, that means that the time was past the last data point.
+    // In this case, the best match for this price is the current price.
+    if (match === undefined) {
+      return this.currentPrice;
+    }
+
+    return match.openPrice;
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  async update() {
+    const { toWei, toBN } = this.web3.utls;
+    const currentTime = this.getTime();
+
+    // Return eatly if the last call was too recent.
+    if (this.lastUpdateTime !== undefined && this.lastUpdateTime + this.minTimeBetweenUpdates > currentTime) {
+      return;
+    }
+
+    // Round down to the nearest ohlc period so the queries captures the OHLC of the period *before* this earliest
+    // timestamp (because the close of that OHLC may be relevant).
+    const earliestHistoricalTimestamp = Math.floor((currentTime - lookback) / this.ohlcPeriod) * this.ohlcPeriod;
+
+    // See https://docs.cryptowat.ch/rest-api/markets/ohlc for how this url is constructed.
+    const ohlcUrl = [
+      `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?`,
+      `afer=${earliestHistoricalTimestamp}&`,
+      `periods=${this.ohlcPeriod}&`,
+      `apikey=${this.apiKey}`
+    ].join("");
+
+    const ohlcResponse = await networker.getJson(url);
+
+    // Return data structure:
+    // {
+    //   "result": {
+    //     "OhlcInterval": [
+    //     [
+    //       CloseTime,
+    //       OpenPrice,
+    //       HighPrice,
+    //       LowPrice,
+    //       ClosePrice,
+    //       Volume,
+    //       QuoteVolume
+    //     ],
+    //     ...
+    //     ]
+    //   }
+    // }
+    // For more info, see: https://docs.cryptowat.ch/rest-api/markets/ohlc
+    this.historicalPricePeriods = ohlcResponse.result[this.ohlcPeriod.toString()]
+      .map(ohlc => ({
+        // Output data should be a list of objects with only the open and close times and prices.
+        openTime: ohlc[0] - this.ohlcPeriod,
+        closeTime: ohlc[0],
+        openPrice: toBN(toWei(ohlc[1])),
+        closePrice: toBN(toWei(ohlc[4]))
+      }))
+      .sort((a, b) => {
+        // Sorts the data such that the oldest elements come first.
+        return a.openTime - b.openTime;
+      });
+
+    // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
+    const priceUrl = `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price?apikey=${this.apikey}`;
+    const priceResponse = await networker.getJson(url);
+
+    // Return data structure:
+    // {
+    //   "result": {
+    //     "price": priceValue
+    //   }
+    // }
+    this.currentPrice = toBN(toWei(priceResponse.result.price));
+    this.lastUpdateTime = currentTime;
+  }
+}
+
+module.exports = {
+  CryptoWatchPriceFeed
+};

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -84,7 +84,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     ].join("");
 
     const ohlcResponse = await this.networker.getJson(ohlcUrl);
-    if (!ohlcResponse.result) {
+    if (!ohlcResponse.result || !ohlcResponse.result[this.ohlcPeriod]) {
       console.error("Could not parse ohlc result:", ohlcResponse);
       return;
     }
@@ -123,7 +123,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
     const priceUrl = `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price?apikey=${this.apikey}`;
     const priceResponse = await this.networker.getJson(priceUrl);
-    if (!priceResponse.result) {
+    if (!priceResponse.result || !priceResponse.result.price) {
       console.error("Could not parse price result:", priceResponse);
       return;
     }

--- a/financial-templates-lib/price-feed/Networker.js
+++ b/financial-templates-lib/price-feed/Networker.js
@@ -4,11 +4,19 @@ const fetch = require("node-fetch");
 // Note: this is separated out to allow this functionality to be mocked out in tests so no real network calls have to
 // be made.
 class Networker {
+  constructor(logger) {
+    this.logger = logger;
+  }
+
   async getJson(url) {
     const response = await fetch(url);
     const json = await response.json();
     if (!json) {
-      throw `Query [${url}] failed to get JSON`;
+      this.logger.error({
+        at: "Networker",
+        message: "Failed to get json response",
+        url: url
+      });
     }
     return json;
   }

--- a/financial-templates-lib/price-feed/Networker.js
+++ b/financial-templates-lib/price-feed/Networker.js
@@ -1,7 +1,8 @@
 const fetch = require("node-fetch");
 
 // This class makes networking calls on behalf of the caller.
-// Note: this is separated out to allow this functionality to be mocked out in tests.
+// Note: this is separated out to allow this functionality to be mocked out in tests so no real network calls have to
+// be made.
 class Networker {
   async getJson(url) {
     const response = await fetch(url);

--- a/financial-templates-lib/price-feed/Networker.js
+++ b/financial-templates-lib/price-feed/Networker.js
@@ -1,0 +1,14 @@
+const fetch = require("node-fetch");
+
+// This class makes networking calls on behalf of the caller.
+// Note: this is separated out to allow this functionality to be mocked out in tests.
+class Networker {
+  async getJson(url) {
+    const response = await fetch(url);
+    const json = await response.json();
+    if (!json) {
+      throw `Query [${url}] failed to get JSON`;
+    }
+    return json;
+  }
+}

--- a/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -1,5 +1,6 @@
 const { CryptoWatchPriceFeed } = require("../../price-feed/CryptoWatchPriceFeed");
 const { NetworkerMock } = require("./NetworkerMock");
+const winston = require("winston");
 
 contract("CryptoWatchPriceFeed.js", function(accounts) {
   let cryptoWatchPriceFeed;
@@ -45,8 +46,13 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
 
   beforeEach(async function() {
     networker = new NetworkerMock();
+    const dummyLogger = winston.createLogger({
+      level: "info",
+      transports: []
+    });
     cryptoWatchPriceFeed = new CryptoWatchPriceFeed(
       web3,
+      dummyLogger,
       apiKey,
       exchange,
       pair,

--- a/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -1,0 +1,92 @@
+const { CryptoWatchPriceFeed } = require("../../price-feed/CryptoWatchPriceFeed");
+const { NetworkerMock } = require("./NetworkerMock");
+
+contract("CryptoWatchPriceFeed.js", function(accounts) {
+  let cryptoWatchPriceFeed;
+  let mockTime = 1588376548;
+  let networker;
+
+  const apiKey = "test-api-key";
+  const exchange = "test-exchange";
+  const pair = "test-pair";
+  const lookback = 120; // 2 minutes.
+  const getTime = () => mockTime;
+  const minTimeBetweenUpdates = 60;
+
+  const { toBN, toWei } = web3.utils;
+
+  // Fake data to inject.
+  // Note: the first element is the historical data and the second is the price.
+  const validResponses = [
+    {
+      result: {
+        "60": [
+          [
+            1588376400, // CloseTime
+            1.1, // OpenPrice
+            1.7, // HighPrice
+            0.5, // LowPrice
+            1.2, // ClosePrice
+            281.73395575, // Volume
+            2705497.370853147 // QuoteVolume
+          ],
+          [1588376460, 1.2, 1.8, 0.6, 1.3, 281.73395575, 2705497.370853147],
+          [1588376520, 1.3, 1.9, 0.7, 1.4, 888.92215493, 8601704.133826157]
+        ]
+      }
+    },
+    {
+      result: {
+        price: 1.5
+      }
+    }
+  ];
+
+  beforeEach(async function() {
+    networker = new NetworkerMock();
+    cryptoWatchPriceFeed = new CryptoWatchPriceFeed(
+      web3,
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      networker,
+      getTime,
+      minTimeBetweenUpdates
+    );
+  });
+
+  it("No update", async function() {
+    assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
+    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1000), undefined);
+  });
+
+  it("Basic historical price", async function() {
+    // Fake data to inject.
+    // Note: the first element is the historical data and the second is the price.
+    networker.getJsonReturns = validResponses;
+
+    await cryptoWatchPriceFeed.update();
+
+    // Before period 1 should return null.
+    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376340), null);
+
+    // During period 1.
+    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(), toWei("1.1"));
+
+    // During period 2.
+    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(), toWei("1.2"));
+
+    // During period 3.
+    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(), toWei("1.3"));
+
+    // After period 3 should return the most recent price.
+    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376521).toString(), toWei("1.5"));
+  });
+
+  it("Basic price", async function() {});
+
+  it("No or bad response", async function() {});
+
+  it("Update frequency", async function() {});
+});

--- a/financial-templates-lib/test/price-feed/NetworkerMock.js
+++ b/financial-templates-lib/test/price-feed/NetworkerMock.js
@@ -1,4 +1,4 @@
-// An implementation of PriceFeedInterface that uses a Uniswap v2 TWAP as the price feed source.
+// A mock of the Networker to allow the user to check the inputs and set the outputs.
 class NetworkerMock {
   // Value that will hold the most recent input to getJson.
   getJsonInputs = [];

--- a/financial-templates-lib/test/price-feed/NetworkerMock.js
+++ b/financial-templates-lib/test/price-feed/NetworkerMock.js
@@ -1,4 +1,4 @@
-// A mock of the Networker to allow the user to check the inputs and set the outputs.
+// A mock of the Networker to allow the user to check the inputs and set the outputs of network requests.
 class NetworkerMock {
   // Value that will hold the most recent input to getJson.
   getJsonInputs = [];

--- a/financial-templates-lib/test/price-feed/NetworkerMock.js
+++ b/financial-templates-lib/test/price-feed/NetworkerMock.js
@@ -1,0 +1,21 @@
+// An implementation of PriceFeedInterface that uses a Uniswap v2 TWAP as the price feed source.
+class NetworkerMock {
+  // Value that will hold the most recent input to getJson.
+  getJsonInputs = [];
+
+  // Value that will be returned on the next call to getJson.
+  // Users of this mock should set this value to force getJson to return the value.
+  getJsonReturns = [];
+
+  // Mocked getJson function.
+  async getJson(url) {
+    // Note: shift and unshift add and remove from the front of the array, so the elements are ordered such that the
+    // first elements in the arrays are the first in/out.
+    this.getJsonInputs.unshift(url);
+    return this.getJsonReturns.shift();
+  }
+}
+
+module.exports = {
+  NetworkerMock
+};


### PR DESCRIPTION
This adds a price feed based on the cryptowatch api: https://docs.cryptowat.ch/rest-api/.

It also adds a `Networker` object that enables mocking of network calls/responses in the tests.

Next step: construct a price feed that aggregates multiple exchange price feeds.

Note: an aggregated price feed will just compose the outputs of multiple individual price feeds by taking them in its constructor.