### PR TITLE
Fix VotingUtils library to integrate DesignatedVoting proxy

### DIFF
--- a/common/VotingUtils.js
+++ b/common/VotingUtils.js
@@ -173,14 +173,7 @@ const batchRevealVotes = async (newReveals, votingContract, account) => {
 // Optimally batch together reward retrievals in the fewest batches possible,
 // each retrieveRewards is one Ethereum transaction. Return the number of successes
 // and batches to the user
-const batchRetrieveRewards = async (
-  requests,
-  roundId,
-  votingContract,
-  votingAccount,
-  signingAccount,
-  designatedVoting
-) => {
+const batchRetrieveRewards = async (requests, roundId, votingContract, votingAccount, signingAccount) => {
   let successes = [];
   let batches = 0;
   for (let i = 0; i < requests.length; i += BATCH_MAX_RETRIEVALS) {
@@ -194,15 +187,9 @@ const batchRetrieveRewards = async (
     }
 
     // Always call `retrieveRewards`, even if there's only one reward. Difference in gas cost is negligible.
-    // @dev: If the user is retrieving rewards through a designated voting proxy, the `retrieveRewards` method only
-    // takes in two parameters: roundId and pendingRequests.
-    let txn;
-    if (designatedVoting) {
-      txn = await designatedVoting.retrieveRewards(roundId, pendingRequests, { from: signingAccount });
-    } else {
-      txn = await votingContract.retrieveRewards(votingAccount, roundId, pendingRequests, { from: signingAccount });
-    }
-    const receipt = txn.receipt;
+    const { receipt } = await votingContract.retrieveRewards(votingAccount, roundId, pendingRequests, {
+      from: signingAccount
+    });
 
     // Add the batch transaction hash to each reveal.
     maxBatchSize.forEach(retrieve => {

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -1,7 +1,6 @@
 const Voting = artifacts.require("Voting");
 const { VotePhasesEnum } = require("../../common/Enums");
 const { BATCH_MAX_COMMITS, BATCH_MAX_REVEALS } = require("../../common/Constants");
-const { computeTopicHash } = require("../../common/EncryptionHelper");
 const publicNetworks = require("../../common/PublicNetworks");
 const sendgrid = require("@sendgrid/mail");
 const fetch = require("node-fetch");
@@ -478,7 +477,14 @@ class VotingSystem {
 
   async constructCommitment(request, roundId, isProd) {
     const fetchedPrice = await fetchPrice(request, isProd);
-    return await _constructCommitment(request, roundId, web3, web3.utils.fromWei(fetchedPrice), this.account);
+    return await _constructCommitment(
+      request,
+      roundId,
+      web3,
+      web3.utils.fromWei(fetchedPrice),
+      this.account,
+      this.account
+    );
   }
 
   async runBatchCommit(requests, roundId, isProd) {
@@ -530,7 +536,7 @@ class VotingSystem {
 
   async constructReveal(request, roundId, isProd) {
     try {
-      return await _constructReveal(request, roundId, web3, this.account, this.voting);
+      return await _constructReveal(request, roundId, web3, this.account, this.voting, this.account);
     } catch (e) {
       if (isProd) {
         console.error("Failed to decrypt message:", e);

--- a/core/scripts/cli/voting/commitVotes.js
+++ b/core/scripts/cli/voting/commitVotes.js
@@ -3,7 +3,7 @@ const style = require("../textStyle");
 const getDefaultAccount = require("../wallet/getDefaultAccount");
 const filterRequests = require("./filterRequestsByRound");
 const { VotePhasesEnum } = require("../../../../common/Enums");
-const { constructCommitment, batchCommitVotes } = require("../../../../common/VotingUtils");
+const { constructCommitment, batchCommitVotes, getVotingRoles } = require("../../../../common/VotingUtils");
 const networkUtils = require("../../../../common/PublicNetworks");
 
 /**
@@ -16,19 +16,19 @@ const networkUtils = require("../../../../common/PublicNetworks");
  * The user can change their votes by committing another price to a pending price request
  *
  * @param {* Object} web3 Web3 provider
- * @param {* Object} voting deployed Voting.sol contract instance
+ * @param {* Object} oracle deployed Voting.sol contract instance
  */
-const commitVotes = async (web3, voting, designatedVoting) => {
+const commitVotes = async (web3, oracle, designatedVoting) => {
   style.spinnerReadingContracts.start();
-  const pendingRequests = await voting.getPendingRequests();
-  const roundId = await voting.getCurrentRoundId();
-  const roundPhase = (await voting.getVotePhase()).toString();
+  const pendingRequests = await oracle.getPendingRequests();
+  const roundId = await oracle.getCurrentRoundId();
+  const roundPhase = (await oracle.getVotePhase()).toString();
+  const account = await getDefaultAccount(web3);
 
   // If the user is using the two key contract, then the voting account is the designated voting contract's address.
-  const signingAccount = await getDefaultAccount(web3);
-  const votingAccount = designatedVoting ? designatedVoting.address : await getDefaultAccount(web3);
+  const { votingAccount, signingAddress, votingContract } = getVotingRoles(account, oracle, designatedVoting);
 
-  const filteredRequests = await filterRequests(pendingRequests, votingAccount, roundId, roundPhase, voting);
+  const filteredRequests = await filterRequests(pendingRequests, votingAccount, roundId, roundPhase, oracle);
   style.spinnerReadingContracts.stop();
 
   if (roundPhase === VotePhasesEnum.REVEAL) {
@@ -73,14 +73,7 @@ const commitVotes = async (web3, voting, designatedVoting) => {
         // Construct commitment
         try {
           newCommitments.push(
-            await constructCommitment(
-              selections[i],
-              roundId,
-              web3,
-              priceInput["price"],
-              signingAccount,
-              designatedVoting
-            )
+            await constructCommitment(selections[i], roundId, web3, priceInput["price"], signingAddress, votingAccount)
           );
         } catch (err) {
           failures.push({ request: selections[i], err });
@@ -90,11 +83,7 @@ const commitVotes = async (web3, voting, designatedVoting) => {
       // Batch commit the votes and display a receipt to the user
       if (newCommitments.length > 0) {
         style.spinnerWritingContracts.start();
-        const { successes, batches } = await batchCommitVotes(
-          newCommitments,
-          designatedVoting ? designatedVoting : voting,
-          signingAccount
-        );
+        const { successes, batches } = await batchCommitVotes(newCommitments, votingContract, signingAddress);
         style.spinnerWritingContracts.stop();
 
         // Construct etherscan link based on network

--- a/core/scripts/cli/voting/filterRequestsByRound.js
+++ b/core/scripts/cli/voting/filterRequestsByRound.js
@@ -36,7 +36,11 @@ const filterRequestsByRound = async (pendingRequests, account, roundId, roundPha
         const request = chronologicalPriceRequests[i];
         const ev = await getLatestEvent("EncryptedVote", request, roundId, account, votingContract);
         if (ev !== null) {
-          filteredRequests.push(request);
+          // Check for already revealed vote.
+          const alreadyRevealedVote = await getLatestEvent("VoteRevealed", request, roundId, account, votingContract);
+          if (!alreadyRevealedVote) {
+            filteredRequests.push(request);
+          }
         }
       }
     }

--- a/core/scripts/cli/voting/retrieveRewards.js
+++ b/core/scripts/cli/voting/retrieveRewards.js
@@ -26,7 +26,7 @@ const retrieveRewards = async (web3, oracle, designatedVoting) => {
   const account = await getDefaultAccount(web3);
 
   // If the user is using the two key contract, then the voting account is the designated voting contract's address.
-  const { votingAccount, signingAddress, votingContract } = getVotingRoles(account, oracle, designatedVoting);
+  const { votingAccount, signingAddress } = getVotingRoles(account, oracle, designatedVoting);
 
   const { rewardsByRoundId, roundIds } = await getAvailableRewards(web3, oracle, votingAccount);
 
@@ -55,10 +55,9 @@ const retrieveRewards = async (web3, oracle, designatedVoting) => {
       const { successes, batches } = await batchRetrieveRewards(
         resolvedVotes,
         roundId,
-        votingContract,
+        oracle,
         votingAccount,
-        signingAddress,
-        designatedVoting
+        signingAddress
       );
       style.spinnerWritingContracts.stop();
 

--- a/core/scripts/cli/voting/retrieveRewards.js
+++ b/core/scripts/cli/voting/retrieveRewards.js
@@ -1,6 +1,6 @@
 const getDefaultAccount = require("../wallet/getDefaultAccount");
 const style = require("../textStyle");
-const { batchRetrieveRewards } = require("../../../../common/VotingUtils");
+const { batchRetrieveRewards, getVotingRoles } = require("../../../../common/VotingUtils");
 const getAvailableRewards = require("./getRewardsByRoundId");
 const inquirer = require("inquirer");
 const argv = require("minimist")(process.argv.slice());
@@ -10,9 +10,9 @@ const argv = require("minimist")(process.argv.slice());
  * For the selected round ID, we batch retrieve all of the rewards for the round.
  *
  * @param {* Object} web3 Web3 provider
- * @param {* Object} voting deployed Voting.sol contract instance
+ * @param {* Object} oracle deployed Voting.sol contract instance
  */
-const retrieveRewards = async (web3, voting, designatedVoting) => {
+const retrieveRewards = async (web3, oracle, designatedVoting) => {
   // TODO(#901): MetaMask provider sometimes has trouble reading past events
   if (argv.network === "metamask") {
     console.log(
@@ -22,9 +22,14 @@ const retrieveRewards = async (web3, voting, designatedVoting) => {
   }
 
   style.spinnerReadingContracts.start();
-  // If the user is using the two key contract, then the account is the designated voting contract's address
-  const account = designatedVoting ? designatedVoting.address : await getDefaultAccount(web3);
-  const { rewardsByRoundId, roundIds } = await getAvailableRewards(web3, voting, account);
+
+  const account = await getDefaultAccount(web3);
+
+  // If the user is using the two key contract, then the voting account is the designated voting contract's address.
+  const { votingAccount, signingAddress, votingContract } = getVotingRoles(account, oracle, designatedVoting);
+
+  const { rewardsByRoundId, roundIds } = await getAvailableRewards(web3, oracle, votingAccount);
+
   style.spinnerReadingContracts.stop();
 
   if (roundIds.length > 0) {
@@ -47,7 +52,14 @@ const retrieveRewards = async (web3, voting, designatedVoting) => {
 
       // Batch retrieve rewards
       style.spinnerWritingContracts.start();
-      const { successes, batches } = await batchRetrieveRewards(resolvedVotes, roundId, voting, account);
+      const { successes, batches } = await batchRetrieveRewards(
+        resolvedVotes,
+        roundId,
+        votingContract,
+        votingAccount,
+        signingAddress,
+        designatedVoting
+      );
       style.spinnerWritingContracts.stop();
 
       // Print results


### PR DESCRIPTION
- Adds a library to `VotingUtils` to get voter address, signer address, and contract to send votes to dependent on whether user is using a designated voting proxy.
- Incorporates this into voting CLI tool. Previously, voting CLI did not support voting through proxy.
- Voting CLI now supports retrieving rewards through proxy. This was broken previously because `retrieveRewards` has a different interface in `Voting.sol` vs `DesignatedVoting.sol`. I opted to just call `Voting.retrieveRewards` but needed to pass in the correct `voterAddress`.
- Voting CLI previously did not filter out already-revealed votes, and attempting to reveal an already-revealed vote would throw an error. I filter these out now
- Library is upstream of the AVS tests in `Voting.js` so I fix these

Signed-off-by: Nick Pai <npai.nyc@gmail.com>