### PR TITLE
Add deadline to createLiquidation()

### DIFF
--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -184,6 +184,7 @@ contract Liquidatable is PricelessPositionManager {
      * @param minCollateralPerToken abort the liquidation if the position's collateral per token is below this value.
      * @param maxCollateralPerToken abort the liquidation if the position's collateral per token exceeds this value.
      * @param maxTokensToLiquidate max number of tokens to liquidate.
+     * @param deadline abort the liquidation if the transaction is mined after this timestamp.
      * @return liquidationId of the newly created liquidation.
      */
     function createLiquidation(

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -235,6 +235,9 @@ contract Liquidatable is PricelessPositionManager {
             );
         }
 
+        // Compute final fee at time of liquidation.
+        finalFeeBond = _computeFinalFees();
+
         // These will be populated within the scope below.
         FixedPoint.Unsigned memory lockedCollateral;
         FixedPoint.Unsigned memory liquidatedCollateral;
@@ -260,9 +263,6 @@ contract Liquidatable is PricelessPositionManager {
 
         // Add to the global liquidation collateral count.
         _addCollateral(rawLiquidationCollateral, lockedCollateral.add(finalFeeBond));
-
-        // Compute final fee at time of liquidation.
-        finalFeeBond = _computeFinalFees();
 
         // Construct liquidation object.
         // Note: all dispute-related values are just zeroed out until a dispute occurs.

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -209,7 +209,6 @@ contract Liquidatable is PricelessPositionManager {
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
 
         tokensLiquidated = FixedPoint.min(maxTokensToLiquidate, positionToLiquidate.tokensOutstanding);
-        FixedPoint.Unsigned memory ratio = tokensLiquidated.div(positionToLiquidate.tokensOutstanding);
 
         // Starting values for the Position being liquidated.
         // If withdrawal request amount is > position's collateral, then set this to 0, otherwise set it to (startCollateral - withdrawal request amount).
@@ -236,11 +235,31 @@ contract Liquidatable is PricelessPositionManager {
             );
         }
 
-        // The actual amount of collateral that gets moved to the liquidation.
-        FixedPoint.Unsigned memory lockedCollateral = startCollateral.mul(ratio);
-        // For purposes of disputes, it's actually this liquidatedCollateral value that's used. This value is net of
-        // withdrawal requests.
-        FixedPoint.Unsigned memory liquidatedCollateral = startCollateralNetOfWithdrawal.mul(ratio);
+        // These will be populated within the scope below.
+        FixedPoint.Unsigned memory lockedCollateral;
+        FixedPoint.Unsigned memory liquidatedCollateral;
+
+        // Scoping to get rid of a stack too deep error.
+        {
+            FixedPoint.Unsigned memory ratio = tokensLiquidated.div(positionToLiquidate.tokensOutstanding);
+
+            // The actual amount of collateral that gets moved to the liquidation.
+            lockedCollateral = startCollateral.mul(ratio);
+
+            // For purposes of disputes, it's actually this liquidatedCollateral value that's used. This value is net of
+            // withdrawal requests.
+            liquidatedCollateral = startCollateralNetOfWithdrawal.mul(ratio);
+
+            // Part of the withdrawal request is also removed. Ideally:
+            // liquidatedCollateral + withdrawalAmountToRemove = lockedCollateral.
+            FixedPoint.Unsigned memory withdrawalAmountToRemove = positionToLiquidate.withdrawalRequestAmount.mul(
+                ratio
+            );
+            _reduceSponsorPosition(sponsor, tokensLiquidated, lockedCollateral, withdrawalAmountToRemove);
+        }
+
+        // Add to the global liquidation collateral count.
+        _addCollateral(rawLiquidationCollateral, lockedCollateral.add(finalFeeBond));
 
         // Compute final fee at time of liquidation.
         finalFeeBond = _computeFinalFees();
@@ -265,20 +284,6 @@ contract Liquidatable is PricelessPositionManager {
                 finalFee: finalFeeBond
             })
         );
