### PR TITLE
Improve gcp scripts to make config file optional

### DIFF
--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -8,7 +8,7 @@ if [ $# -ne 2 ]; then
 fi
 
 echo "Deploying" $1
-echo "Using ENV file:" $1
+echo "Using ENV file:" $2
 gcloud compute instances create-with-container $1 \
     --container-image docker.io/umaprotocol/protocol:latest \
     --container-env-file $2 \

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 2 ]|| [ $# -gt 2 ]; then
+if [ $# -ne 2 ] || [ $# -gt 2 ]; then
     echo "Incorrect number of arguments supplied! First argument is bot's name. Second argument is path to config file."
     echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt"
     exit 1

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 2 ]; then
+if [ $# -ne 2 ]|| [ $# -gt 2 ]; then
     echo "Incorrect number of arguments supplied! First argument is bot's name. Second argument is path to config file."
     echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt"
     exit 1

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    echo "Incorrect number of arguments supplied! First and only required argument is bot's name. Optionally include a config file."
+    echo "Incorrect number of arguments supplied! First argument is the bot's name. Second argument (optional) is a config file with environment variables to supply to the bot."
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot ./scripts/bot-deployment/ETHBTC-monitor-bot-env.txt [update env variables]"
     exit 1

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -3,7 +3,8 @@ set -e
 
 if [ $# -eq 0 ]; then
     echo "Incorrect number of arguments supplied! First and only argument is bot's name. Optionally include a config file"
-    echo "example: ./PushBotHotFix.sh ethbtc-monitor-bot"
+    echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
+    echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot ./scripts/bot-deployment/ETHBTC-monitor-bot-env.txt [update env variables]"
     exit 1
 fi
 

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 1 ]; then
-    echo "Incorrect number of arguments supplied! First and only argument is bot's name."
+if [ $# -eq 0 ]; then
+    echo "Incorrect number of arguments supplied! First and only argument is bot's name. Optionally include a config file"
     echo "example: ./PushBotHotFix.sh ethbtc-monitor-bot"
     exit 1
 fi
 
-echo "Pushing hot fix to" $1
 echo "Building docker container..."
 docker build -t umaprotocol/protocol:hotfix .
 
@@ -15,8 +14,23 @@ echo "Pushing docker container to docker hub..."
 docker push umaprotocol/protocol:hotfix
 
 echo "Pushing docker container to docker hub..."
-gcloud compute instances update-container $1 \
-    --container-image docker.io/umaprotocol/protocol:hotfix \
-    --zone us-central1-a \
-    --container-restart-policy on-failure \
-    --container-stdin
+if [ $# -eq 1 ]; then
+    echo "Pushing hot fix to" $1
+    echo "Using no new enviroment variable. Keeping current configuration."
+    gcloud compute instances update-container $1 \
+        --container-image docker.io/umaprotocol/protocol:hotfix \
+        --zone us-central1-a \
+        --container-restart-policy on-failure \
+        --container-stdin
+fi
+
+if [ $# -eq 2 ]; then
+    echo "Pushing hot fix to" $1
+    echo "Using enviroment variable config file" $2
+    gcloud compute instances update-container $1 \
+        --container-image docker.io/umaprotocol/protocol:hotfix \
+        --container-env-file $2 \
+        --zone us-central1-a \
+        --container-restart-policy on-failure \
+        --container-stdin
+fi

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    echo "Incorrect number of arguments supplied! First and only argument is bot's name. Optionally include a config file"
+    echo "Incorrect number of arguments supplied! First and only required argument is bot's name. Optionally include a config file."
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot ./scripts/bot-deployment/ETHBTC-monitor-bot-env.txt [update env variables]"
     exit 1

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -eq 0 ]; then
+if [ $# -eq 0 ]|| [ $# -gt 2 ]; then
     echo "Incorrect number of arguments supplied! First argument is the bot's name. Second argument (optional) is a config file with environment variables to supply to the bot."
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot ./scripts/bot-deployment/ETHBTC-monitor-bot-env.txt [update env variables]"

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -17,7 +17,7 @@ docker push umaprotocol/protocol:hotfix
 echo "Pushing docker container to docker hub..."
 if [ $# -eq 1 ]; then
     echo "Pushing hot fix to" $1
-    echo "Using no new enviroment variable. Keeping current configuration."
+    echo "No configuration file provided. Keeping current configuration"
     gcloud compute instances update-container $1 \
         --container-image docker.io/umaprotocol/protocol:hotfix \
         --zone us-central1-a \

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -eq 0 ]|| [ $# -gt 2 ]; then
+if [ $# -eq 0 ] || [ $# -gt 2 ]; then
     echo "Incorrect number of arguments supplied! First argument is the bot's name. Second argument (optional) is a config file with environment variables to supply to the bot."
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
     echo "example: ./scripts/bot-deployment/UpdateBotGCP.sh ethbtc-monitor-bot ./scripts/bot-deployment/ETHBTC-monitor-bot-env.txt [update env variables]"

--- a/scripts/bot-deployment/UpdateBotGCP.sh
+++ b/scripts/bot-deployment/UpdateBotGCP.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    echo "Incorrect number of arguments supplied! First argument is bot's name. Second optional argument is path to config file."
+    echo "Incorrect number of arguments supplied! First argument is the bot's name. Second argument (optional) is a config file with environment variables to supply to the bot."
     echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
     echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt [Update env variables]"
     exit 1

--- a/scripts/bot-deployment/UpdateBotGCP.sh
+++ b/scripts/bot-deployment/UpdateBotGCP.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -eq 0 ]; then
+if [ $# -eq 0 ] || [ $# -gt 2 ]; then
     echo "Incorrect number of arguments supplied! First argument is the bot's name. Second argument (optional) is a config file with environment variables to supply to the bot."
     echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
     echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt [Update env variables]"

--- a/scripts/bot-deployment/UpdateBotGCP.sh
+++ b/scripts/bot-deployment/UpdateBotGCP.sh
@@ -10,7 +10,7 @@ fi
 
 if [ $# -eq 1 ]; then
     echo "Updating" $1
-    echo "Using no new enviroment variable. Keeping current configuration"
+    echo "No configuration file provided. Keeping current configuration"
     gcloud compute instances update-container $1 \
         --container-image docker.io/umaprotocol/protocol:latest \
         --zone us-central1-a \

--- a/scripts/bot-deployment/UpdateBotGCP.sh
+++ b/scripts/bot-deployment/UpdateBotGCP.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 2 ]; then
-    echo "Incorrect number of arguments supplied! First argument is bot's name. Second argument is path to config file."
-    echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt"
+if [ $# -eq 0 ]; then
+    echo "Incorrect number of arguments supplied! First argument is bot's name. Second optional argument is path to config file."
+    echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot [keep env variables]"
+    echo "example: ./UpdateBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt [Update env variables]"
     exit 1
 fi
 
-echo "Updating" $1
-echo "Using ENV file:" $2
-gcloud compute instances update-container $1 \
-    --container-image docker.io/umaprotocol/protocol:latest \
-    --container-env-file $2 \
-    --zone us-central1-a \
-    --container-restart-policy on-failure \
-    --container-stdin
+if [ $# -eq 1 ]; then
+    echo "Updating" $1
+    echo "Using no new enviroment variable. Keeping current configuration"
+    gcloud compute instances update-container $1 \
+        --container-image docker.io/umaprotocol/protocol:latest \
+        --zone us-central1-a \
+        --container-restart-policy on-failure \
+        --container-stdin
+
+fi
+
+if [ $# -eq 2 ]; then
+    echo "Updating" $1
+    echo "Using enviroment variable config file" $2
+    gcloud compute instances update-container $1 \
+        --container-image docker.io/umaprotocol/protocol:latest \
+        --container-env-file $2 \
+        --zone us-central1-a \
+        --container-restart-policy on-failure \
+        --container-stdin
+fi


### PR DESCRIPTION
This PR makes specifying environment variables config option with the `UpdateBotGCP.sh` and `PushBotHotFix.sh` scripts. If no configs are specified then the GCP instances will keep their previous configs.