### PR TITLE
Delete old GAE versions on deployment

### DIFF
--- a/ci/deploy_to_staging.sh
+++ b/ci/deploy_to_staging.sh
@@ -30,3 +30,9 @@ gsutil cp gs://staging-deployment-configuration/voter-app.yaml voter-dapp/app.ya
 # Deploy docs
 ./scripts/deploy_docs.sh documentation/gae_app.yaml -q
 
+# Delete old versions.
+# TODO: this currently deletes any versions that aren't being used. It'd be preferable to leave the last few versions
+# for each service.
+VERSIONS_TO_DELETE=$(gcloud app versions list --filter="TRAFFIC_SPLIT=0.00" --format="value(VERSION.ID)")
+
+gcloud app versions delete -q $out

--- a/ci/deploy_to_staging.sh
+++ b/ci/deploy_to_staging.sh
@@ -35,4 +35,4 @@ gsutil cp gs://staging-deployment-configuration/voter-app.yaml voter-dapp/app.ya
 # for each service.
 VERSIONS_TO_DELETE=$(gcloud app versions list --filter="TRAFFIC_SPLIT=0.00" --format="value(VERSION.ID)")
 
-gcloud app versions delete -q $out
+gcloud app versions delete -q $VERSIONS_TO_DELETE


### PR DESCRIPTION
This just means we won't have to manually delete old versions when app engine hits its max and starts causing the deployments to fail.