### PR TITLE
Improve slack transport object formatting

### DIFF
--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -59,7 +59,7 @@ const slackFormatter = info => {
         if (subKey == "tx") {
           formattedResponse.blocks[
             formattedResponse.blocks.length - 1
-          ].text.text += `    - _tx_: <https://etherscan.io/tx/${info[key][subKey]}|${info[key][subKey]}> \n`;
+          ].text.text += `    - _tx_: <https://etherscan.io/tx/${info[key][subKey]}|${info[key][subKey]}>\n`;
         }
         // If the value within the object itself is an object we dont want to spread it any further. Rather,
         // convert the object to a string and print it along side it's key value pair.
@@ -80,7 +80,7 @@ const slackFormatter = info => {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: ` • _tx_: <https://etherscan.io/tx/${info[key]}|${info[key]}> \n`
+            text: ` • _tx_: <https://etherscan.io/tx/${info[key]}|${info[key]}>\n`
           }
         });
       } else if (key == "mrkdwn") {

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -61,6 +61,8 @@ const slackFormatter = info => {
             formattedResponse.blocks.length - 1
           ].text.text += `    - _tx_: <https://etherscan.io/tx/${info[key][subKey]}|${info[key][subKey]}> \n`;
         }
+        // If the value within the object itself is an object we dont want to spread it any further. Rather,
+        // convert the object to a string and print it along side it's key value pair.
         if (typeof info[key][subKey] === "object" && info[key][subKey] !== null) {
           formattedResponse.blocks[
             formattedResponse.blocks.length - 1

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -60,6 +60,11 @@ const slackFormatter = info => {
           formattedResponse.blocks[
             formattedResponse.blocks.length - 1
           ].text.text += `    - _tx_: <https://etherscan.io/tx/${info[key][subKey]}|${info[key][subKey]}> \n`;
+        }
+        if (typeof info[key][subKey] === "object" && info[key][subKey] !== null) {
+          formattedResponse.blocks[
+            formattedResponse.blocks.length - 1
+          ].text.text += `    - _${subKey}_: ${JSON.stringify(info[key][subKey])}\n`;
         } else {
           formattedResponse.blocks[
             formattedResponse.blocks.length - 1


### PR DESCRIPTION
This PR modifies how the slack bot text formatted handles spreading nested objects. When a key-value pair is passed to Winston the slack transport formatted is meant to spread this text to make it readable from slack. Example usage of the logger is:
```
  Logger.info({
    at: "Monitor#index",
    message: "Monitor started 🕵️‍♂️",
    empAddress: address,
    pollingDelay: pollingDelay,
    priceFeedConfig
  });
```
Here the `priceFeedConfig` is an object that the slack formatted should spread to show the contents in slack. Before this PR the formatted would output a message like this:

![image](https://user-images.githubusercontent.com/12886084/82030989-7b3d5080-9699-11ea-9212-271141b537a8.png)

The problem here is that the `priceFeedConfig` has an object _within_ the object, two levels down. This should be spread accordingly. 

The change in this PR ensures that any level of nested objects are spread. The implementation enforces that any 3rd level down is `stringified` such that no further nesting of bullet points are created. The screenshot below shows the associated output of the same log message after the update:

![image](https://user-images.githubusercontent.com/12886084/82031014-81333180-9699-11ea-94ed-9c1c69565b17.png)

