### PR TITLE
[P2-M03] Track sponsors via events

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -67,7 +67,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
     // also need to attack the base chain for this long to prevent dispute transactions from processing.
     uint256 public constant STRICT_LIQUIDATION_LIVENESS = 3600;
 
-    event CreatedExpiringMultiParty(address indexed expiringMultiPartyAddress, address indexed partyMemberAddress);
+    event CreatedExpiringMultiParty(address indexed expiringMultiPartyAddress, address indexed deployerAddress);
 
     /**
      * @notice Constructs the ExpiringMultiPartyCreator contract.
@@ -110,17 +110,13 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
 
     /**
      * @notice Creates an instance of expiring multi party and registers it within the registry.
-     * @dev caller is automatically registered as the first (and only) party member.
      * @param params is a `ConstructorParams` object from ExpiringMultiParty.
      * @return address of the deployed ExpiringMultiParty contract
      */
     function createExpiringMultiParty(Params memory params) public returns (address) {
         ExpiringMultiParty derivative = new ExpiringMultiParty(_convertParams(params));
 
-        address[] memory parties = new address[](1);
-        parties[0] = msg.sender;
-
-        _registerContract(parties, address(derivative));
+        _registerContract(new address[](0), address(derivative));
 
         emit CreatedExpiringMultiParty(address(derivative), msg.sender);
 

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -214,6 +214,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
         emit RequestTransferPositionExecuted(msg.sender, newSponsorAddress);
         emit NewSponsor(newSponsorAddress);
+        emit EndedSponsorPosition(msg.sender);
     }
 
     /**
@@ -478,6 +479,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
             // Reset the position state as all the value has been removed after settlement.
             delete positions[msg.sender];
+            emit EndedSponsorPosition(msg.sender);
         }
 
         // Take the min of the remaining collateral and the collateral "owed". If the contract is undercapitalized,

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -15,7 +15,7 @@ const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
 const Timer = artifacts.require("Timer");
 
-contract("ExpiringMultiParty", function(accounts) {
+contract("ExpiringMultiPartyCreator", function(accounts) {
   let contractCreator = accounts[0];
 
   // Contract variables
@@ -133,7 +133,7 @@ contract("ExpiringMultiParty", function(accounts) {
     let expiringMultiPartyAddress;
     truffleAssert.eventEmitted(createdAddressResult, "CreatedExpiringMultiParty", ev => {
       expiringMultiPartyAddress = ev.expiringMultiPartyAddress;
-      return ev.expiringMultiPartyAddress != 0 && ev.partyMemberAddress == contractCreator;
+      return ev.expiringMultiPartyAddress != 0 && ev.deployerAddress == contractCreator;
     });
 
     // Ensure value returned from the event is the same as returned from the function.
@@ -163,9 +163,8 @@ contract("ExpiringMultiParty", function(accounts) {
     let expiringMultiPartyAddress;
     truffleAssert.eventEmitted(createdAddressResult, "CreatedExpiringMultiParty", ev => {
       expiringMultiPartyAddress = ev.expiringMultiPartyAddress;
-      return ev.expiringMultiPartyAddress != 0 && ev.partyMemberAddress == contractCreator;
+      return ev.expiringMultiPartyAddress != 0 && ev.deployerAddress == contractCreator;
     });
     assert.isTrue(await registry.isContractRegistered(expiringMultiPartyAddress));
-    assert.isTrue(await registry.isPartyMemberOfContract(contractCreator, expiringMultiPartyAddress));
   });
 });

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -433,7 +433,10 @@ contract("Liquidatable", function(accounts) {
     });
   });
 
-  describe("Liquidation has been created", () => {
+  describe("Full liquidation has been created", () => {
+    // Used to catch events.
+    let liquidationResult;
+
     beforeEach(async () => {
       // Create position
       await liquidationContract.create(
@@ -453,7 +456,7 @@ contract("Liquidatable", function(accounts) {
 
       // Create a Liquidation
       liquidationTime = await liquidationContract.getCurrentTime();
-      await liquidationContract.createLiquidation(
+      liquidationResult = await liquidationContract.createLiquidation(
         sponsor,
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
@@ -485,6 +488,11 @@ contract("Liquidatable", function(accounts) {
         assert.equal(newLiquidation.disputer, zeroAddress);
         assert.equal(newLiquidation.liquidationTime.toString(), liquidationTime.toString());
         assert.equal(newLiquidation.settlementPrice.toString(), "0");
+      });
+      it("EndedSponsorPosition event was emitted", async () => {
+        truffleAssert.eventEmitted(liquidationResult, "EndedSponsorPosition", ev => {
+          return ev.sponsor == sponsor;
+        });
       });
       it("Liquidation does not exist", async () => {
         assert(await didContractThrow(liquidationContract.liquidations(sponsor, liquidationParams.falseLiquidationId)));

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -792,14 +792,18 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(redeemedAmount.toString(), expectedTotalSponsorCollateralReturned.toString());
 
     // Execute the settlement and check balances.
-    await settleExpired({ from: sponsor });
-    await pricelessPositionManager.settleExpired({ from: sponsor });
+    settleExpiredResult = await settleExpired({ from: sponsor });
     const sponsorFinalCollateral = await collateral.balanceOf(sponsor);
     const sponsorFinalSynthetic = await tokenCurrency.balanceOf(sponsor);
     assert.equal(
       sponsorFinalCollateral.sub(sponsorInitialCollateral).toString(),
       expectedTotalSponsorCollateralReturned
     );
+
+    // Check events.
+    truffleAssert.eventEmitted(settleExpiredResult, "EndedSponsorPosition", ev => {
+      return ev.sponsor == sponsor;
+    });
 
     // The token Sponsor should have no synthetic positions left after settlement.
     assert.equal(sponsorFinalSynthetic, 0);


### PR DESCRIPTION
- emit EndedSponsorPosition when sponsors are removed via transfers, settlements post-expiry, and liquidations.
- No longer register any party members with EMPCreator
- In EMPCreator's `CreatedExpiringMultiParty` event, renamed parameter from `partyMemberAddress` to `deployerAddress`

Signed-off-by: Nick Pai <npai.nyc@gmail.com>