### PR TITLE
Implement pricefeed identifier volatility monitor

### DIFF
--- a/common/FormattingUtils.js
+++ b/common/FormattingUtils.js
@@ -14,6 +14,11 @@ const formatDate = (timestampInSeconds, web3) => {
   ).toString();
 };
 
+const formatHours = (seconds, decimals = 2) => {
+  // 3600 seconds in an hour.
+  return (seconds / 3600).toFixed(decimals);
+};
+
 // formatWei converts a string or BN instance from Wei to Ether, e.g., 1e19 -> 10.
 const formatWei = (num, web3) => {
   // Web3's `fromWei` function doesn't work on BN objects in minified mode (e.g.,
@@ -78,6 +83,7 @@ function createEtherscanLinkMarkdown(web3, hex) {
 
 module.exports = {
   formatDate,
+  formatHours,
   formatWei,
   formatWithMaxDecimals,
   createFormatFunction,

--- a/common/gckms/GckmsConfig.js
+++ b/common/gckms/GckmsConfig.js
@@ -10,8 +10,6 @@ const publicNetworkNames = Object.values(require("../PublicNetworks.js")).map(el
 
 let configOverride = {};
 
-console.log(process.env.GCKMS_CONFIG);
-
 // If there is no env variable providing the config, attempt to pull it from a file.
 // TODO: this is kinda hacky. We should refactor this to only take in the config using one method.
 if (process.env.GCKMS_CONFIG) {

--- a/financial-templates-lib/test/price-feed/PriceFeedMock.js
+++ b/financial-templates-lib/test/price-feed/PriceFeedMock.js
@@ -11,10 +11,23 @@ class PriceFeedMock extends PriceFeedInterface {
     this.currentPrice = currentPrice;
     this.historicalPrice = historicalPrice;
     this.lastUpdateTime = lastUpdateTime;
+    this.historicalPrices = [];
   }
 
   setCurrentPrice(currentPrice) {
     this.currentPrice = currentPrice;
+  }
+
+  // Store an array of historical prices [{timestamp, price}] so that getHistoricalPrice can return
+  // a price for a specific timestamp if found in this array.
+  setHistoricalPrices(historicalPrices) {
+    historicalPrices.forEach(_price => {
+      if (!_price.timestamp || !_price.price) {
+        throw "Invalid historical price => [{timestamp, price}]";
+      }
+
+      this.historicalPrices[_price.timestamp] = _price.price;
+    });
   }
 
   setHistoricalPrice(historicalPrice) {
@@ -30,7 +43,11 @@ class PriceFeedMock extends PriceFeedInterface {
   }
 
   getHistoricalPrice(time) {
-    return this.historicalPrice;
+    // If a price for `time` was set via `setHistoricalPrices`, then return that price, otherwise return the mocked
+    // historical price.
+    if (time in this.historicalPrices) {
+      return this.historicalPrices[time];
+    } else return this.historicalPrice;
   }
 
   getLastUpdateTime() {

--- a/financial-templates-lib/test/price-feed/PriceFeedMock.js
+++ b/financial-templates-lib/test/price-feed/PriceFeedMock.js
@@ -22,7 +22,7 @@ class PriceFeedMock extends PriceFeedInterface {
   // a price for a specific timestamp if found in this array.
   setHistoricalPrices(historicalPrices) {
     historicalPrices.forEach(_price => {
-      if (!_price.timestamp || !_price.price) {
+      if (isNaN(_price.timestamp) || !_price.price) {
         throw "Invalid historical price => [{timestamp, price}]";
       }
 
@@ -47,7 +47,8 @@ class PriceFeedMock extends PriceFeedInterface {
     // historical price.
     if (time in this.historicalPrices) {
       return this.historicalPrices[time];
-    } else return this.historicalPrice;
+    }
+    return this.historicalPrice;
   }
 
   getLastUpdateTime() {

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -248,7 +248,7 @@ class SyntheticPegMonitor {
         min = _price;
       }
       if (_price.gt(max)) {
-        mx = _price;
+        max = _price;
       }
     }
 

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -77,8 +77,8 @@ class SyntheticPegMonitor {
       this.logger.warn({
         at: "SyntheticPegMonitor",
         message: "Unable to get price",
-        uniswapTokenPrice: uniswapTokenPrice,
-        cryptoWatchTokenPrice: cryptoWatchTokenPrice
+        uniswapTokenPrice: uniswapTokenPrice.toString(),
+        cryptoWatchTokenPrice: cryptoWatchTokenPrice.toString()
       });
       return;
     }

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -50,7 +50,6 @@ class SyntheticPegMonitor {
       },
       volatilityAlertThreshold: {
         // `volatilityAlertThreshold`: Error threshold for pricefeed's price volatility over `volatilityWindow`.
-        // Expressed as a %.
         value: this.web3.utils.toBN(this.web3.utils.toWei("0.05")),
         isValid: x => {
           return toBN(x).lte(toBN(toWei("100"))) && toBN(x).gt(toBN("0"));

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -145,6 +145,9 @@ async function run(
       await medianizerPriceFeed.update();
       // 4.b Check for synthetic peg deviation
       await syntheticPegMonitor.checkPriceDeviation();
+      // 4.c Check for price feed volatility
+      await syntheticPegMonitor.checkPegVolatility();
+      await syntheticPegMonitor.checkSyntheticVolatility();
 
       await delay(Number(pollingDelay));
 

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -30,7 +30,9 @@ contract("SyntheticPegMonitor", function(accounts) {
 
     // Tested module that uses the two price feeds.
     syntheticPegMonitorConfig = {
-      deviationAlertThreshold: toBN(toWei("0.2")) // Any deviation larger than 0.2 should fire an alert
+      deviationAlertThreshold: toBN(toWei("0.2")), // Any deviation larger than 0.2 should fire an alert
+      volatilityWindow: 5, // Small window for testing
+      volatilityAlertThreshold: toBN(toWei("0.05"))
     };
     syntheticPegMonitor = new SyntheticPegMonitor(
       spyLogger,
@@ -40,67 +42,84 @@ contract("SyntheticPegMonitor", function(accounts) {
       syntheticPegMonitorConfig
     );
   });
-  it("Calculate percentage error returns expected values", async function() {
-    // Test with simple values with know percentage error.
-    assert.equal(
-      syntheticPegMonitor._calculateDeviationError(toBN(toWei("1")), toBN(toWei("1"))).toString(),
-      toBN(toWei("0")).toString()
-    );
-    assert.equal(
-      syntheticPegMonitor._calculateDeviationError(toBN(toWei("1.11")), toBN(toWei("1"))).toString(),
-      toBN(toWei("0.11")).toString()
-    );
-    assert.equal(
-      syntheticPegMonitor._calculateDeviationError(toBN(toWei("1.25")), toBN(toWei("1"))).toString(),
-      toBN(toWei("0.25")).toString()
-    );
 
-    // More aggressive test with local validation of the calculation.
-    assert.equal(
-      syntheticPegMonitor._calculateDeviationError(toBN(toWei("3.1415")), toBN(toWei("3.14159"))).toString(),
-      toBN(toWei("3.1415")) // actual
-        .sub(toBN(toWei("3.14159"))) // expected
-        .mul(toBN(toWei("1"))) // Scale the numerator before division
-        .div(toBN(toWei("3.14159"))) // expected
-        .abs()
-        .toString()
-    );
+  describe("Synthetic price deviation from peg", function() {
+    it("Calculate percentage error returns expected values", async function() {
+      // Test with simple values with know percentage error.
+      assert.equal(
+        syntheticPegMonitor._calculateDeviationError(toBN(toWei("1")), toBN(toWei("1"))).toString(),
+        toBN(toWei("0")).toString()
+      );
+      assert.equal(
+        syntheticPegMonitor._calculateDeviationError(toBN(toWei("1.11")), toBN(toWei("1"))).toString(),
+        toBN(toWei("0.11")).toString()
+      );
+      assert.equal(
+        syntheticPegMonitor._calculateDeviationError(toBN(toWei("1.25")), toBN(toWei("1"))).toString(),
+        toBN(toWei("0.25")).toString()
+      );
+
+      // More aggressive test with local validation of the calculation.
+      assert.equal(
+        syntheticPegMonitor._calculateDeviationError(toBN(toWei("3.1415")), toBN(toWei("3.14159"))).toString(),
+        toBN(toWei("3.1415")) // actual
+          .sub(toBN(toWei("3.14159"))) // expected
+          .mul(toBN(toWei("1"))) // Scale the numerator before division
+          .div(toBN(toWei("3.14159"))) // expected
+          .abs()
+          .toString()
+      );
+    });
+
+    it("Correctly emits messages", async function() {
+      // Zero price deviation should not emit any events.
+      // Inject prices to feeds
+      medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
+      uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
+
+      // Check for price deviation from monitor module.
+      await syntheticPegMonitor.checkPriceDeviation();
+      assert.equal(spy.callCount, 0); // There should be no messages sent at this point.
+
+      // Price deviation above the threshold of 20% should send a message.
+      medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
+      uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1.25")));
+      await syntheticPegMonitor.checkPriceDeviation();
+      assert.equal(spy.callCount, 1); // There should be one message sent at this point.
+      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "1.25")); // uniswap price
+      assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
+      assert.isTrue(lastSpyLogIncludes(spy, "25.00")); // percentage error
+
+      // Price deviation at the threshold of 20% should send a message.
+      medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
+      uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1.2")));
+      await syntheticPegMonitor.checkPriceDeviation();
+      assert.equal(spy.callCount, 1); // There should be no new messages sent.
+
+      // Price deviation below the threshold of 20% should send a message.
+      medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
+      uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("0.7")));
+      await syntheticPegMonitor.checkPriceDeviation();
+      assert.equal(spy.callCount, 2); // There should be one message sent at this point.
+      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "0.7")); // uniswap price
+      assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
+      assert.isTrue(lastSpyLogIncludes(spy, "30.00")); // percentage error
+    });
   });
 
-  it("Correctly emits messages ", async function() {
-    // Zero price deviation should not emit any events.
-    // Inject prices to feeds
-    medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
-    uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
+  describe("Pricefeed volatility", function() {
+    it("Calculate price volatility returns expected values", async function() {
+      // Inject prices into pricefeed.
+      const latestTime = medianizerPriceFeedMock.getLatestTime();
 
-    // Check for price deviation from monitor module.
-    await syntheticPegMonitor.checkPriceDeviation();
-    assert.equal(spy.callCount, 0); // There should be no messages sent at this point.
+      assert.equal(
+        syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, latestTime, 3).toString(),
+        toBN(toWei("0.05")).toString()
+      );
+    });
 
-    // Price deviation above the threshold of 20% should send a message.
-    medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
-    uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1.25")));
-    await syntheticPegMonitor.checkPriceDeviation();
-    assert.equal(spy.callCount, 1); // There should be one message sent at this point.
-    assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
-    assert.isTrue(lastSpyLogIncludes(spy, "1.25")); // uniswap price
-    assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
-    assert.isTrue(lastSpyLogIncludes(spy, "25.00")); // percentage error
-
-    // Price deviation at the threshold of 20% should send a message.
-    medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
-    uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1.2")));
-    await syntheticPegMonitor.checkPriceDeviation();
-    assert.equal(spy.callCount, 1); // There should be no new messages sent.
-
-    // Price deviation below the threshold of 20% should send a message.
-    medianizerPriceFeedMock.setCurrentPrice(toBN(toWei("1")));
-    uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("0.7")));
-    await syntheticPegMonitor.checkPriceDeviation();
-    assert.equal(spy.callCount, 2); // There should be one message sent at this point.
-    assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
-    assert.isTrue(lastSpyLogIncludes(spy, "0.7")); // uniswap price
-    assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
-    assert.isTrue(lastSpyLogIncludes(spy, "30.00")); // percentage error
+    it("Correctly emits messages", async function() {});
   });
 });

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -154,7 +154,9 @@ contract("SyntheticPegMonitor", function(accounts) {
       // and the volatility should be (3 / 10 = 0.3) or 30%.
       medianizerPriceFeedMock.setLastUpdateTime(103);
       assert.equal(
-        syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 103, volatilityWindow).toString(),
+        syntheticPegMonitor
+          ._calculateHistoricalVolatility(medianizerPriceFeedMock, 103, volatilityWindow)
+          .volatility.toString(),
         toBN(toWei("0.3")).toString()
       );
 
@@ -163,7 +165,9 @@ contract("SyntheticPegMonitor", function(accounts) {
       // and the volatility should be 0%.
       medianizerPriceFeedMock.setLastUpdateTime(100);
       assert.equal(
-        syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 100, volatilityWindow).toString(),
+        syntheticPegMonitor
+          ._calculateHistoricalVolatility(medianizerPriceFeedMock, 100, volatilityWindow)
+          .volatility.toString(),
         "0"
       );
 
@@ -180,7 +184,9 @@ contract("SyntheticPegMonitor", function(accounts) {
       // and the volatility should be (4 / 12 = 0.3333) or 33%.
       medianizerPriceFeedMock.setLastUpdateTime(106);
       assert.equal(
-        syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 106, volatilityWindow).toString(),
+        syntheticPegMonitor
+          ._calculateHistoricalVolatility(medianizerPriceFeedMock, 106, volatilityWindow)
+          .volatility.toString(),
         toBN(toWei("0.333333333333333333")).toString() // 18 3's is max that can be represented with Wei.
       );
     });


### PR DESCRIPTION
This implements methods for checking pricefeed price volatility in the `SyntheticPegMonitor`:
- `checkPegVolatility`: check's medianizer's vol
- `checkSyntheticVolatility`: check synthetic's vol

This adds two configuration params to the monitor: `volatilityWindow` and `volatilityAlertThreshold`. Volatility is calculated as the % difference between the Minimum and the Maximum price over a time range. The time range's most recent time is the monitor's `lastUpdateTime` and the latest time is `lastUpdateTime - volatilityWindow`.

___
Console logs:

```sh
2020-05-19 17:22:23 [debug]: {
  "at": "SyntheticPegMonitor",
  "message": "Checking synthetic price volatility",
  "pricefeedVolatility": "806876552798844232",
  "pricefeedLatestPrice": "40059428888888888",
  "minPrice": "22170540000000000",
  "maxPrice": "40059428888888888",
  "bot-identifier": "ethbtc-monitor-kovan-local"
}
2020-05-19 17:22:23 [error]: {
  "at": "SyntheticPegMonitor",
  "message": "High synthetic price volatility alert 🌋",
  "mrkdwn": "Latest updated UMATEST/DAI price is 0.04. Price moved 80.68% over the last 0.17 hour(s). Threshold is 10.00 %.",
  "bot-identifier": "ethbtc-monitor-kovan-local"
}
```

___
Slack logs

```
• syntheticPegMonitorObject:
   - deviationAlertThreshold: 200000000000000000
   - volatilityWindow: 360
   - volatilityAlertThreshold: 50000000000000000
```

![Screen Shot 2020-05-19 at 12 52 58](https://user-images.githubusercontent.com/9457025/82355073-b8724d00-99cf-11ea-9ffd-804e7d8715ad.png)

Signed-off-by: Nick Pai <npai.nyc@gmail.com>