### PR TITLE
Better pager duty error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,3 @@ WORKDIR core/
 # Command to run any command provided by the COMMAND env variable.
 # Use the command listed at the top to run the voting script repeatedly in a 60 second loop.
 ENTRYPOINT ["/bin/bash", "scripts/runCommand.sh"]
-CMD ["--network=test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # To `docker run` with your locally built image, replace `umaprotocol/voting` with <username>/<imagename>.
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:11
+FROM node:12
 
 # Pull down latest version of code from Github.
 RUN git clone https://github.com/UMAprotocol/protocol.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # To `docker run` with your locally built image, replace `umaprotocol/voting` with <username>/<imagename>.
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:12
+FROM node:11
 
 # Pull down latest version of code from Github.
 RUN git clone https://github.com/UMAprotocol/protocol.git
@@ -38,3 +38,4 @@ WORKDIR core/
 # Command to run any command provided by the COMMAND env variable.
 # Use the command listed at the top to run the voting script repeatedly in a 60 second loop.
 ENTRYPOINT ["/bin/bash", "scripts/runCommand.sh"]
+CMD ["--network=test"]

--- a/financial-templates-lib/logger/PagerDutyTransport.js
+++ b/financial-templates-lib/logger/PagerDutyTransport.js
@@ -16,22 +16,27 @@ module.exports = class PagerDutyTransport extends Transport {
   }
 
   async log(info, callback) {
-    // TODO: refactor this processing to better parse mrkdwn and complex data structure from winston.
-    await this.pd.incidents.createIncident(this.fromEmail, {
-      incident: {
-        type: "incident",
-        title: `${info.level}: ${info.at} ⭢ ${info.message}`,
-        service: {
-          id: this.serviceId,
-          type: "service_reference"
-        },
-        urgency: info.level == "warn" ? "low" : "high", // If level is warn then urgency is low. If level is error then urgency is high.
-        body: {
-          type: "incident_body",
-          details: info.mrkdwn ? info.mrkdwn : info // If the message has markdown then add it. Else put the whole info object.
+    try {
+      await this.pd.incidents.createIncident(this.fromEmail, {
+        incident: {
+          type: "incident",
+          title: `${info.level}: ${info.at} ⭢ ${info.message}`,
+          service: {
+            id: this.serviceId,
+            type: "service_reference"
+          },
+          urgency: info.level == "warn" ? "low" : "high", // If level is warn then urgency is low. If level is error then urgency is high.
+          body: {
+            type: "incident_body",
+            details: info.mrkdwn ? info.mrkdwn : info // If the message has markdown then add it. Else put the whole info object.
+          }
         }
-      }
-    });
+      });
+      callback();
+    } catch (error) {
+      console.error("PagerDuty error", error);
+    }
+
     callback();
   }
 };


### PR DESCRIPTION
This PR adds a `try catch` block around the pager duty message sending function call. This change comes from testing a miss-configured monitor bot where pagerduty locked up the Winston logger. This try catch enables the pagerduty transport to gracefully fail without locking up winston.