### PR TITLE
Fix long code snippit markdown

### DIFF
--- a/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
+++ b/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
@@ -42,19 +42,9 @@ const empCreator = await ExpiringMultiPartyCreator.deployed();
 
 Note that in this example, `priceFeedIdentifier`, `syntheticName`, and `syntheticSymbol` are set to "UMATEST", "Test UMA Token", and "UMATEST", respectively, but you can set these parameters to any names you prefer in the local environment. <!-- TODO: add link to process for adding identifiers to mainnet when that doc is ready -->
 
+<!-- prettier-ignore -->
 ```js
-const constructorParams = {
-  expirationTimestamp: "1585699200",
-  collateralAddress: TestnetERC20.address,
-  priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
-  syntheticName: "Test UMA Token",
-  syntheticSymbol: "UMATEST",
-  collateralRequirement: { rawValue: web3.utils.toWei("1.5") },
-  disputeBondPct: { rawValue: web3.utils.toWei("0.1") },
-  sponsorDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") },
-  disputerDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") },
-  minSponsorTokens: { rawValue: "100000000000000" },
-  timerAddress: "0x0000000000000000000000000000000000000000"
+const constructorParams = { expirationTimestamp: "1585699200", collateralAddress: TestnetERC20.address, priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"), syntheticName: "Test UMA Token", syntheticSymbol: "UMATEST", collateralRequirement: { rawValue: web3.utils.toWei("1.5") }, disputeBondPct: { rawValue: web3.utils.toWei("0.1") }, sponsorDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, disputerDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, minSponsorTokens: { rawValue: '100000000000000' }, timerAddress: '0x0000000000000000000000000000000000000000' }
 };
 ```
 


### PR DESCRIPTION
This PR addresses an issue with a long code snippet in the markdown linter. Pretter lints code within code blocks within markdown to remain consistent within all documentation. However there are some examples in the documentation where this is not desired. The code chunk changed in this PR should not be linted as this linting prevents the code chunk from being able to be copied into a truffle console.