### PR TITLE
Fix bug in CryptoWatchPriceFeed

### DIFF
--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -137,7 +137,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       });
 
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
-    const priceUrl = `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price?apikey=${this.apikey}`;
+    const priceUrl = `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price?apikey=${this.apiKey}`;
     const priceResponse = await this.networker.getJson(priceUrl);
     if (!ohlcResponse || !priceResponse.result || !priceResponse.result.price) {
       console.error("Could not parse price result:", priceResponse);


### PR DESCRIPTION
This PR addresses a small typo in the `CryptoWatchPriceFeed` which made running all elements of the infrastructure impossible as the api key could not be read correctly. 