### PR TITLE
[P2-L06] Add require messages back to EMP

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -143,12 +143,12 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable {
         constructorParams.tokenFactoryAddress = tokenFactoryAddress;
 
         // Enforce configuration constraints.
-        require(_isValidTimestamp(params.expirationTimestamp));
-        require(bytes(params.syntheticName).length != 0);
-        require(bytes(params.syntheticSymbol).length != 0);
+        require(_isValidTimestamp(params.expirationTimestamp), "Invalid expiration timestamp");
+        require(bytes(params.syntheticName).length != 0, "Missing synthetic name");
+        require(bytes(params.syntheticSymbol).length != 0, "Missing synthetic symbol");
         constructorParams.withdrawalLiveness = STRICT_WITHDRAWAL_LIVENESS;
         constructorParams.liquidationLiveness = STRICT_LIQUIDATION_LIVENESS;
-        require(collateralTokenWhitelist.isOnWhitelist(params.collateralAddress));
+        require(collateralTokenWhitelist.isOnWhitelist(params.collateralAddress), "Collateral is not whitelisted");
 
         // Input from function call.
         constructorParams.expirationTimestamp = params.expirationTimestamp;

--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -143,7 +143,7 @@ abstract contract FeePayer is Testable {
             FixedPoint.Unsigned memory _pfc = pfc();
 
             // The final fee must be < pfc or the fee will be larger than 100%.
-            require(_pfc.isGreaterThan(amount));
+            require(_pfc.isGreaterThan(amount), "Final fee is more than PfC");
 
             // Adjust the cumulative fee multiplier by the fee paid and the current PFC.
             _adjustCumulativeFeeMultiplier(amount, _pfc);

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -157,8 +157,11 @@ contract Liquidatable is PricelessPositionManager {
             params.timerAddress
         )
     {
-        require(params.collateralRequirement.isGreaterThan(1));
-        require(params.sponsorDisputeRewardPct.add(params.disputerDisputeRewardPct).isLessThan(1));
+        require(params.collateralRequirement.isGreaterThan(1), "CR is more than 100%");
+        require(
+            params.sponsorDisputeRewardPct.add(params.disputerDisputeRewardPct).isLessThan(1),
+            "Rewards are more than 100%"
+        );
 
         // Set liquidatable specific variables.
         liquidationLiveness = params.liquidationLiveness;
@@ -217,7 +220,10 @@ contract Liquidatable is PricelessPositionManager {
             // Check the max price constraint to ensure that the Position's collateralization ratio hasn't increased beyond
             // what the liquidator was willing to liquidate at.
             // collateralPerToken >= startCollateralNetOfWithdrawal / startTokens.
-            require(collateralPerToken.mul(startTokens).isGreaterThanOrEqual(startCollateralNetOfWithdrawal));
+            require(
+                collateralPerToken.mul(startTokens).isGreaterThanOrEqual(startCollateralNetOfWithdrawal),
+                "CR is more than max liq. price"
+            );
         }
 
         // The actual amount of collateral that gets moved to the liquidation.
@@ -343,7 +349,8 @@ contract Liquidatable is PricelessPositionManager {
         require(
             (msg.sender == liquidation.disputer) ||
                 (msg.sender == liquidation.liquidator) ||
-                (msg.sender == liquidation.sponsor)
+                (msg.sender == liquidation.sponsor),
+            "Caller cannot withdraw rewards"
         );
 
         // Settles the liquidation if necessary.
@@ -488,7 +495,8 @@ contract Liquidatable is PricelessPositionManager {
         // Revert if the caller is attempting to access an invalid liquidation
         // (one that has never been created or one has never been initialized).
         require(
-            liquidationId < liquidationArray.length && liquidationArray[liquidationId].state != Status.Uninitialized
+            liquidationId < liquidationArray.length && liquidationArray[liquidationId].state != Status.Uninitialized,
+            "Invalid liquidation ID"
         );
         return liquidationArray[liquidationId];
     }
@@ -502,7 +510,10 @@ contract Liquidatable is PricelessPositionManager {
     // source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
     function _disputable(uint256 liquidationId, address sponsor) internal view {
         LiquidationData storage liquidation = _getLiquidationData(sponsor, liquidationId);
-        require((getCurrentTime() < _getLiquidationExpiry(liquidation)) && (liquidation.state == Status.PreDispute));
+        require(
+            (getCurrentTime() < _getLiquidationExpiry(liquidation)) && (liquidation.state == Status.PreDispute),
+            "Liquidation not disputable"
+        );
     }
 
     function _withdrawable(uint256 liquidationId, address sponsor) internal view {
@@ -512,7 +523,8 @@ contract Liquidatable is PricelessPositionManager {
         // Must be disputed or the liquidation has passed expiry.
         require(
             (state > Status.PreDispute) ||
-                ((_getLiquidationExpiry(liquidation) <= getCurrentTime()) && (state == Status.PreDispute))
+                ((_getLiquidationExpiry(liquidation) <= getCurrentTime()) && (state == Status.PreDispute)),
+            "Liquidation not withdrawable"
         );
     }
 }


### PR DESCRIPTION
This PR adds ~2000 bytes to the `deployedBytecode`, giving us ~1300 bytes to finish remaining EMP tasks

```
Contract is 23275 bytes in size.
This leaves a total of 1301 bytes within the EIP170 limit.
```