### PR TITLE
Add MedianizerPriceFeed

### DIFF
--- a/financial-templates-lib/price-feed/MedianizerPriceFeed.js
+++ b/financial-templates-lib/price-feed/MedianizerPriceFeed.js
@@ -21,17 +21,17 @@ class MedianizerPriceFeed extends PriceFeedInterface {
       return null;
     }
 
-    return _computeMedian(currentPrices);
+    return this._computeMedian(currentPrices);
   }
 
   getHistoricalPrice(time) {
     const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
 
-    if (currentPrices.some(element => element === undefined || element === null)) {
+    if (historicalPrices.some(element => element === undefined || element === null)) {
       return null;
     }
 
-    return _computeMedian(historicalPrices);
+    return this._computeMedian(historicalPrices);
   }
 
   getLastUpdateTime() {

--- a/financial-templates-lib/price-feed/MedianizerPriceFeed.js
+++ b/financial-templates-lib/price-feed/MedianizerPriceFeed.js
@@ -1,0 +1,70 @@
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+
+// An implementation of PriceFeedInterface that medianizes other price feeds.
+class MedianizerPriceFeed extends PriceFeedInterface {
+  // Constructs the MedianizerPriceFeed.
+  // priceFeeds a list of priceFeeds to medianize. All elements must be of type PriceFeedInterface. Must be an array of
+  // at least one element.
+  constructor(priceFeeds) {
+    super();
+
+    if (priceFeeds.length === 0) {
+      throw "MedianizerPriceFeed cannot be constructed with no constituent price feeds.";
+    }
+
+    this.priceFeeds = priceFeeds;
+  }
+
+  getCurrentPrice() {
+    const currentPrices = this.priceFeeds.map(priceFeed => priceFeed.getCurrentPrice());
+    if (currentPrices.some(element => element === undefined || element === null)) {
+      return null;
+    }
+
+    return _computeMedian(currentPrices);
+  }
+
+  getHistoricalPrice(time) {
+    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
+
+    if (currentPrices.some(element => element === undefined || element === null)) {
+      return null;
+    }
+
+    return _computeMedian(historicalPrices);
+  }
+
+  getLastUpdateTime() {
+    const lastUpdateTimes = this.priceFeeds.map(priceFeed => priceFeed.getLastUpdateTime());
+
+    if (lastUpdateTimes.some(element => element === undefined || element === null)) {
+      return null;
+    }
+
+    // Take the most recent update time.
+    return Math.max(...lastUpdateTimes);
+  }
+
+  async update() {
+    for (const priceFeed of this.priceFeeds) {
+      await priceFeed.update();
+    }
+  }
+
+  // Inputs are expected to be BNs.
+  _computeMedian(inputs) {
+    inputs.sort((a, b) => a.cmp(b));
+
+    // Compute midpoint (top index / 2).
+    const maxIndex = inputs.length - 1;
+    const midpoint = maxIndex / 2;
+
+    // If the count is odd, the midpoint will land on a whole number, taking an average of the same number.
+    // If the count is even, the midpoint will land on X.5, averaging the index below and above.
+    return inputs[Math.floor(midpoint)].add(inputs[Math.ceil(midpoint)]).divn(2);
+  }
+}
+
+module.exports = {
+  MedianizerPriceFeed
+};

--- a/financial-templates-lib/price-feed/PriceFeedInterface.js
+++ b/financial-templates-lib/price-feed/PriceFeedInterface.js
@@ -8,7 +8,7 @@ class PriceFeedInterface {
 
   // Gets the current price (as a BN) for this feed synchronously from the in-memory state of this price feed object.
   // This price should be up-to-date as of the last time `update()` was called. If `update()` has never been called,
-  // this should return `undefined`. If no price could be retrieved, it should return `null`.
+  // this should return `null` or `undefined`. If no price could be retrieved, it should return `null` or `undefined`.
   // Note: derived classes *must* override this method.
   getCurrentPrice() {
     this._abstractFunctionCalled();
@@ -16,15 +16,17 @@ class PriceFeedInterface {
 
   // Gets the price (as a BN) for the time specified. Similar to `getCurrentPrice()`, the price is derived from the
   // in-memory state of the price feed object, so this method is syncrhonous. This price should be up-to-date as of the
-  // last time `update()` was called. If `update()` has never been called, this should return `undefined`. If the time
-  // is before the pre-determined historical lookback window of this PriceFeed object, then this method should return
-  // `null`. If the historical price could not be computed for any other reason, this method should return `null`.
+  // last time `update()` was called. If `update()` has never been called, this should return `null` or `undefined. If
+  // the time is before the pre-determined historical lookback window of this PriceFeed object, then this method should
+  // return `null` or `undefined`. If the historical price could not be computed for any other reason, this method
+  // should return `null` or `undefined`.
   // Note: derived classes *must* override this method.
   getHistoricalPrice(time) {
     this._abstractFunctionCalled();
   }
 
-  // This returns the last time that the `update()` method was called. If it hasn't been calle
+  // This returns the last time that the `update()` method was called. If it hasn't been called, this method should
+  // return `null` or `undefined`.
   // Note: derived classes *must* override this method.
   getLastUpdateTime() {
     this._abstractFunctionCalled();

--- a/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -4,6 +4,16 @@ const { MedianizerPriceFeed } = require("../../price-feed/MedianizerPriceFeed");
 const { PriceFeedMock } = require("./PriceFeedMock.js");
 
 contract("MedianizerPriceFeed.js", function(accounts) {
+  it("Update", async function() {
+    const priceFeeds = [new PriceFeedMock()];
+
+    const medianizerPriceFeed = new MedianizerPriceFeed(priceFeeds);
+    await medianizerPriceFeed.update();
+    await medianizerPriceFeed.update();
+
+    assert.equal(priceFeeds[0].updateCalled, 2);
+  });
+
   it("Basic medians", async function() {
     const priceFeeds = [
       //                currentPrice      historicalPrice    lastUpdatedTime
@@ -11,5 +21,77 @@ contract("MedianizerPriceFeed.js", function(accounts) {
       new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000),
       new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25)
     ];
+
+    const medianizerPriceFeed = new MedianizerPriceFeed(priceFeeds);
+
+    // Should return the median current price.
+    assert.equal(medianizerPriceFeed.getCurrentPrice(), toWei("2"));
+
+    // Should return the median historical price (because we're using mocks, the timestamp doesn't matter).
+    const arbitraryHistoricalTimestamp = 1000;
+    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("25"));
+
+    // Should return the *maximum* lastUpdatedTime.
+    assert.equal(medianizerPriceFeed.getLastUpdateTime(), 50000);
+  });
+
+  it("Even count median", async function() {
+    const priceFeeds = [
+      //                currentPrice      historicalPrice    lastUpdatedTime
+      new PriceFeedMock(toBN(toWei("1")), toBN(toWei("17")), 100),
+      new PriceFeedMock(toBN(toWei("2")), toBN(toWei("58")), 50000),
+      new PriceFeedMock(toBN(toWei("3")), toBN(toWei("45")), 25),
+      new PriceFeedMock(toBN(toWei("4")), toBN(toWei("100")), 25)
+    ];
+
+    const medianizerPriceFeed = new MedianizerPriceFeed(priceFeeds);
+
+    // Should return the average of 3 and 2 since there are an even number of elements.
+    assert.equal(medianizerPriceFeed.getCurrentPrice(), toWei("2.5"));
+
+    // Should return the average of 58 and 45 since there are an even number of elements.
+    // Note: because we're using mocks, the timestamp doesn't matter.
+    const arbitraryHistoricalTimestamp = 1000;
+    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("51.5"));
+  });
+
+  it("null inputs", async function() {
+    const priceFeeds = [
+      //                currentPrice      historicalPrice    lastUpdatedTime
+      new PriceFeedMock(toBN(toWei("1")), toBN(toWei("17")), 100),
+      new PriceFeedMock(null, null, null)
+    ];
+
+    const medianizerPriceFeed = new MedianizerPriceFeed(priceFeeds);
+
+    // Should return null since there was a null price output.
+    assert.equal(medianizerPriceFeed.getCurrentPrice(), null);
+
+    // Should return null since there was a null price output.
+    const arbitraryHistoricalTimestamp = 1000;
+    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), null);
+
+    // Should return null since there was a null input.
+    assert.equal(medianizerPriceFeed.getLastUpdateTime(), null);
+  });
+
+  it("undefined inputs", async function() {
+    const priceFeeds = [
+      //                currentPrice      historicalPrice    lastUpdatedTime
+      new PriceFeedMock(toBN(toWei("1")), toBN(toWei("17")), 100),
+      new PriceFeedMock(undefined, undefined, undefined)
+    ];
+
+    const medianizerPriceFeed = new MedianizerPriceFeed(priceFeeds);
+
+    // Should return null since there was an undefined price output.
+    assert.equal(medianizerPriceFeed.getCurrentPrice(), null);
+
+    // Should return null since there was an undefined price output.
+    const arbitraryHistoricalTimestamp = 1000;
+    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), null);
+
+    // Should return null since there was an undefined output.
+    assert.equal(medianizerPriceFeed.getLastUpdateTime(), null);
   });
 });

