### PR TITLE
Respond to initial EMP audit issues

### DIFF
--- a/core/contracts/financial-templates/common/FeePayer.sol
+++ b/core/contracts/financial-templates/common/FeePayer.sol
@@ -150,7 +150,7 @@ abstract contract FeePayer is Testable, Lockable {
      * @notice Gets the current profit from corruption for this contract in terms of the collateral currency.
      * @dev This is equivalent to the collateral pool available from which to pay fees. Therefore, derived contracts are
      * expected to implement this so that pay-fee methods can correctly compute the owed fees as a % of PfC.
-     * @return pfc value for equal to the current profic from corrution denominated in collateral currency.
+     * @return pfc value for equal to the current profit from corrution denominated in collateral currency.
      */
     function pfc() public view nonReentrantView() returns (FixedPoint.Unsigned memory) {
         return _pfc();

--- a/core/contracts/financial-templates/common/FeePayer.sol
+++ b/core/contracts/financial-templates/common/FeePayer.sol
@@ -88,8 +88,9 @@ abstract contract FeePayer is Testable, Lockable {
     /**
      * @notice Pays UMA DVM regular fees (as a % of the collateral pool) to the Store contract.
      * @dev These must be paid periodically for the life of the contract. If the contract has not paid its regular fee
-     * in a week or more then a late penalty is applied which is sent to the caller. This will revert if the amount of
-     * fees owed are greater than the pfc. An event is only fired if the fees charged are greater than 0.
+     * in a week or more then a late penalty is applied which is sent to the caller. If the amount of
+     * fees owed are greater than the pfc, then this will pay as much as possible from the available collateral.
+     * An event is only fired if the fees charged are greater than 0.
      * @return totalPaid Amount of collateral that the contract paid (sum of the amount paid to the Store and caller).
      * This returns 0 and exit early if there is no pfc, fees were already paid during the current block, or the fee rate is 0.
      */

--- a/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol
@@ -4,7 +4,16 @@ pragma experimental ABIEncoderV2;
 import "./Liquidatable.sol";
 
 
+/**
+ * @title Expiring Multi Party.
+ * @notice Convenient wrapper for Liquidatable.
+ */
 contract ExpiringMultiParty is Liquidatable {
+    /**
+     * @notice Constructs the ExpiringMultiParty contract.
+     * @param params struct to define input parameters for construction of Liquidatable. Some params
+     * are fed directly into the PricelessPositionManager's constructor within the inheritance tree.
+     */
     constructor(ConstructorParams memory params)
         public
         Liquidatable(params)

--- a/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
@@ -68,6 +68,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
      * @param _finderAddress UMA protocol Finder used to discover other protocol contracts.
      * @param _collateralTokenWhitelist UMA protocol contract to track whitelisted collateral.
      * @param _tokenFactoryAddress ERC20 token factory used to deploy synthetic token instances.
+     * @param _timerAddress Contract that stores the current time in a testing environment.
      */
     constructor(
         address _finderAddress,

--- a/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
@@ -186,7 +186,9 @@ contract Liquidatable is PricelessPositionManager {
      * @param maxCollateralPerToken abort the liquidation if the position's collateral per token exceeds this value.
      * @param maxTokensToLiquidate max number of tokens to liquidate.
      * @param deadline abort the liquidation if the transaction is mined after this timestamp.
-     * @return liquidationId of the newly created liquidation.
+     * @return liquidationId ID of the newly created liquidation.
+     * @return tokensLiquidated amount of synthetic tokens removed and liquidated from the `sponsor`'s position.
+     * @return finalFeeBond amount of collateral to be posted by liquidator and returned if not disputed successfully.
      */
     function createLiquidation(
         address sponsor,
@@ -312,6 +314,7 @@ contract Liquidatable is PricelessPositionManager {
      * bond amount is calculated from `disputeBondPct` times the collateral in the liquidation.
      * @param liquidationId of the disputed liquidation.
      * @param sponsor the address of the sponsor whose liquidation is being disputed.
+     * @return totalPaid amount of collateral charged to disputer (i.e. final fee bond + dispute bond).
      */
     function dispute(uint256 liquidationId, address sponsor)
         external

--- a/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -143,6 +143,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
      * @param _syntheticName name for the token contract that will be deployed.
      * @param _syntheticSymbol symbol for the token contract that will be deployed.
      * @param _tokenFactoryAddress deployed UMA token factory to create the synthetic token.
+     * @param _minSponsorTokens minimum amount of collateral that must exist at any time in a position.
      * @param _timerAddress Contract that stores the current time in a testing environment.
      * Must be set to 0x0 for production environments that use live time.
      */
@@ -174,8 +175,8 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
      ****************************************/
 
     /**
-     * @notice Requests to transfer ownership of the caller's current position to `newSponsorAddress`.
-     * Once the request liveness is passed, the sponsor can execute the transfer.
+     * @notice Requests to transfer ownership of the caller's current position to a new sponsor address.
+     * Once the request liveness is passed, the sponsor can execute the transfer and specify the new sponsor.
      * @dev The liveness length is the same as the withdrawal liveness.
      */
     function requestTransferPosition() public onlyPreExpiration() nonReentrant() {
@@ -585,6 +586,12 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         emit EmergencyShutdown(msg.sender, oldExpirationTimestamp, expirationTimestamp);
     }
 
+    /**
+     * @notice Theoretically supposed to pays fees and moves money between margin accounts to make sure they
+     * reflect the NAV of the contract. However, this contract does not use this functionality.
+     * @dev This is supposed to be implemented by any contract that inherits `AdministrateeInterface` and callable
+     * only by the Governor contract. This method is therefore minimally implemented in this contract and does nothing.
+     */
     function remargin() external override onlyPreExpiration() nonReentrant() {
         return;
     }

--- a/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -588,7 +588,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
 
     /**
      * @notice Theoretically supposed to pays fees and moves money between margin accounts to make sure they
-     * reflect the NAV of the contract. However, this contract does not use this functionality.
+     * reflect the NAV of the contract. However, this functionality doesn't apply to this contract.
      * @dev This is supposed to be implemented by any contract that inherits `AdministrateeInterface` and callable
      * only by the Governor contract. This method is therefore minimally implemented in this contract and does nothing.
      */

--- a/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -587,7 +587,7 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
     }
 
     /**
-     * @notice Theoretically supposed to pays fees and moves money between margin accounts to make sure they
+     * @notice Theoretically supposed to pay fees and move money between margin accounts to make sure they
      * reflect the NAV of the contract. However, this functionality doesn't apply to this contract.
      * @dev This is supposed to be implemented by any contract that inherits `AdministrateeInterface` and callable
      * only by the Governor contract. This method is therefore minimally implemented in this contract and does nothing.

--- a/core/scripts/cli/sponsor/showMarketDetails.js
+++ b/core/scripts/cli/sponsor/showMarketDetails.js
@@ -89,7 +89,7 @@ const showMarketDetails = async (web3, artifacts, emp) => {
     await printSponsorSummary(sponsorAddress);
     const position = await emp.positions(sponsorAddress);
 
-    const hasPendingWithdrawal = position.requestPassTimestamp.toString() !== "0";
+    const hasPendingWithdrawal = position.withdrawalRequestPassTimestamp.toString() !== "0";
     if (hasPendingWithdrawal) {
       console.log(
         "Because you have a pending withdrawal, other contract functions are blocked. Either execute or cancel your withdrawal. You can still request to transfer your position to a new sponsor address and cancel this request, but you cannot execute the transfer until the withdrawal request is processed."

--- a/core/scripts/cli/sponsor/transfer.js
+++ b/core/scripts/cli/sponsor/transfer.js
@@ -79,7 +79,7 @@ const transfer = async (web3, emp) => {
     // Transfer request has passed, user can transfer or cancel.
     else {
       // Executing transfer requests can only occur if there are no pending withdrawals.
-      const hasPendingWithdrawal = position.requestPassTimestamp.toString() !== "0";
+      const hasPendingWithdrawal = position.withdrawalRequestPassTimestamp.toString() !== "0";
 
       if (hasPendingWithdrawal) {
         console.log(

--- a/core/scripts/cli/sponsor/withdraw.js
+++ b/core/scripts/cli/sponsor/withdraw.js
@@ -57,7 +57,7 @@ const withdraw = async (web3, artifacts, emp) => {
   };
 
   // First check if user has a withdrawal request pending.
-  const withdrawalRequestPassedTimestamp = position.requestPassTimestamp;
+  const withdrawalRequestPassedTimestamp = position.withdrawalRequestPassTimestamp;
   if (withdrawalRequestPassedTimestamp.toString() !== "0") {
     const withdrawRequestAmount = position.withdrawalRequestAmount.toString();
     const currentTime = await emp.getCurrentTime();

--- a/core/test/financial-templates/PricelessPositionManager.js
+++ b/core/test/financial-templates/PricelessPositionManager.js
@@ -465,7 +465,7 @@ contract("PricelessPositionManager", function(accounts) {
 
     // Check that withdrawal-request related parameters in pricelessPositionManager are reset
     const positionData = await pricelessPositionManager.positions(sponsor);
-    assert.equal(positionData.requestPassTimestamp.toString(), 0);
+    assert.equal(positionData.withdrawalRequestPassTimestamp.toString(), 0);
     assert.equal(positionData.withdrawalRequestAmount.toString(), 0);
 
     // Verify state of pricelessPositionManager post-withdrawal.
@@ -812,7 +812,7 @@ contract("PricelessPositionManager", function(accounts) {
     const sponsorsPosition = await pricelessPositionManager.positions(sponsor);
     assert.equal(sponsorsPosition.rawCollateral.rawValue, 0);
     assert.equal(sponsorsPosition.tokensOutstanding.rawValue, 0);
-    assert.equal(sponsorsPosition.requestPassTimestamp.toString(), 0);
+    assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
   });
@@ -1088,7 +1088,7 @@ contract("PricelessPositionManager", function(accounts) {
     const sponsorsPosition = await pricelessPositionManager.positions(sponsor);
     assert.equal(sponsorsPosition.rawCollateral.rawValue, 0);
     assert.equal(sponsorsPosition.tokensOutstanding.rawValue, 0);
-    assert.equal(sponsorsPosition.requestPassTimestamp.toString(), 0);
+    assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
 
@@ -1232,7 +1232,7 @@ contract("PricelessPositionManager", function(accounts) {
       const sponsorsPosition = await pricelessPositionManager.positions(sponsor);
       assert.equal(sponsorsPosition.rawCollateral.rawValue, 0);
       assert.equal(sponsorsPosition.tokensOutstanding.rawValue, 0);
-      assert.equal(sponsorsPosition.requestPassTimestamp.toString(), 0);
+      assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
     });
@@ -1742,7 +1742,7 @@ contract("PricelessPositionManager", function(accounts) {
     const sponsorsPosition = await customPricelessPositionManager.positions(sponsor);
     assert.equal(sponsorsPosition.rawCollateral.rawValue, 0);
     assert.equal(sponsorsPosition.tokensOutstanding.rawValue, 0);
-    assert.equal(sponsorsPosition.requestPassTimestamp.toString(), 0);
+    assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
   });

--- a/financial-templates-lib/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyClient.js
@@ -126,11 +126,11 @@ class ExpiringMultiPartyClient {
             acc.concat([
               {
                 sponsor: address,
-                requestPassTimestamp: positions[i].requestPassTimestamp,
+                withdrawalRequestPassTimestamp: positions[i].withdrawalRequestPassTimestamp,
                 withdrawalRequestAmount: positions[i].withdrawalRequestAmount.toString(),
                 numTokens: positions[i].tokensOutstanding.toString(),
                 amountCollateral: collateral[i].toString(),
-                hasPendingWithdrawal: positions[i].requestPassTimestamp > 0
+                hasPendingWithdrawal: positions[i].withdrawalRequestPassTimestamp > 0
               }
             ]),
       []

--- a/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
@@ -99,7 +99,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("50"),
           amountCollateral: toWei("10"),
           hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
+          withdrawalRequestPassTimestamp: "0",
           withdrawalRequestAmount: "0"
         }
       ] // expected position
@@ -116,7 +116,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("100"),
           amountCollateral: toWei("20"),
           hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
+          withdrawalRequestPassTimestamp: "0",
           withdrawalRequestAmount: "0"
         }
       ]
@@ -133,7 +133,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("100"),
           amountCollateral: toWei("20"),
           hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
+          withdrawalRequestPassTimestamp: "0",
           withdrawalRequestAmount: "0"
         },
         {
@@ -141,7 +141,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("45"),
           amountCollateral: toWei("100"),
           hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
+          withdrawalRequestPassTimestamp: "0",
           withdrawalRequestAmount: "0"
         }
       ]
@@ -174,7 +174,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("100"),
           amountCollateral: toWei("20"),
           hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
+          withdrawalRequestPassTimestamp: "0",
           withdrawalRequestAmount: "0"
         }
       ]
@@ -205,7 +205,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("100"),
           amountCollateral: toWei("20"),
           hasPendingWithdrawal: true,
-          requestPassTimestamp: (await emp.getCurrentTime()).add(await emp.withdrawalLiveness()).toString(),
+          withdrawalRequestPassTimestamp: (await emp.getCurrentTime()).add(await emp.withdrawalLiveness()).toString(),
           withdrawalRequestAmount: toWei("10")
         }
       ]
@@ -232,7 +232,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           numTokens: toWei("100"),
           amountCollateral: toWei("150"),
           hasPendingWithdrawal: false,
-          requestPassTimestamp: "0",
+          withdrawalRequestPassTimestamp: "0",
           withdrawalRequestAmount: "0"
         }
       ],


### PR DESCRIPTION
- The `pfc` function in `FeePayer` has a comment that says “profic from corrution”
- Now that `PositionData` has two request deadlines, consider renaming `requestPassTimestamp` to `withdrawalRequestPassTimestamp`
- The `requestTransferPosition`  comment references a non-existent `newSponsorAddress` parameter
- The `payRegularFees`  comment says it will revert if the fees exceed the `pfc`, but that’s no longer true
- The `ExpiringMultiParty` contract doesn’t have any NatSpec comments.
- The `ExpiringMultiPartyCreator` constructor NatSpec is missing a `@param` for `_timerAddress`
- The `@return` statement of `createLiquidation` only describes one parameter
- The `dispute` function is missing its `@return` statement
- The `PricelessPositionManager` constructor is missing the `@param statement` for  the `_minSponsorTokens` parameter
- There are no NatSpec comments on the `remargin` function