### PR TITLE
Add service account argument to bot deployment script

### DIFF
--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 2 ] || [ $# -gt 2 ]; then
-    echo "Incorrect number of arguments supplied! First argument is bot's name. Second argument is path to config file."
-    echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt"
+if [ $# -ne 3 ]; then
+    echo "Incorrect number of arguments supplied! First argument is bot's name. Second argument is path to config file. Third is the service account the bot should run as."
+    echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt ethbtc-account@project-name.iam.gserviceaccount.com"
     exit 1
 fi
 
 echo "Deploying" $1
 echo "Using ENV file:" $2
+echo "Running as Service Account:" $3
 gcloud compute instances create-with-container $1 \
     --container-image docker.io/umaprotocol/protocol:latest \
     --container-env-file $2 \
     --zone us-central1-a \
     --container-restart-policy on-failure \
-    --container-stdin
+    --container-stdin \
+    --service-account $3


### PR DESCRIPTION
Providing a service account will allow us to grant specific gcloud privileges to the instance up front, like key access or storage reads.