### PR TITLE
Change createPriceFeed constructor param order to match other infrastructure

### DIFF
--- a/disputer/index.js
+++ b/disputer/index.js
@@ -39,7 +39,7 @@ async function run(address, shouldPoll, pollingDelay, priceFeedConfig) {
   // Setup price feed.
   // TODO: consider making getTime async and using contract time.
   const getTime = () => Math.round(new Date().getTime() / 1000);
-  const priceFeed = await createPriceFeed(web3, Logger, new Networker(Logger), getTime, priceFeedConfig);
+  const priceFeed = await createPriceFeed(Logger, web3, new Networker(Logger), getTime, priceFeedConfig);
 
   if (!priceFeed) {
     throw "Price feed config is invalid";

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -4,7 +4,7 @@ const { UniswapPriceFeed } = require("./UniswapPriceFeed");
 
 const Uniswap = require("../../core/build/contracts/Uniswap.json");
 
-async function createPriceFeed(web3, logger, networker, getTime, config) {
+async function createPriceFeed(logger, web3, networker, getTime, config) {
   if (config.type === "cryptowatch") {
     const requiredFields = ["apiKey", "exchange", "pair", "lookback", "minTimeBetweenUpdates"];
 

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -75,7 +75,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       // on the nested config.
       const combinedConfig = { ...config, type: undefined, ...medianizedFeedConfig };
 
-      const priceFeed = await createPriceFeed(web3, logger, networker, getTime, combinedConfig);
+      const priceFeed = await createPriceFeed(logger, web3, networker, getTime, combinedConfig);
 
       if (priceFeed === null) {
         // If one of the nested feeds errored and returned null, just return null up the stack.

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -37,7 +37,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       minTimeBetweenUpdates
     };
 
-    assert.equal(await createPriceFeed(web3, logger, networker, getTime, config), null);
+    assert.equal(await createPriceFeed(logger, web3, networker, getTime, config), null);
   });
 
   it("Valid CryptoWatch config", async function() {
@@ -50,7 +50,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       minTimeBetweenUpdates
     };
 
-    const validCryptoWatchFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+    const validCryptoWatchFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
     assert.isTrue(validCryptoWatchFeed instanceof CryptoWatchPriceFeed);
     assert.equal(validCryptoWatchFeed.apiKey, apiKey);
@@ -70,18 +70,18 @@ contract("CreatePriceFeed.js", function(accounts) {
       minTimeBetweenUpdates
     };
 
-    assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, apiKey: undefined }), null);
+    assert.equal(await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, apiKey: undefined }), null);
     assert.equal(
-      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, exchange: undefined }),
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, exchange: undefined }),
       null
     );
-    assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, pair: undefined }), null);
+    assert.equal(await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, pair: undefined }), null);
     assert.equal(
-      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, lookback: undefined }),
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, lookback: undefined }),
       null
     );
     assert.equal(
-      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, minTimeBetweenUpdates: undefined }),
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, minTimeBetweenUpdates: undefined }),
       null
     );
   });
@@ -94,7 +94,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       lookback
     };
 
-    const validUniswapFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+    const validUniswapFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
     assert.isTrue(validUniswapFeed instanceof UniswapPriceFeed);
     assert.equal(validUniswapFeed.uniswap.options.address, uniswapAddress);
@@ -112,15 +112,15 @@ contract("CreatePriceFeed.js", function(accounts) {
     };
 
     assert.equal(
-      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, uniswapAddress: undefined }),
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, uniswapAddress: undefined }),
       null
     );
     assert.equal(
-      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, twapLength: undefined }),
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, twapLength: undefined }),
       null
     );
     assert.equal(
-      await createPriceFeed(web3, logger, networker, getTime, { ...validConfig, lookback: undefined }),
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, lookback: undefined }),
       null
     );
   });
@@ -145,7 +145,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       ]
     };
 
-    const validMedianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+    const validMedianizerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
     assert.isTrue(validMedianizerFeed instanceof MedianizerPriceFeed);
     assert.isTrue(validMedianizerFeed.priceFeeds[0] instanceof CryptoWatchPriceFeed);
@@ -172,7 +172,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       ]
     };
 
-    const validMedianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+    const validMedianizerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
     assert.equal(validMedianizerFeed.priceFeeds[0].lookback, lookbackOverride);
   });
@@ -187,13 +187,13 @@ contract("CreatePriceFeed.js", function(accounts) {
       minTimeBetweenUpdates
     };
 
-    const medianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+    const medianizerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
     // medianizedFeeds is missing.
-    assert.equal(await createPriceFeed(web3, logger, networker, getTime, config), null);
+    assert.equal(await createPriceFeed(logger, web3, networker, getTime, config), null);
 
     // medianizedFeeds is 0 length.
-    assert.equal(await createPriceFeed(web3, logger, networker, getTime, { ...config, medianizedFeeds: [] }), null);
+    assert.equal(await createPriceFeed(logger, web3, networker, getTime, { ...config, medianizedFeeds: [] }), null);
   });
 
   it("Medianizer feed cannot have a nested feed with an invalid config", async function() {
@@ -212,7 +212,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       ]
     };
 
-    const medianizerFeed = await createPriceFeed(web3, logger, networker, getTime, config);
+    const medianizerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
     assert.equal(medianizerFeed, null);
   });

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -42,7 +42,7 @@ async function run(address, shouldPoll, pollingDelay, priceFeedConfig) {
   // Setup price feed.
   // TODO: consider making getTime async and using contract time.
   const getTime = () => Math.round(new Date().getTime() / 1000);
-  const priceFeed = await createPriceFeed(web3, Logger, new Networker(Logger), getTime, priceFeedConfig);
+  const priceFeed = await createPriceFeed(Logger, web3, new Networker(Logger), getTime, priceFeedConfig);
 
   if (!priceFeed) {
     throw "Price feed config is invalid";


### PR DESCRIPTION
The constructor parameters in the `createPriceFeed` have `web3` coming before the `logger`. This is the only js library in all off-chain infrastructure that does not first have the logger come first. This PR corrects this.