### PR TITLE
Streamline EMP Creation process

### DIFF
--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -12,5 +12,6 @@
   "Telegram SAFT": {},
   "USD/ETH": {},
   "Custom Index (1)": {},
-  "Custom Index (100)": {}
+  "Custom Index (100)": {},
+  "ETH/BTC": {}
 }

--- a/core/migrations/14_deploy_expiring_multi_party_creator.js
+++ b/core/migrations/14_deploy_expiring_multi_party_creator.js
@@ -5,6 +5,8 @@ const AddressWhitelist = artifacts.require("AddressWhitelist");
 const TokenFactory = artifacts.require("TokenFactory");
 const { getKeysForNetwork, deploy, enableControllableTiming } = require("../../common/MigrationUtils.js");
 const Timer = artifacts.require("Timer");
+const Registry = artifacts.require("Registry");
+const { RegistryRolesEnum } = require("../../common/Enums.js");
 
 module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
@@ -22,7 +24,7 @@ module.exports = async function(deployer, network, accounts) {
   await deploy(deployer, network, ExpiringMultiPartyLib);
   await deployer.link(ExpiringMultiPartyLib, ExpiringMultiPartyCreator);
 
-  await deploy(
+  const { contract: expiringMultiPartyCreator } = await deploy(
     deployer,
     network,
     ExpiringMultiPartyCreator,
@@ -32,4 +34,6 @@ module.exports = async function(deployer, network, accounts) {
     controllableTiming ? Timer.address : "0x0000000000000000000000000000000000000000",
     { from: keys.deployer }
   );
+
+  await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, expiringMultiPartyCreator.address);
 };

--- a/core/migrations/14_deploy_expiring_multi_party_creator.js
+++ b/core/migrations/14_deploy_expiring_multi_party_creator.js
@@ -19,6 +19,7 @@ module.exports = async function(deployer, network, accounts) {
 
   const finder = await Finder.deployed();
   const tokenFactory = await TokenFactory.deployed();
+  const registry = await Registry.deployed();
 
   // Deploy EMPLib and link to EMPCreator.
   await deploy(deployer, network, ExpiringMultiPartyLib);

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -52,6 +52,8 @@ const deployEMP = async callback => {
       await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
     }
 
+    const priceFeedIdentifier = web3.utils.utf8ToHex("BTC/USD");
+
     // Create a new EMP
     const constructorParams = {
       expirationTimestamp: "1596240000", // 2020-08-01T00:00:00.000Z. Note, this date will no longer work once it is in the past.

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -19,6 +19,7 @@ const Token = artifacts.require("ExpandedERC20");
 const Registry = artifacts.require("Registry");
 const TestnetERC20 = artifacts.require("TestnetERC20");
 const Timer = artifacts.require("Timer");
+const TokenFactory = artifacts.require("TokenFactory");
 const argv = require("minimist")(process.argv.slice(), { boolean: ["mock_dvm"] });
 
 // Contracts we need to interact with.
@@ -67,6 +68,18 @@ const deployEMP = async callback => {
     let _emp = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams, { from: deployer });
     await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: deployer });
     emp = await ExpiringMultiParty.at(_emp);
+
+    const empConstructorParams = {
+      ...constructorParams,
+      finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
+      timerAddress: await expiringMultiPartyCreator.timerAddress(),
+      withdrawalLiveness: (await expiringMultiPartyCreator.STRICT_WITHDRAWAL_LIVENESS()).toString(),
+      liquidationLiveness: (await expiringMultiPartyCreator.STRICT_LIQUIDATION_LIVENESS()).toString()
+    };
+
+    const encodedParameters = web3.eth.abi.encodeParameters(ExpiringMultiParty.abi[0].inputs, [empConstructorParams]);
+    console.log("Encoded EMP Parameters", encodedParameters);
 
     // Done!
     console.log(`Created a new EMP @ ${emp.address} with the configuration:`);

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -17,8 +17,9 @@ const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const MockOracle = artifacts.require("MockOracle");
 const Token = artifacts.require("ExpandedERC20");
 const Registry = artifacts.require("Registry");
-const WETH9 = artifacts.require("WETH9");
+const TestnetERC20 = artifacts.require("TestnetERC20");
 const Timer = artifacts.require("Timer");
+const argv = require("minimist")(process.argv.slice(), { boolean: ["mock_dvm"] });
 
 // Contracts we need to interact with.
 let collateralToken;
@@ -36,68 +37,45 @@ const deployEMP = async callback => {
   try {
     const accounts = await web3.eth.getAccounts();
     const deployer = accounts[0];
-    // Create position with a non-default account so the default CLI user can go through the new sponsor experience.
-    const firstSponsor = accounts[1];
     expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
 
-    // Use WETH as the collateral token.
-    collateralToken = await WETH9.deployed();
+    // Use Dai as the collateral token.
+    collateralToken = await TestnetERC20.deployed();
 
-    // Create identifier whitelist and register the price tracking ticker with it.
-    identifierWhitelist = await IdentifierWhitelist.deployed();
-    const priceFeedIdentifier = web3.utils.utf8ToHex("BTC/USD");
-    await identifierWhitelist.addSupportedIdentifier(priceFeedIdentifier);
-
-    // Create a mockOracle and finder. Register the mockOracle with the finder.
-    finder = await Finder.deployed();
-    mockOracle = await MockOracle.new(finder.address, Timer.address);
-    const mockOracleInterfaceName = web3.utils.utf8ToHex(interfaceName.Oracle);
-    await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
-
-    // Grant EMP the right to register new financial templates.
-    registry = await Registry.deployed();
-    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, expiringMultiPartyCreator.address, {
-      from: deployer
-    });
+    if (argv.mock_dvm) {
+      // Create a mockOracle and finder. Register the mockOracle with the finder.
+      finder = await Finder.deployed();
+      mockOracle = await MockOracle.new(finder.address, Timer.address);
+      console.log("Mock Oracle deployed:", mockOracle.address);
+      const mockOracleInterfaceName = web3.utils.utf8ToHex(interfaceName.Oracle);
+      await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
+    }
 
     // Create a new EMP
     const constructorParams = {
-      expirationTimestamp: "1601510400", // 2020-09-01T00:00:00.000Z. Note, this date will no longer work once it is in the past.
+      expirationTimestamp: "1596240000", // 2020-08-01T00:00:00.000Z. Note, this date will no longer work once it is in the past.
       collateralAddress: collateralToken.address,
       priceFeedIdentifier: priceFeedIdentifier,
-      syntheticName: "BTCUSD",
-      syntheticSymbol: "BTCUSD",
-      collateralRequirement: { rawValue: toWei("1.5") },
-      disputeBondPct: { rawValue: toWei("0.1") },
-      sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
-      disputerDisputeRewardPct: { rawValue: toWei("0.1") },
-      minSponsorTokens: { rawValue: toWei("0.01") }
+      syntheticName: "ETH/BTC",
+      syntheticSymbol: "ETH/BTC",
+      collateralRequirement: { rawValue: toWei("1.2") },
+      disputeBondPct: { rawValue: toWei("0.03") },
+      sponsorDisputeRewardPct: { rawValue: toWei("0.05") },
+      disputerDisputeRewardPct: { rawValue: toWei("0.05") },
+      minSponsorTokens: { rawValue: toWei("250") }
     };
     let _emp = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams, { from: deployer });
     await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: deployer });
     emp = await ExpiringMultiParty.at(_emp);
 
