### PR TITLE
fix error in contract monitor

### DIFF
--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -61,7 +61,9 @@ class ContractMonitor {
     let latestLiquidationEvents = this.empEventClient.getAllLiquidationEvents();
 
     // Get liquidation events that are newer than the last block number we've seen
-    let newLiquidationEvents = latestLiquidationEvents.filter(event => event.blockNumber > this.lastDisputeBlockNumber);
+    let newLiquidationEvents = latestLiquidationEvents.filter(
+      event => event.blockNumber > this.lastLiquidationBlockNumber
+    );
 
     for (let event of newLiquidationEvents) {
       // Sample message:


### PR DESCRIPTION
This PR addresses a bug in the contract monitor module. Previously the wrong block number reference was being used. This PR addresses this.