### PR TITLE
Contracts and unit tests for minimal financial template that incorporates the DVM

### DIFF
--- a/core/contracts/financial-templates/demo/DepositBox.sol
+++ b/core/contracts/financial-templates/demo/DepositBox.sol
@@ -5,32 +5,33 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
-import "../FeePayer.sol";
+import "../implementation/FeePayer.sol";
 
-import "../../../common/implementation/FixedPoint.sol";
+import "../../common/implementation/FixedPoint.sol";
 
-import "../../../oracle/interfaces/IdentifierWhitelistInterface.sol";
-import "../../../oracle/interfaces/OracleInterface.sol";
-import "../../../oracle/interfaces/AdministrateeInterface.sol";
-import "../../../oracle/implementation/ContractCreator.sol";
+import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
+import "../../oracle/interfaces/OracleInterface.sol";
+import "../../oracle/interfaces/AdministrateeInterface.sol";
+import "../../oracle/implementation/ContractCreator.sol";
 
 
 /**
  * @title Token Deposit Box
  * @notice This is a minimal example of a financial template that depends on price requests from the DVM.
- * Specifically, this contract should be thought of as a "Deposit Box" into which the user deposits some ERC20 collateral.
+ * This contract should be thought of as a "Deposit Box" into which the user deposits some ERC20 collateral.
  * The main feature of this box is that the user can withdraw their ERC20 corresponding to a desired USD amount.
  * When the user wants to make a withdrawal, a price request is enqueued with the UMA DVM.
  * For simplicty, the user is constrained to have one outstanding withdrawal request at any given time.
- * Regular fees are charged on the collateral in the deposit box throughout
- * the lifetime of the deposit box, and final fees are charged on each price request.
+ * Regular fees are charged on the collateral in the deposit box throughout the lifetime of the deposit box,
+ * and final fees are charged on each price request.
  *
  * This example is intended to accompany a technical tutorial for how to integrate the DVM into a project.
- * The main feature this demo serves to showcase is how to build a financial product on-chain that "pulls" price requests
- * from the DVM on-demand, which is an implementation of the "priceless" oracle framework.
+ * The main feature this demo serves to showcase is how to build a financial product on-chain that "pulls" price
+ * requests from the DVM on-demand, which is an implementation of the "priceless" oracle framework.
  *
  * The typical user flow would be:
- * - User sets up a deposit box for the (wETH - USD) price-identifier. The "collateral currency" in this deposit box is therefore wETH.
+ * - User sets up a deposit box for the (wETH - USD) price-identifier. The "collateral currency" in this deposit
+ *   box is therefore wETH.
  *   The user can subsequently make withdrawal requests for USD-denominated amounts of wETH.
  * - User deposits 10 wETH into their deposit box.
  * - User later requests to withdraw $100 USD of wETH.

--- a/core/contracts/financial-templates/implementation/demo/DepositBox.sol
+++ b/core/contracts/financial-templates/implementation/demo/DepositBox.sol
@@ -1,0 +1,348 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import "../FeePayer.sol";
+import "../../../common/implementation/FixedPoint.sol";
+
+import "../../../oracle/interfaces/IdentifierWhitelistInterface.sol";
+import "../../../oracle/interfaces/OracleInterface.sol";
+import "../../../oracle/interfaces/AdministrateeInterface.sol";
+import "../../../oracle/implementation/ContractCreator.sol";
+
+
+/**
+ * @title Token Deposit Box
+ * @notice This is a minimal example of a financial template that depends on price requests from the DVM.
+ * Specifically, this contract should be thought of as a "Deposit Box" into which the user deposits some ERC20 collateral.
+ * The main feature of this box is that the user can withdraw their ERC20 corresponding to a desired USD amount.
+ * When the user wants to make a withdrawal, a price request is enqueued with the UMA DVM.
+ * it would take for the UMA DVM to return the corresponding amount of ERC20. For simplicty, the user is constrained to
+ * have one outstanding withdrawal request at any given time. Regular fees are charged on the collateral in the deposit box throughout
+ * the lifetime of the deposit box, and final fees are charged on each price request.
+ *
+ * Note that this toy example would perform poorly as a mainnet product, given the long period of time
+ * This example is intended to accompany a technical tutorial for how to integrate the DVM into a project.
+ * The main feature this demo serves to showcase is how to build a financial product on-chain that "pulls" price requests
+ * from the DVM, which is an implementation of the "priceless" oracle framework.
+ *
+ * The typical user flow would be:
+ * - User sets up a deposit box for the (wETH - USD) price-identifier. The "collateral currency" in this deposit box is therefore wETH.
+ *   The user can subsequently make withdrawal requests for USD-denominated amounts of wETH.
+ * - User deposits 10 wETH into their deposit box.
+ * - User later requests to withdraw $100 USD of wETH.
+ * - DepositBox asks DVM for latest wETH/USD exchange rate.
+ * - DVM resolves the exchange rate at: 1 wETH is worth 200 USD.
+ * - DepositBox transfers 0.5 wETH to user.
+ */
+contract DepositBox is FeePayer, AdministrateeInterface, ContractCreator {
+    using SafeMath for uint256;
+    using FixedPoint for FixedPoint.Unsigned;
+    using SafeERC20 for IERC20;
+
+    // Represents a single caller's deposit box. All collateral is held by this contract.
+    struct DepositBoxData {
+        // Requested amount of collateral, denominated in quote asset of the price identifier.
+        // Example: If the price identifier is wETH-USD, and the `withdrawalRequestAmount = 100`, then
+        // this represents a withdrawal request for 100 USD worth of wETH.
+        FixedPoint.Unsigned withdrawalRequestAmount;
+        // Timestamp of the latest withdrawal request. A withdrawal request is pending if `requestPassTimestamp != 0`.
+        uint256 requestPassTimestamp;
+        // Raw collateral value. This value should never be accessed directly -- always use _getFeeAdjustedCollateral().
+        // To add or remove collateral, use _addCollateral() and _removeCollateral().
+        FixedPoint.Unsigned rawCollateral;
+    }
+
+    // Maps addresses to their deposit boxes. Each address can have only one position.
+    mapping(address => DepositBoxData) public depositBoxes;
+
+    // Unique identifier for DVM price feed ticker.
+    bytes32 public priceIdentifier;
+
+    // Similar to the rawCollateral in DepositBoxData, this value should not be used directly.
+    // _getFeeAdjustedCollateral(), _addCollateral() and _removeCollateral() must be used to access and adjust.
+    FixedPoint.Unsigned public rawTotalDepositBoxCollateral;
+
+    /****************************************
+     *                EVENTS                *
+     ****************************************/
+
+    event NewDepositBox(address indexed user);
+    event EndedDepositBox(address indexed user);
+    event Deposit(address indexed user, uint256 indexed collateralAmount);
+    event RequestWithdrawal(address indexed user, uint256 indexed collateralAmount, uint256 requestPassTimestamp);
+    event RequestWithdrawalExecuted(
+        address indexed user,
+        uint256 indexed collateralAmount,
+        uint256 exchangeRate,
+        uint256 requestPassTimestamp
+    );
+    event RequestWithdrawalCanceled(
+        address indexed user,
+        uint256 indexed collateralAmount,
+        uint256 requestPassTimestamp
+    );
+
+    /****************************************
+     *               MODIFIERS              *
+     ****************************************/
+
+    modifier noPendingWithdrawal(address user) {
+        _depositBoxHasNoPendingWithdrawal(user);
+        _;
+    }
+
+    /**
+     * @notice Construct the DepositBox.
+     * @param _collateralAddress ERC20 token to be deposited.
+     * @param _finderAddress UMA protocol Finder used to discover other protocol contracts.
+     * @param _priceIdentifier registered in the DVM, used to price the ERC20 deposited.
+     * The price identifier consists of a "base" asset and a "quote" asset. The "base" asset corresponds to the collateral ERC20
+     * currency deposited into this account, and it is denominated in the "quote" asset on withdrawals.
+     * @param _timerAddress Contract that stores the current time in a testing environment.
+     * Must be set to 0x0 for production environments that use live time.
+     */
+    constructor(
+        address _collateralAddress,
+        address _finderAddress,
+        bytes32 _priceIdentifier,
+        address _timerAddress
+    )
+        public
+        ContractCreator(_finderAddress)
+        FeePayer(_collateralAddress, _finderAddress, _timerAddress)
+        nonReentrant()
+    {
+        require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier), "Unsupported price identifier");
+
+        priceIdentifier = _priceIdentifier;
+    }
+
+    /**
+     * @notice This should be called after construction of the DepositBox and handles registration with the Registry, which is required
+     * to make price requests in production environments.
+     * @dev This contract must hold the `ContractCreator` role with the Registry in order to register itself as a financial-template with the DVM.
+     */
+    function initialize() public nonReentrant() {
+        _registerContract(new address[](0), address(this));
+    }
+
+    /**
+     * @notice Transfers `collateralAmount` of `collateralCurrency` into caller's deposit box.
+     * @dev This contract must be approved to spend
+     * at least `collateralAmount` of `collateralCurrency`.
+     * @param collateralAmount total amount of collateral tokens to be sent to the sponsor's position.
+     */
+    function deposit(FixedPoint.Unsigned memory collateralAmount) public fees() nonReentrant() {
+        require(collateralAmount.isGreaterThan(0), "Invalid collateral amount");
+        DepositBoxData storage depositBoxData = _getDepositBoxData(msg.sender);
+        if (_getFeeAdjustedCollateral(depositBoxData.rawCollateral).isEqual(0)) {
+            emit NewDepositBox(msg.sender);
+        }
+
+        // Increase the individual deposit box and global collateral balance by collateral amount.
+        _incrementCollateralBalances(depositBoxData, collateralAmount);
+
+        emit Deposit(msg.sender, collateralAmount.rawValue);
+
+        // Move collateral currency from sender to contract.
+        collateralCurrency.safeTransferFrom(msg.sender, address(this), collateralAmount.rawValue);
+    }
+
+    /**
+     * @notice Starts a withdrawal request that allows the sponsor to withdraw
+     * `denominatedCollateralAmount` from their position denominated in the quote asset of the price identifier, following a DVM price resolution.
+     * @dev The request will be pending for the duration of the DVM vote and can be cancelled at any time. Only one withdrawal request can exist for the user.
+     * @param denominatedCollateralAmount the quote-asset denominated amount of collateral requested to withdraw.
+     */
+    function requestWithdrawal(FixedPoint.Unsigned memory denominatedCollateralAmount)
+        public
+        noPendingWithdrawal(msg.sender)
+        nonReentrant()
+    {
+        DepositBoxData storage depositBoxData = _getDepositBoxData(msg.sender);
+        require(denominatedCollateralAmount.isGreaterThan(0), "Invalid collateral amount");
+
+        // Update the position object for the user.
+        depositBoxData.withdrawalRequestAmount = denominatedCollateralAmount;
+        depositBoxData.requestPassTimestamp = getCurrentTime();
+
+        emit RequestWithdrawal(msg.sender, denominatedCollateralAmount.rawValue, depositBoxData.requestPassTimestamp);
+
+        // Every price request costs a fixed fee.
+        _payFinalFees(address(this), _computeFinalFees());
+        // A price request is sent for the current timestamp.
+        _requestOraclePrice(depositBoxData.requestPassTimestamp);
+    }
+
+    /**
+     * @notice After a passed withdrawal request (i.e., by a call to `requestWithdrawal` and subsequent DVM price resolution),
+     * withdraws `depositBoxData.withdrawalRequestAmount` of collateral currency denominated in the quote asset.
+     * @dev Might not withdraw the full requested amount in order to account for precision loss or if the full requested
+     * amount exceeds the collateral in the position (due to paying fees).
+     * @return amountWithdrawn The actual amount of collateral withdrawn.
+     */
+    function withdrawPassedRequest()
+        external
+        fees()
+        nonReentrant()
+        returns (FixedPoint.Unsigned memory amountWithdrawn)
+    {
+        DepositBoxData storage depositBoxData = _getDepositBoxData(msg.sender);
+        require(depositBoxData.requestPassTimestamp != 0, "No pending withdrawal");
+
+        // Get the resolved price or revert.
+        FixedPoint.Unsigned memory exchangeRate = _getOraclePrice(depositBoxData.requestPassTimestamp);
+
+        // Calculate denomated amount of collateral.
+        // Example 1: User wants to withdraw $100 of ETH, exchange rate is $200/ETH, therefore user to receive 0.5 ETH.
+        // Example 2: User wants to withdraw $250 of ETH, exchange rate is $200/ETH, therefore user to receive 1.25 ETH.
+        FixedPoint.Unsigned memory denominatedAmountToWithdraw = depositBoxData.withdrawalRequestAmount.div(
+            exchangeRate
+        );
+
+        // If withdrawal request amount is >= position collateral, then withdraw the full collateral amount and delete the deposit box data.
+        if (denominatedAmountToWithdraw.isGreaterThanOrEqual(_getFeeAdjustedCollateral(depositBoxData.rawCollateral))) {
+            denominatedAmountToWithdraw = _getFeeAdjustedCollateral(depositBoxData.rawCollateral);
+
+            // Reset the position state as all the value has been removed after settlement.
+            delete depositBoxes[msg.sender];
+            emit EndedDepositBox(msg.sender);
+        }
+
+        // Decrease the individual deposit box and global collateral balance.
+        amountWithdrawn = _decrementCollateralBalances(depositBoxData, denominatedAmountToWithdraw);
+
+        emit RequestWithdrawalExecuted(
+            msg.sender,
+            amountWithdrawn.rawValue,
+            exchangeRate.rawValue,
+            depositBoxData.requestPassTimestamp
+        );
+
+        // Reset withdrawal request by setting withdrawal request timestamp to 0.
+        _resetWithdrawalRequest(depositBoxData);
+
+        // Transfer approved withdrawal amount from the contract to the caller.
+        collateralCurrency.safeTransfer(msg.sender, amountWithdrawn.rawValue);
+    }
+
+    /**
+     * @notice Cancels a pending withdrawal request.
+     */
+    function cancelWithdrawal() external nonReentrant() {
+        DepositBoxData storage depositBoxData = _getDepositBoxData(msg.sender);
+        require(depositBoxData.requestPassTimestamp != 0, "No pending withdrawal");
+
+        emit RequestWithdrawalCanceled(
+            msg.sender,
+            depositBoxData.withdrawalRequestAmount.rawValue,
+            depositBoxData.requestPassTimestamp
+        );
+
+        // Reset withdrawal request by setting withdrawal request timestamp to 0.
+        _resetWithdrawalRequest(depositBoxData);
+    }
+
+    /**
+     * @notice `emergencyShutdown` and `remargin` are required to be implemented by all financial contracts and exposed to the DVM, but
+     * because this is a minimal demo they will simply exit silently.
+     */
+    function emergencyShutdown() external override nonReentrant() {
+        return;
+    }
+
+    function remargin() external override nonReentrant() {
+        return;
+    }
+
+    /**
+     * @notice Accessor method for a user's collateral.
+     * @dev This is necessary because the struct returned by the depositBoxes() method shows
+     * rawCollateral, which isn't a user-readable value.
+     * @param user address whose collateral amount is retrieved.
+     */
+    function getCollateral(address user) external view nonReentrantView() returns (FixedPoint.Unsigned memory) {
+        // Note: do a direct access to avoid the validity check.
+        return _getFeeAdjustedCollateral(depositBoxes[user].rawCollateral);
+    }
+
+    /**
+     * @notice Accessor method for the total collateral stored within the entire contract.
+     */
+    function totalDepositBoxCollateral() external view nonReentrantView() returns (FixedPoint.Unsigned memory) {
+        return _getFeeAdjustedCollateral(rawTotalDepositBoxCollateral);
+    }
+
+    /****************************************
+     *          INTERNAL FUNCTIONS          *
+     ****************************************/
+
+    // Requests a price for `priceIdentifier` at `requestedTime` from the Oracle.
+    function _requestOraclePrice(uint256 requestedTime) internal {
+        OracleInterface oracle = _getOracle();
+        oracle.requestPrice(priceIdentifier, requestedTime);
+    }
+
+    // Ensure individual and global consistency when increasing collateral balances. Returns the change to the position.
+    function _incrementCollateralBalances(
+        DepositBoxData storage depositBoxData,
+        FixedPoint.Unsigned memory collateralAmount
+    ) internal returns (FixedPoint.Unsigned memory) {
+        _addCollateral(depositBoxData.rawCollateral, collateralAmount);
+        return _addCollateral(rawTotalDepositBoxCollateral, collateralAmount);
+    }
+
+    // Ensure individual and global consistency when decrementing collateral balances. Returns the change to the
+    // position. We elect to return the amount that the global collateral is decreased by, rather than the individual
+    // position's collateral, because we need to maintain the invariant that the global collateral is always
+    // <= the collateral owned by the contract to avoid reverts on withdrawals. The amount returned = amount withdrawn.
+    function _decrementCollateralBalances(
+        DepositBoxData storage depositBoxData,
+        FixedPoint.Unsigned memory collateralAmount
+    ) internal returns (FixedPoint.Unsigned memory) {
+        _removeCollateral(depositBoxData.rawCollateral, collateralAmount);
+        return _removeCollateral(rawTotalDepositBoxCollateral, collateralAmount);
+    }
+
+    function _resetWithdrawalRequest(DepositBoxData storage depositBoxData) internal {
+        depositBoxData.withdrawalRequestAmount = FixedPoint.fromUnscaledUint(0);
+        depositBoxData.requestPassTimestamp = 0;
+    }
+
+    function _getDepositBoxData(address user) internal view returns (DepositBoxData storage) {
+        return depositBoxes[user];
+    }
+
+    function _depositBoxHasNoPendingWithdrawal(address user) internal view {
+        require(_getDepositBoxData(user).requestPassTimestamp == 0, "Pending withdrawal");
+    }
+
+    function _getIdentifierWhitelist() internal view returns (IdentifierWhitelistInterface) {
+        return IdentifierWhitelistInterface(finder.getImplementationAddress(OracleInterfaces.IdentifierWhitelist));
+    }
+
+    function _getOracle() internal view returns (OracleInterface) {
+        return OracleInterface(finder.getImplementationAddress(OracleInterfaces.Oracle));
+    }
+
+    // Fetches a resolved Oracle price from the Oracle. Reverts if the Oracle hasn't resolved for this request.
+    function _getOraclePrice(uint256 requestedTime) internal view returns (FixedPoint.Unsigned memory) {
+        OracleInterface oracle = _getOracle();
+        require(oracle.hasPrice(priceIdentifier, requestedTime), "Unresolved oracle price");
+        int256 oraclePrice = oracle.getPrice(priceIdentifier, requestedTime);
+
+        // For simplicity we don't want to deal with negative prices.
+        if (oraclePrice < 0) {
+            oraclePrice = 0;
+        }
+        return FixedPoint.Unsigned(uint256(oraclePrice));
+    }
+
+    function _pfc() internal virtual override view returns (FixedPoint.Unsigned memory) {
+        return _getFeeAdjustedCollateral(rawTotalDepositBoxCollateral);
+    }
+}

