### PR TITLE
Add UMIP-2 Upgrade Scripts

### DIFF
--- a/core/scripts/umip-2/1_Propose.js
+++ b/core/scripts/umip-2/1_Propose.js
@@ -1,0 +1,65 @@
+// This script generates and submits UMIP-2 upgrade transactions to the DVM. It can be run on a local ganache
+// fork of the main net or can be run directly on the main net to execute the upgrade transactions.
+// To run this on the localhost first fork main net into Ganache with the proposerWallet unlocked as follows:
+// ganache-cli --fork https://mainnet.infura.io/v3/d70106f59aef456c9e5bfbb0c2cc7164 --unlock 0x2bAaA41d155ad8a4126184950B31F50A1513cE25
+// Then execute the script as: truffle exec ./scripts/umip-2/1_Propose.js --network mainnet-fork from core
+
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const Governor = artifacts.require("Governor");
+
+const { RegistryRolesEnum } = require("../../../common/Enums.js");
+
+const tdr = require("truffle-deploy-registry");
+
+const proposerWallet = "0x2bAaA41d155ad8a4126184950B31F50A1513cE25";
+const zeroAddress = "0x0000000000000000000000000000000000000000";
+
+async function runExport() {
+  console.log("Running UMIP-2 Upgrade🔥");
+  console.log("Connected to network id", await web3.eth.net.getId());
+
+  const identifierWhitelist = await IdentifierWhitelist.deployed();
+  const governor = await Governor.deployed();
+
+  // After it's given ownership, the upgrade transaction needs to be executed.
+  const identifierBytes = web3.utils.utf8ToHex("ETH/BTC");
+  const addEthBtcIdentifierTx = identifierWhitelist.contract.methods
+    .addSupportedIdentifier(identifierBytes)
+    .encodeABI();
+
+  console.log("addEthBtcIdentifierTx", addEthBtcIdentifierTx);
+
+  await governor.propose(
+    [
+      {
+        to: identifierWhitelist.address,
+        value: 0,
+        data: addEthBtcIdentifierTx
+      }
+    ],
+    { from: proposerWallet }
+  );
+
+  console.log(`
+
+Newly Proposed DVM Identifier: 
+
+ETH/BTC (UTF8)
+${identifierBytes} (HEX)
+
+`);
+}
+
+run = async function(callback) {
+  try {
+    await runExport();
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+// Attach this function to the exported function in order to allow the script to be executed through both truffle and a test runner.
+run.runExport = runExport;
+module.exports = run;

--- a/core/scripts/umip-2/2_VoteSimulate.js
+++ b/core/scripts/umip-2/2_VoteSimulate.js
@@ -1,0 +1,1 @@
+../umip-3/2_VoteSimulate.js

--- a/core/scripts/umip-2/3_Verify.js
+++ b/core/scripts/umip-2/3_Verify.js
@@ -1,0 +1,33 @@
+// This script verify that the UMPIP-3 upgrade was executed correctly by checking deployed bytecodes,
+// assigned ownerships and roles. It can be run on the main net after the upgrade is completed
+// or on the local Ganache mainnet fork to validate the execution of the previous  two scripts.
+// This script does not need any wallets unlocked and does not make any on-chain state changes. It can be run as:
+// truffle exec ./scripts/umip-3/3_Verify.js --network mainnet-fork
+
+const assert = require("assert").strict;
+
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+
+async function runExport() {
+  console.log("Running UMIP-2 Upgrade Verifier🔥");
+
+  const identifierWhitelist = await IdentifierWhitelist.deployed();
+
+  assert.equal(await identifierWhitelist.isIdentifierSupported(web3.utils.utf8ToHex("ETH/BTC")), true);
+
+  console.log("Upgrade Verified!");
+}
+
+run = async function(callback) {
+  try {
+    await runExport();
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+// Attach this function to the exported function in order to allow the script to be executed through both truffle and a test runner.
+run.runExport = runExport;
+module.exports = run;

--- a/core/scripts/umip-3/2_VoteSimulate.js
+++ b/core/scripts/umip-3/2_VoteSimulate.js
@@ -161,14 +161,14 @@ async function runExport() {
     (await voting.getCurrentRoundId()).toString()
   );
 
-  assert.equal((await voting.getPendingRequests()).length, 1); // There should be no pending requests as vote is concluded
+  assert.equal((await voting.getPendingRequests()).length, 0); // There should be no pending requests as vote is concluded
 
   /** *******************************************************************
    * 4) Execute proposal submitted to governor now that voting is done *
    **********************************************************************/
 
   console.log("4. EXECUTING GOVERNOR PROPOSALS");
-  const proposalId = (await governor.numProposals()).subn(2).toString(); // most recent proposal in voting.sol
+  const proposalId = (await governor.numProposals()).subn(1).toString(); // most recent proposal in voting.sol
   const proposal = await governor.getProposal(proposalId);
 
   // for every transactions within the proposal


### PR DESCRIPTION
In reusing the voting simulation from UMIP-3, there was a little weirdness due to the failed upgrade, which meant there was an extra proposal in the queue. I removed that weirdness to allow UMIP-2 to use the same code. I'm open to other ways of doing this, but I figured this would cause the least churn.

Side note: to use the vote simulation script, you have to pass in the --repeated flag so it uses the post-UMIP-3 commit hash. I figured that wasn't worth changing.

I'm okay with some of this code being a little janky since we'll likely delete/deprecate it in fairly short order, but curious how others feel.