### PR TITLE
Update economic_architecture.md link error

### DIFF
--- a/documentation/oracle/economic_architecture.md
+++ b/documentation/oracle/economic_architecture.md
@@ -42,7 +42,7 @@ The DVM collects two types of fees from registered financial contracts, a “reg
 Each financial contract must report its PfC in terms of its single collateral currency.
 
 The regular fee is paid periodically by financial contracts (generally whenever someone interacts with them).
-They are calculated based on the PfC, the amount of time since they last paid them, and the current fee rate. The exact formula used can be found in the `computeRegularFee` function of the `Store` contract [here](https://docs.umaproject.org/uma/contracts/Store.html#Store-computeRegularFee-uint256-uint256-struct-FixedPoint-Unsigned-).
+They are calculated based on the PfC, the amount of time since they last paid them, and the current fee rate. The exact formula used can be found in the `computeRegularFee` function of the `Store` contract [here](https://docs.umaproject.org/uma/contracts/Store.html#Store-computeRegularFee-uint256-uint256-struct-FixedPoint-Unsigned).
 These fees are paid into the `Store` contract.
 $UMA-holders control which address has `Withdrawer` privilege from the `Store`. 
 The owner of the `Withdrawer` privilege uses the funds from the `Store` to perform “buy and burn” operations on the $UMA tokens to maintain CoC > PfC.

--- a/documentation/oracle/economic_architecture.md
+++ b/documentation/oracle/economic_architecture.md
@@ -42,7 +42,7 @@ The DVM collects two types of fees from registered financial contracts, a “reg
 Each financial contract must report its PfC in terms of its single collateral currency.
 
 The regular fee is paid periodically by financial contracts (generally whenever someone interacts with them).
-They are calculated based on the PfC, the amount of time since they last paid them, and the current fee rate. The exact formula used can be found in the `computeRegularFee` function of the `Store` contract [here](https://docs.umaproject.org/uma/contracts/Store.html#Store-computeRegularFee-uint256-uint256-struct-FixedPoint-Unsigned).
+They are calculated based on the PfC, the amount of time since they last paid them, and the current fee rate. The exact formula used can be found in the `computeRegularFee` function of the `Store` contract [here](https://docs.umaproject.org/uma/contracts/Store.html#Store-computeRegularFee-uint256-uint256-struct-FixedPoint-Unsigned\-).
 These fees are paid into the `Store` contract.
 $UMA-holders control which address has `Withdrawer` privilege from the `Store`. 
 The owner of the `Withdrawer` privilege uses the funds from the `Store` to perform “buy and burn” operations on the $UMA tokens to maintain CoC > PfC.

--- a/documentation/oracle/economic_architecture.md
+++ b/documentation/oracle/economic_architecture.md
@@ -42,7 +42,7 @@ The DVM collects two types of fees from registered financial contracts, a “reg
 Each financial contract must report its PfC in terms of its single collateral currency.
 
 The regular fee is paid periodically by financial contracts (generally whenever someone interacts with them).
-They are calculated based on the PfC, the amount of time since they last paid them, and the current fee rate. The exact formula used can be found in the `computeRegularFee` function of the `Store` contract [here](https://docs.umaproject.org/uma/contracts/Store.html#Store-computeRegularFee-uint256-uint256-struct-FixedPoint-Unsigned\-).
+They are calculated based on the PfC, the amount of time since they last paid them, and the current fee rate. The exact formula used can be found in the `computeRegularFee` function of the `Store` contract [here](https://bit.ly/2yBUPlj).
 These fees are paid into the `Store` contract.
 $UMA-holders control which address has `Withdrawer` privilege from the `Store`. 
 The owner of the `Withdrawer` privilege uses the funds from the `Store` to perform “buy and burn” operations on the $UMA tokens to maintain CoC > PfC.


### PR DESCRIPTION
This PR fixes an issue with a link rendering in the `Economic Architecture ` documentation. Previously this link rendered like this:
![image](https://user-images.githubusercontent.com/12886084/83009308-dadf1880-a016-11ea-87d7-4d31a9dcfaa0.png)


The fix presented in this PR is to use a link shortener, rather than solving the actual issue. This was done as a quick workaround as fixing how the docs interpret this link will be a much longer tailed fix and there was no easy obvious solution.