### PR TITLE
Fix minor issues in CLI

### DIFF
--- a/core/scripts/cli/sponsor/create.js
+++ b/core/scripts/cli/sponsor/create.js
@@ -22,8 +22,12 @@ const create = async (web3, artifacts, emp) => {
     name: "tokensCreated",
     validate: value => value > 0 || "Number of tokens must be positive"
   });
-  // Use BigNumber.js to so that we can set ROUNDING_MODE to round ceiling. We need to do this to make sure we send
-  // enough collateral to create the requested tokens.
+
+  // Apply settings to BigNumber.js library.
+  // Note: ROUNDING_MODE is set to round ceiling so we send at least enough collateral to create the requested tokens.
+  // Note: RANGE is set to 500 so values don't overflow to infinity until they hit +-1e500.
+  // Note: EXPONENTIAL_AT is set to 500 to keep BigNumber from using exponential notation until the numbers hit
+  // +-1e500.
   BigNumber.set({ ROUNDING_MODE: 2, RANGE: 500, EXPONENTIAL_AT: 500 });
   const scalingFactor = BigNumber(toWei("1"));
   const tokens = BigNumber(toWei(input["tokensCreated"]));

--- a/core/scripts/cli/sponsor/create.js
+++ b/core/scripts/cli/sponsor/create.js
@@ -24,7 +24,7 @@ const create = async (web3, artifacts, emp) => {
   });
   // Use BigNumber.js to so that we can set ROUNDING_MODE to round ceiling. We need to do this to make sure we send
   // enough collateral to create the requested tokens.
-  BigNumber.set({ ROUNDING_MODE: 2 });
+  BigNumber.set({ ROUNDING_MODE: 2, RANGE: 500, EXPONENTIAL_AT: 500 });
   const scalingFactor = BigNumber(toWei("1"));
   const tokens = BigNumber(toWei(input["tokensCreated"]));
   const gcr = totalPositionCollateral.times(scalingFactor).div(totalTokensOutstanding);

--- a/core/scripts/cli/sponsor/marketUtils.js
+++ b/core/scripts/cli/sponsor/marketUtils.js
@@ -28,9 +28,11 @@ const getMarketSummary = async (web3, artifacts) => {
     })
   );
 
-  const etherscanBaseUrl = PublicNetworks[web3.networkId]
-    ? PublicNetworks[web3.networkId].etherscan
-    : "https://fake-etherscan.com";
+  const networkId = await web3.eth.net.getId();
+
+  const etherscanBaseUrl = PublicNetworks[networkId]
+    ? PublicNetworks[networkId].etherscan
+    : "https://fake-etherscan.com/";
 
   const markets = await Promise.all(
     emps.map(async emp => {
@@ -52,7 +54,7 @@ const getMarketSummary = async (web3, artifacts) => {
 
       const expirationTimestamp = (await emp.expirationTimestamp()).toString();
 
-      const etherscanLink = `${etherscanBaseUrl}/contracts/${emp.address}`;
+      const etherscanLink = `${etherscanBaseUrl}address/${emp.address}`;
 
       return {
         emp,

--- a/core/scripts/cli/sponsor/transactionUtils.js
+++ b/core/scripts/cli/sponsor/transactionUtils.js
@@ -2,9 +2,10 @@ const style = require("../textStyle");
 const PublicNetworks = require("../../../../common/PublicNetworks");
 
 const submitTransaction = async (web3, submitFn, message, transactionNum, totalTransactions) => {
-  const etherscanBaseUrl = PublicNetworks[web3.networkId]
-    ? PublicNetworks[web3.networkId].etherscan
-    : "https://fake-etherscan.com";
+  const networkId = await web3.eth.net.getId();
+  const etherscanBaseUrl = PublicNetworks[networkId]
+    ? PublicNetworks[networkId].etherscan
+    : "https://fake-etherscan.com/";
 
   if (totalTransactions > 1) {
     console.log(`(${transactionNum}/${totalTransactions}) ${message}`);
@@ -14,7 +15,7 @@ const submitTransaction = async (web3, submitFn, message, transactionNum, totalT
   style.spinnerWritingContracts.start();
   const { receipt } = await submitFn();
   style.spinnerWritingContracts.stop();
-  const etherscanLink = `${etherscanBaseUrl}/tx/${receipt.transactionHash}`;
+  const etherscanLink = `${etherscanBaseUrl}tx/${receipt.transactionHash}`;
   console.log(`Transaction submitted. Transaction link: ${etherscanLink}`);
 };
 


### PR DESCRIPTION
This fixes two small issues in the CLI:
- We weren't pulling in the network id correctly from ganache, causing all etherscan links to be "fake-etherscan".
- Passing in larger numbers of tokens caused the BigNumber library to start printing numbers in scientific notation, causing issues elsewhere.
- Etherscan urls using `/contract/` didn't seem to work -- at least not on kovan.