-
-        // Scoping to get rid of a stack too deep error.
-        // Adjust the sponsor's remaining position.
-        {
-            // Part of the withdrawal request is also removed. Ideally:
-            // liquidatedCollateral + withdrawalAmountToRemove = lockedCollateral.
-            FixedPoint.Unsigned memory withdrawalAmountToRemove = positionToLiquidate.withdrawalRequestAmount.mul(
-                ratio
-            );
-            _reduceSponsorPosition(sponsor, tokensLiquidated, lockedCollateral, withdrawalAmountToRemove);
-        }
-
-        // Add to the global liquidation collateral count.
-        _addCollateral(rawLiquidationCollateral, lockedCollateral.add(finalFeeBond));
 
         emit LiquidationCreated(
             sponsor,

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -190,7 +190,8 @@ contract Liquidatable is PricelessPositionManager {
         address sponsor,
         FixedPoint.Unsigned calldata minCollateralPerToken,
         FixedPoint.Unsigned calldata maxCollateralPerToken,
-        FixedPoint.Unsigned calldata maxTokensToLiquidate
+        FixedPoint.Unsigned calldata maxTokensToLiquidate,
+        uint256 deadline
     )
         external
         fees()
@@ -201,6 +202,9 @@ contract Liquidatable is PricelessPositionManager {
             FixedPoint.Unsigned memory finalFeeBond
         )
     {
+        // Check that this transaction was mined pre-deadline.
+        require(getCurrentTime() <= deadline, "Mined after deadline");
+
         // Retrieve Position data for sponsor
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
 

--- a/core/scripts/IntegrationTests.js
+++ b/core/scripts/IntegrationTests.js
@@ -17,6 +17,7 @@
 const { toWei, toBN } = web3.utils;
 const { RegistryRolesEnum } = require("../../common/Enums.js");
 const { interfaceName } = require("../utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../common/Constants.js");
 
 // Contract to test
 const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
@@ -56,6 +57,7 @@ contract("IntegrationTest", function(accounts) {
 
   const mintAndApprove = toBN(toWei("100000000000000")); // number of tokens minted and approved by each account
   const timeOffsetBetweenTests = toBN(60 * 60); // timestep advance between loop iterations (1 hour)
+  const unreachableDeadline = MAX_UINT_VAL;
 
   beforeEach(async () => {
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
@@ -228,8 +230,10 @@ contract("IntegrationTest", function(accounts) {
         const positionTokensOutstanding = (await expiringMultiParty.positions(sponsor)).tokensOutstanding;
         await expiringMultiParty.createLiquidation(
           sponsor,
+          { rawValue: "0" },
           { rawValue: GCR.toString() }, // the liquidation is submitted at the GCR price
           { rawValue: positionTokensOutstanding.toString() }, // all tokens in the position are liquidated
+          unreachableDeadline,
           { from: liquidator }
         );
 
@@ -432,8 +436,10 @@ contract("IntegrationTest", function(accounts) {
         const positionTokensOutstanding = (await expiringMultiParty.positions(sponsor)).tokensOutstanding;
         await expiringMultiParty.createLiquidation(
           sponsor,
+          { rawValue: "0" },
           { rawValue: GCR.toString() },
           { rawValue: positionTokensOutstanding.toString() },
+          unreachableDeadline,
           { from: liquidator }
         );
 
@@ -659,8 +665,10 @@ contract("IntegrationTest", function(accounts) {
 
         await expiringMultiParty.createLiquidation(
           sponsor,
+          { rawValue: "0" },
           { rawValue: GCR.toString() },
           { rawValue: positionTokensOutstanding.toString() },
+          unreachableDeadline,
           { from: liquidator }
         );
 

--- a/core/scripts/PrecisionErrors.js
+++ b/core/scripts/PrecisionErrors.js
@@ -15,6 +15,8 @@ const assert = require("assert").strict;
 const truffleAssert = require("truffle-assertions");
 const { toWei, fromWei, toBN, utf8ToHex } = web3.utils;
 const { interfaceName } = require("../utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../common/Constants.js");
+const unreachableDeadline = MAX_UINT_VAL;
 
 // Contracts to test
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
@@ -1030,8 +1032,10 @@ async function runExport() {
    */
   createLiquidationResult = await emp.createLiquidation(
     sponsor,
+    { rawValue: "0" },
     { rawValue: testConfig.collateralRatio },
     { rawValue: testConfig.amountToLiquidate },
+    unreachableDeadline,
     { from: sponsor }
   );
   expectedRemainingCollateral = toBN(await collateral.balanceOf(emp.address)).sub(toBN(testConfig.amountToLiquidate));
@@ -1061,8 +1065,10 @@ async function runExport() {
    */
   createLiquidationResult = await emp.createLiquidation(
     sponsor,
+    { rawValue: "0" },
     { rawValue: testConfig.collateralRatio },
     { rawValue: testConfig.amountToLiquidate },
+    unreachableDeadline,
     { from: sponsor }
   );
   expectedRemainingCollateral = expectedRemainingCollateral.sub(toBN(testConfig.amountToLiquidate));
@@ -1092,8 +1098,10 @@ async function runExport() {
    */
   createLiquidationResult = await emp.createLiquidation(
     sponsor,
+    { rawValue: "0" },
     { rawValue: testConfig.collateralRatio },
     { rawValue: testConfig.amountToLiquidate },
+    unreachableDeadline,
     { from: sponsor }
   );
   expectedRemainingCollateral = expectedRemainingCollateral.sub(toBN(testConfig.amountToLiquidate));

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -446,6 +446,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       await liquidationContract.createLiquidation(

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -2,6 +2,7 @@
 const { didContractThrow } = require("../../../common/SolidityTestUtils.js");
 const { LiquidationStatesEnum } = require("../../../common/Enums");
 const { interfaceName } = require("../../utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../../common/Constants.js");
 const truffleAssert = require("truffle-assertions");
 const { toWei, fromWei, hexToUtf8, toBN } = web3.utils;
 
@@ -65,6 +66,7 @@ contract("Liquidatable", function(accounts) {
     .muln(1);
   const pendingWithdrawalAmount = "0"; // Amount to liquidate can be less than amount of collateral iff there is a pending withdrawal
   const amountOfCollateralToLiquidate = amountOfCollateral.add(toBN(pendingWithdrawalAmount));
+  const unreachableDeadline = MAX_UINT_VAL;
 
   // Set final fee to a flat 1 collateral token.
   const finalFeeAmount = toBN(toWei("1"));
@@ -180,6 +182,7 @@ contract("Liquidatable", function(accounts) {
             { rawValue: "0" },
             { rawValue: pricePerToken.toString() },
             { rawValue: amountOfSynthetic.toString() },
+            unreachableDeadline,
             { from: liquidator }
           )
         )
@@ -207,9 +210,36 @@ contract("Liquidatable", function(accounts) {
             { rawValue: "0" },
             { rawValue: pricePerToken.toString() },
             { rawValue: amountOfSynthetic.toString() },
+            unreachableDeadline,
             { from: liquidator }
           )
         )
+      );
+    });
+    it("Liquidation is mined after the deadline", async () => {
+      const currentTime = await liquidationContract.getCurrentTime();
+      assert(
+        await didContractThrow(
+          liquidationContract.createLiquidation(
+            sponsor,
+            { rawValue: "0" },
+            { rawValue: pricePerToken.toString() },
+            { rawValue: amountOfSynthetic.toString() },
+            currentTime.subn(1).toString(),
+            { from: liquidator }
+          )
+        )
+      );
+    });
+    it("Liquidation is mined before the deadline", async () => {
+      const currentTime = await liquidationContract.getCurrentTime();
+      await liquidationContract.createLiquidation(
+        sponsor,
+        { rawValue: "0" },
+        { rawValue: pricePerToken.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        currentTime.addn(1).toString(),
+        { from: liquidator }
       );
     });
     it("Collateralization is out of bounds", async () => {
@@ -221,6 +251,7 @@ contract("Liquidatable", function(accounts) {
             // The `maxCollateralPerToken` is below the actual collateral per token, so the liquidate call should fail.
             { rawValue: pricePerToken.subn(1).toString() },
             { rawValue: amountOfSynthetic.toString() },
+            unreachableDeadline,
             { from: liquidator }
           )
         )
@@ -233,6 +264,7 @@ contract("Liquidatable", function(accounts) {
             { rawValue: pricePerToken.addn(1).toString() },
             { rawValue: pricePerToken.addn(2).toString() },
             { rawValue: amountOfSynthetic.toString() },
+            unreachableDeadline,
             { from: liquidator }
           )
         )
@@ -244,6 +276,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       await liquidationContract.createLiquidation(
@@ -251,6 +284,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       assert.equal(liquidationId.toString(), liquidationParams.liquidationId.toString());
@@ -261,6 +295,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
 
@@ -273,6 +308,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
 
@@ -291,6 +327,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       // Should return the correct final fee amount.
@@ -302,6 +339,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
 
@@ -320,6 +358,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
@@ -343,6 +382,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
 
@@ -368,6 +408,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       await liquidationContract.createLiquidation(
@@ -375,6 +416,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       assert.equal(
@@ -411,6 +453,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       let position = await liquidationContract.positions(sponsor);
@@ -432,6 +475,7 @@ contract("Liquidatable", function(accounts) {
         // Due to rounding problems, have to increase the pricePerToken.
         { rawValue: pricePerToken.muln(2).toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       ({ liquidationId } = await liquidationContract.createLiquidation.call(
@@ -439,6 +483,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
+        unreachableDeadline,
         { from: liquidator }
       ));
       await liquidationContract.createLiquidation(
@@ -446,6 +491,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.divn(5).toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       liquidation = await liquidationContract.liquidations(sponsor, liquidationId);
@@ -470,6 +516,7 @@ contract("Liquidatable", function(accounts) {
             { rawValue: "0" },
             { rawValue: pricePerToken.muln(2).toString() },
             { rawValue: liquidationAmount.toString() },
+            unreachableDeadline,
             { from: liquidator }
           )
         )
@@ -505,6 +552,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
 
@@ -902,6 +950,7 @@ contract("Liquidatable", function(accounts) {
           { rawValue: "0" },
           { rawValue: pricePerToken.toString() },
           { rawValue: amountOfSynthetic.toString() },
+          unreachableDeadline,
           { from: liquidator }
         );
         await liquidationContract.createLiquidation(
@@ -909,6 +958,7 @@ contract("Liquidatable", function(accounts) {
           { rawValue: "0" },
           { rawValue: pricePerToken.toString() },
           { rawValue: amountOfSynthetic.toString() },
+          unreachableDeadline,
           { from: liquidator }
         );
         assert.equal(
@@ -1233,6 +1283,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       // Dispute
@@ -1272,6 +1323,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
@@ -1335,6 +1387,7 @@ contract("Liquidatable", function(accounts) {
             { rawValue: "0" },
             { rawValue: pricePerToken.toString() },
             { rawValue: amountOfSynthetic.toString() },
+            unreachableDeadline,
             { from: liquidator }
           )
         )
@@ -1366,6 +1419,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: pricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
       // Fast forward time to expiry.
@@ -1459,6 +1513,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: USDCPricePerToken.toString() },
         { rawValue: amountOfSynthetic.toString() },
+        unreachableDeadline,
         { from: liquidator }
       );
 
@@ -1690,6 +1745,7 @@ contract("Liquidatable", function(accounts) {
         { rawValue: "0" },
         { rawValue: toWei("1.5") },
         { rawValue: numTokens },
+        unreachableDeadline,
         { from: liquidator }
       );
     });

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -1,5 +1,6 @@
 const { LiquidationStatesEnum } = require("../../common/Enums");
 const { interfaceName } = require("../../core/utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../common/Constants.js");
 const winston = require("winston");
 const sinon = require("sinon");
 
@@ -41,6 +42,7 @@ contract("Disputer.js", function(accounts) {
   let spy;
 
   const zeroAddress = "0x0000000000000000000000000000000000000000";
+  const unreachableDeadline = MAX_UINT_VAL;
 
   before(async function() {
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
@@ -137,6 +139,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await emp.createLiquidation(
@@ -144,6 +147,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await emp.createLiquidation(
@@ -151,6 +155,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -191,6 +196,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -199,6 +205,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -235,6 +242,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -243,6 +251,7 @@ contract("Disputer.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("1.75") },
       { rawValue: toWei("1") },
+      unreachableDeadline,
       { from: liquidator }
     );
 

--- a/financial-templates-lib/test/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyClient.js
@@ -2,6 +2,7 @@ const { toWei } = web3.utils;
 const winston = require("winston");
 
 const { interfaceName } = require("../../core/utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../common/Constants.js");
 
 const { ExpiringMultiPartyClient } = require("../ExpiringMultiPartyClient");
 const { delay } = require("../delay");
@@ -19,6 +20,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
   const sponsor2 = accounts[1];
 
   const zeroAddress = "0x0000000000000000000000000000000000000000";
+  const unreachableDeadline = MAX_UINT_VAL;
 
   let collateralToken;
   let emp;
@@ -152,6 +154,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: sponsor1 }
     );
     await emp.createLiquidation(
@@ -159,6 +162,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: sponsor1 }
     );
 
@@ -249,6 +253,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await emp.createLiquidation(
@@ -256,6 +261,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await client._update();
@@ -288,6 +294,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await emp.createLiquidation(
@@ -295,6 +302,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await client._update();
@@ -358,6 +366,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await emp.createLiquidation(
@@ -365,6 +374,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("9999999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await client._update();

--- a/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/test/ExpiringMultiPartyEventClient.js
@@ -2,6 +2,7 @@ const { toWei } = web3.utils;
 const winston = require("winston");
 
 const { interfaceName } = require("../../core/utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../common/Constants.js");
 
 const { ExpiringMultiPartyEventClient } = require("../ExpiringMultiPartyEventClient");
 const { delay } = require("../delay");
@@ -21,6 +22,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
   const sponsor2 = accounts[3];
 
   const zeroAddress = "0x0000000000000000000000000000000000000000";
+  const unreachableDeadline = MAX_UINT_VAL;
 
   // Contracts
   let collateralToken;
@@ -108,6 +110,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -138,6 +141,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
     await client.clearState();
@@ -176,6 +180,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -209,6 +214,7 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -49,12 +49,16 @@ class Liquidator {
     }
 
     for (const position of underCollateralizedPositions) {
+      // Note: query the time again during each iteration to ensure the deadline is set reasonably.
+      const currentBlockTime = await this.empContract.methods.getCurrentTime().call();
+      const fiveMinutes = 300;
       // Create the transaction.
       const liquidation = this.empContract.methods.createLiquidation(
         position.sponsor,
         { rawValue: "0" },
         { rawValue: this.web3.utils.toWei(priceFeed) },
-        { rawValue: position.numTokens }
+        { rawValue: position.numTokens },
+        parseInt(currentBlockTime) + fiveMinutes
       );
 
       // Simple version of inventory management: simulate the transaction and assume that if it fails, the caller didn't have enough collateral.

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -2,6 +2,7 @@ const { toWei } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
 const { interfaceName } = require("../../core/utils/Constants.js");
+const { MAX_UINT_VAL } = require("../../common/Constants.js");
 
 // Script to test
 const { ContractMonitor } = require("../ContractMonitor");
@@ -29,6 +30,7 @@ contract("ContractMonitor.js", function(accounts) {
   const sponsor2 = accounts[4];
 
   const zeroAddress = "0x0000000000000000000000000000000000000000";
+  const unreachableDeadline = MAX_UINT_VAL;
 
   // Contracts
   let collateralToken;
@@ -129,6 +131,7 @@ contract("ContractMonitor.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -156,6 +159,7 @@ contract("ContractMonitor.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: sponsor1 } // not the monitored liquidator address
     );
 
@@ -177,6 +181,7 @@ contract("ContractMonitor.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -203,6 +208,7 @@ contract("ContractMonitor.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: sponsor1 }
     );
 
@@ -232,6 +238,7 @@ contract("ContractMonitor.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: liquidator }
     );
 
@@ -273,6 +280,7 @@ contract("ContractMonitor.js", function(accounts) {
       { rawValue: "0" },
       { rawValue: toWei("99999") },
       { rawValue: toWei("100") },
+      unreachableDeadline,
       { from: sponsor1 }
     );
 


### PR DESCRIPTION
This adds a `deadline` parameter to `createLiquidation()` to protect callers from the price moving against them (and invalidating their liquidation) in the case that their transaction sits longer than expected in the mempool.

Note: the only logical changes to createLiquidation are the addition of the require at the top. Everything else is just restructuring to avoid the stack too deep error.