### PR TITLE
Add DepositTo

### DIFF
--- a/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
@@ -5,5 +5,8 @@ import "./Liquidatable.sol";
 
 
 contract ExpiringMultiParty is Liquidatable {
-    constructor(ConstructorParams memory params) public Liquidatable(params) nonReentrant() {}
+    constructor(ConstructorParams memory params)
+        public
+        Liquidatable(params) // Note: since there is no logic here, there is no need to add a re-entrancy guard.
+    {}
 }

--- a/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
+++ b/core/contracts/financial-templates/implementation/ExpiringMultiParty.sol
@@ -7,6 +7,9 @@ import "./Liquidatable.sol";
 contract ExpiringMultiParty is Liquidatable {
     constructor(ConstructorParams memory params)
         public
-        Liquidatable(params) // Note: since there is no logic here, there is no need to add a re-entrancy guard.
-    {}
+        Liquidatable(params)
+    // Note: since there is no logic here, there is no need to add a re-entrancy guard.
+    {
+
+    }
 }

--- a/core/contracts/financial-templates/implementation/FeePayer.sol
+++ b/core/contracts/financial-templates/implementation/FeePayer.sol
@@ -33,7 +33,7 @@ abstract contract FeePayer is Testable, Lockable {
     FinderInterface public finder;
 
     // Tracks the last block time when the fees were paid.
-    uint256 public lastPaymentTime;
+    uint256 private lastPaymentTime;
 
     // Tracks the cumulative fees that have been paid by the contract for use by derived contracts.
     // The multiplier starts at 1, and is updated by computing cumulativeFeeMultiplier * (1 - effectiveFee).

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -76,7 +76,7 @@ contract Liquidatable is PricelessPositionManager {
     mapping(address => LiquidationData[]) public liquidations;
 
     // Total collateral in liquidation.
-    FixedPoint.Unsigned private rawLiquidationCollateral;
+    FixedPoint.Unsigned public rawLiquidationCollateral;
 
     // Immutable contract parameters.
 

--- a/core/contracts/financial-templates/implementation/Liquidatable.sol
+++ b/core/contracts/financial-templates/implementation/Liquidatable.sol
@@ -76,7 +76,7 @@ contract Liquidatable is PricelessPositionManager {
     mapping(address => LiquidationData[]) public liquidations;
 
     // Total collateral in liquidation.
-    FixedPoint.Unsigned public rawLiquidationCollateral;
+    FixedPoint.Unsigned private rawLiquidationCollateral;
 
     // Immutable contract parameters.
 

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -61,7 +61,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     // Similar to the rawCollateral in PositionData, this value should not be used directly.
     // _getFeeAdjustedCollateral(), _addCollateral() and _removeCollateral() must be used to access and adjust.
-    FixedPoint.Unsigned public rawTotalPositionCollateral;
+    FixedPoint.Unsigned private rawTotalPositionCollateral;
 
     // Synthetic token created by this contract.
     ExpandedIERC20 public tokenCurrency;

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -243,28 +243,40 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     }
 
     /**
-     * @notice Transfers `collateralAmount` of `collateralCurrency` into the sponsor's position.
+     * @notice Transfers `collateralAmount` of `collateralCurrency` into the specified sponsor's position.
      * @dev Increases the collateralization level of a position after creation. This contract must be approved to spend
      * at least `collateralAmount` of `collateralCurrency`.
+     * @param sponsor the sponsor to credit the deposit to.
      * @param collateralAmount total amount of collateral tokens to be sent to the sponsor's position.
      */
-    function deposit(FixedPoint.Unsigned memory collateralAmount)
+    function depositTo(address sponsor, FixedPoint.Unsigned memory collateralAmount)
         public
         onlyPreExpiration()
-        noPendingWithdrawal(msg.sender)
+        noPendingWithdrawal(sponsor)
         fees()
         nonReentrant()
     {
         require(collateralAmount.isGreaterThan(0), "Invalid collateral amount");
-        PositionData storage positionData = _getPositionData(msg.sender);
+        PositionData storage positionData = _getPositionData(sponsor);
 
         // Increase the position and global collateral balance by collateral amount.
         _incrementCollateralBalances(positionData, collateralAmount);
 
-        emit Deposit(msg.sender, collateralAmount.rawValue);
+        emit Deposit(sponsor, collateralAmount.rawValue);
 
         // Move collateral currency from sender to contract.
         collateralCurrency.safeTransferFrom(msg.sender, address(this), collateralAmount.rawValue);
+    }
+
+    /**
+     * @notice Transfers `collateralAmount` of `collateralCurrency` into the caller's position.
+     * @dev Increases the collateralization level of a position after creation. This contract must be approved to spend
+     * at least `collateralAmount` of `collateralCurrency`.
+     * @param collateralAmount total amount of collateral tokens to be sent to the sponsor's position.
+     */
+    function deposit(FixedPoint.Unsigned memory collateralAmount) public {
+        // This is just a thin wrapper over depositTo that specified the sender as the sponsor.
+        depositTo(msg.sender, collateralAmount);
     }
 
     /**

--- a/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/implementation/PricelessPositionManager.sol
@@ -61,7 +61,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     // Similar to the rawCollateral in PositionData, this value should not be used directly.
     // _getFeeAdjustedCollateral(), _addCollateral() and _removeCollateral() must be used to access and adjust.
-    FixedPoint.Unsigned private rawTotalPositionCollateral;
+    FixedPoint.Unsigned public rawTotalPositionCollateral;
 
     // Synthetic token created by this contract.
     ExpandedIERC20 public tokenCurrency;

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -873,7 +873,7 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal((await pricelessPositionManager.getCollateral(other)).toString(), "0");
   });
 
-  it("Sponsor can use depositTo to other account", async function() {
+  it("Existing sponsor can use depositTo on other account", async function() {
     await collateral.approve(pricelessPositionManager.address, toWei("1000"), { from: other });
     await collateral.approve(pricelessPositionManager.address, toWei("1000"), { from: sponsor });
 


### PR DESCRIPTION
This PR adds a method called depositTo that allows anyone to make a deposit into anyone else's account. This should enable users to implicitly separate wallets that they use to top-up their positions from more privileged wallets used to do more complex position management.

ExpiringMultiPartyLib bytecode notes:
```
Pre-PR:                                               27 bytes under the bytecode limit.
After adding depositTo:                               70 bytes over the limit.
After removing public variable and re-entrancy check: 12 bytes under the limit.
```