### PR TITLE
[P02-H02] Restrict liquidations by min collateralization ratio as well

### DIFF
--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -177,6 +177,7 @@ contract("Liquidatable", function(accounts) {
         await didContractThrow(
           liquidationContract.createLiquidation(
             sponsor,
+            { rawValue: "0" },
             { rawValue: pricePerToken.toString() },
             { rawValue: amountOfSynthetic.toString() },
             { from: liquidator }
@@ -203,7 +204,34 @@ contract("Liquidatable", function(accounts) {
         await didContractThrow(
           liquidationContract.createLiquidation(
             sponsor,
+            { rawValue: "0" },
             { rawValue: pricePerToken.toString() },
+            { rawValue: amountOfSynthetic.toString() },
+            { from: liquidator }
+          )
+        )
+      );
+    });
+    it("Collateralization is out of bounds", async () => {
+      assert(
+        await didContractThrow(
+          liquidationContract.createLiquidation(
+            sponsor,
+            { rawValue: "0" },
+            // The `maxCollateralPerToken` is below the actual collateral per token, so the liquidate call should fail.
+            { rawValue: pricePerToken.subn(1).toString() },
+            { rawValue: amountOfSynthetic.toString() },
+            { from: liquidator }
+          )
+        )
+      );
+      assert(
+        await didContractThrow(
+          liquidationContract.createLiquidation(
+            sponsor,
+            // The `minCollateralPerToken` is above the actual collateral per token, so the liquidate call should fail.
+            { rawValue: pricePerToken.addn(1).toString() },
+            { rawValue: pricePerToken.addn(2).toString() },
             { rawValue: amountOfSynthetic.toString() },
             { from: liquidator }
           )
@@ -213,12 +241,14 @@ contract("Liquidatable", function(accounts) {
     it("Returns correct ID", async () => {
       const { liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
       );
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -228,6 +258,7 @@ contract("Liquidatable", function(accounts) {
     it("Pulls correct token amount", async () => {
       const { tokensLiquidated } = await liquidationContract.createLiquidation.call(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -239,6 +270,7 @@ contract("Liquidatable", function(accounts) {
       const intitialBalance = await syntheticToken.balanceOf(liquidator);
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -256,6 +288,7 @@ contract("Liquidatable", function(accounts) {
 
       const { finalFeeBond } = await liquidationContract.createLiquidation.call(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -266,6 +299,7 @@ contract("Liquidatable", function(accounts) {
       const intitialBalance = await collateralToken.balanceOf(liquidator);
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -283,6 +317,7 @@ contract("Liquidatable", function(accounts) {
     it("Emits an event", async () => {
       const createLiquidationResult = await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -305,6 +340,7 @@ contract("Liquidatable", function(accounts) {
       // Create first liquidation
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -329,12 +365,14 @@ contract("Liquidatable", function(accounts) {
       // Create second liquidation
       const { liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
       );
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -363,12 +401,14 @@ contract("Liquidatable", function(accounts) {
       // Create partial liquidation.
       let { liquidationId, tokensLiquidated } = await liquidationContract.createLiquidation.call(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
         { from: liquidator }
       );
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
         { from: liquidator }
@@ -388,6 +428,7 @@ contract("Liquidatable", function(accounts) {
       // A independent and identical liquidation can be created.
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         // Due to rounding problems, have to increase the pricePerToken.
         { rawValue: pricePerToken.muln(2).toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
@@ -395,12 +436,14 @@ contract("Liquidatable", function(accounts) {
       );
       ({ liquidationId } = await liquidationContract.createLiquidation.call(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
         { from: liquidator }
       ));
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
         { from: liquidator }
@@ -424,6 +467,7 @@ contract("Liquidatable", function(accounts) {
         await didContractThrow(
           liquidationContract.createLiquidation(
             sponsor,
+            { rawValue: "0" },
             { rawValue: pricePerToken.muln(2).toString() },
             { rawValue: liquidationAmount.toString() },
             { from: liquidator }
@@ -455,6 +499,7 @@ contract("Liquidatable", function(accounts) {
       liquidationTime = await liquidationContract.getCurrentTime();
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -846,12 +891,14 @@ contract("Liquidatable", function(accounts) {
         // Create another liquidation
         const { liquidationId } = await liquidationContract.createLiquidation.call(
           sponsor,
+          { rawValue: "0" },
           { rawValue: pricePerToken.toString() },
           { rawValue: amountOfSynthetic.toString() },
           { from: liquidator }
         );
         await liquidationContract.createLiquidation(
           sponsor,
+          { rawValue: "0" },
           { rawValue: pricePerToken.toString() },
           { rawValue: amountOfSynthetic.toString() },
           { from: liquidator }
@@ -1175,6 +1222,7 @@ contract("Liquidatable", function(accounts) {
       // Create a Liquidation
       await edgeLiquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -1213,6 +1261,7 @@ contract("Liquidatable", function(accounts) {
       // however due to the pending withdrawal amount, the liquidated collateral gets reduced to 0.
       const createLiquidationResult = await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -1275,6 +1324,7 @@ contract("Liquidatable", function(accounts) {
         await didContractThrow(
           liquidationContract.createLiquidation(
             sponsor,
+            { rawValue: "0" },
             { rawValue: pricePerToken.toString() },
             { rawValue: amountOfSynthetic.toString() },
             { from: liquidator }
@@ -1305,6 +1355,7 @@ contract("Liquidatable", function(accounts) {
       liquidationTime = await liquidationContract.getCurrentTime();
       await liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -1397,6 +1448,7 @@ contract("Liquidatable", function(accounts) {
       // Create a Liquidation which can be tested against.
       await USDCLiquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: USDCPricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
         { from: liquidator }
@@ -1627,6 +1679,7 @@ contract("Liquidatable", function(accounts) {
       // Create a liquidation.
       await _liquidationContract.createLiquidation(
         sponsor,
+        { rawValue: "0" },
         { rawValue: toWei("1.5") },
         { rawValue: numTokens },
         { from: liquidator }

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -120,18 +120,21 @@ contract("Disputer.js", function(accounts) {
 
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
       { from: liquidator }
     );
     await emp.createLiquidation(
       sponsor2,
+      { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
       { from: liquidator }
     );
     await emp.createLiquidation(
       sponsor3,
+      { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -171,6 +174,7 @@ contract("Disputer.js", function(accounts) {
 
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -178,6 +182,7 @@ contract("Disputer.js", function(accounts) {
 
     await emp.createLiquidation(
       sponsor2,
+      { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -213,12 +218,19 @@ contract("Disputer.js", function(accounts) {
 
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
       { from: liquidator }
     );
 
-    await emp.createLiquidation(sponsor2, { rawValue: toWei("1.75") }, { rawValue: toWei("1") }, { from: liquidator });
+    await emp.createLiquidation(
+      sponsor2,
+      { rawValue: "0" },
+      { rawValue: toWei("1.75") },
+      { rawValue: toWei("1") },
+      { from: liquidator }
+    );
 
     // Send most of the user's balance elsewhere leaving only enough to dispute sponsor1's position.
     const transferAmount = (await collateralToken.balanceOf(disputeBot)).sub(toBN(toWei("1")));

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -141,11 +141,18 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     // If a position is liquidated it should be removed from the list of positions and added to the undisputed liquidations.
     const { liquidationId } = await emp.createLiquidation.call(
       sponsor2,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: sponsor1 }
     );
-    await emp.createLiquidation(sponsor2, { rawValue: toWei("99999") }, { rawValue: toWei("100") }, { from: sponsor1 });
+    await emp.createLiquidation(
+      sponsor2,
+      { rawValue: "0" },
+      { rawValue: toWei("99999") },
+      { rawValue: toWei("100") },
+      { from: sponsor1 }
+    );
 
     await updateAndVerify(
       client,
@@ -231,12 +238,14 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     // Create a new liquidation for account[0]'s position.
     const { liquidationId } = await emp.createLiquidation.call(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
       { from: liquidator }
     );
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -268,12 +277,14 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     // Create a new liquidation for account[0]'s position.
     await emp.createLiquidation.call(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
       { from: liquidator }
     );
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -336,12 +347,14 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     // Create a new liquidation for account[0]'s position.
     const { liquidationId } = await emp.createLiquidation.call(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
       { from: liquidator }
     );
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
       { from: liquidator }

--- a/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
@@ -105,6 +105,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
     // Create liquidation to liquidate sponsor2 from sponsor1
     const txObject1 = await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -134,6 +135,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
     // Correctly adds a second event after creating a new liquidation
     const txObject2 = await emp.createLiquidation(
       sponsor2,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -171,6 +173,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
     // Create liquidation to liquidate sponsor2 from sponsor1
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -203,6 +206,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
     const liquidationTime = (await emp.getCurrentTime()).toNumber();
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -53,6 +53,7 @@ class Liquidator {
       // Create the transaction.
       const liquidation = this.empContract.methods.createLiquidation(
         position.sponsor,
+        { rawValue: "0" },
         { rawValue: this.web3.utils.toWei(priceFeed) },
         { rawValue: position.numTokens }
       );

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -126,6 +126,7 @@ contract("ContractMonitor.js", function(accounts) {
     // Create liquidation to liquidate sponsor2 from sponsor1
     const txObject1 = await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -152,6 +153,7 @@ contract("ContractMonitor.js", function(accounts) {
     // Liquidate another position and ensure the Contract monitor emits the correct params
     const txObject2 = await emp.createLiquidation(
       sponsor2,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: sponsor1 } // not the monitored liquidator address
@@ -172,6 +174,7 @@ contract("ContractMonitor.js", function(accounts) {
     // Create liquidation to dispute.
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -195,7 +198,13 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "15.00")); // dispute bond of 10% of sponsor 1's 150 collateral => 15
 
     // Create a second liquidation to dispute from a non-monitored account.
-    await emp.createLiquidation(sponsor2, { rawValue: toWei("99999") }, { rawValue: toWei("100") }, { from: sponsor1 });
+    await emp.createLiquidation(
+      sponsor2,
+      { rawValue: "0" },
+      { rawValue: toWei("99999") },
+      { rawValue: toWei("100") },
+      { from: sponsor1 }
+    );
 
     // the disputer is also not monitored
     const txObject2 = await emp.dispute("0", sponsor2, {
@@ -220,6 +229,7 @@ contract("ContractMonitor.js", function(accounts) {
     let liquidationTime = (await emp.getCurrentTime()).toNumber();
     await emp.createLiquidation(
       sponsor1,
+      { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
       { from: liquidator }
@@ -258,7 +268,13 @@ contract("ContractMonitor.js", function(accounts) {
 
     // Create a second liquidation from a non-monitored address (sponsor1).
     liquidationTime = (await emp.getCurrentTime()).toNumber();
-    await emp.createLiquidation(sponsor2, { rawValue: toWei("99999") }, { rawValue: toWei("100") }, { from: sponsor1 });
+    await emp.createLiquidation(
+      sponsor2,
+      { rawValue: "0" },
+      { rawValue: toWei("99999") },
+      { rawValue: toWei("100") },
+      { from: sponsor1 }
+    );
 
     // Dispute the liquidator from a non-monitor address (sponsor2)
     await emp.dispute("0", sponsor2, {


### PR DESCRIPTION
A liquidator can now specify a min and a max for collateralization ratio
of the position they are liquidating.

The idea is to avoid a delayed liquidation ending up liquidating a
position in haircut territory. E.g., if a liquidation takes a long time
to process and the underlying price moves significantly in that time.

Signed-off-by: Prasad Tare <prasad.tare@gmail.com>