### PR TITLE
Add Blackbox monitor server to Liquidator bot

### DIFF
--- a/common/ServerUtils.js
+++ b/common/ServerUtils.js
@@ -1,0 +1,36 @@
+const express = require("express");
+
+// Starts a simple server that exposes one GET route that can be called by an external party to monitor this
+// bot's uptime. Returns the Server node or throws.
+/**
+ * @notice Starts a simple server with one route. Designed to be used as a health status server that an external
+ * monitor can check periodically to see if a parent process is alive.
+ * @param {Number} [port] Server to listen on this port number. If `port` is omitted or is 0, the operating system
+ * will assign an arbitrary unused port, which is useful for cases like automated tasks (tests, etc.).
+ * Source: https://expressjs.com/en/4x/api.html#app.listen
+ * @return server The newly constructed server node. API: https://nodejs.org/api/http.html#http_class_http_server.
+ * @return portNumber The port number the new server is listening on.
+ */
+const startServer = port => {
+  const app = express();
+
+  // Define routes.
+  app.get("/", (req, res) =>
+    res.status(200).json({
+      message: "Bot is up"
+    })
+  );
+  //
+  // source: https://expressjs.com/en/4x/api.html#app.listen
+  const server = app.listen(port);
+  const portNumber = server.address().port;
+
+  return {
+    server,
+    portNumber
+  };
+};
+
+module.exports = {
+  startServer
+};

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -35,7 +35,8 @@ async function run(address, shouldPoll, pollingDelay, priceFeedConfig, monitorPo
       message: "liquidator started 🕵️‍♂️",
       empAddress: address,
       pollingDelay: pollingDelay,
-      priceFeedConfig
+      priceFeedConfig,
+      monitorPort
     });
 
     // Setup web3 accounts an contract instance
@@ -109,7 +110,9 @@ const Poll = async function(callback) {
 
     const priceFeedConfig = JSON.parse(process.env.PRICE_FEED_CONFIG);
 
-    await run(process.env.EMP_ADDRESS, true, pollingDelay, priceFeedConfig);
+    const portNumber = 8888;
+
+    await run(process.env.EMP_ADDRESS, true, pollingDelay, priceFeedConfig, portNumber);
   } catch (error) {
     Logger.error({
       at: "Liquidator#index",

--- a/liquidator/test/index.js
+++ b/liquidator/test/index.js
@@ -1,5 +1,6 @@
 const { toWei, utf8ToHex } = web3.utils;
 const fetch = require("node-fetch");
+const { delay } = require("../../financial-templates-lib/helpers/delay");
 
 // Script to test
 const Poll = require("../index.js");
@@ -99,8 +100,10 @@ contract("index.js", function(accounts) {
     }
     assert.isTrue(errorThrown);
 
-    // Start bot, which should start the server
-    await Poll.run(address, true, 10_000, priceFeedConfig, monitorPort);
+    // Start bot synchronously so that we can attempt to send a request to the monitor server without
+    // having to wait for the `run` method to return. Wait a little bit for bot to start before sending the request.
+    Poll.run(address, false, 10_000, priceFeedConfig, monitorPort);
+    await delay(1000); // Empirically, anything > 100 ms seems to be sufficient delay.
 
     // Pinging server while bot is alive should succeed.
     const response = await fetch(`${url}${route}`);

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -130,11 +130,10 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     });
     // Get the latest `encryptedVote` for each (identifier, time).
     const encryptedVoteMap = {};
-    const ev = encryptedVoteEvents[1];
-    // for (const ev of encryptedVoteEvents) {
-    encryptedVoteMap[toPriceRequestKey(ev.returnValues.identifier, ev.returnValues.time)] =
-      ev.returnValues.encryptedVote;
-    // }
+    for (const ev of encryptedVoteEvents) {
+      encryptedVoteMap[toPriceRequestKey(ev.returnValues.identifier, ev.returnValues.time)] =
+        ev.returnValues.encryptedVote;
+    }
     for (const request of pendingRequests) {
       voteStatuses.push({ committedValue: encryptedVoteMap[toPriceRequestKey(request.identifier, request.time)] });
     }

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -130,10 +130,11 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     });
     // Get the latest `encryptedVote` for each (identifier, time).
     const encryptedVoteMap = {};
-    for (const ev of encryptedVoteEvents) {
-      encryptedVoteMap[toPriceRequestKey(ev.returnValues.identifier, ev.returnValues.time)] =
-        ev.returnValues.encryptedVote;
-    }
+    const ev = encryptedVoteEvents[1];
+    // for (const ev of encryptedVoteEvents) {
+    encryptedVoteMap[toPriceRequestKey(ev.returnValues.identifier, ev.returnValues.time)] =
+      ev.returnValues.encryptedVote;
+    // }
     for (const request of pendingRequests) {
       voteStatuses.push({ committedValue: encryptedVoteMap[toPriceRequestKey(request.identifier, request.time)] });
     }


### PR DESCRIPTION
This adds a blackbox monitor server to the Liquidator. Follow on PR's to add this to other bots. We need to be confident that this is compatible with GCP health check infra.


Signed-off-by: Nick Pai <npai.nyc@gmail.com>