### PR TITLE
Fix javascript formatting in truffle tutorial

### DIFF
--- a/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
+++ b/documentation/synthetic_tokens/tutorials/creating_from_truffle.md
@@ -44,8 +44,7 @@ Note that in this example, `priceFeedIdentifier`, `syntheticName`, and `syntheti
 
 <!-- prettier-ignore -->
 ```js
-const constructorParams = { expirationTimestamp: "1585699200", collateralAddress: TestnetERC20.address, priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"), syntheticName: "Test UMA Token", syntheticSymbol: "UMATEST", collateralRequirement: { rawValue: web3.utils.toWei("1.5") }, disputeBondPct: { rawValue: web3.utils.toWei("0.1") }, sponsorDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, disputerDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, minSponsorTokens: { rawValue: '100000000000000' }, timerAddress: '0x0000000000000000000000000000000000000000' }
-}
+const constructorParams = { expirationTimestamp: "1606780800", collateralAddress: TestnetERC20.address, priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"), syntheticName: "Test UMA Token", syntheticSymbol: "UMATEST", collateralRequirement: { rawValue: web3.utils.toWei("1.5") }, disputeBondPct: { rawValue: web3.utils.toWei("0.1") }, sponsorDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, disputerDisputeRewardPct: { rawValue: web3.utils.toWei("0.1") }, minSponsorTokens: { rawValue: '100000000000000' }, timerAddress: '0x0000000000000000000000000000000000000000' }
 ```
 
 5. Before the contract for the synthetic tokens can be created, the price identifier for the synthetic tokens must be registered with `IdentifierWhitelist`.
@@ -96,18 +95,19 @@ await collateralToken.approve(emp.address, web3.utils.toWei("10000"))
 await emp.create({ rawValue: web3.utils.toWei("150") }, { rawValue: web3.utils.toWei("100") })
 ```
 
-3. Let’s check that we now have synthetic tokens. We should have 100 synthetic tokens and 9,850 collateral tokens.
+3. Let’s check that we now have synthetic tokens. We should have 100 synthetic tokens and 9,850 collateral tokens remaining.
 
+<!-- prettier-ignore -->
 ```js
-const syntheticToken = await SyntheticToken.at(await emp.tokenCurrency())(await collateralToken.balanceOf(accounts[0]))
-  .toString()(
-    // collateral token balance
-    await syntheticToken.balanceOf(accounts[0])
-  )
-  .toString()
-// synthetic token balance
+const syntheticToken = await SyntheticToken.at(await emp.tokenCurrency())
+// synthetic token balance. Should equal what we minted in step 2.
+(await syntheticToken.balanceOf(accounts[0])).toString()
+
+// Collateral token balance. Should equal original balance (1000e18) minus deposit (150e18).
+(await collateralToken.balanceOf(accounts[0])).toString()
+
+// position information. Can see the all key information about our position.
 await emp.positions(accounts[0])
-// position information
 ```
 
 ## Redeem tokens against a contract
@@ -124,16 +124,16 @@ await emp.redeem({ rawValue: web3.utils.toWei("50") })
    Because the contract does not have an on-chain price feed to determine the token redemption value for the tokens, it will give us collateral equal to the proportional value value of the total collateral deposited to back the 100 tokens (50/100 \* 150 = 75).
    Our collateral token balance should increase to 9,925.
 
+<!-- prettier-ignore -->
 ```js
-// Print balance
-const collateralBalance = await collateralToken.balanceOf(accounts[0])
-collateralBalance.toString()
-// collateral token balance
-const syntheticBalance = await syntheticToken.balanceOf(accounts[0])
-syntheticBalance.toString()
-// synthetic token balance
-await emp.positions(accounts[0])
+// Print balance of collateral token.
+(await collateralToken.balanceOf(accounts[0])).toString()
+
+// Print balance of the synthetic token.
+(await syntheticToken.balanceOf(accounts[0])).toString()
+
 // position information
+await emp.positions(accounts[0])
 ```
 
 ## Deposit and withdraw collateral
@@ -141,10 +141,10 @@ await emp.positions(accounts[0])
 1. As a token sponsor, we may wish to add additional collateral to our position to avoid being liquidated by a token holder.
    Let’s deposit 10 additional collateral tokens to our position and see our updated balance, from 9,925 to 9,915.
 
+<!-- prettier-ignore -->
 ```js
-await emp
-  .deposit({ rawValue: web3.utils.toWei("10") })(await collateralToken.balanceOf(accounts[0]))
-  .toString()
+await emp.deposit({ rawValue: web3.utils.toWei("10") })
+(await collateralToken.balanceOf(accounts[0])).toString()
 ```
 
 2. For a token sponsor to withdraw collateral from his position, there are typically 2 ways to do this.
@@ -166,10 +166,10 @@ await emp.withdrawPassedRequest()
 
 4. Let’s now check that our collateral token balance has returned to 9,925.
 
+<!-- prettier-ignore -->
 ```js
 // collateral token balance
-const tokenBalance = await collateralToken.balanceOf(accounts[0])
-tokenBalance.toString()
+(await collateralToken.balanceOf(accounts[0])).toString()
 ```
 
 <!--

--- a/documentation/synthetic_tokens/tutorials/prerequisites.md
+++ b/documentation/synthetic_tokens/tutorials/prerequisites.md
@@ -24,6 +24,7 @@ If everything worked, we should see the line "> Compiled successfully using:" in
 
 1. Install the [Ganache UI](https://truffleframework.com/ganache).
 2. Run Ganache on localhost port `9545` (use the above links for instructions on how to do this).
+3. Note that to deploy new Priceless position managers you must set your gas to at least 9 million in Ganache. To do this click the gear icon at the top right of Ganache, then click "CHAIN" and set the "GAS LIMIT" field to `10000000`. Then click the "RESTART" button top right. This will enable your Ganache instance to deploy larger contracts.
 
 If everything was setup correctly, we should be able to run automated tests from `protocol/core`:
 

--- a/documentation/synthetic_tokens/tutorials/prerequisites.md
+++ b/documentation/synthetic_tokens/tutorials/prerequisites.md
@@ -24,7 +24,7 @@ If everything worked, we should see the line "> Compiled successfully using:" in
 
 1. Install the [Ganache UI](https://truffleframework.com/ganache).
 2. Run Ganache on localhost port `9545` (use the above links for instructions on how to do this).
-3. Note that to deploy new Priceless position managers you must set your gas to at least 9 million in Ganache. To do this click the gear icon at the top right of Ganache, then click "CHAIN" and set the "GAS LIMIT" field to `10000000`. Then click the "RESTART" button top right. This will enable your Ganache instance to deploy larger contracts.
+3. Note that to deploy new `ExpiringMultiPartyCreator`, the main factory used in the priceless financial contract, you must set your gas limit to at least 9 million in Ganache. To do this click the gear icon at the top right of Ganache, then click "CHAIN" and set the "GAS LIMIT" field to `10000000`. Then click the "RESTART" button top right. This will enable your Ganache instance to deploy larger contracts.
 
 If everything was setup correctly, we should be able to run automated tests from `protocol/core`:
 


### PR DESCRIPTION
This PR addresses some small formatting issues that made the tutorials difficult to navigate. Specifically, the prettier linter made some sections of code more cumbersome to copy-paste. This PR addresses these issues by using 
```
<!-- prettier-ignore -->
```
On code blocks that the linter wanted to format incorrectly.

This PR also updates the `prerequisites.md` to tell users to use at least 9 million gas to prevent the creation of an EMP from reverting.