### PR TITLE
Gas limit tweaks and EMP bytecode optimization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
     docker:
       - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -i 1234 -l 6720000
+        command: ganache-cli -i 1234 -l 9000000
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -149,7 +149,7 @@ jobs:
     docker:
       - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -i 1234 -l 6720000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
+        command: ganache-cli -i 1234 -l 9000000 -p 9545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
     working_directory: ~/protocol
     steps:
       - restore_cache:

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -21,7 +21,7 @@ const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "
 
 // Default options
 const gasPx = 20000000000; // 20 gwei
-const gas = 6720000; // Conservative estimate of the block gas limit.
+const gas = 9000000; // Conservative estimate of the block gas limit.
 
 // Adds a public network.
 // Note: All public networks can be accessed using keys from GCS using the ManagedSecretProvider or using a mnemonic in the
@@ -143,7 +143,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 500
+          runs: 200
         }
       }
     }

--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 import "../../oracle/implementation/ContractCreator.sol";
 import "../../common/implementation/Testable.sol";
 import "../../common/implementation/AddressWhitelist.sol";
-import "./ExpiringMultiParty.sol";
+import "./ExpiringMultiPartyLib.sol";
 
 
 /**
@@ -115,7 +115,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
      * @return address of the deployed ExpiringMultiParty contract
      */
     function createExpiringMultiParty(Params memory params) public returns (address) {
-        ExpiringMultiParty derivative = new ExpiringMultiParty(_convertParams(params));
+        address derivative = ExpiringMultiPartyLib.deploy(_convertParams(params));
 
         address[] memory parties = new address[](1);
         parties[0] = msg.sender;

--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyLib.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyLib.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "./ExpiringMultiParty.sol";
+
+
+/**
+ * @title Provides convenient Expiring Multi Party contract utilities.
+ * @dev Useing this library to deploy EMP's allows calling contracts to avoid importing the full EMP bytecode.
+ */
+library ExpiringMultiPartyLib {
+    /**
+     * @notice Returns address of new EMP deployed with given `params` configuration.
+     * @dev Caller will need to register new EMP with the Registry to begin requesting prices. Caller is also
+     * responsible for enforcing constraints on `params`.
+     * @param params is a `ConstructorParams` object from ExpiringMultiParty.
+     * @return address of the deployed ExpiringMultiParty contract
+     */
+    function deploy(ExpiringMultiParty.ConstructorParams memory params) public returns (address) {
+        ExpiringMultiParty derivative = new ExpiringMultiParty(params);
+        return address(derivative);
+    }
+}

--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyLib.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyLib.sol
@@ -6,7 +6,7 @@ import "./ExpiringMultiParty.sol";
 
 /**
  * @title Provides convenient Expiring Multi Party contract utilities.
- * @dev Useing this library to deploy EMP's allows calling contracts to avoid importing the full EMP bytecode.
+ * @dev Using this library to deploy EMP's allows calling contracts to avoid importing the full EMP bytecode.
  */
 library ExpiringMultiPartyLib {
     /**

--- a/core/migrations/14_deploy_expiring_multi_party_creator.js
+++ b/core/migrations/14_deploy_expiring_multi_party_creator.js
@@ -1,5 +1,6 @@
 const Finder = artifacts.require("Finder");
 const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
+const ExpiringMultiPartyLib = artifacts.require("ExpiringMultiPartyLib");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
 const TokenFactory = artifacts.require("TokenFactory");
 const { getKeysForNetwork, deploy, enableControllableTiming } = require("../../common/MigrationUtils.js");
@@ -16,6 +17,10 @@ module.exports = async function(deployer, network, accounts) {
 
   const finder = await Finder.deployed();
   const tokenFactory = await TokenFactory.deployed();
+
+  // Deploy EMPLib and link to EMPCreator.
+  await deploy(deployer, network, ExpiringMultiPartyLib);
+  await deployer.link(ExpiringMultiPartyLib, ExpiringMultiPartyCreator);
 
   await deploy(
     deployer,

--- a/core/scripts/local/CalculateContractBytecode.js
+++ b/core/scripts/local/CalculateContractBytecode.js
@@ -16,7 +16,7 @@ module.exports = async function(callback) {
   // Load contracts into script and output info.
   console.log("loading", argv.contract + ".json");
   let obj = require("./../../build/contracts/" + argv.contract + ".json");
-  const byteCodeSize = (obj.bytecode.length - 2) / 2;
+  const byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
   const remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
   console.log("Contract is", byteCodeSize, "bytes in size.");
   console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");


### PR DESCRIPTION
This PR contains several features
- Increases gas limit on CI local Ethereum networks to more realistic (but conservative) 9,000,000.
- Reduces # of runs on optimizer in truffle-config to default of 200. Fewer runs = lower deployment cost and less deployed bytecode.
- Change `bytecode` to `deployedBytecode` in `CalculateContractBytecode.js` script.
- Abstract deployment of EMP into a library, which EMPCreator will call via `createExpiringMultiParty(params)`. H/t to @mrice32 for the idea. This separates EMP bytecode on-chain from the EMP-creator, which means that the EMP-creator is no longer the bytecode bottleneck for deploying the EMP set of contracts. 

`deployedBytecode` Statistics:
___
This PR:
- EMP Creator = `3041` bytes
- EMP = `17170` bytes
- EMPLib = `20974` bytes

Previous:
- EMP Creator = `22983` bytes
- EMP = `17170` bytes 

Integrating this PR will give us the neccessary bytecode space to merge in both #1305  and #1334 . #1305 adds ~900 bytes and #1334 adds ~500 bytes. The bytecode limit is ~24,500 bytes, so we will have plenty of bytecode remaining.