### PR TITLE
Add invert parameter to Uniswap price feed

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -20,7 +20,7 @@ const privateKey = process.env.PRIVATE_KEY
 const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "9317010b1b6343558b7eff9d25934f38";
 
 // Default options
-const gasPx = 50000000000; // 20 gwei
+const gasPx = 20000000000; // 20 gwei
 const gas = 9000000; // Conservative estimate of the block gas limit.
 
 // Adds a public network.

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -20,7 +20,7 @@ const privateKey = process.env.PRIVATE_KEY
 const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "9317010b1b6343558b7eff9d25934f38";
 
 // Default options
-const gasPx = 20000000000; // 20 gwei
+const gasPx = 50000000000; // 20 gwei
 const gas = 9000000; // Conservative estimate of the block gas limit.
 
 // Adds a public network.

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -49,7 +49,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.uniswapAddress,
       config.twapLength,
       config.lookback,
-      getTime
+      getTime,
+      config.invertPrice // Not checked in config because this parameter just defaults to false.
     );
   } else if (config.type === "medianizer") {
     const requiredFields = ["medianizedFeeds"];

--- a/financial-templates-lib/price-feed/UniswapPriceFeed.js
+++ b/financial-templates-lib/price-feed/UniswapPriceFeed.js
@@ -97,9 +97,9 @@ class UniswapPriceFeed extends PriceFeedInterface {
     const reserve1 = toBN(event.returnValues.reserve1);
 
     if (this.invertPrice) {
-      return reserve1.mul(fixedPointAdjustment).div(reserve0);
-    } else {
       return reserve0.mul(fixedPointAdjustment).div(reserve1);
+    } else {
+      return reserve1.mul(fixedPointAdjustment).div(reserve0);
     }
   }
 

--- a/financial-templates-lib/price-feed/UniswapPriceFeed.js
+++ b/financial-templates-lib/price-feed/UniswapPriceFeed.js
@@ -4,7 +4,7 @@ const { MAX_SAFE_JS_INT } = require("../../common/Constants");
 
 // An implementation of PriceFeedInterface that uses a Uniswap v2 TWAP as the price feed source.
 class UniswapPriceFeed extends PriceFeedInterface {
-  constructor(logger, abi, web3, uniswapAddress, twapLength, historicalLookback, getTime) {
+  constructor(logger, abi, web3, uniswapAddress, twapLength, historicalLookback, getTime, invertPrice) {
     super();
     this.logger = logger;
     this.web3 = web3;
@@ -12,6 +12,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
     this.twapLength = twapLength;
     this.getTime = getTime;
     this.historicalLookback = historicalLookback;
+    this.invertPrice = invertPrice;
   }
 
   getCurrentPrice() {
@@ -95,7 +96,11 @@ class UniswapPriceFeed extends PriceFeedInterface {
     const reserve0 = toBN(event.returnValues.reserve0);
     const reserve1 = toBN(event.returnValues.reserve1);
 
-    return reserve1.mul(fixedPointAdjustment).div(reserve0);
+    if (this.invertPrice) {
+      return reserve1.mul(fixedPointAdjustment).div(reserve0);
+    } else {
+      return reserve0.mul(fixedPointAdjustment).div(reserve1);
+    }
   }
 
   _computeTwap(eventsIn, startTime, endTime) {

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -19,6 +19,7 @@ contract("CreatePriceFeed.js", function(accounts) {
   const minTimeBetweenUpdates = 60;
   const twapLength = 180;
   const uniswapAddress = toChecksumAddress(randomHex(20));
+  const invertPrice = true;
 
   beforeEach(async function() {
     networker = new NetworkerMock();
@@ -101,6 +102,14 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validUniswapFeed.twapLength, twapLength);
     assert.equal(validUniswapFeed.historicalLookback, lookback);
     assert.equal(validUniswapFeed.getTime(), getTime());
+    assert.equal(validUniswapFeed.invertPrice, undefined);
+
+    // Invert parameter should be passed through.
+    const validInvertedUniswapFeed = await createPriceFeed(logger, web3, networker, getTime, {
+      ...config,
+      invertPrice: true
+    });
+    assert.isTrue(validInvertedUniswapFeed.invertPrice);
   });
 
   it("Invalid Uniswap config", async function() {

--- a/financial-templates-lib/test/price-feed/UniswapPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/UniswapPriceFeed.js
@@ -15,13 +15,14 @@ contract("UniswapPriceFeed.js", function(accounts) {
   let mockUniswap;
   let uniswapPriceFeed;
   let mockTime = 0;
+  let dummyLogger;
 
   beforeEach(async function() {
     uniswapMock = await UniswapMock.new({ from: owner });
 
     // The UniswapPriceFeed does not emit any info `level` events.  Therefore no need to test Winston outputs.
     // DummyLogger will not print anything to console as only capture `info` level events.
-    const dummyLogger = winston.createLogger({
+    dummyLogger = winston.createLogger({
       level: "info",
       transports: [new winston.transports.Console()]
     });
@@ -216,7 +217,7 @@ contract("UniswapPriceFeed.js", function(accounts) {
       3600,
       3600,
       () => mockTime,
-      false
+      true
     );
 
     await uniswapMock.setPrice(toWei("2"), toWei("1"));

--- a/financial-templates-lib/test/price-feed/UniswapPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/UniswapPriceFeed.js
@@ -33,7 +33,8 @@ contract("UniswapPriceFeed.js", function(accounts) {
       uniswapMock.address,
       3600,
       3600,
-      () => mockTime
+      () => mockTime,
+      false
     );
   });
 
@@ -204,6 +205,24 @@ contract("UniswapPriceFeed.js", function(accounts) {
 
     // The TWAP lookback is 1 hour (3600 seconds). The price feed should return null if we attempt to go any further back than that.
     assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime - 3601), null);
+  });
+
+  it("Invert price", async function() {
+    uniswapPriceFeed = new UniswapPriceFeed(
+      dummyLogger,
+      Uniswap.abi,
+      web3,
+      uniswapMock.address,
+      3600,
+      3600,
+      () => mockTime,
+      false
+    );
+
+    await uniswapMock.setPrice(toWei("2"), toWei("1"));
+    await uniswapPriceFeed.update();
+
+    assert.equal(uniswapPriceFeed.getLastBlockPrice().toString(), toWei("2"));
   });
   // TODO: add the following TWAP tests using simulated block times:
   // - Some events pre TWAP window, some inside window.


### PR DESCRIPTION
Add inversion parameter so the UniswapPriceFeed doesn't require a particular ordering of reserve tokens in the Uniswap smart contract.