### PR TITLE
Updated bots to use consistant time source

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -3,18 +3,18 @@
 
 class Disputer {
   constructor(logger, expiringMultiPartyClient, gasEstimator, account) {
-    this.account = account;
     this.logger = logger;
+    this.account = account;
 
     // Expiring multiparty contract to read contract state
     this.empClient = expiringMultiPartyClient;
+    this.web3 = this.empClient.web3;
 
     // Gas Estimator to calculate the current Fast gas rate
     this.gasEstimator = gasEstimator;
 
     // Instance of the expiring multiparty to perform on-chain disputes
     this.empContract = this.empClient.emp;
-    this.web3 = this.empClient.web3;
   }
 
   // Update the client and gasEstimator clients.

--- a/financial-templates-lib/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyClient.js
@@ -135,7 +135,7 @@ class ExpiringMultiPartyClient {
             ]),
       []
     );
-    this.lastUpdateTimestamp = (await this.emp.methods.currentTime().call()).toNumber();
+    this.lastUpdateTimestamp = await this.emp.methods.getCurrentTime().call();
     this.logger.debug({
       at: "ExpiringMultiPartyClient",
       message: "Expiring multi party state updated",

--- a/financial-templates-lib/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyClient.js
@@ -19,6 +19,9 @@ class ExpiringMultiPartyClient {
     this.expiredLiquidations = [];
     this.disputedLiquidations = [];
     this.collateralRequirement = null;
+
+    // Store the last on-chain time the clients were updated to inform price request information.
+    this.lastUpdateTimestamp = 0;
   }
 
   // Returns an array of { sponsor, numTokens, amountCollateral } for each open position.
@@ -53,6 +56,9 @@ class ExpiringMultiPartyClient {
 
   // Returns an array of sponsor addresses.
   getAllSponsors = () => this.sponsorAddresses;
+
+  // Returns the last update timestamp.
+  getLastUpdateTime = () => this.lastUpdateTimestamp;
 
   update = async () => {
     this.collateralRequirement = this.web3.utils.toBN(
@@ -129,6 +135,12 @@ class ExpiringMultiPartyClient {
             ]),
       []
     );
+    this.lastUpdateTimestamp = (await this.emp.methods.currentTime().call()).toNumber();
+    this.logger.debug({
+      at: "ExpiringMultiPartyClient",
+      message: "Expiring multi party state updated",
+      lastUpdateTimestamp: this.lastUpdateTimestamp
+    });
   };
   _isUnderCollateralized = (numTokens, amountCollateral, trv) => {
     const { toBN, toWei } = this.web3.utils;

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -95,7 +95,7 @@ class ExpiringMultiPartyEventClient {
       });
     }
     this.lastBlockNumberSeen = currentBlockNumber;
-    this.lastUpdateTimestamp = (await this.emp.methods.currentTime().call()).toNumber();
+    this.lastUpdateTimestamp = await this.emp.methods.getCurrentTime().call();
     this.logger.debug({
       at: "ExpiringMultiPartyEventClient",
       message: "Expiring multi party event state updated",

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -3,8 +3,8 @@
 // necessarily.// If no updateThreshold is specified then default to updating every 60 seconds.
 class ExpiringMultiPartyEventClient {
   constructor(logger, empAbi, web3, empAddress) {
-    this.web3 = web3;
     this.logger = logger;
+    this.web3 = web3;
 
     // EMP contract
     this.emp = new this.web3.eth.Contract(empAbi, empAddress);
@@ -17,6 +17,7 @@ class ExpiringMultiPartyEventClient {
 
     // Last block number seen by the client.
     this.lastBlockNumberSeen = 0;
+    this.lastUpdateTimestamp = 0;
   }
   // Delete all events within the client
   clearState = async () => {
@@ -33,6 +34,9 @@ class ExpiringMultiPartyEventClient {
 
   // Returns an array of dispute events.
   getAllDisputeSettlementEvents = () => this.disputeSettlementEvents;
+
+  // Returns the last update timestamp.
+  getLastUpdateTime = () => this.lastUpdateTimestamp;
 
   update = async () => {
     const currentBlockNumber = await this.web3.eth.getBlockNumber();
@@ -91,6 +95,12 @@ class ExpiringMultiPartyEventClient {
       });
     }
     this.lastBlockNumberSeen = currentBlockNumber;
+    this.lastUpdateTimestamp = (await this.emp.methods.currentTime().call()).toNumber();
+    this.logger.debug({
+      at: "ExpiringMultiPartyClient",
+      message: "Expiring multi party state updated",
+      lastUpdateTimestamp: this.lastUpdateTimestamp
+    });
   };
 }
 

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -97,8 +97,8 @@ class ExpiringMultiPartyEventClient {
     this.lastBlockNumberSeen = currentBlockNumber;
     this.lastUpdateTimestamp = (await this.emp.methods.currentTime().call()).toNumber();
     this.logger.debug({
-      at: "ExpiringMultiPartyClient",
-      message: "Expiring multi party state updated",
+      at: "ExpiringMultiPartyEventClient",
+      message: "Expiring multi party event state updated",
       lastUpdateTimestamp: this.lastUpdateTimestamp
     });
   };

--- a/financial-templates-lib/clients/TokenBalanceClient.js
+++ b/financial-templates-lib/clients/TokenBalanceClient.js
@@ -52,6 +52,11 @@ class TokenBalanceClient {
       this.tokenBalances.syntheticBalances[account] = await this.syntheticToken.methods.balanceOf(account).call();
       this.tokenBalances.etherBalances[account] = await this.web3.eth.getBalance(account);
     }
+
+    this.logger.debug({
+      at: "TokenBalanceClient",
+      message: "Token balance storage updated"
+    });
   };
 
   _registerAddress = address => {

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -26,7 +26,7 @@ class Liquidator {
 
   // Queries underCollateralized positions and performs liquidations against any under collateralized positions.
   queryAndLiquidate = async priceFunction => {
-    const contractTime = await this.empContract.methods.getCurrentTime().call();
+    const contractTime = this.empClient.getLastUpdateTime();
     const priceFeed = priceFunction(contractTime);
 
     this.logger.debug({
@@ -50,7 +50,7 @@ class Liquidator {
 
     for (const position of underCollateralizedPositions) {
       // Note: query the time again during each iteration to ensure the deadline is set reasonably.
-      const currentBlockTime = await this.empContract.methods.getCurrentTime().call();
+      const currentBlockTime = this.empClient.getLastUpdateTime();
       const fiveMinutes = 300;
       // Create the transaction.
       const liquidation = this.empContract.methods.createLiquidation(

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -20,6 +20,7 @@ class BalanceMonitor {
     this.client = tokenBalanceClient;
     this.web3 = this.client.web3;
 
+    // Bot addresses and thresholds to monitor.
     this.botsToMonitor = botsToMonitor;
 
     this.formatDecimalString = createFormatFunction(this.web3, 2);

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -14,9 +14,9 @@ class CRMonitor {
     this.logger = logger;
 
     this.empClient = expiringMultiPartyClient;
-    this.empContract = this.empClient.emp;
     this.web3 = this.empClient.web3;
 
+    // Wallet addresses and thresholds to monitor.
     this.walletsToMonitor = walletsToMonitor;
 
     this.formatDecimalString = createFormatFunction(this.web3, 2);
@@ -29,7 +29,7 @@ class CRMonitor {
   // Queries all monitored wallet ballance for collateralization ratio against a given threshold.
   checkWalletCrRatio = async priceFunction => {
     // yield the price feed at the current time.
-    const contractTime = await this.empContract.methods.getCurrentTime().call();
+    const contractTime = await this.empClient.getLastUpdateTime();
     const priceFeed = priceFunction(contractTime);
     this.logger.debug({
       at: "CRMonitor",

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -3,19 +3,20 @@ const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common
 class ContractMonitor {
   constructor(logger, expiringMultiPartyEventClient, monitoredLiquidators, monitoredDisputers) {
     this.logger = logger;
+
     // Bot and ecosystem accounts to monitor. Will inform the console logs when events are detected from these accounts.
     this.monitoredLiquidators = monitoredLiquidators;
     this.monitoredDisputers = monitoredDisputers;
 
-    // Previous contract state used to check for new entries between calls
-    this.lastLiquidationBlockNumber = 0;
-    this.lastDisputeBlockNumber = 0;
-    this.lastDisputeSettlementBlockNumber = 0;
-
-    // EMP event client to read latest contract events
+    // EMP event client to read latest contract events.
     this.empEventClient = expiringMultiPartyEventClient;
     this.empContract = this.empEventClient.emp;
     this.web3 = this.empEventClient.web3;
+
+    // Previous contract state used to check for new entries between calls.
+    this.lastLiquidationBlockNumber = 0;
+    this.lastDisputeBlockNumber = 0;
+    this.lastDisputeSettlementBlockNumber = 0;
 
     // Contract constants
     // TODO: replace this with an actual query to the collateral currency symbol


### PR DESCRIPTION
This PR refactors the liquidator and collateralization ratio monitor to both use the timestamp that the client last updated to query prices, rather than the current contract time. This is important as it is possible there is a deviation in price between the blockchain query and the price query resulting in inconsistent behavior of the bots.

A few commenting and order changes were also made to continue working towards clean bot code. Additionally, state update logs were also added that were stripped out in the previous PR.

Close #1335