### PR TITLE
Removed and updated linter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -12,6 +12,12 @@
         "singleQuote": false,
         "explicitTypes": "always"
       }
+    },
+    {
+      "files": "*.md",
+      "options": {
+        "semi": false
+      }
     }
   ]
 }

--- a/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
+++ b/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
@@ -45,7 +45,7 @@ Note that in this example, `priceFeedIdentifier`, `syntheticName`, and `syntheti
 <!-- prettier-ignore -->
 ```js
 const constructorParams = { expirationTimestamp: "1585699200", collateralAddress: TestnetERC20.address, priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"), syntheticName: "Test UMA Token", syntheticSymbol: "UMATEST", collateralRequirement: { rawValue: web3.utils.toWei("1.5") }, disputeBondPct: { rawValue: web3.utils.toWei("0.1") }, sponsorDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, disputerDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, minSponsorTokens: { rawValue: '100000000000000' }, timerAddress: '0x0000000000000000000000000000000000000000' }
-};
+}
 ```
 
 5. Before the contract for the synthetic tokens can be created, the price identifier for the synthetic tokens must be registered with `IdentifierWhitelist`.
@@ -125,12 +125,12 @@ await emp.redeem({ rawValue: web3.utils.toWei("50") })
    Our collateral token balance should increase to 9,925.
 
 ```js
-;(await collateralToken.balanceOf(accounts[0]))
-  .toString()(
-    // collateral token balance
-    await syntheticToken.balanceOf(accounts[0])
-  )
-  .toString()
+// Print balance
+const collateralBalance = await collateralToken.balanceOf(accounts[0])
+collateralBalance.toString()
+// collateral token balance
+const syntheticBalance = await syntheticToken.balanceOf(accounts[0])
+syntheticBalance.toString()
 // synthetic token balance
 await emp.positions(accounts[0])
 // position information
@@ -167,8 +167,9 @@ await emp.withdrawPassedRequest()
 4. Let’s now check that our collateral token balance has returned to 9,925.
 
 ```js
-;(await collateralToken.balanceOf(accounts[0])).toString()
 // collateral token balance
+const tokenBalance = await collateralToken.balanceOf(accounts[0])
+tokenBalance.toString()
 ```
 
 <!--

--- a/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
+++ b/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
@@ -35,7 +35,7 @@ $(npm bin)/truffle console --network test
    This command should return “undefined”.
 
 ```js
-const empCreator = await ExpiringMultiPartyCreator.deployed();
+const empCreator = await ExpiringMultiPartyCreator.deployed()
 ```
 
 4. Define the parameters for the synthetic tokens you would like to create.
