### PR TITLE
Optimize list markets operation in the CLI

### DIFF
--- a/core/scripts/cli/sponsor/listExpiredMarkets.js
+++ b/core/scripts/cli/sponsor/listExpiredMarkets.js
@@ -11,7 +11,7 @@ const listExpiredMarkets = async (web3, artifacts) => {
   const choices = [];
   for (let i = 0; i < markets.length; i++) {
     const market = markets[i];
-    if (market.contractState === PositionStatesEnum.OPEN) {
+    if (!market || market.contractState === PositionStatesEnum.OPEN) {
       continue;
     }
     const state = market.contractState === PositionStatesEnum.EXPIRED_PRICE_REQUESTED ? "Pending" : "Settled";

--- a/core/scripts/cli/sponsor/listMarkets.js
+++ b/core/scripts/cli/sponsor/listMarkets.js
@@ -11,7 +11,7 @@ const listMarkets = async (web3, artifacts) => {
   const choices = [];
   for (let i = 0; i < markets.length; i++) {
     const market = markets[i];
-    if (market.contractState !== PositionStatesEnum.OPEN) {
+    if (!market || market.contractState !== PositionStatesEnum.OPEN) {
       continue;
     }
     const asPercent = web3.utils.fromWei(market.collateralRequirement.muln(100).toString());


### PR DESCRIPTION
The list markets operation was taking a long time when more than a few contracts were deployed, so they were parallelized to make the process a bit faster.

The spinner stop operation was also moved so it keeps spinning until the contract reads are done.