### PR TITLE
EMPCreator refactors

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiPartyCreator.sol
@@ -51,8 +51,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
     AddressWhitelist public collateralTokenWhitelist;
     // - Address of TokenFactory to pass into newly constructed ExpiringMultiParty contracts
     address public tokenFactoryAddress;
-    // - Address of contract that keeps track of time for testing environments, or 0x0 for production that use live time.
-    address public timerContractAddress;
     // - Discretize expirations such that they must expire on the first of each month.
     mapping(uint256 => bool) public validExpirationTimestamps;
     // - Time for pending withdrawal to be disputed: 120 minutes. Lower liveness increases sponsor usability.
@@ -85,7 +83,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
     ) public ContractCreator(_finderAddress) Testable(_timerAddress) nonReentrant() {
         collateralTokenWhitelist = AddressWhitelist(_collateralTokenWhitelist);
         tokenFactoryAddress = _tokenFactoryAddress;
-        timerContractAddress = _timerAddress;
         uint32[16] memory timestamps = [
             1585699200, // 2020-04-01T00:00:00.000Z
             1588291200, // 2020-05-01T00:00:00.000Z
@@ -142,7 +139,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
         // Known from creator deployment.
         constructorParams.finderAddress = finderAddress;
         constructorParams.tokenFactoryAddress = tokenFactoryAddress;
-        constructorParams.timerAddress = timerContractAddress;
+        constructorParams.timerAddress = timerAddress;
 
         // Enforce configuration constraints.
         require(_isValidTimestamp(params.expirationTimestamp), "Invalid expiration timestamp");

--- a/core/scripts/DeploySyntheticTokens.js
+++ b/core/scripts/DeploySyntheticTokens.js
@@ -49,9 +49,7 @@ const parseLine = line => {
     sponsorDisputeReward: fields[7],
     disputeReward: fields[8],
     // Hardcode min sponsor tokens. Most users of this script aren't interested in configuring this value.
-    minSponsorTokens: "0.01",
-    // Use actual block time.
-    timerAddress: "0x0000000000000000000000000000000000000000"
+    minSponsorTokens: "0.01"
   };
 };
 
@@ -101,8 +99,7 @@ const actualDeploy = async inputCsv => {
       disputeBondPct: percentToFixedPoint(params.disputeBond),
       sponsorDisputeRewardPct: percentToFixedPoint(params.sponsorDisputeReward),
       disputerDisputeRewardPct: percentToFixedPoint(params.disputeReward),
-      minSponsorTokens: percentToFixedPoint(params.minSponsorTokens),
-      timerAddress: params.timerAddress
+      minSponsorTokens: percentToFixedPoint(params.minSponsorTokens)
     };
     const address = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams);
     await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams);

--- a/core/scripts/local/AdvanceEMP.js
+++ b/core/scripts/local/AdvanceEMP.js
@@ -14,7 +14,7 @@ const Voting = artifacts.require("Voting");
 
 const advanceTime = async callback => {
   try {
-    const leapForward = argv.time ? argv.time : 3600;
+    const leapForward = argv.time ? argv.time : 7200;
     console.log(`Advancing contract time forward by ${leapForward} seconds`);
 
     // Since MockOracle and EMP share the same Timer, it suffices to just advance the oracle's time.

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -71,8 +71,7 @@ const deployEMP = async callback => {
       disputeBondPct: { rawValue: toWei("0.1") },
       sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
       disputerDisputeRewardPct: { rawValue: toWei("0.1") },
-      minSponsorTokens: { rawValue: toWei("0.01") },
-      timerAddress: Timer.address
+      minSponsorTokens: { rawValue: toWei("0.01") }
     };
     let _emp = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams, { from: deployer });
     await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: deployer });

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -63,10 +63,6 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
     assert.equal(await expiringMultiPartyCreator.tokenFactoryAddress(), (await TokenFactory.deployed()).address);
   });
 
-  it("Timer address should be set on construction", async function() {
-    assert.equal(await expiringMultiPartyCreator.timerContractAddress(), (await Timer.deployed()).address);
-  });
-
   it("Expiration timestamp must be one of the allowed timestamps", async function() {
     // Change only expiration timestamp.
     const validExpiration = "1598918400";
@@ -159,7 +155,7 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
     );
 
     // Deployed EMP timer should be same as EMP creator.
-    assert.equal(await expiringMultiParty.timerAddress(), await expiringMultiPartyCreator.timerContractAddress());
+    assert.equal(await expiringMultiParty.timerAddress(), await expiringMultiPartyCreator.timerAddress());
   });
 
   it("Creation correctly registers ExpiringMultiParty within the registry", async function() {

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -14,6 +14,7 @@ const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
 const Timer = artifacts.require("Timer");
+const Finder = artifacts.require("Finder");
 
 contract("ExpiringMultiPartyCreator", function(accounts) {
   let contractCreator = accounts[0];
@@ -49,8 +50,7 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
       disputeBondPct: { rawValue: toWei("0.1") },
       sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
       disputerDisputeRewardPct: { rawValue: toWei("0.1") },
-      minSponsorTokens: { rawValue: toWei("1") },
-      timerAddress: Timer.address
+      minSponsorTokens: { rawValue: toWei("1") }
     };
 
     identifierWhitelist = await IdentifierWhitelist.deployed();
@@ -61,6 +61,10 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
 
   it("TokenFactory address should be set on construction", async function() {
     assert.equal(await expiringMultiPartyCreator.tokenFactoryAddress(), (await TokenFactory.deployed()).address);
+  });
+
+  it("Timer address should be set on construction", async function() {
+    assert.equal(await expiringMultiPartyCreator.timerContractAddress(), (await Timer.deployed()).address);
   });
 
   it("Expiration timestamp must be one of the allowed timestamps", async function() {
@@ -153,6 +157,9 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
       hexToUtf8(await expiringMultiParty.priceIdentifier()),
       hexToUtf8(constructorParams.priceFeedIdentifier)
     );
+
+    // Deployed EMP timer should be same as EMP creator.
+    assert.equal(await expiringMultiParty.timerAddress(), await expiringMultiPartyCreator.timerContractAddress());
   });
 
   it("Creation correctly registers ExpiringMultiParty within the registry", async function() {


### PR DESCRIPTION
- EMPCreator should deploy EMP's with same Timer that it is initialized with
- Withdrawal and Liquidation liveness extended to 120 mins

Signed-off-by: Nick Pai <npai.nyc@gmail.com>