@@ -52,29 +52,29 @@ const constructorParams = { expirationTimestamp: "1585699200", collateralAddress
    This is important to ensure that the UMA DVM can resolve any disputes for these synthetic tokens.
 
 ```js
-const identifierWhitelist = await IdentifierWhitelist.deployed();
-await identifierWhitelist.addSupportedIdentifier(constructorParams.priceFeedIdentifier);
+const identifierWhitelist = await IdentifierWhitelist.deployed()
+await identifierWhitelist.addSupportedIdentifier(constructorParams.priceFeedIdentifier)
 ```
 
 6. We also need to register the `empCreator` factory with the `registry` to give it permission to create new expiring multiparty (emp) synthetic tokens.
 
 ```js
-const registry = await Registry.deployed();
-await registry.addMember(1, empCreator.address);
+const registry = await Registry.deployed()
+await registry.addMember(1, empCreator.address)
 ```
 
 7. We also need to register the collateral token with the `collateralTokenWhitelist`.
 
 ```js
-collateralTokenWhitelist = await AddressWhitelist.at(await empCreator.collateralTokenWhitelist());
-await collateralTokenWhitelist.addToWhitelist(TestnetERC20.address);
+collateralTokenWhitelist = await AddressWhitelist.at(await empCreator.collateralTokenWhitelist())
+await collateralTokenWhitelist.addToWhitelist(TestnetERC20.address)
 ```
 
 8. Now, we can create a new expiring multiparty synthetic token with the factory instance.
 
 ```js
-const txResult = await empCreator.createExpiringMultiParty(constructorParams);
-const emp = await ExpiringMultiParty.at(txResult.logs[0].args.expiringMultiPartyAddress);
+const txResult = await empCreator.createExpiringMultiParty(constructorParams)
+const emp = await ExpiringMultiParty.at(txResult.logs[0].args.expiringMultiPartyAddress)
 ```
 
 ## Create new tokens from an existing contract
@@ -85,15 +85,15 @@ const emp = await ExpiringMultiParty.at(txResult.logs[0].args.expiringMultiParty
    Give permission to the empCreator to spend the collateral tokens on our behalf.
 
 ```js
-const collateralToken = await TestnetERC20.deployed();
-await collateralToken.allocateTo(accounts[0], web3.utils.toWei("10000"));
-await collateralToken.approve(emp.address, web3.utils.toWei("10000"));
+const collateralToken = await TestnetERC20.deployed()
+await collateralToken.allocateTo(accounts[0], web3.utils.toWei("10000"))
+await collateralToken.approve(emp.address, web3.utils.toWei("10000"))
 ```
 
 2. We can now create a synthetic token position. We will deposit 150 units of collateral (the first argument) to create 100 units of synthetic tokens (the second argument).
 
 ```js
-await emp.create({ rawValue: web3.utils.toWei("150") }, { rawValue: web3.utils.toWei("100") });
+await emp.create({ rawValue: web3.utils.toWei("150") }, { rawValue: web3.utils.toWei("100") })
 ```
 
 3. Let’s check that we now have synthetic tokens. We should have 100 synthetic tokens and 9,850 collateral tokens.
@@ -104,9 +104,9 @@ const syntheticToken = await SyntheticToken.at(await emp.tokenCurrency())(await 
     // collateral token balance
     await syntheticToken.balanceOf(accounts[0])
   )
-  .toString();
+  .toString()
 // synthetic token balance
-await emp.positions(accounts[0]);
+await emp.positions(accounts[0])
 // position information
 ```
 
@@ -115,8 +115,8 @@ await emp.positions(accounts[0]);
 1. Because we are a token sponsor for this synthetic token contract, we can redeem some of the tokens we minted even before the synthetic token expires. Let's redeem half.
 
 ```js
-await syntheticToken.approve(emp.address, web3.utils.toWei("10000"));
-await emp.redeem({ rawValue: web3.utils.toWei("50") });
+await syntheticToken.approve(emp.address, web3.utils.toWei("10000"))
+await emp.redeem({ rawValue: web3.utils.toWei("50") })
 ```
 
 2. Let’s check that our synthetic token balance has decreased and our collateral token balance has increased.
@@ -125,14 +125,14 @@ await emp.redeem({ rawValue: web3.utils.toWei("50") });
    Our collateral token balance should increase to 9,925.
 
 ```js
-(await collateralToken.balanceOf(accounts[0]))
+;(await collateralToken.balanceOf(accounts[0]))
   .toString()(
     // collateral token balance
     await syntheticToken.balanceOf(accounts[0])
   )
-  .toString();
+  .toString()
 // synthetic token balance
-await emp.positions(accounts[0]);
+await emp.positions(accounts[0])
 // position information
 ```
 
@@ -144,7 +144,7 @@ await emp.positions(accounts[0]);
 ```js
 await emp
   .deposit({ rawValue: web3.utils.toWei("10") })(await collateralToken.balanceOf(accounts[0]))
-  .toString();
+  .toString()
 ```
 
 2. For a token sponsor to withdraw collateral from his position, there are typically 2 ways to do this.
@@ -152,7 +152,7 @@ await emp
    In this scenario, because we are the only token sponsor, we will have to withdraw collateral the “slow” way. First, we need to request a withdrawal of 10 collateral tokens.
 
 ```js
-await emp.requestWithdrawal({ rawValue: web3.utils.toWei("10") });
+await emp.requestWithdrawal({ rawValue: web3.utils.toWei("10") })
 ```
 
 3. Now, we need to simulate the withdrawal liveness period passing without a dispute of our withdrawal request.
@@ -160,14 +160,14 @@ await emp.requestWithdrawal({ rawValue: web3.utils.toWei("10") });
    Once the 1001 has elapsed, we can withdraw the amount we previously requested.
 
 ```js
-await emp.setCurrentTime((await emp.getCurrentTime()).toNumber() + 1001);
-await emp.withdrawPassedRequest();
+await emp.setCurrentTime((await emp.getCurrentTime()).toNumber() + 1001)
+await emp.withdrawPassedRequest()
 ```
 
 4. Let’s now check that our collateral token balance has returned to 9,925.
 
 ```js
-(await collateralToken.balanceOf(accounts[0])).toString();
+;(await collateralToken.balanceOf(accounts[0])).toString()
 // collateral token balance
 ```
 


### PR DESCRIPTION
The linter breaks `truffle console`. This Pr adds an overide to ignore semicolons on `.md files`