### PR TITLE
Scaffolding logger dependency injection

### DIFF
--- a/disputer/index.js
+++ b/disputer/index.js
@@ -32,9 +32,9 @@ async function run(price, address, shouldPoll) {
   const emp = await ExpiringMultiParty.at(address);
 
   // Client and dispute bot
-  const empClient = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
-  const gasEstimator = new GasEstimator();
-  const disputer = new Disputer(empClient, gasEstimator, accounts[0]);
+  const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
+  const gasEstimator = new GasEstimator(Logger);
+  const disputer = new Disputer(Logger, empClient, gasEstimator, accounts[0]);
 
   while (true) {
     try {

--- a/financial-templates-lib/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/ExpiringMultiPartyClient.js
@@ -1,11 +1,11 @@
 const { delay } = require("./delay");
-const { Logger } = require("./logger/Logger");
 const { LiquidationStatesEnum } = require("../common/Enums");
 
 // A thick client for getting information about an ExpiringMultiParty.
 // If no updateThreshold is specified then default to updating every 60 seconds.
 class ExpiringMultiPartyClient {
-  constructor(abi, web3, empAddress, updateThreshold = 60) {
+  constructor(logger, abi, web3, empAddress, updateThreshold = 60) {
+    this.logger = logger;
     this.updateThreshold = updateThreshold;
     this.lastUpdateTimestamp;
 
@@ -31,7 +31,7 @@ class ExpiringMultiPartyClient {
   update = async () => {
     const currentTime = Math.floor(Date.now() / 1000);
     if (currentTime < this.lastUpdateTimestamp + this.updateThreshold) {
-      Logger.debug({
+      this.logger.debug({
         at: "ExpiringMultiPartyClient",
         message: "EMP state update skipped",
         currentTime: currentTime,
@@ -42,7 +42,7 @@ class ExpiringMultiPartyClient {
     } else {
       await this._update();
       this.lastUpdateTimestamp = currentTime;
-      Logger.debug({
+      this.logger.debug({
         at: "ExpiringMultiPartyClient",
         message: "EMP state updated",
         lastUpdateTimestamp: this.lastUpdateTimestamp
@@ -55,7 +55,7 @@ class ExpiringMultiPartyClient {
     const currentTime = Math.floor(Date.now() / 1000);
     await this._update();
     this.lastUpdateTimestamp = currentTime;
-    Logger.debug({
+    this.logger.debug({
       at: "ExpiringMultiPartyClient",
       message: "EMP state force updated",
       lastUpdateTimestamp: this.lastUpdateTimestamp
@@ -104,7 +104,7 @@ class ExpiringMultiPartyClient {
       try {
         await this._update();
       } catch (error) {
-        Logger.error({
+        this.logger.error({
           at: "ExpiringMultiPartyClient",
           message: "client polling error",
           error: error

--- a/financial-templates-lib/GasEstimator.js
+++ b/financial-templates-lib/GasEstimator.js
@@ -63,7 +63,7 @@ class GasEstimator {
         throw "bad json response";
       }
     } catch (error) {
-      Logger.error({
+      this.logger.error({
         at: "GasEstimator",
         message: "client polling error",
         error: error

--- a/financial-templates-lib/GasEstimator.js
+++ b/financial-templates-lib/GasEstimator.js
@@ -3,11 +3,11 @@
 
 const fetch = require("node-fetch");
 const url = "https://ethgasstation.info/json/ethgasAPI.json";
-const { Logger } = require("./logger/Logger");
 
 // If no updateThreshold is specified then default to updating every 60 seconds.
 class GasEstimator {
-  constructor(updateThreshold = 60, defaultFastPriceGwei = 40) {
+  constructor(logger, updateThreshold = 60, defaultFastPriceGwei = 40) {
+    this.logger = logger;
     this.updateThreshold = updateThreshold;
     this.lastUpdateTimestamp;
     this.lastFastPriceGwei;
@@ -21,7 +21,7 @@ class GasEstimator {
   update = async () => {
     const currentTime = Math.floor(Date.now() / 1000);
     if (currentTime < this.lastUpdateTimestamp + this.updateThreshold) {
-      Logger.debug({
+      this.logger.debug({
         at: "GasEstimator",
         message: "Gas estimator update skipped",
         currentTime: currentTime,
@@ -33,7 +33,7 @@ class GasEstimator {
     } else {
       await this._update();
       this.lastUpdateTimestamp = currentTime;
-      Logger.debug({
+      this.logger.debug({
         at: "GasEstimator",
         message: "Gas estimator updated",
         lastUpdateTimestamp: this.lastUpdateTimestamp,

--- a/financial-templates-lib/price-feed/UniswapPriceFeed.js
+++ b/financial-templates-lib/price-feed/UniswapPriceFeed.js
@@ -1,14 +1,12 @@
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 
-const { delay } = require("../delay");
-const { Logger } = require("../logger/Logger");
-const { LiquidationStatesEnum } = require("../../common/Enums");
 const { MAX_SAFE_JS_INT } = require("../../common/Constants");
 
 // An implementation of PriceFeedInterface that uses a Uniswap v2 TWAP as the price feed source.
 class UniswapPriceFeed extends PriceFeedInterface {
-  constructor(abi, web3, uniswapAddress, twapLength, historicalLookback, getTime) {
+  constructor(logger, abi, web3, uniswapAddress, twapLength, historicalLookback, getTime) {
     super();
+    this.logger = logger;
     this.web3 = web3;
     this.uniswap = new web3.eth.Contract(abi, uniswapAddress);
     this.twapLength = twapLength;

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -1,4 +1,5 @@
 const { toWei } = web3.utils;
+const winston = require("winston");
 
 const { interfaceName } = require("../../core/utils/Constants.js");
 
@@ -68,8 +69,13 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       timerAddress: Timer.address
     };
 
+    const dummyLogger = winston.createLogger({
+      level: "info",
+      transports: []
+    });
+
     emp = await ExpiringMultiParty.new(constructorParams);
-    client = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
+    client = new ExpiringMultiPartyClient(dummyLogger, ExpiringMultiParty.abi, web3, emp.address);
     await collateralToken.approve(emp.address, toWei("1000000"), { from: sponsor1 });
     await collateralToken.approve(emp.address, toWei("1000000"), { from: sponsor2 });
 

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -69,9 +69,11 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       timerAddress: Timer.address
     };
 
+    // The ExpiringMultiPartyClient does not emit any info `level` events.  Therefore no need to test Winston outputs.
+    // DummyLogger will not print anything to console as only capture `info` level events.
     const dummyLogger = winston.createLogger({
       level: "info",
-      transports: []
+      transports: [new winston.transports.Console()]
     });
 
     emp = await ExpiringMultiParty.new(constructorParams);

--- a/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
@@ -80,7 +80,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
     // The ExpiringMultiPartyEventClient does not emit any info level events. Therefore no need to test Winston outputs.
     const dummyLogger = winston.createLogger({
       level: "info",
-      transports: []
+      transports: [new winston.transports.Console()]
     });
 
     client = new ExpiringMultiPartyEventClient(dummyLogger, ExpiringMultiParty.abi, web3, emp.address);

--- a/financial-templates-lib/test/GasEstimator.js
+++ b/financial-templates-lib/test/GasEstimator.js
@@ -41,7 +41,11 @@ contract("GasEstimator.js", function() {
 
   describe("Construction with custom config", () => {
     beforeEach(() => {
-      gasEstimator = new GasEstimator((updateThreshold = 1.5), (defaultFastPriceGwei = 10));
+      const dummyLogger = winston.createLogger({
+        level: "info",
+        transports: [new winston.transports.Console()]
+      });
+      gasEstimator = new GasEstimator(dummyLogger, (updateThreshold = 1.5), (defaultFastPriceGwei = 10));
     });
 
     it("Default parameters are set correctly", () => {

--- a/financial-templates-lib/test/GasEstimator.js
+++ b/financial-templates-lib/test/GasEstimator.js
@@ -1,4 +1,5 @@
 const { delay } = require("../delay");
+const winston = require("winston");
 
 const { GasEstimator } = require("../GasEstimator");
 
@@ -7,7 +8,11 @@ contract("GasEstimator.js", function() {
 
   describe("Construction with default config", () => {
     beforeEach(() => {
-      gasEstimator = new GasEstimator();
+      const dummyLogger = winston.createLogger({
+        level: "info",
+        transports: []
+      });
+      gasEstimator = new GasEstimator(dummyLogger);
     });
 
     it("Default parameters are set correctly", () => {

--- a/financial-templates-lib/test/GasEstimator.js
+++ b/financial-templates-lib/test/GasEstimator.js
@@ -10,7 +10,7 @@ contract("GasEstimator.js", function() {
     beforeEach(() => {
       const dummyLogger = winston.createLogger({
         level: "info",
-        transports: []
+        transports: [new winston.transports.Console()]
       });
       gasEstimator = new GasEstimator(dummyLogger);
     });

--- a/financial-templates-lib/test/price-feed/UniswapPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/UniswapPriceFeed.js
@@ -1,4 +1,5 @@
 const { toWei, toBN } = web3.utils;
+const winston = require("winston");
 
 const { UniswapPriceFeed } = require("../../price-feed/UniswapPriceFeed");
 const { mineTransactionsAtTime } = require("../../../common/SolidityTestUtils.js");
@@ -17,7 +18,23 @@ contract("UniswapPriceFeed.js", function(accounts) {
 
   beforeEach(async function() {
     uniswapMock = await UniswapMock.new({ from: owner });
-    uniswapPriceFeed = new UniswapPriceFeed(Uniswap.abi, web3, uniswapMock.address, 3600, 3600, () => mockTime);
+
+    // The UniswapPriceFeed does not emit any info `level` events.  Therefore no need to test Winston outputs.
+    // DummyLogger will not print anything to console as only capture `info` level events.
+    const dummyLogger = winston.createLogger({
+      level: "info",
+      transports: [new winston.transports.Console()]
+    });
+
+    uniswapPriceFeed = new UniswapPriceFeed(
+      dummyLogger,
+      Uniswap.abi,
+      web3,
+      uniswapMock.address,
+      3600,
+      3600,
+      () => mockTime
+    );
   });
 
   it("Basic current price", async function() {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -37,7 +37,7 @@ async function run(price, address, shouldPoll) {
 
   // Client and liquidator bot
   const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
-  const gasEstimator = new GasEstimator();
+  const gasEstimator = new GasEstimator(Logger);
   const liquidator = new Liquidator(Logger, empClient, gasEstimator, accounts[0]);
 
   while (true) {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -36,9 +36,9 @@ async function run(price, address, shouldPoll) {
   const emp = await ExpiringMultiParty.at(address);
 
   // Client and liquidator bot
-  const empClient = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
+  const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
   const gasEstimator = new GasEstimator();
-  const liquidator = new Liquidator(empClient, gasEstimator, accounts[0]);
+  const liquidator = new Liquidator(Logger, empClient, gasEstimator, accounts[0]);
 
   while (true) {
     try {

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -37,6 +37,8 @@ contract("Liquidator.js", function(accounts) {
   let syntheticToken;
   let mockOracle;
 
+  let spy;
+
   before(async function() {
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
     await collateralToken.addMember(1, contractCreator, {
@@ -96,6 +98,8 @@ contract("Liquidator.js", function(accounts) {
     await syntheticToken.approve(emp.address, toWei("100000000"), { from: sponsor2 });
     await syntheticToken.approve(emp.address, toWei("100000000"), { from: sponsor3 });
     await syntheticToken.approve(emp.address, toWei("100000000"), { from: liquidatorBot });
+
+    spy = sinon.spy();
 
     const spyLogger = winston.createLogger({
       level: "info",

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -1,5 +1,6 @@
 const { toWei, hexToUtf8, toBN } = web3.utils;
-
+const winston = require("winston");
+const sinon = require("sinon");
 const { LiquidationStatesEnum } = require("../../common/Enums");
 const { interfaceName } = require("../../core/utils/Constants.js");
 
@@ -9,6 +10,9 @@ const { Liquidator } = require("../liquidator.js");
 // Helper client script
 const { ExpiringMultiPartyClient } = require("../../financial-templates-lib/ExpiringMultiPartyClient");
 const { GasEstimator } = require("../../financial-templates-lib/GasEstimator");
+
+// Custom winston transport module to monitor winston log outputs
+const { SpyTransport, lastSpyLogIncludes } = require("../../financial-templates-lib/logger/SpyTransport");
 
 // Contracts and helpers
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
@@ -93,12 +97,17 @@ contract("Liquidator.js", function(accounts) {
     await syntheticToken.approve(emp.address, toWei("100000000"), { from: sponsor3 });
     await syntheticToken.approve(emp.address, toWei("100000000"), { from: liquidatorBot });
 
+    const spyLogger = winston.createLogger({
+      level: "info",
+      transports: [new SpyTransport({ level: "info" }, { spy: spy })]
+    });
+
     // Create a new instance of the ExpiringMultiPartyClient & gasEstimator to construct the liquidator
-    empClient = new ExpiringMultiPartyClient(ExpiringMultiParty.abi, web3, emp.address);
-    gasEstimator = new GasEstimator();
+    empClient = new ExpiringMultiPartyClient(spyLogger, ExpiringMultiParty.abi, web3, emp.address);
+    gasEstimator = new GasEstimator(spyLogger);
 
     // Create a new instance of the liquidator to test
-    liquidator = new Liquidator(empClient, gasEstimator, accounts[0]);
+    liquidator = new Liquidator(spyLogger, empClient, gasEstimator, accounts[0]);
   });
 
   it("Can correctly detect undercollateralized positions and liquidate them", async function() {


### PR DESCRIPTION
This PR refactors 1) disputer, 2) liquidator, 3) ExpiringMultiPartyClient 4) UniswapPriceFeed to all follow a dependency injection pattern enabling re-usage of the Winston logging instance injected from the base class. This pattern was implemented in the monitoring bots infrastructure to enable stub testing of Winston events emitted and to have one single logger instance through a bot implementation. Se [PR 1252](https://github.com/UMAprotocol/protocol/pull/1252) for more info on Winston testing.

Note that this PR does not use this dependency injection to perform testing on the bots Winston messages. Rather this refactor sets up the ability for testing to be performed and this is deferred for a later PR and is documented in [issue 1348](https://github.com/UMAprotocol/protocol/issues/1348).