### PR TITLE
Add CreatePriceFeed factory

### DIFF
--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -1,0 +1,126 @@
+const { MedianizerPriceFeed } = require("./MedianizerPriceFeed");
+const { CryptoWatchPriceFeed } = require("./CryptoWatchPriceFeed");
+const { UniswapPriceFeed } = require("./UniswapPriceFeed");
+
+const Uniswap = require("../../core/build/contracts/Uniswap.json");
+
+async function createPriceFeed(web3, logger, networker, getTime, config) {
+  if (config.type === "cryptowatch") {
+    const requiredFields = ["apiKey", "exchange", "pair", "lookback", "minTimeBetweenUpdates"];
+
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating CryptoWatchPriceFeed",
+      config
+    });
+
+    return new CryptoWatchPriceFeed(
+      logger,
+      web3,
+      config.apiKey,
+      config.exchange,
+      config.pair,
+      config.lookback,
+      networker,
+      getTime,
+      config.minTimeBetweenUpdates
+    );
+  } else if (config.type === "uniswap") {
+    const requiredFields = ["uniswapAddress", "twapLength", "lookback"];
+
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating UniswapPriceFeed",
+      config
+    });
+
+    return new UniswapPriceFeed(
+      logger,
+      Uniswap.abi,
+      web3,
+      config.uniswapAddress,
+      config.twapLength,
+      config.lookback,
+      getTime
+    );
+  } else if (config.type === "medianizer") {
+    const requiredFields = ["medianizedFeeds"];
+
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    if (config.medianizedFeeds.length === 0) {
+      logger.error({
+        at: "createPriceFeed",
+        message: "MedianizerPriceFeed configured with 0 feeds to medianize"
+      });
+      return null;
+    }
+
+    // Loop over all the price feeds to medianize.
+    const priceFeeds = [];
+    for (const medianizedFeedConfig of config.medianizedFeeds) {
+      // The medianized feeds should inherit config options from the parent config if it doesn't define those values
+      // itself.
+      // Note: ensure that type isn't inherited because this could create infinite recursion if the type isn't defined
+      // on the nested config.
+      const combinedConfig = { ...config, type: undefined, ...medianizedFeedConfig };
+
+      const priceFeed = await createPriceFeed(web3, logger, networker, getTime, combinedConfig);
+
+      if (priceFeed === null) {
+        // If one of the nested feeds errored and returned null, just return null up the stack.
+        // Note: no need to log an error since the nested feed construction should have thrown it.
+        return null;
+      }
+
+      priceFeeds.push(priceFeed);
+    }
+
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating MedianizerPriceFeed",
+      config
+    });
+
+    return new MedianizerPriceFeed(priceFeeds);
+  }
+
+  logger.error({
+    at: "createPriceFeed",
+    message: "Invalid price feed type specified",
+    config
+  });
+
+  return null;
+}
+
+function isMissingField(config, requiredFields, logger) {
+  const missingField = requiredFields.find(field => config[field] === undefined);
+  if (missingField !== undefined) {
+    logger.error({
+      at: "createPriceFeed",
+      message: "Config is missing field",
+      priceFeedType: config.type,
+      requiredFields,
+      missingField,
+      config
+    });
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  createPriceFeed
+};

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -40,7 +40,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(await createPriceFeed(web3, logger, networker, getTime, config), null);
   });
 
