### PR TITLE
Added additional logging levels and comment cleanup

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -57,8 +57,7 @@ class Disputer {
       } catch (error) {
         this.logger.error({
           at: "Disputer",
-          message:
-            "Cannot dispute liquidation: not enough collateral (or large enough approval) to initiate dispute.✋",
+          message: "Cannot dispute liquidation: not enough collateral (or large enough approval) to initiate dispute✋",
           sponsor: disputeableLiquidation.sponsor,
           liquidation: disputeableLiquidation,
           error: error
@@ -86,7 +85,7 @@ class Disputer {
       } catch (error) {
         this.logger.error({
           at: "Disputer",
-          message: "Failed to dispute liquidation",
+          message: "Failed to dispute liquidation🚨",
           error: error
         });
         continue;
@@ -170,7 +169,7 @@ class Disputer {
       } catch (error) {
         this.logger.error({
           at: "Disputer",
-          message: "Failed to withdraw dispute rewards",
+          message: "Failed to withdraw dispute rewards🚨",
           error: error
         });
         continue;

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -22,7 +22,7 @@ const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 async function run(price, address, shouldPoll) {
   Logger.info({
     at: "Disputer#index",
-    message: "Disputer started",
+    message: "Disputer started🔎",
     empAddress: argv.address,
     currentPrice: argv.price
   });
@@ -42,7 +42,7 @@ async function run(price, address, shouldPoll) {
       await disputer.queryAndWithdrawRewards();
     } catch (error) {
       Logger.error({
-        at: "Disputer#index",
+        at: "Disputer#index🚨",
         message: "Disputer error",
         error: error
       });

--- a/financial-templates-lib/helpers/GasEstimator.js
+++ b/financial-templates-lib/helpers/GasEstimator.js
@@ -65,7 +65,7 @@ class GasEstimator {
     } catch (error) {
       this.logger.error({
         at: "GasEstimator",
-        message: "client polling error",
+        message: "client polling error🚨",
         error: error
       });
 

--- a/financial-templates-lib/logger/Logger.js
+++ b/financial-templates-lib/logger/Logger.js
@@ -1,14 +1,18 @@
-// The logger has a number of different levels based on the severity of the incident:
-// -> Debugs: self explanatory. Normal status-based logging. These can trigger
-//   every iteration. Unlimited volume. Prints to console.
-// -> Info: when something happens that is notable, but not necessarily actionable.
-//   These should not trigger every iteration. Any on-chain event that executed correctly.
-//   Print to console & trigger a slack message.
-// -> Error: anything that requires human intervention. If the bot is low on funds or a
-//   transaction fails(some txn failures are sporadic and normal, but it may be difficult
-//   to distinguish).These can trigger every iteration, but only if it's because the bot
-//   encounters a persistent issue that requires human intervention to solve.
-//   Print to console, trigger a slack message and place a phone call to DRI.
+// The logger has a four different levels based on the severity of the incident:
+// -> Debug. Can be considered a console log. Used periodically to inform status updates of repetitive state changes like
+//    polling or no events found. Only viewable on GCE logs.
+// -> Info. Used to report informative events, like a liquidation/dispute/dispute settlement. These events are noteworthy
+//    but don’t require action or acknowledgment from any team member. Viewable on GCE logs and sends a slack message
+//    to appropriate channels.
+// -> Warn. Used to report warning events that might require response but don't necessarily indicate system failure.
+//    Require Acknowledgment from person on duty, or escalation occurs until warning is acknowledged. For example
+//    warnings would be used to indicate that a bot’s balance has dropped below a given threshold or a collateralization
+//    ratio of a given account moves below a threshold. Viewable on GCE logs, sends a slack message to appropriate
+//    channel and initiates a PagerDuty incident with urgency setting ‘low’.
+// -> Error. Used to report system failure or situations that require immediate response from appropriate team members.
+//    For example an error level message is generated when a liquidation/dispute/dispute settlement transaction from a
+//    UMA bot reverts, token price deviates significantly from the target price or a bot crashes. Viewable on GCE logs,
+//    sends a slack message to appropriate channel and initiates a PagerDuty incident with urgency setting ‘high’.
 
 // calling debug/info/error logging requires an specificity formatted json object as a param for the logger.
 // All objects must have an `at`, `message` as a minimum to describe where the error was logged from

--- a/financial-templates-lib/logger/Logger.js
+++ b/financial-templates-lib/logger/Logger.js
@@ -1,18 +1,18 @@
 // The logger has a four different levels based on the severity of the incident:
-// -> Debug. Can be considered a console log. Used periodically to inform status updates of repetitive state changes like
-//    polling or no events found. Only viewable on GCE logs.
-// -> Info. Used to report informative events, like a liquidation/dispute/dispute settlement. These events are noteworthy
-//    but don’t require action or acknowledgment from any team member. Viewable on GCE logs and sends a slack message
-//    to appropriate channels.
-// -> Warn. Used to report warning events that might require response but don't necessarily indicate system failure.
-//    Require Acknowledgment from person on duty, or escalation occurs until warning is acknowledged. For example
-//    warnings would be used to indicate that a bot’s balance has dropped below a given threshold or a collateralization
-//    ratio of a given account moves below a threshold. Viewable on GCE logs, sends a slack message to appropriate
-//    channel and initiates a PagerDuty incident with urgency setting ‘low’.
-// -> Error. Used to report system failure or situations that require immediate response from appropriate team members.
-//    For example an error level message is generated when a liquidation/dispute/dispute settlement transaction from a
-//    UMA bot reverts, token price deviates significantly from the target price or a bot crashes. Viewable on GCE logs,
-//    sends a slack message to appropriate channel and initiates a PagerDuty incident with urgency setting ‘high’.
+// -> Debug. It can be considered a console log. Used periodically to inform status updates of repetitive state changes
+//    like polling or no events found. Only viewable on GCE logs.
+// -> Info. Used to report informative events, like a  liquidation/dispute/dispute settlement. These events are
+//    noteworthy but don’t require action or acknowledgment from any
+//    team member. Viewable on GCE logs and sends a slack message to appropriate channels.
+// -> Warn. Used to report warning events that might require a response but don't necessarily indicate system failure.
+//    Require Acknowledgment from the person on duty, or escalation occurs until the warning is acknowledged. For
+//    example, warnings would be used to indicate that a bot’s balance has dropped below a given threshold or a
+//    collateralization ratio of a given account moves below a threshold. Viewable on GCE logs, send a slack message to
+//    the appropriate channel and initiates a PagerDuty incident with urgency set ‘low’.
+// -> Error. Used to report system failure or situations that require an immediate response from appropriate team members.
+//    For example, an error level message is generated when a liquidation/dispute/dispute settlement transaction from a UMA
+//    bot reverts, token price deviates significantly from the target price or a bot crashes. Viewable on GCE logs, send a
+//    slack message to the appropriate channel and initiates a PagerDuty incident with urgency setting ‘high’.
 
 // calling debug/info/error logging requires an specificity formatted json object as a param for the logger.
 // All objects must have an `at`, `message` as a minimum to describe where the error was logged from

--- a/financial-templates-lib/logger/PagerDutyTransport.js
+++ b/financial-templates-lib/logger/PagerDutyTransport.js
@@ -1,4 +1,8 @@
-// This transport enables winston logging to send messages to pager duty.
+// This transport enables winston logging to send messages to pager duty. All pager duty logs are either `low` or `high`
+// urgency. If set to `low` the incident has a less aggressive escalation policy. In this `low` setting if the
+// notification is not acknowledged by the person on call within 30 mins a second person is contacted until the warning
+// is acknowledged. If set to `high` the incident is aggressively escalated. If no acknowledgement within 5 minutes a
+//  second person is contacted until the message is acknowledged.
 
 const Transport = require("winston-transport");
 const pdClient = require("node-pagerduty");

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -53,7 +53,7 @@ async function run(price, address, shouldPoll) {
     } catch (error) {
       Logger.error({
         at: "liquidator#index",
-        message: "liquidator polling error",
+        message: "liquidator polling error🚨",
         error: error
       });
     }

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -68,7 +68,7 @@ class Liquidator {
         this.logger.error({
           at: "Liquidator",
           message:
-            "Cannot liquidate position: not enough synthetic (or large enough approval) to initiate liquidation.",
+            "Cannot liquidate position: not enough synthetic (or large enough approval) to initiate liquidation✋",
           sponsor: position.sponsor,
           position: position,
           error: error
@@ -96,7 +96,7 @@ class Liquidator {
       } catch (error) {
         this.logger.error({
           at: "Liquidator",
-          message: "Failed to liquidate position",
+          message: "Failed to liquidate position🚨",
           error: error
         });
         continue;

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -41,7 +41,7 @@ class BalanceMonitor {
     // send a winston event. The message structure is defined with the `_createLowBalanceMrkdwn` formatter.
     for (let bot of this.botsToMonitor) {
       if (this._ltThreshold(this.client.getCollateralBalance(bot.address), bot.collateralThreshold)) {
-        this.logger.info({
+        this.logger.warn({
           at: "BalanceMonitor",
           message: "Low collateral balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(
@@ -54,7 +54,7 @@ class BalanceMonitor {
         });
       }
       if (this._ltThreshold(this.client.getSyntheticBalance(bot.address), bot.syntheticThreshold)) {
-        this.logger.info({
+        this.logger.warn({
           at: "BalanceMonitor",
           message: "Low synthetic balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(
@@ -67,7 +67,7 @@ class BalanceMonitor {
         });
       }
       if (this._ltThreshold(this.client.getEtherBalance(bot.address), bot.etherThreshold)) {
-        this.logger.info({
+        this.logger.warn({
           at: "BalanceMonitor",
           message: "Low Ether balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -78,9 +78,9 @@ class CRMonitor {
           " is " +
           this.formatDecimalString(priceFeed);
 
-        this.logger.info({
+        this.logger.warn({
           at: "ContractMonitor",
-          message: "Collateralization ratio alert 🚨!",
+          message: "Collateralization ratio alert 🙅‍♂️!",
           mrkdwn: mrkdwn
         });
       }

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -115,7 +115,7 @@ async function run(price, address, shouldPoll) {
     } catch (error) {
       Logger.error({
         at: "Monitors#index",
-        message: "Monitor polling error",
+        message: "Monitor polling error🚨",
         error: error
       });
     }


### PR DESCRIPTION
This PR adds the additional `warn` level to the Winston monitoring stack. After this refinement our bots have 4 distinct levels of notification as follows:
1. **Debug.** It can be considered a console log. Used periodically to inform status updates of repetitive state changes like polling or no events found. Only viewable on GCE logs. 
2. **Info.** Used to report informative events, like a liquidation/dispute/dispute settlement. These events are noteworthy but don’t require action or acknowledgment from any team member. Viewable on GCE logs and sends a slack message to appropriate channels. 
3. **Warn.** Used to report warning events that might require a response but don't necessarily indicate system failure. Require Acknowledgment from the person on duty, or escalation occurs until the warning is acknowledged. For example, warnings would be used to indicate that a bot’s balance has dropped below a given threshold or a collateralization ratio of a given account moves below a threshold. Viewable on GCE logs, send a slack message to the appropriate channel and initiates a PagerDuty incident with urgency set ‘low’. 
4. **Error.** Used to report system failure or situations that require an immediate response from appropriate team members. For example, an error level message is generated when a liquidation/dispute/dispute settlement transaction from a UMA bot reverts, token price deviates significantly from the target price or a bot crashes. Viewable on GCE logs, send a slack message to the appropriate channel and initiates a PagerDuty incident with urgency setting ‘high’.

Additionally, this PR adds a number of small updates to other Winston messages through our bot stack to ensure consistency.

Close #1372