--- a/core/test/financial-templates/demo/DepositBox.js
+++ b/core/test/financial-templates/demo/DepositBox.js
@@ -1,4 +1,4 @@
-const { toWei, utf8ToHex, toBN } = web3.utils;
+const { toWei, utf8ToHex, hexToUtf8, toBN } = web3.utils;
 const { didContractThrow } = require("../../../../common/SolidityTestUtils.js");
 const truffleAssert = require("truffle-assertions");
 const { RegistryRolesEnum } = require("../../../../common/Enums.js");
@@ -19,6 +19,7 @@ const Store = artifacts.require("Store");
 contract("DepositBox", function(accounts) {
   let contractCreator = accounts[0];
   let user = accounts[1];
+  let otherUser = accounts[2];
 
   // Contract variables
   let collateralToken;
@@ -75,64 +76,186 @@ contract("DepositBox", function(accounts) {
     assert.isTrue(await registry.isContractRegistered(depositBox.address));
   });
 
-  describe("Zero regular and final fees", function() {
+  describe("Typical deposit and withdraw user flow", function() {
     const amountToDeposit = toWei("5"); // i.e. deposit 5 ETH
     const amountToWithdraw = toWei("150"); // i.e. withdraw $150 in ETH.
-    const exchangeRate = toWei("225"); // i.e. 1 ETH/USD = $225
+    const amountToOverdraw = toWei("2000"); // i.e. withdraw $2000 in ETH, which is 10 ETH at $225 exchange rate
+    const exchangeRate = toWei("200"); // i.e. 1 ETH/USD = $225
+
+    beforeEach(async function() {
+        // Set regular and final fee.
+
+        // Regular fee is charged on % of collateral locked in deposit box per second.
+        // Set regular fees to unrealistcally high (but convenient for testing) 1% per second.
+        await store.setFixedOracleFeePerSecondPerPfc({ rawValue: toWei("0.01") });
+
+        // Final fees are fixed charges per price request. 
+        // Set this to 1 token per call.
+        await store.setFinalFee(collateralToken.address, { rawValue: toWei("1") });
+    })
 
     it("Deposit ERC20", async function() {
-      const userStartingBalance = await collateralToken.balanceOf(user);
+        const userStartingBalance = await collateralToken.balanceOf(user);
 
-      // Submit the deposit.
-      let txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
-      truffleAssert.eventEmitted(txn, "Deposit", ev => {
-        return ev.user == user && ev.collateralAmount == amountToDeposit.toString();
-      });
-      truffleAssert.eventEmitted(txn, "NewDepositBox", ev => {
-        return ev.user == user;
-      });
+        // Submit the deposit.
+        let txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+        truffleAssert.eventEmitted(txn, "Deposit", ev => {
+            return ev.user == user && ev.collateralAmount == amountToDeposit.toString();
+        });
+        truffleAssert.eventEmitted(txn, "NewDepositBox", ev => {
+            return ev.user == user;
+        });
 
-      // Check balances after the deposit.
-      const userEndingBalance = await collateralToken.balanceOf(user);
-      assert.equal(
-        userEndingBalance.toString(),
-        toBN(userStartingBalance)
-          .sub(toBN(amountToDeposit))
-          .toString()
-      );
-      assert.equal((await depositBox.getCollateral(user)).toString(), amountToDeposit.toString());
-      assert.equal((await depositBox.totalDepositBoxCollateral()).toString(), amountToDeposit.toString());
+        // Check balances after the deposit. 0 fees should have been charged
+        // since the contract has not advanced any time.
+        const userEndingBalance = await collateralToken.balanceOf(user);
+        assert.equal(
+            userEndingBalance.toString(),
+            toBN(userStartingBalance)
+            .sub(toBN(amountToDeposit))
+            .toString()
+        );
+        assert.equal((await depositBox.getCollateral(user)).toString(), amountToDeposit.toString());
+        assert.equal((await depositBox.totalDepositBoxCollateral()).toString(), amountToDeposit.toString());
+        assert.equal((await depositBox.pfc()).toString(), amountToDeposit.toString());
 
-      // Cannot submit a deposit for 0 collateral.
-      assert(await didContractThrow(depositBox.deposit({ rawValue: "0" }, { from: user })));
+        // Cannot submit a deposit for 0 collateral.
+        assert(await didContractThrow(depositBox.deposit({ rawValue: "0" }, { from: user })));
 
-      // Can submit a subsequent deposit.
-      txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
-      truffleAssert.eventNotEmitted(txn, "NewDepositBox");
-      assert.equal(
-        (await depositBox.getCollateral(user)).toString(),
-        toBN(amountToDeposit)
-          .mul(toBN(2))
-          .toString()
-      );
-      assert.equal(
-        (await depositBox.totalDepositBoxCollateral()).toString(),
-        toBN(amountToDeposit)
-          .mul(toBN(2))
-          .toString()
-      );
+        // Can submit a subsequent deposit.
+        txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+        truffleAssert.eventNotEmitted(txn, "NewDepositBox");
+        assert.equal(
+            (await depositBox.getCollateral(user)).toString(),
+            toBN(amountToDeposit)
+            .mul(toBN(2))
+            .toString()
+        );
+        assert.equal(
+            (await depositBox.totalDepositBoxCollateral()).toString(),
+            toBN(amountToDeposit)
+            .mul(toBN(2))
+            .toString()
+        );
     });
 
     it("Request withdrawal for ERC20 denominated in USD", async function() {
-      // Can only request one withdrawal at a time.
+        // Deposit funds.
+        await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+
+        // Submit the withdrawal request.
+        const requestTimestamp = await depositBox.getCurrentTime();
+        let txn = await depositBox.requestWithdrawal({ rawValue: amountToWithdraw }, { from: user });
+        truffleAssert.eventEmitted(txn, "RequestWithdrawal", ev => {
+          return ev.user == user && ev.collateralAmount == amountToWithdraw.toString() && ev.requestPassTimestamp == requestTimestamp.toNumber();
+        });
+
+        // Oracle should have an enqueued price after calling dispute.
+        const pendingRequests = await mockOracle.getPendingQueries();
+        assert.equal(hexToUtf8(pendingRequests[0]["identifier"]), hexToUtf8(priceFeedIdentifier));
+        assert.equal(pendingRequests[0].time, requestTimestamp.toNumber());   
+        
+        // A final fee should have been charged on the collateral which should get deducted from the user balances.
+        assert.equal((await depositBox.getCollateral(user)).toString(), toBN(amountToDeposit).sub(toBN(toWei("1"))).toString());
+        assert.equal((await depositBox.totalDepositBoxCollateral()).toString(), toBN(amountToDeposit).sub(toBN(toWei("1"))).toString());
+        assert.equal((await depositBox.pfc()).toString(), toBN(amountToDeposit).sub(toBN(toWei("1"))).toString());
+        assert.equal((await collateralToken.balanceOf(store.address)).toString(), toWei("1").toString());
+
+        // Can only request one withdrawal at a time.
+        assert(await didContractThrow(depositBox.requestWithdrawal({ rawValue: amountToWithdraw }, { from: user })));
+
+        // A user with a pending withdrawal can cancel the withdrawal request.
+        assert(await didContractThrow(depositBox.cancelWithdrawal({ from: otherUser })));
+        txn = await depositBox.cancelWithdrawal({ from: user });
+        truffleAssert.eventEmitted(txn, "RequestWithdrawalCanceled", ev => {
+            return ev.user == user && ev.collateralAmount == amountToWithdraw.toString() && ev.requestPassTimestamp == requestTimestamp.toNumber();
+        });  
+        assert(await didContractThrow(depositBox.cancelWithdrawal({ from: user })));
+
+        // Cannot submit a withdrawal for 0 collateral.
+        assert(await didContractThrow(depositBox.requestWithdrawal({ rawValue: "0" }, { from: user })));
+
+        // User can submit another withdrawal request.
+        await depositBox.requestWithdrawal({ rawValue: amountToWithdraw }, { from: user });
     });
 
-    it("Cancel withdrawal", async function() {});
+    it("Execute withdrawal after price resolves for less than full balance", async function() {
+        // Deposit funds and submit withdrawal request.
+        await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+        const requestTimestamp = await depositBox.getCurrentTime();
+        await depositBox.requestWithdrawal({ rawValue: amountToWithdraw }, { from: user });
+        const userStartingBalance = await collateralToken.balanceOf(user);
 
-    it("Execute withdrawal after price resolves", async function() {});
+        // Cannot execute the withdrawal until a price resolves.
+        assert(await didContractThrow(depositBox.executeWithdrawal({ from: user })));
+
+        // Manually push a price to the DVM.
+        await mockOracle.pushPrice(priceFeedIdentifier, requestTimestamp.toNumber(), exchangeRate);
+
+        // Advance time forward by one second to simulate regular fees being charged.
+        await depositBox.setCurrentTime(requestTimestamp.addn(1));
+
+        // Cannot execute the withdrawal if there is no pending withdrawal for the user.
+        assert(await didContractThrow(depositBox.executeWithdrawal({ from: otherUser })));
+
+        // Execute the withdrawal request, which should withdraw (150/200 = 0.75) tokens.
+        let txn = await depositBox.executeWithdrawal({ from: user });
+        truffleAssert.eventEmitted(txn, "RequestWithdrawalExecuted", ev => {
+          return ev.user == user && ev.collateralAmount == toWei("0.75").toString() && ev.requestPassTimestamp == requestTimestamp.toNumber() && ev.exchangeRate == exchangeRate.toString();
+        });
+        
+        // The user's balance should be deducted by the final fee + withdrawal amount + regular fee:
+        // - final fee = 1
+        // - withdrawal amount = (150/200) = 0.75
+        // - regular fee = 1 second * 0.01 * (PfC - final fee) = 1 * 0.01 * 4 = 0.04
+        // --> Total balance = (5 - 1 - 0.75 - 0.04) = 3.21 
+        assert.equal((await depositBox.getCollateral(user)).toString(), toWei("3.21").toString());
+        assert.equal((await depositBox.totalDepositBoxCollateral()).toString(), toWei("3.21").toString());
+        assert.equal((await depositBox.pfc()).toString(), toWei("3.21").toString());
+        assert.equal((await collateralToken.balanceOf(store.address)).toString(), toWei("1.04").toString());
+        const userEndingBalance = await collateralToken.balanceOf(user);
+        assert.equal(toBN(userEndingBalance).sub(toBN(userStartingBalance)).toString(), toWei("0.75").toString());
+
+        // User can submit another withdrawal request.
+        await depositBox.requestWithdrawal({ rawValue: amountToWithdraw }, { from: user });
+    });
+
+    it("Execute withdrawal after price resolves for more than full balance", async function() {
+        // Deposit funds and submit withdrawal request.
+        await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+        const requestTimestamp = await depositBox.getCurrentTime();
+        await depositBox.requestWithdrawal({ rawValue: amountToOverdraw }, { from: user });
+        const userStartingBalance = await collateralToken.balanceOf(user);
+
+        // Manually push a price to the DVM.
+        await mockOracle.pushPrice(priceFeedIdentifier, requestTimestamp.toNumber(), exchangeRate);
+
+        // Execute the withdrawal request, which should withdraw the user's full balance and delete the deposit box.
+        // The user has 4 collateral remaining after the final fee.
+        let txn = await depositBox.executeWithdrawal({ from: user });
+        truffleAssert.eventEmitted(txn, "RequestWithdrawalExecuted", ev => {
+          return ev.user == user && ev.collateralAmount == toWei("4").toString() && ev.requestPassTimestamp == requestTimestamp.toNumber() && ev.exchangeRate == exchangeRate.toString();
+        });
+        truffleAssert.eventEmitted(txn, "EndedDepositBox", ev => {
+            return ev.user == user;
+        });
+        
+        // The deposit box balances should be 0.
+        assert.equal((await depositBox.getCollateral(user)).toString(), "0");
+        assert.equal((await depositBox.totalDepositBoxCollateral()).toString(), "0");
+        assert.equal((await depositBox.pfc()).toString(), "0");
+        const userEndingBalance = await collateralToken.balanceOf(user);
+        assert.equal(toBN(userEndingBalance).sub(toBN(userStartingBalance)).toString(), toWei("4").toString());
+
+        // User cannot submit a withdrawal request because they don't have enough deposited to pay for a price request.
+        assert(await didContractThrow(depositBox.requestWithdrawal({ rawValue: amountToWithdraw }, { from: user })));
+
+        // When user deposits again, they will begin a new deposit box.
+        txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+        truffleAssert.eventEmitted(txn, "NewDepositBox", ev => {
+            return ev.user == user;
+        });
+    });
+
   });
-
-  describe("Regular fees", function() {});
-
-  describe("Final fees", function() {});
 });

--- a/core/test/financial-templates/demo/DepositBox.js
+++ b/core/test/financial-templates/demo/DepositBox.js
@@ -1,0 +1,138 @@
+const { toWei, utf8ToHex, toBN } = web3.utils;
+const { didContractThrow } = require("../../../../common/SolidityTestUtils.js");
+const truffleAssert = require("truffle-assertions");
+const { RegistryRolesEnum } = require("../../../../common/Enums.js");
+const { interfaceName } = require("../../../utils/Constants.js");
+
+// Tested Contract
+const DepositBox = artifacts.require("DepositBox");
+
+// Helper Contracts
+const Token = artifacts.require("ExpandedERC20");
+const Registry = artifacts.require("Registry");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const Timer = artifacts.require("Timer");
+const Finder = artifacts.require("Finder");
+const MockOracle = artifacts.require("MockOracle");
+const Store = artifacts.require("Store");
+
+contract("DepositBox", function(accounts) {
+  let contractCreator = accounts[0];
+  let user = accounts[1];
+
+  // Contract variables
+  let collateralToken;
+  let registry;
+  let depositBox;
+  let timer;
+  let mockOracle;
+  let finder;
+  let store;
+
+  // Constants
+  const priceFeedIdentifier = utf8ToHex("ETH/USD");
+
+  beforeEach(async function() {
+    // Collateral token to be deposited in DepositBox.
+    collateralToken = await Token.new("ETH", "ETH", 18, { from: contractCreator });
+
+    // Whitelist price feed identifier.
+    identifierWhitelist = await IdentifierWhitelist.deployed();
+    await identifierWhitelist.addSupportedIdentifier(priceFeedIdentifier, {
+      from: contractCreator
+    });
+
+    timer = await Timer.deployed();
+    store = await Store.deployed();
+
+    // Create a mockOracle and register it with the finder. We use the MockOracle so that we can manually
+    // modify timestamps and push prices for demonstration purposes.
+    finder = await Finder.deployed();
+    mockOracle = await MockOracle.new(finder.address, timer.address, {
+      from: contractCreator
+    });
+    const mockOracleInterfaceName = web3.utils.utf8ToHex(interfaceName.Oracle);
+    await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address, { from: contractCreator });
+
+    // Deploy a new DepositBox contract that will connect to the mockOracle for price requests.
+    registry = await Registry.deployed();
+    depositBox = await DepositBox.new(collateralToken.address, finder.address, priceFeedIdentifier, Timer.address);
+
+    // Note: Upon calling `initialize()`, the DepositBox will attempt to register itself with the Registry in order to make price requests in production environments,
+    // but the MockOracle in test environments does not require contracts to be registered in order to make price requests.
+    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, depositBox.address, {
+      from: contractCreator
+    });
+    await depositBox.initialize();
+
+    // Mint the user some ERC20 to begin the test.
+    await collateralToken.addMember(1, contractCreator, { from: contractCreator });
+    await collateralToken.mint(user, toWei("1000"), { from: contractCreator });
+    await collateralToken.approve(depositBox.address, toWei("1000"), { from: user });
+  });
+
+  it("Creation correctly registers DepositBox within the registry", async function() {
+    assert.isTrue(await registry.isContractRegistered(depositBox.address));
+  });
+
+  describe("Zero regular and final fees", function() {
+    const amountToDeposit = toWei("5"); // i.e. deposit 5 ETH
+    const amountToWithdraw = toWei("150"); // i.e. withdraw $150 in ETH.
+    const exchangeRate = toWei("225"); // i.e. 1 ETH/USD = $225
+
+    it("Deposit ERC20", async function() {
+      const userStartingBalance = await collateralToken.balanceOf(user);
+
+      // Submit the deposit.
+      let txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+      truffleAssert.eventEmitted(txn, "Deposit", ev => {
+        return ev.user == user && ev.collateralAmount == amountToDeposit.toString();
+      });
+      truffleAssert.eventEmitted(txn, "NewDepositBox", ev => {
+        return ev.user == user;
+      });
+
+      // Check balances after the deposit.
+      const userEndingBalance = await collateralToken.balanceOf(user);
+      assert.equal(
+        userEndingBalance.toString(),
+        toBN(userStartingBalance)
+          .sub(toBN(amountToDeposit))
+          .toString()
+      );
+      assert.equal((await depositBox.getCollateral(user)).toString(), amountToDeposit.toString());
+      assert.equal((await depositBox.totalDepositBoxCollateral()).toString(), amountToDeposit.toString());
+
+      // Cannot submit a deposit for 0 collateral.
+      assert(await didContractThrow(depositBox.deposit({ rawValue: "0" }, { from: user })));
+
+      // Can submit a subsequent deposit.
+      txn = await depositBox.deposit({ rawValue: amountToDeposit }, { from: user });
+      truffleAssert.eventNotEmitted(txn, "NewDepositBox");
+      assert.equal(
+        (await depositBox.getCollateral(user)).toString(),
+        toBN(amountToDeposit)
+          .mul(toBN(2))
+          .toString()
+      );
+      assert.equal(
+        (await depositBox.totalDepositBoxCollateral()).toString(),
+        toBN(amountToDeposit)
+          .mul(toBN(2))
+          .toString()
+      );
+    });
+
+    it("Request withdrawal for ERC20 denominated in USD", async function() {
+      // Can only request one withdrawal at a time.
+    });
+
+    it("Cancel withdrawal", async function() {});
+
+    it("Execute withdrawal after price resolves", async function() {});
+  });
+
+  describe("Regular fees", function() {});
+
+  describe("Final fees", function() {});
+});


### PR DESCRIPTION
This example will set up a “Checking Account” contract in which the user deposits ETH into the contract and can periodically withdraw ETH corresponding to a desired USD amount. When the user wants to make a withdrawal, a price request is enqueued with the UMA DVM. 

To be used in documentation explaining the flow of our system to a prospective user.