### PR TITLE
Inject `getTime` method into GasEstimator instead of hard-coding real-world time

### DIFF
--- a/disputer/index.js
+++ b/disputer/index.js
@@ -34,7 +34,8 @@ async function run(price, address, shouldPoll, pollingDelay) {
 
   // Client and dispute bot
   const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
-  const gasEstimator = new GasEstimator(Logger);
+  const getTime = () => empClient.getLastUpdateTime();
+  const gasEstimator = new GasEstimator(Logger, getTime);
   const disputer = new Disputer(Logger, empClient, gasEstimator, accounts[0]);
 
   while (true) {

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -34,7 +34,7 @@ async function run(price, address, shouldPoll, pollingDelay) {
 
   // Client and dispute bot
   const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
-  const getTime = () => empClient.getLastUpdateTime();
+  const getTime = () => emp.getCurrentTime();
   const gasEstimator = new GasEstimator(Logger, getTime);
   const disputer = new Disputer(Logger, empClient, gasEstimator, accounts[0]);
 

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -115,7 +115,7 @@ contract("Disputer.js", function(accounts) {
 
     // Create a new instance of the ExpiringMultiPartyClient & GasEstimator to construct the disputer
     empClient = new ExpiringMultiPartyClient(spyLogger, ExpiringMultiParty.abi, web3, emp.address);
-    const getTime = () => empClient.getLastUpdateTime();
+    const getTime = () => emp.getCurrentTime();
     gasEstimator = new GasEstimator(spyLogger, getTime);
 
     // Create a new instance of the disputer to test

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -115,7 +115,8 @@ contract("Disputer.js", function(accounts) {
 
     // Create a new instance of the ExpiringMultiPartyClient & GasEstimator to construct the disputer
     empClient = new ExpiringMultiPartyClient(spyLogger, ExpiringMultiParty.abi, web3, emp.address);
-    gasEstimator = new GasEstimator(spyLogger);
+    const getTime = () => empClient.getLastUpdateTime();
+    gasEstimator = new GasEstimator(spyLogger, getTime);
 
     // Create a new instance of the disputer to test
     disputer = new Disputer(spyLogger, empClient, gasEstimator, accounts[0]);

--- a/financial-templates-lib/helpers/GasEstimator.js
+++ b/financial-templates-lib/helpers/GasEstimator.js
@@ -6,11 +6,12 @@ const url = "https://ethgasstation.info/json/ethgasAPI.json";
 
 // If no updateThreshold is specified then default to updating every 60 seconds.
 class GasEstimator {
-  constructor(logger, updateThreshold = 60, defaultFastPriceGwei = 40) {
+  constructor(logger, getTime, updateThreshold = 60, defaultFastPriceGwei = 40) {
     this.logger = logger;
     this.updateThreshold = updateThreshold;
     this.lastUpdateTimestamp;
     this.lastFastPriceGwei;
+    this.getTime = getTime;
 
     // If the script fails or the API response fails default to this value
     this.defaultFastPriceGwei = defaultFastPriceGwei;
@@ -19,7 +20,7 @@ class GasEstimator {
 
   // Calls update unless it was recently called, as determined by this.updateThreshold.
   update = async () => {
-    const currentTime = Math.floor(Date.now() / 1000);
+    const currentTime = this.getTime();
     if (currentTime < this.lastUpdateTimestamp + this.updateThreshold) {
       this.logger.debug({
         at: "GasEstimator",

--- a/financial-templates-lib/helpers/GasEstimator.js
+++ b/financial-templates-lib/helpers/GasEstimator.js
@@ -6,12 +6,12 @@ const url = "https://ethgasstation.info/json/ethgasAPI.json";
 
 // If no updateThreshold is specified then default to updating every 60 seconds.
 class GasEstimator {
-  constructor(logger, getTime, updateThreshold = 60, defaultFastPriceGwei = 40) {
+  constructor(logger, asyncGetTime, updateThreshold = 60, defaultFastPriceGwei = 40) {
     this.logger = logger;
     this.updateThreshold = updateThreshold;
     this.lastUpdateTimestamp;
     this.lastFastPriceGwei;
-    this.getTime = getTime;
+    this.asyncGetTime = asyncGetTime;
 
     // If the script fails or the API response fails default to this value
     this.defaultFastPriceGwei = defaultFastPriceGwei;
@@ -20,7 +20,7 @@ class GasEstimator {
 
   // Calls update unless it was recently called, as determined by this.updateThreshold.
   update = async () => {
-    const currentTime = this.getTime();
+    const currentTime = await this.asyncGetTime();
     if (currentTime < this.lastUpdateTimestamp + this.updateThreshold) {
       this.logger.debug({
         at: "GasEstimator",

--- a/financial-templates-lib/test/helpers/GasEstimator.js
+++ b/financial-templates-lib/test/helpers/GasEstimator.js
@@ -8,13 +8,15 @@ const { GasEstimator } = require("../../helpers/GasEstimator");
 contract("GasEstimator.js", function() {
   let gasEstimator;
 
+  const getTime = () => Math.floor(Date.now() / 1000);
+
   describe("Construction with default config", () => {
     beforeEach(() => {
       const dummyLogger = winston.createLogger({
         level: "info",
         transports: [new winston.transports.Console()]
       });
-      gasEstimator = new GasEstimator(dummyLogger);
+      gasEstimator = new GasEstimator(dummyLogger, getTime);
     });
 
     it("Default parameters are set correctly", () => {
@@ -47,7 +49,7 @@ contract("GasEstimator.js", function() {
         level: "info",
         transports: [new winston.transports.Console()]
       });
-      gasEstimator = new GasEstimator(dummyLogger, (updateThreshold = 2), (defaultFastPriceGwei = 10));
+      gasEstimator = new GasEstimator(dummyLogger, getTime, (updateThreshold = 2), (defaultFastPriceGwei = 10));
     });
 
     it("Default parameters are set correctly", () => {

--- a/financial-templates-lib/test/helpers/GasEstimator.js
+++ b/financial-templates-lib/test/helpers/GasEstimator.js
@@ -8,7 +8,7 @@ const { GasEstimator } = require("../../helpers/GasEstimator");
 contract("GasEstimator.js", function() {
   let gasEstimator;
 
-  const getTime = () => Math.floor(Date.now() / 1000);
+  const getTime = () => new Promise(resolve => resolve(Math.floor(Date.now() / 1000)));
 
   describe("Construction with default config", () => {
     beforeEach(() => {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -40,7 +40,8 @@ async function run(price, address, shouldPoll, pollingDelay) {
 
   // Client and liquidator bot
   const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
-  const gasEstimator = new GasEstimator(Logger);
+  const getTime = () => empClient.getLastUpdateTime();
+  const gasEstimator = new GasEstimator(Logger, getTime);
   const liquidator = new Liquidator(Logger, empClient, gasEstimator, accounts[0]);
 
   while (true) {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -39,17 +39,18 @@ async function run(address, shouldPoll, pollingDelay, priceFeedConfig) {
   const accounts = await web3.eth.getAccounts();
   const emp = await ExpiringMultiParty.at(address);
 
-  // Client and liquidator bot
-  const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
   const getTime = () => empClient.getLastUpdateTime();
   const gasEstimator = new GasEstimator(Logger, getTime);
-  const liquidator = new Liquidator(Logger, empClient, gasEstimator, priceFeed, accounts[0]);
 
   // Price feed.
   const priceFeed = await createPriceFeed(web3, Logger, new Networker(Logger), getTime, priceFeedConfig);
   if (!priceFeed) {
     throw "Price feed config is invalid";
   }
+
+  // Client and liquidator bot
+  const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
+  const liquidator = new Liquidator(Logger, empClient, gasEstimator, priceFeed, accounts[0]);
 
   while (true) {
     try {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -39,7 +39,7 @@ async function run(address, shouldPoll, pollingDelay, priceFeedConfig) {
   const accounts = await web3.eth.getAccounts();
   const emp = await ExpiringMultiParty.at(address);
 
-  const getTime = () => empClient.getLastUpdateTime();
+  const getTime = () => emp.getCurrentTime();
   const gasEstimator = new GasEstimator(Logger, getTime);
 
   // Price feed.

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -111,7 +111,8 @@ contract("Liquidator.js", function(accounts) {
 
     // Create a new instance of the ExpiringMultiPartyClient & gasEstimator to construct the liquidator
     empClient = new ExpiringMultiPartyClient(spyLogger, ExpiringMultiParty.abi, web3, emp.address);
-    gasEstimator = new GasEstimator(spyLogger);
+    const getTime = () => empClient.getLastUpdateTime();
+    gasEstimator = new GasEstimator(spyLogger, getTime);
 
     // Create a new instance of the liquidator to test
     liquidatorConfig = {

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -113,7 +113,7 @@ contract("Liquidator.js", function(accounts) {
 
     // Create a new instance of the ExpiringMultiPartyClient & gasEstimator to construct the liquidator
     empClient = new ExpiringMultiPartyClient(spyLogger, ExpiringMultiParty.abi, web3, emp.address);
-    const getTime = () => empClient.getLastUpdateTime();
+    const getTime = () => emp.getCurrentTime();
     gasEstimator = new GasEstimator(spyLogger, getTime);
 
     // Create a new instance of the price feed mock.


### PR DESCRIPTION
@mrice32 also fixes the `getTime` method injected into the PriceFeed in the Liquidator bot. Both the price feed and the gas estimator can call `empClient.getLastUpdateTime()` synchronously.