-    // To create new tokens or deposit new collateral, must approve EMP to spend collateral.
-    await collateralToken.approve(emp.address, toWei("1000000"), { from: firstSponsor });
-    // To redeem tokens, must approve EMP to spend synthetic tokens.
-    syntheticToken = await Token.at(await emp.tokenCurrency());
-    await syntheticToken.approve(emp.address, toWei("100000000"), { from: firstSponsor });
-
-    // Create one small position so that you can create new positions from the CLI
-    // (currently, it does not support creating the first position for the EMP).
-    // Collateralize this at the minimum CR allowed.
-    // Acquire 1000 of the collateralToken by depositing 1000 ETH.
-    await collateralToken.deposit({ value: toWei("1000"), from: firstSponsor });
-    await emp.create({ rawValue: toWei("1.5") }, { rawValue: toWei("1") }, { from: firstSponsor });
-
     // Done!
-    console.log(`Using Mock Oracle @ ${mockOracle.address}`);
     console.log(`Created a new EMP @ ${emp.address} with the configuration:`);
     console.log(`Deployer address @ ${deployer}`);
-    console.log(`First sponsor with under-collateralized position @ ${firstSponsor}`);
     console.table(constructorParams);
   } catch (err) {
     console.error(err);
+    callback(err);
+    return;
   }
   callback();
 };

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -63,7 +63,7 @@ const deployEMP = async callback => {
       disputeBondPct: { rawValue: toWei("0.03") },
       sponsorDisputeRewardPct: { rawValue: toWei("0.05") },
       disputerDisputeRewardPct: { rawValue: toWei("0.05") },
-      minSponsorTokens: { rawValue: toWei("250") }
+      minSponsorTokens: { rawValue: toWei("500") }
     };
     let _emp = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams, { from: deployer });
     await expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, { from: deployer });

--- a/core/test/financial-templates/ExpiringMultiPartyCreator.js
+++ b/core/test/financial-templates/ExpiringMultiPartyCreator.js
@@ -32,9 +32,6 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
     registry = await Registry.deployed();
     expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
-    await registry.addMember(RegistryRolesEnum.CONTRACT_CREATOR, expiringMultiPartyCreator.address, {
-      from: contractCreator
-    });
 
     // Whitelist collateral currency
     collateralTokenWhitelist = await AddressWhitelist.at(await expiringMultiPartyCreator.collateralTokenWhitelist());


### PR DESCRIPTION
This changes a few pieces of code to make the creation process faster/simpler:
- Updates the migrations to pre-register the EMP creator with the Registry..
- Updates the deployEmp script with production-y parameters, so very little will need to be changed when deploying to mainnet.
- Removes parts of the deployEmp script that aren't absolutely required to deploying the EMP contract.
- Adds a log message to the deployEmp script that encodes the construction params used for EMP contract. This will be useful when attempting to verify the contract on Etherscan.