-  it("Valid CryptoWatch", async function() {
+  it("Valid CryptoWatch config", async function() {
     const config = {
       type: "cryptowatch",
       apiKey,
@@ -60,7 +60,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validCryptoWatchFeed.getTime(), getTime());
   });
 
-  it("Invalid CryptoWatch", async function() {
+  it("Invalid CryptoWatch config", async function() {
     const validConfig = {
       type: "cryptowatch",
       apiKey,
@@ -86,7 +86,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     );
   });
 
-  it("Valid Uniswap", async function() {
+  it("Valid Uniswap config", async function() {
     const config = {
       type: "uniswap",
       uniswapAddress,
@@ -103,7 +103,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validUniswapFeed.getTime(), getTime());
   });
 
-  it("Invalid Uniswap", async function() {
+  it("Invalid Uniswap config", async function() {
     const validConfig = {
       type: "uniswap",
       uniswapAddress,
@@ -125,7 +125,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     );
   });
 
-  it("Valid Medianizer Inheritance", async function() {
+  it("Valid Medianizer inherited config", async function() {
     const config = {
       type: "medianizer",
       apiKey,
@@ -155,7 +155,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validMedianizerFeed.priceFeeds[1].uniswap.options.address, uniswapAddress);
   });
 
-  it("Valid Medianizer Override", async function() {
+  it("Valid Medianizer override config", async function() {
     const lookbackOverride = 5;
     const config = {
       type: "medianizer",
@@ -177,7 +177,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validMedianizerFeed.priceFeeds[0].lookback, lookbackOverride);
   });
 
-  it("Medianizer feed cannot have no feeds to medianize", async function() {
+  it("Medianizer feed cannot have 0 nested feeds to medianize", async function() {
     const config = {
       type: "medianizer",
       apiKey,
@@ -196,7 +196,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...config, medianizedFeeds: [] }), null);
   });
 
-  it("Medianizer feed cannot have invalid nested feed", async function() {
+  it("Medianizer feed cannot have a nested feed with an invalid config", async function() {
     const config = {
       type: "medianizer",
       apiKey,

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -1,0 +1,219 @@
+const { createPriceFeed } = require("../../price-feed/CreatePriceFeed");
+const { CryptoWatchPriceFeed } = require("../../price-feed/CryptoWatchPriceFeed");
+const { UniswapPriceFeed } = require("../../price-feed/UniswapPriceFeed");
+const { MedianizerPriceFeed } = require("../../price-feed/MedianizerPriceFeed");
+const { NetworkerMock } = require("./NetworkerMock");
+const winston = require("winston");
+
+contract("CreatePriceFeed.js", function(accounts) {
+  const { toChecksumAddress, randomHex } = web3.utils;
+
+  let mockTime = 1588376548;
+  let networker;
+
+  const apiKey = "test-api-key";
+  const exchange = "test-exchange";
+  const pair = "test-pair";
+  const lookback = 120;
+  const getTime = () => mockTime;
+  const minTimeBetweenUpdates = 60;
+  const twapLength = 180;
+  const uniswapAddress = toChecksumAddress(randomHex(20));
+
+  beforeEach(async function() {
+    networker = new NetworkerMock();
+    logger = winston.createLogger({
+      level: "info",
+      transports: []
+    });
+  });
+
+  it("No type", async function() {
+    const config = {
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates
+    };
+
+    assert.equal(await createPriceFeed(web3, logger, networker, getTime, config), null);
+  });
+
+  it("Valid CryptoWatch", async function() {
+    const config = {
+      type: "cryptowatch",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates
+    };
+
+    const validCryptoWatchFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+
+    assert.isTrue(validCryptoWatchFeed instanceof CryptoWatchPriceFeed);
+    assert.equal(validCryptoWatchFeed.apiKey, apiKey);
+    assert.equal(validCryptoWatchFeed.exchange, exchange);
+    assert.equal(validCryptoWatchFeed.pair, pair);
+    assert.equal(validCryptoWatchFeed.lookback, lookback);
+    assert.equal(validCryptoWatchFeed.getTime(), getTime());
+  });
+
+  it("Invalid CryptoWatch", async function() {
+    const validConfig = {
+      type: "cryptowatch",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates
+    };
+
+    assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, apiKey: undefined }), null);
+    assert.equal(
+      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, exchange: undefined }),
+      null
+    );
+    assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, pair: undefined }), null);
+    assert.equal(
+      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, lookback: undefined }),
+      null
+    );
+    assert.equal(
+      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, minTimeBetweenUpdates: undefined }),
+      null
+    );
+  });
+
+  it("Valid Uniswap", async function() {
+    const config = {
+      type: "uniswap",
+      uniswapAddress,
+      twapLength,
+      lookback
+    };
+
+    const validUniswapFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+
+    assert.isTrue(validUniswapFeed instanceof UniswapPriceFeed);
+    assert.equal(validUniswapFeed.uniswap.options.address, uniswapAddress);
+    assert.equal(validUniswapFeed.twapLength, twapLength);
+    assert.equal(validUniswapFeed.historicalLookback, lookback);
+    assert.equal(validUniswapFeed.getTime(), getTime());
+  });
+
+  it("Invalid Uniswap", async function() {
+    const validConfig = {
+      type: "uniswap",
+      uniswapAddress,
+      twapLength,
+      lookback
+    };
+
+    assert.equal(
+      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, uniswapAddress: undefined }),
+      null
+    );
+    assert.equal(
+      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, twapLength: undefined }),
+      null
+    );
+    assert.equal(
+      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, lookback: undefined }),
+      null
+    );
+  });
+
+  it("Valid Medianizer Inheritance", async function() {
+    const config = {
+      type: "medianizer",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates,
+      uniswapAddress,
+      twapLength,
+      medianizedFeeds: [
+        {
+          type: "cryptowatch"
+        },
+        {
+          type: "uniswap"
+        }
+      ]
+    };
+
+    const validMedianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+
+    assert.isTrue(validMedianizerFeed instanceof MedianizerPriceFeed);
+    assert.isTrue(validMedianizerFeed.priceFeeds[0] instanceof CryptoWatchPriceFeed);
+    assert.isTrue(validMedianizerFeed.priceFeeds[1] instanceof UniswapPriceFeed);
+
+    assert.equal(validMedianizerFeed.priceFeeds[0].pair, pair);
+    assert.equal(validMedianizerFeed.priceFeeds[1].uniswap.options.address, uniswapAddress);
+  });
+
+  it("Valid Medianizer Override", async function() {
+    const lookbackOverride = 5;
+    const config = {
+      type: "medianizer",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates,
+      medianizedFeeds: [
+        {
+          type: "cryptowatch",
+          lookback: lookbackOverride
+        }
+      ]
+    };
+
+    const validMedianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+
+    assert.equal(validMedianizerFeed.priceFeeds[0].lookback, lookbackOverride);
+  });
+
+  it("Medianizer feed cannot have no feeds to medianize", async function() {
+    const config = {
+      type: "medianizer",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates
+    };
+
+    const medianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+
+    // medianizedFeeds is missing.
+    assert.equal(await createPriceFeed(web3, logger, networker, getTime, config), null);
+
+    // medianizedFeeds is 0 length.
+    assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...config, medianizedFeeds: [] }), null);
+  });
+
+  it("Medianizer feed cannot have invalid nested feed", async function() {
+    const config = {
+      type: "medianizer",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates,
+      medianizedFeeds: [
+        {
+          type: "cryptowatch"
+        },
+        {} // Invalid because the second medianized feed has no type.
+      ]
+    };
+
+    const medianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+
+    assert.equal(medianizerFeed, null);
+  });
+});


### PR DESCRIPTION
This adds a price feed factory that will generate a price feed from the provided config.

This allows price feed users, like the various bots, to read in a config from a file and pass that config (or some subset of that config) into the `createPriceFeed` factory function to construct a price feed. This means that those bots don't have to do any direct price feed configuration, keeping their code clean of any price feed implementation details.

This is the last prerequisite to injecting the price feed implementations into the bots.