### PR TITLE
Update bot deployment scripts

### DIFF
--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -13,7 +13,8 @@ echo "Running as Service Account:" $3
 gcloud compute instances create-with-container $1 \
     --container-image docker.io/umaprotocol/protocol:latest \
     --container-env-file $2 \
-    --zone us-central1-a \
+    --zone northamerica-northeast1-b \
     --container-restart-policy on-failure \
     --container-stdin \
-    --service-account $3
+    --service-account $3 \
+    --scopes cloud-platform

--- a/scripts/bot-deployment/PushBotConfigs.sh
+++ b/scripts/bot-deployment/PushBotConfigs.sh
@@ -2,8 +2,8 @@
 set -e
 
 if [ $# -ne 1 ]; then
-    echo "Incorrect number of arguments supplied! Expect destination directory for bot config files"
-    echo "example: ./RetrieveBotConfigs.sh ./"
+    echo "Incorrect number of arguments supplied! Expect directory containing configs to push"
+    echo "example: ./PushBotConfigs.sh ./configs/"
     exit 1
 fi
 

--- a/scripts/bot-deployment/PushBotConfigs.sh
+++ b/scripts/bot-deployment/PushBotConfigs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Incorrect number of arguments supplied! Expect destination directory for bot config files"
+    echo "example: ./RetrieveBotConfigs.sh ./"
+    exit 1
+fi
+
+gsutil cp $1/*.env gs://bot-configs/

--- a/scripts/bot-deployment/PushBotHotFix.sh
+++ b/scripts/bot-deployment/PushBotHotFix.sh
@@ -20,7 +20,7 @@ if [ $# -eq 1 ]; then
     echo "No configuration file provided. Keeping current configuration"
     gcloud compute instances update-container $1 \
         --container-image docker.io/umaprotocol/protocol:hotfix \
-        --zone us-central1-a \
+        --zone northamerica-northeast1-b \
         --container-restart-policy on-failure \
         --container-stdin
 fi
@@ -31,7 +31,7 @@ if [ $# -eq 2 ]; then
     gcloud compute instances update-container $1 \
         --container-image docker.io/umaprotocol/protocol:hotfix \
         --container-env-file $2 \
-        --zone us-central1-a \
+        --zone northamerica-northeast1-b \
         --container-restart-policy on-failure \
         --container-stdin
 fi

--- a/scripts/bot-deployment/UpdateBotGCP.sh
+++ b/scripts/bot-deployment/UpdateBotGCP.sh
@@ -13,7 +13,7 @@ if [ $# -eq 1 ]; then
     echo "No configuration file provided. Keeping current configuration"
     gcloud compute instances update-container $1 \
         --container-image docker.io/umaprotocol/protocol:latest \
-        --zone us-central1-a \
+        --zone northamerica-northeast1-b \
         --container-restart-policy on-failure \
         --container-stdin
 
@@ -25,7 +25,7 @@ if [ $# -eq 2 ]; then
     gcloud compute instances update-container $1 \
         --container-image docker.io/umaprotocol/protocol:latest \
         --container-env-file $2 \
-        --zone us-central1-a \
+        --zone northamerica-northeast1-b \
         --container-restart-policy on-failure \
         --container-stdin
 fi


### PR DESCRIPTION
This PR:
- Adds a script to push all configs in a directory up to the bot-configs bucket.
- Updates the GCP zone that the bots are deployed in.
- Adds a scope parameter to the deployment script that will allow the bots to access outside services like GCP Storage and GCKMS.