### PR TITLE
Add timeout to truffle

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -28,6 +28,7 @@ const gas = 9000000; // Conservative estimate of the block gas limit.
 // shell environment.
 function addPublicNetwork(networks, name, networkId) {
   const options = {
+    networkCheckTimeout: 10000,
     network_id: networkId,
     gas: gas,
     gasPrice: gasPx


### PR DESCRIPTION
Often when running truffle using GCP the connection will time out. This is despite having a 1gb fiber line but is solely due to slow round trip connection to GCP. Increasing this timeout on truffle makes the connection more consistent.