--- a/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -1,0 +1,14 @@
+const { toWei, toBN } = web3.utils;
+
+const { MedianizerPriceFeed } = require("../../price-feed/MedianizerPriceFeed");
+const { PriceFeedMock } = require("./PriceFeedMock.js");
+
+contract("MedianizerPriceFeed.js", function(accounts) {
+  it("Basic medians", async function() {
+    const priceFeeds = [
+      new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100),
+      new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000),
+      new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25)
+    ];
+  });
+});

--- a/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -6,6 +6,7 @@ const { PriceFeedMock } = require("./PriceFeedMock.js");
 contract("MedianizerPriceFeed.js", function(accounts) {
   it("Basic medians", async function() {
     const priceFeeds = [
+      //                currentPrice      historicalPrice    lastUpdatedTime
       new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100),
       new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000),
       new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25)

--- a/financial-templates-lib/test/price-feed/PriceFeedMock.js
+++ b/financial-templates-lib/test/price-feed/PriceFeedMock.js
@@ -1,0 +1,47 @@
+const { PriceFeedInterface } = require("../../price-feed/PriceFeedInterface");
+
+// An implementation of PriceFeedInterface that medianizes other price feeds.
+class PriceFeedMock extends PriceFeedInterface {
+  // Constructs the MedianizerPriceFeed.
+  // priceFeeds a list of priceFeeds to medianize. All elements must be of type PriceFeedInterface. Must be an array of
+  // at least one element.
+  constructor(currentPrice, historicalPrice, lastUpdateTime) {
+    super();
+    this.updateCalled = 0;
+    this.currentPrice = currentPrice;
+    this.historicalPrice = historicalPrice;
+    this.lastUpdateTime = lastUpdateTime;
+  }
+
+  setCurrentPrice(currentPrice) {
+    this.currentPrice = currentPrice;
+  }
+
+  setHistoricalPrice(historicalPrice) {
+    this.historicalPrice = historicalPrice;
+  }
+
+  setLastUpdateTime(lastUpdateTime) {
+    this.lastUpdateTime = lastUpdateTime;
+  }
+
+  getCurrentPrice() {
+    return this.currentPrice;
+  }
+
+  getHistoricalPrice(time) {
+    return this.historicalPrice;
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  async update() {
+    this.updateCalled++;
+  }
+}
+
+module.exports = {
+  PriceFeedMock
+};


### PR DESCRIPTION
Adds a price feed that takes price feeds as constructor inputs and medianizes their outputs.

This will allow the implementation of an exchange price median using this price feed constructed with the multiple CryptoWatchPriceFeeds.

There were a few implementation decisions that were made that impact how this price feed will perform in production:
1. It returns the *max* of all of its constituent price feeds' `lastUpdateTime`s.
2. It returns `null` whenever any of the constituent price feeds return `null` or `undefined` for any call. This implies that it's effectively a "weakest link breaks the chain" type of system and errs on the side of being more correct but less reliable.

Note: this implementation also includes a `MockPriceFeed` to make unit testing easier.