### PR TITLE
Many fixes to Sponsor CLI 

### DIFF
--- a/core/scripts/cli/sponsor/create.js
+++ b/core/scripts/cli/sponsor/create.js
@@ -2,10 +2,19 @@ const BigNumber = require("bignumber.js");
 const inquirer = require("inquirer");
 const { wrapToWeth, getCurrencySymbol, getIsWeth } = require("./currencyUtils");
 const { submitTransaction } = require("./transactionUtils");
+const getDefaultAccount = require("../wallet/getDefaultAccount");
+
+// Apply settings to BigNumber.js library.
+// Note: ROUNDING_MODE is set to round ceiling so we send at least enough collateral to create the requested tokens.
+// Note: RANGE is set to 500 so values don't overflow to infinity until they hit +-1e500.
+// Note: EXPONENTIAL_AT is set to 500 to keep BigNumber from using exponential notation until the numbers hit
+// +-1e500.
+BigNumber.set({ ROUNDING_MODE: 2, RANGE: 500, EXPONENTIAL_AT: 500 });
 
 const create = async (web3, artifacts, emp, hasExistingPosition) => {
   const ExpandedERC20 = artifacts.require("ExpandedERC20");
   const { toWei, fromWei } = web3.utils;
+  const account = await getDefaultAccount(web3);
 
   // TODO: Understand why we need a .rawValue in one case but not the other.
   const totalPositionCollateral = BigNumber((await emp.totalPositionCollateral()).rawValue.toString());
@@ -35,12 +44,6 @@ const create = async (web3, artifacts, emp, hasExistingPosition) => {
     }
   });
 
-  // Apply settings to BigNumber.js library.
-  // Note: ROUNDING_MODE is set to round ceiling so we send at least enough collateral to create the requested tokens.
-  // Note: RANGE is set to 500 so values don't overflow to infinity until they hit +-1e500.
-  // Note: EXPONENTIAL_AT is set to 500 to keep BigNumber from using exponential notation until the numbers hit
-  // +-1e500.
-  BigNumber.set({ ROUNDING_MODE: 2, RANGE: 500, EXPONENTIAL_AT: 500 });
   const scalingFactor = BigNumber(toWei("1"));
   const tokens = BigNumber(toWei(input["tokensCreated"]));
   const gcr = totalPositionCollateral.times(scalingFactor).div(totalTokensOutstanding);
@@ -54,6 +57,18 @@ const create = async (web3, artifacts, emp, hasExistingPosition) => {
   const collateralSymbol = await getCurrencySymbol(web3, artifacts, collateralCurrency);
   const requiredCollateralSymbol = isWeth ? "ETH" : collateralSymbol;
   console.log(`You'll need ${fromWei(collateralNeeded)} ${requiredCollateralSymbol} to mint tokens`);
+
+  // Check if user has enough balance to continue.
+  const userCollateralBalance = await collateralCurrency.balanceOf(account);
+  if (BigNumber(userCollateralBalance).lt(collateralNeeded)) {
+    console.log(
+      `You do not have enough collateral to create this position. Your current collateral balance is: ${fromWei(
+        userCollateralBalance
+      )} ${requiredCollateralSymbol}`
+    );
+    return;
+  }
+
   const confirmation = await inquirer.prompt({
     type: "confirm",
     message: "Continue?",
@@ -79,7 +94,7 @@ const create = async (web3, artifacts, emp, hasExistingPosition) => {
     await submitTransaction(
       web3,
       async () => await emp.create({ rawValue: collateralNeeded }, { rawValue: tokens.toString() }),
-      "Minting more tokens",
+      "Minting synthetic tokens",
       transactionNum,
       totalTransactions
     );

--- a/core/scripts/cli/sponsor/currencyUtils.js
+++ b/core/scripts/cli/sponsor/currencyUtils.js
@@ -35,8 +35,12 @@ const getCurrencySymbol = async (web3, artifacts, collateralCurrency) => {
   if (await getIsWeth(web3, artifacts, collateralCurrency)) {
     return "WETH";
   } else {
-    // TODO: Do all collateral currencies we care about support `symbol()`?
-    return "collateral tokens";
+    try {
+      return await collateralCurrency.symbol();
+    } catch (err) {
+      // Return this if we cannot read `symbol()`.
+      return "collateral tokens";
+    }
   }
 };
 

--- a/core/scripts/cli/sponsor/liquidationUtils.js
+++ b/core/scripts/cli/sponsor/liquidationUtils.js
@@ -1,0 +1,40 @@
+const { LiquidationStatesEnum } = require("../../../../common/Enums.js");
+
+/**
+ * @notice Fetch all liquidation events for a given sponsor. Use this instead of reading `emp.getLiquidations(sponsor)`
+ * because liquidations are deleted after their rewards are withdrawn.
+ * @param {Object} emp EMP contract
+ * @param {String} sponsor Sponsor addre
+ */
+const getLiquidationEvents = async (emp, sponsor) => {
+  return await emp.getPastEvents("LiquidationCreated", {
+    fromBlock: 0,
+    filter: { sponsor }
+  });
+};
+
+/**
+ * @notice Informs sponsor about the state of their previous liquidation events.
+ * @param {Integer} state Liquidation state
+ */
+const liquidationStateToDisplay = state => {
+  switch (state) {
+    case LiquidationStatesEnum.DISPUTE_SUCCEEDED:
+      return "SUCCESSFULLY DISPUTED";
+    case LiquidationStatesEnum.PRE_DISPUTE:
+      return "PENDING OR EXPIRED";
+    case LiquidationStatesEnum.PENDING_DISPUTE:
+      return "PENDING DISPUTE";
+    default:
+      // All liquidation rewards have been withdrawn.
+      return "EXPIRED OR NO MORE REWARDS TO WITHDRAW";
+    // Note: The state will never be DISPUTE_FAILED because this state is only temporarily
+    // set when the liquidator calls `withdrawLiquidation` and the dispute fails. The liquidation
+    // data is subsequently deleted in the same struct.
+  }
+};
+
+module.exports = {
+  getLiquidationEvents,
+  liquidationStateToDisplay
+};

--- a/core/scripts/cli/sponsor/liquidationUtils.js
+++ b/core/scripts/cli/sponsor/liquidationUtils.js
@@ -22,7 +22,7 @@ const liquidationStateToDisplay = state => {
     case LiquidationStatesEnum.DISPUTE_SUCCEEDED:
       return "SUCCESSFULLY DISPUTED";
     case LiquidationStatesEnum.PRE_DISPUTE:
-      return "PENDING OR EXPIRED";
+      return "LIQUIDATION PENDING OR EXPIRED";
     case LiquidationStatesEnum.PENDING_DISPUTE:
       return "PENDING DISPUTE";
     default:

--- a/core/scripts/cli/sponsor/showMarketDetails.js
+++ b/core/scripts/cli/sponsor/showMarketDetails.js
@@ -13,12 +13,13 @@ const showMarketDetails = async (web3, artifacts, emp) => {
   const ExpandedERC20 = artifacts.require("ExpandedERC20");
   const { fromWei } = web3.utils;
   const sponsorAddress = await getDefaultAccount(web3);
-  const collateral = (await emp.getCollateral(sponsorAddress)).toString();
+  let collateral = (await emp.getCollateral(sponsorAddress)).toString();
 
+  // This function should only be called if the sponsor has an existing position.
   const printSponsorSummary = async sponsorAddress => {
     const collateral = (await emp.getCollateral(sponsorAddress)).toString();
     if (collateral === "0") {
-      console.log("You are not currently a sponsor");
+      throw "Sponsor does not have a position; cannot print a sponsor summar";
     } else {
       const position = await emp.positions(sponsorAddress);
       const collateralCurrency = await ExpandedERC20.at(await emp.collateralCurrency());
@@ -141,8 +142,13 @@ const showMarketDetails = async (web3, artifacts, emp) => {
     default:
       console.log("unimplemented state");
   }
-  console.log("\nYour updated position:");
-  await printSponsorSummary(sponsorAddress);
+
+  // Print updated position summary if applicable.
+  collateral = (await emp.getCollateral(sponsorAddress)).toString();
+  if (collateral !== "0") {
+    console.log("\nYour updated position:");
+    await printSponsorSummary(sponsorAddress);
+  }
 };
 
 module.exports = showMarketDetails;

--- a/core/scripts/cli/sponsor/viewLiquidationDetails.js
+++ b/core/scripts/cli/sponsor/viewLiquidationDetails.js
@@ -1,14 +1,19 @@
 const inquirer = require("inquirer");
 const getDefaultAccount = require("../wallet/getDefaultAccount");
-const { LiquidationStatesEnum } = require("../../../../common/Enums.js");
 const { getIsWeth, unwrapToEth } = require("./currencyUtils");
 const { submitTransaction } = require("./transactionUtils");
 
 const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => {
+  // If liquidation data is empty, then liquidation rewards have already been withdrawn.
+  if (liquidation.liquidator === "0x0000000000000000000000000000000000000000") {
+    console.log("Cannot withdraw rewards from this liquidation");
+    return;
+  }
   const ExpandedERC20 = artifacts.require("ExpandedERC20");
 
   const sponsorAddress = await getDefaultAccount(web3);
-  const display = `Liquidated at epoch time ${liquidation.liquidationTime} by ${liquidation.liquidator}`;
+  const liquidationTimeReadable = new Date(Number(liquidation.liquidationTime.toString()) * 1000);
+  const display = `Liquidated at time ${liquidationTimeReadable} by ${liquidation.liquidator}`;
   const backChoice = "Back";
   const withdrawAction = "Withdraw";
   choices = [{ name: backChoice }];

--- a/core/scripts/cli/sponsor/viewLiquidationDetails.js
+++ b/core/scripts/cli/sponsor/viewLiquidationDetails.js
@@ -6,7 +6,7 @@ const { submitTransaction } = require("./transactionUtils");
 const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => {
   // If liquidation data is empty, then liquidation rewards have already been withdrawn.
   if (liquidation.liquidator === "0x0000000000000000000000000000000000000000") {
-    console.log("Cannot withdraw rewards from this liquidation");
+    console.log("No more rewards to withdraw from this liquidation");
     return;
   }
   const ExpandedERC20 = artifacts.require("ExpandedERC20");
@@ -15,7 +15,7 @@ const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => 
   const liquidationTimeReadable = new Date(Number(liquidation.liquidationTime.toString()) * 1000);
   const display = `Liquidated at time ${liquidationTimeReadable} by ${liquidation.liquidator}`;
   const backChoice = "Back";
-  const withdrawAction = "Withdraw";
+  const withdrawAction = "Dispute succeeded; withdraw rewards";
   choices = [{ name: backChoice }];
   // Check if the sponsor can withdraw by seeing if `withdrawLiquidation` reverts.
   try {
@@ -23,6 +23,15 @@ const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => 
     choices.push({ name: withdrawAction });
   } catch (err) {
     // Withdraw wouldn't work so it shouldn't be a valid option.
+    if (liquidation.state === "1") {
+      console.log("Liquidation has not been disputed and has not expired yet");
+    } else if (liquidation.state === "2") {
+      console.log("Liquidation is pending dispute and a price has not resolved yet");
+    } else if (liquidation.state === "3") {
+      console.log("You have already withdrawn rewards from this successfully disputed liquidation");
+    } else {
+      console.log("Cannot withdraw from this liquidation");
+    }
   }
   const input = await inquirer.prompt({
     type: "list",
@@ -35,7 +44,7 @@ const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => 
   }
   const confirmation = await inquirer.prompt({
     type: "confirm",
-    message: "Withdrawing collateral. Continue?",
+    message: "Withdrawing collateral from successfully disputed liquidation. Continue?",
     name: "confirm"
   });
   if (confirmation["confirm"]) {
@@ -43,7 +52,11 @@ const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => 
     const isWeth = await getIsWeth(web3, artifacts, collateralCurrency);
 
     const withdrawalAmount = await emp.withdrawLiquidation.call(id, sponsorAddress);
-    await submitTransaction(web3, async () => await emp.withdrawLiquidation(id, sponsorAddress), "Withdrawing");
+    await submitTransaction(
+      web3,
+      async () => await emp.withdrawLiquidation(id, sponsorAddress),
+      `Withdrawing ${web3.utils.fromWei(withdrawalAmount.toString())} tokens`
+    );
     if (isWeth) {
       await unwrapToEth(web3, artifacts, emp, withdrawalAmount.toString());
     }

--- a/core/scripts/cli/sponsor/viewLiquidationDetails.js
+++ b/core/scripts/cli/sponsor/viewLiquidationDetails.js
@@ -89,9 +89,16 @@ const viewWithdrawRewardsMenu = async (web3, artifacts, emp, liquidation, id) =>
     if (liquidation.state === LiquidationStatesEnum.PRE_DISPUTE) {
       // If liquidation state is PRE_DISPUTE and `withdrawLiquidation` fails, then the liquidation has either expired
       // or is pre-expiry. Only a liquidator can withdraw from an expired liquidation.
-      console.log(
-        "Cannot withdraw rewards from a liquidation that is pre-expiry and has not been disputed, or has already expired"
-      );
+
+      const currentTime = web3.utils.toBN(await emp.getCurrentTime());
+      const liquidationExpirationTime = web3.utils
+        .toBN(liquidation.liquidationTime)
+        .add(web3.utils.toBN(await emp.liquidationLiveness()));
+      if (liquidationExpirationTime.lte(currentTime)) {
+        console.log("Cannot withdraw rewards from a liquidation that has expired");
+      } else {
+        console.log("Cannot withdraw rewards from a liquidation that is pre-expiry and has not been disputed");
+      }
     } else if (liquidation.state === LiquidationStatesEnum.PENDING_DISPUTE) {
       // If the liquidation state is PENDING_DISPUTE and `withdrawLiquidation` fails, then it indicates that either
       // a price has not resolved yet, or a price has resolved that indicates that the dispute will FAIL.

--- a/core/scripts/cli/sponsor/viewLiquidationDetails.js
+++ b/core/scripts/cli/sponsor/viewLiquidationDetails.js
@@ -110,10 +110,10 @@ const viewWithdrawRewardsMenu = async (web3, artifacts, emp, liquidation, id) =>
       let oracle = await OracleInterface.at(
         await finder.getImplementationAddress(web3.utils.utf8ToHex(interfaceName.Oracle))
       );
-      // Need to pass {from:emp.address} in this EMP view-only calls because of this web3 view method bug
-      // https://github.com/ethereum/solidity/issues/4840#issue-352539391 that would return true regardless
-      // if the Oracle has actually resolved a price. This is because `hasPrice` and `getPrice` have the
-      // `onlyRegisteredContract` modifier.
+      // Need to explicitly pass {from:emp.address} in these EMP view-only calls because they will revert due to their
+      // `onlyRegisteredContract` modifier. However, web3 will not throw an error as expected even if the method
+      // reverts on-chain. More details [here](https://github.com/ethereum/web3.js/issues/1903) and
+      // [here](https://github.com/ethereum/solidity/issues/4840).
       if (await oracle.hasPrice(await emp.priceIdentifier(), liquidation.liquidationTime, { from: emp.address })) {
         console.log(liquidation.liquidationTime);
         const resolvedPrice = await oracle.getPrice(await emp.priceIdentifier(), liquidation.liquidationTime, {

--- a/core/scripts/cli/sponsor/viewLiquidationDetails.js
+++ b/core/scripts/cli/sponsor/viewLiquidationDetails.js
@@ -1,38 +1,69 @@
 const inquirer = require("inquirer");
 const getDefaultAccount = require("../wallet/getDefaultAccount");
-const { getIsWeth, unwrapToEth } = require("./currencyUtils");
+const { getIsWeth, unwrapToEth, getCurrencySymbol } = require("./currencyUtils");
 const { submitTransaction } = require("./transactionUtils");
+const { LiquidationStatesEnum } = require("../../../../common/Enums");
 
 const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => {
-  // If liquidation data is empty, then liquidation rewards have already been withdrawn.
-  if (liquidation.liquidator === "0x0000000000000000000000000000000000000000") {
-    console.log("No more rewards to withdraw from this liquidation");
+  // If liquidation `sponsor` property is empty, then either the sponsor's liquidation rewards have been withdrawn or the
+  // liquidation data has been deleted following an expired liquidation or a failed dispute.
+  // Therefore, this should catch all liquidations with state == `UNINITIALIZED` following a deletion of the liquidation struct.
+  if (liquidation.sponsor === "0x0000000000000000000000000000000000000000") {
+    console.log("There are no rewards to withdraw from this liquidation");
     return;
   }
-  const ExpandedERC20 = artifacts.require("ExpandedERC20");
 
+  // Now we know that the liquidation still has rewards to be withdrawn, but we need to check if the sponsor is eligible
+  // to receive rewards.
+  const ExpandedERC20 = artifacts.require("ExpandedERC20");
   const sponsorAddress = await getDefaultAccount(web3);
   const liquidationTimeReadable = new Date(Number(liquidation.liquidationTime.toString()) * 1000);
   const display = `Liquidated at time ${liquidationTimeReadable} by ${liquidation.liquidator}`;
   const backChoice = "Back";
+  // Sponsors can withdraw rewards only if a liquidation has been disputed successfully.
   const withdrawAction = "Dispute succeeded; withdraw rewards";
   choices = [{ name: backChoice }];
+
   // Check if the sponsor can withdraw by seeing if `withdrawLiquidation` reverts.
   try {
     await emp.withdrawLiquidation.call(id, sponsorAddress);
     choices.push({ name: withdrawAction });
   } catch (err) {
-    // Withdraw wouldn't work so it shouldn't be a valid option.
-    if (liquidation.state === "1") {
-      console.log("Liquidation has not been disputed and has not expired yet");
-    } else if (liquidation.state === "2") {
-      console.log("Liquidation is pending dispute and a price has not resolved yet");
-    } else if (liquidation.state === "3") {
+    // Withdraw wouldn't work so it shouldn't be a valid option. Let's print out a detailed response to the user to indicate why
+    // `withdraw` will fail.
+
+    // The sponsor can only withdraw rewards from a successfully disputed liquidation.
+    if (liquidation.state === LiquidationStatesEnum.PRE_DISPUTE) {
+      // If liquidation state is PRE_DISPUTE and `withdrawLiquidation` fails, then the liquidation has either expired
+      // or is pre-expiry. Only a liquidator can withdraw from an expired liquidation.
+      console.log(
+        "Cannot withdraw rewards from a liquidation that is pre-expiry and has not been disputed, or has already expired"
+      );
+    } else if (liquidation.state === LiquidationStatesEnum.PENDING_DISPUTE) {
+      // If the liquidation state is PENDING_DISPUTE and `withdrawLiquidation` fails, then it indicates that either
+      // a price has not resolved yet, or a price has resolved that indicates that the dispute will FAIL.
+      console.log(
+        "Liquidation has been disputed, but it is currently pending dispute and awaiting a price resolution, or a price has already resolved and the dispute will fail"
+      );
+    } else if (liquidation.state === LiquidationStatesEnum.DISPUTE_SUCCEEDED) {
+      // If the liquidation state is DISPUTE_SUCCEEDED and `withdrawLiquidation` fails, then the sponsor has already
+      // withdrawn their rewards.
       console.log("You have already withdrawn rewards from this successfully disputed liquidation");
     } else {
-      console.log("Cannot withdraw from this liquidation");
+      // The code should never reach here.
+      // If the code reaches here, then the liquidation data has not been deleted yet and the sponsor cannot withdraw rewards.
+      // The liquidation state must be in the DISPUTE_FAILED state, which should not be possible because the liquidation state
+      // should pass from PENDING_DISPUTE --> DISPUTE_FAILED and then DISPUTE_FAILED --> UNINITIALIZED following the liquidator calling
+      // `withdrawRewards`.
+      console.log(
+        "Cannot withdraw rewards. Liquidation has been unsuccessfully disputed and the liquidation has executed."
+      );
     }
+
+    // The liquidation state should never be UNINITIALIZED here because we already checked if the `liquidation.sponsor` is the zero address.
+    // It is impossible for the state to be UNINITIALIZE and the sponsor to not be the zero address.
   }
+
   const input = await inquirer.prompt({
     type: "list",
     name: "choice",
@@ -49,13 +80,14 @@ const viewLiquidationDetails = async (web3, artifacts, emp, liquidation, id) => 
   });
   if (confirmation["confirm"]) {
     const collateralCurrency = await ExpandedERC20.at(await emp.collateralCurrency());
+    const collateralSymbol = await getCurrencySymbol(web3, artifacts, collateralCurrency);
     const isWeth = await getIsWeth(web3, artifacts, collateralCurrency);
 
     const withdrawalAmount = await emp.withdrawLiquidation.call(id, sponsorAddress);
     await submitTransaction(
       web3,
       async () => await emp.withdrawLiquidation(id, sponsorAddress),
-      `Withdrawing ${web3.utils.fromWei(withdrawalAmount.toString())} tokens`
+      `Withdrawing ${web3.utils.fromWei(withdrawalAmount.toString())} ${collateralSymbol}`
     );
     if (isWeth) {
       await unwrapToEth(web3, artifacts, emp, withdrawalAmount.toString());

--- a/core/scripts/cli/sponsor/withdraw.js
+++ b/core/scripts/cli/sponsor/withdraw.js
@@ -33,7 +33,7 @@ const withdraw = async (web3, artifacts, emp) => {
   const executeWithdrawal = async () => {
     const confirmation = await inquirer.prompt({
       type: "confirm",
-      message: "Would you like to excecute this withdrawal?",
+      message: "Would you like to execute this withdrawal?",
       name: "confirm"
     });
     if (confirmation["confirm"]) {

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -4,6 +4,10 @@
  * and configuring the contracts to use the mock oracle which is more useful for testing.
  *
  * This script is intended to make testing the Sponsor CLI easier.
+ *
+ * How to run on local testnet: $(npm bin)/truffle exec ./scripts/local/DeployEMP.js --network test --test true
+ * - The `--test` flag will deploy a MockOracle, whitelist the collateral currency and the pricefeed identifier,
+ *   and create an initial sponsor position.
  */
 const { toWei, utf8ToHex, hexToUtf8 } = web3.utils;
 const { interfaceName } = require("../../utils/Constants.js");

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -6,7 +6,6 @@
  * This script is intended to make testing the Sponsor CLI easier.
  */
 const { toWei, utf8ToHex, hexToUtf8 } = web3.utils;
-const { RegistryRolesEnum } = require("../../../common/Enums.js");
 const { interfaceName } = require("../../utils/Constants.js");
 
 // Deployed contract ABI's and addresses we need to fetch.
@@ -15,8 +14,6 @@ const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const Finder = artifacts.require("Finder");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const MockOracle = artifacts.require("MockOracle");
-const Token = artifacts.require("ExpandedERC20");
-const Registry = artifacts.require("Registry");
 const TestnetERC20 = artifacts.require("TestnetERC20");
 const Timer = artifacts.require("Timer");
 const TokenFactory = artifacts.require("TokenFactory");

--- a/core/scripts/local/DisputeLiquidationEMP.js
+++ b/core/scripts/local/DisputeLiquidationEMP.js
@@ -1,0 +1,95 @@
+// Dispute a liquidation from accounts[0]. To be used in testing.
+const { toWei, fromWei, toBN } = web3.utils;
+const { LiquidationStatesEnum } = require("../../../common/Enums.js");
+
+// Deployed contract ABI's and addresses we need to fetch.
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const TestnetERC20 = artifacts.require("TestnetERC20");
+
+const argv = require("minimist")(process.argv.slice(), { string: ["emp", "id"] });
+
+// Contracts we need to interact with.
+let emp;
+let collateralToken;
+
+const getDisputeLiquidationEvent = async (emp, disputer) => {
+  const events = await emp.getPastEvents("LiquidationDisputed", {
+    fromBlock: 0,
+    filter: { disputer: disputer }
+  });
+  // Sort descending (highest block first). Primary sort on block number. Secondary sort on transactionIndex. Tertiary sort on logIndex.
+  // This returns most recent event.
+  events.sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) {
+      return b.blockNumber - a.blockNumber;
+    }
+
+    if (a.transactionIndex !== b.transactionIndex) {
+      return b.transactionIndex - a.transactionIndex;
+    }
+
+    return b.logIndex - a.logIndex;
+  });
+  return events[0];
+};
+
+const disputeEMP = async callback => {
+  try {
+    const empAddress = argv.emp;
+    if (!empAddress) {
+      console.log('Missing "emp" command line argument, please specify an EMP contract address');
+      return;
+    }
+    emp = await ExpiringMultiParty.at(empAddress);
+    const accounts = await web3.eth.getAccounts();
+    const sponsor = accounts[0];
+    const liquidator = accounts[1];
+    console.log(`Liquidator: ${liquidator}`);
+    console.log(`Sponsor that was liquidated: ${sponsor}`);
+
+    const liquidationId = argv.id;
+    if (!liquidationId) {
+      console.log("Missing 'id' command line argument, this selects which liquidation to dispute");
+      return;
+    }
+    console.log(`Disputing liquidation with ID ${liquidationId}`);
+    let liquidations = await emp.getLiquidations(sponsor);
+    const liquidation = liquidations[liquidationId];
+
+    // Check liquidation state
+    if (liquidation.state !== LiquidationStatesEnum.PRE_DISPUTE) {
+      console.log("Liquidation state must be PRE_DISPUTE to dispute");
+      return;
+    }
+    console.group("Liquidation details:");
+    const liquidationPrice = toBN(toWei(liquidation.liquidatedCollateral.toString())).div(
+      toBN(liquidation.tokensOutstanding.toString())
+    );
+    console.log(`- liquidation price: ${fromWei(liquidationPrice)}`);
+    console.groupEnd();
+
+    // Send the dispute. Approve EMP to spend at least dispute bond amount of collateral.
+    collateralToken = await TestnetERC20.deployed();
+    await collateralToken.allocateTo(sponsor, toWei("1000")); // This amount should cover the dispute bond.
+    await collateralToken.approve(emp.address, toWei("1000"), { from: sponsor });
+    await emp.dispute(liquidationId, sponsor, { from: sponsor });
+    console.log(`Sponsor has disputed liquidation ${liquidationId}`);
+
+    // Check event.
+    const event = await getDisputeLiquidationEvent(emp, sponsor);
+    console.log("Dispute event:", event.args);
+
+    // Check if dispute went through.
+    liquidations = await emp.getLiquidations(sponsor);
+    if (liquidations[liquidationId].state !== LiquidationStatesEnum.PENDING_DISPUTE) {
+      console.log("Liquidation state did not change to PENDING_DISPUTE");
+    }
+  } catch (err) {
+    console.error(err);
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+module.exports = disputeEMP;

--- a/core/scripts/local/PushPriceEMP.js
+++ b/core/scripts/local/PushPriceEMP.js
@@ -1,0 +1,60 @@
+// Push a price for latest mock oracle price request. To be used in testing.
+const { toWei, fromWei, utf8ToHex, hexToUtf8 } = web3.utils;
+const { interfaceName } = require("../../utils/Constants");
+
+// Deployed contract ABI's and addresses we need to fetch.
+const MockOracle = artifacts.require("MockOracle");
+const Finder = artifacts.require("Finder");
+
+const argv = require("minimist")(process.argv.slice(), { string: ["id", "price"] });
+
+// Contracts we need to interact with.
+let mockOracle;
+let finder;
+
+const pushPriceEMP = async callback => {
+  try {
+    finder = await Finder.deployed();
+    mockOracle = await MockOracle.at(await finder.getImplementationAddress(utf8ToHex(interfaceName.Oracle)));
+    const priceFeedIdentifier = utf8ToHex("ETH/BTC");
+    const pendingRequests = await mockOracle.getPendingQueries();
+
+    let priceRequestIndex = argv.id;
+    if (!priceRequestIndex) {
+      console.log('Optional price request "id" not specified, defaulting to index 0');
+      priceRequestIndex = 0;
+    }
+    if (priceRequestIndex >= pendingRequests.length) {
+      console.log(
+        `Price request "id" is greater than count of pending requests, defaulting to highest index ${pendingRequests.length -
+          1}`
+      );
+      priceRequestIndex = pendingRequests.length - 1;
+    }
+    // This might fail if there is more than 1 pending request.
+    console.log(
+      `MockOracle latest price request for ${hexToUtf8(pendingRequests[priceRequestIndex]["identifier"])} @ time ${
+        pendingRequests[0].time
+      }`
+    );
+
+    // Now, push a price to the oracle.
+    // If the dispute price is lower than the liquidation price (1.2), then the dispute will succeed.
+    let disputePrice;
+    if (!argv.price) {
+      console.log("Pushing default price of 1");
+      disputePrice = toWei("1");
+    } else {
+      disputePrice = toWei(argv.price);
+    }
+    await mockOracle.pushPrice(priceFeedIdentifier, pendingRequests[0].time, disputePrice);
+    console.log(`Pushed a price to the mock oracle: ${fromWei(disputePrice)}`);
+  } catch (err) {
+    console.error(err);
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+module.exports = pushPriceEMP;

--- a/core/scripts/local/liquidateEMP.js
+++ b/core/scripts/local/liquidateEMP.js
@@ -1,4 +1,4 @@
-// Liquidates the position for acconts[0]. To be used in testing.
+// Liquidates the position for accounts[0]. To be used in testing.
 const { toWei, fromWei, toBN } = web3.utils;
 const { MAX_UINT_VAL } = require("../../../common/Constants");
 
@@ -39,8 +39,8 @@ const liquidateEMP = async callback => {
 
     const liquidationPrice = toBN(toWei(collateral.toString())).div(toBN(tokensOutstanding.toString()));
     console.group("Liquidation params:");
-    console.log(`- minPrice: ${fromWei(liquidationPrice)}`);
-    console.log(`- maxPrice: ${fromWei(liquidationPrice)}`);
+    console.log(`- minPrice: ${fromWei(toBN(liquidationPrice).sub(toBN(toWei("0.01"))))}`);
+    console.log(`- maxPrice: ${fromWei(toBN(liquidationPrice).add(toBN(toWei("0.01"))))}`);
     console.log(`- maxTokensToLiquidate: ${fromWei(tokensToLiquidate.toString())}`);
     const unreachableDeadline = MAX_UINT_VAL;
     console.log(`- deadline: ${unreachableDeadline}`);

--- a/core/scripts/local/liquidateEMP.js
+++ b/core/scripts/local/liquidateEMP.js
@@ -1,4 +1,9 @@
-// Liquidates the position for accounts[0]. To be used in testing.
+/**
+ * @notice Liquidates the sponsor's position, where the sponsor is accounts[0] and the liquidator
+ * is accounts[1].
+ *
+ * Example run: `$(npm bin)/truffle exec ./scripts/local/LiquidateEMP.js --network test --emp 0x6E2F1B57AF5C6237B7512b4DdC1FFDE2Fb7F90B9`
+ */
 const { toWei, fromWei, toBN } = web3.utils;
 const { MAX_UINT_VAL } = require("../../../common/Constants");
 
@@ -18,25 +23,29 @@ let syntheticToken;
  /*****************************************************/
 const liquidateEMP = async callback => {
   try {
+    // Accounts
+    const accounts = await web3.eth.getAccounts();
+    const sponsor = accounts[0];
+    const liquidator = accounts[1];
+    console.log(`Liquidator: ${liquidator}`);
+    console.log(`Sponsor that we are liquidating: ${sponsor}`);
+
+    // Get position details
     const empAddress = argv.emp;
     if (!empAddress) {
       console.log('Missing "emp" command line argument, please specify an EMP contract address');
       return;
     }
     emp = await ExpiringMultiParty.at(empAddress);
-    const accounts = await web3.eth.getAccounts();
-    const sponsor = accounts[0];
-    const liquidator = accounts[1];
-    console.log(`Liquidator: ${liquidator}`);
-    console.log(`Sponsor that we are liquidating: ${sponsor}`);
     let collateral = await emp.getCollateral(sponsor);
     console.log(`Current collateral in position: ${fromWei(collateral.toString())}`);
     const position = await emp.positions(sponsor);
     let tokensOutstanding = position.tokensOutstanding;
     console.log(`Current tokens outstanding: ${fromWei(tokensOutstanding.toString())}`);
+
+    // Set up liquidation object.
     const tokensToLiquidate = toWei("1000");
     console.log(`Amount to liquidate: ${fromWei(tokensToLiquidate)}`);
-
     const liquidationPrice = toBN(toWei(collateral.toString())).div(toBN(tokensOutstanding.toString()));
     console.group("Liquidation params:");
     console.log(`- minPrice: ${fromWei(toBN(liquidationPrice).sub(toBN(toWei("0.01"))))}`);
@@ -61,10 +70,19 @@ const liquidateEMP = async callback => {
     syntheticToken = await ExpandedERC20.at(await emp.tokenCurrency());
     await syntheticToken.approve(emp.address, tokensToLiquidate, { from: liquidator });
 
+    // Send the transaction.
     await emp.createLiquidation(
       sponsor,
-      { rawValue: liquidationPrice.toString() },
-      { rawValue: liquidationPrice.toString() },
+      {
+        rawValue: toBN(liquidationPrice)
+          .sub(toBN(toWei("0.01")))
+          .toString()
+      },
+      {
+        rawValue: toBN(liquidationPrice)
+          .add(toBN(toWei("0.01")))
+          .toString()
+      },
       { rawValue: tokensToLiquidate.toString() },
       unreachableDeadline,
       { from: liquidator }

--- a/core/scripts/local/liquidateEMP.js
+++ b/core/scripts/local/liquidateEMP.js
@@ -1,0 +1,80 @@
+// Liquidates the position for acconts[0]. To be used in testing.
+const { toWei, fromWei, toBN } = web3.utils;
+const { MAX_UINT_VAL } = require("../../../common/Constants");
+
+// Deployed contract ABI's and addresses we need to fetch.
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const TestnetERC20 = artifacts.require("TestnetERC20");
+const ExpandedERC20 = artifacts.require("ExpandedERC20");
+const argv = require("minimist")(process.argv.slice(), { string: ["emp"] });
+
+// Contracts we need to interact with.
+let collateralToken;
+let emp;
+let syntheticToken;
+
+/** ***************************************************
+ * Main Script
+ /*****************************************************/
+const liquidateEMP = async callback => {
+  try {
+    const empAddress = argv.emp;
+    if (!empAddress) {
+      console.log('Missing "emp" command line argument, please specify an EMP contract address');
+      return;
+    }
+    emp = await ExpiringMultiParty.at(empAddress);
+    const accounts = await web3.eth.getAccounts();
+    const sponsor = accounts[0];
+    const liquidator = accounts[1];
+    console.log(`Liquidator: ${liquidator}`);
+    console.log(`Sponsor that we are liquidating: ${sponsor}`);
+    let collateral = await emp.getCollateral(sponsor);
+    console.log(`Current collateral in position: ${fromWei(collateral.toString())}`);
+    const position = await emp.positions(sponsor);
+    let tokensOutstanding = position.tokensOutstanding;
+    console.log(`Current tokens outstanding: ${fromWei(tokensOutstanding.toString())}`);
+    const tokensToLiquidate = toWei("1000");
+    console.log(`Amount to liquidate: ${fromWei(tokensToLiquidate)}`);
+
+    const liquidationPrice = toBN(toWei(collateral.toString())).div(toBN(tokensOutstanding.toString()));
+    console.group("Liquidation params:");
+    console.log(`- minPrice: ${fromWei(liquidationPrice)}`);
+    console.log(`- maxPrice: ${fromWei(liquidationPrice)}`);
+    console.log(`- maxTokensToLiquidate: ${fromWei(tokensToLiquidate.toString())}`);
+    const unreachableDeadline = MAX_UINT_VAL;
+    console.log(`- deadline: ${unreachableDeadline}`);
+    console.groupEnd();
+
+    // Create tokens for liquidator to liquidate with.
+    collateralToken = await TestnetERC20.deployed();
+    const collateralLiquidation = toWei("2000");
+    await collateralToken.allocateTo(liquidator, collateralLiquidation);
+    await collateralToken.approve(emp.address, collateralLiquidation, { from: liquidator });
+    await emp.create({ rawValue: collateralLiquidation }, { rawValue: tokensToLiquidate }, { from: liquidator });
+    console.log(
+      `Created ${fromWei(tokensToLiquidate)} tokens (backed by ${fromWei(collateralLiquidation)} collateral)`
+    );
+
+    // Approve EMP to spend synthetic in order to call createLiquidation. Note that an additional approval is required for the EMP
+    // to spend finalFeeBond amount of collateral, but I assume that final fee is set to 0 in test environments.
+    syntheticToken = await ExpandedERC20.at(await emp.tokenCurrency());
+    await syntheticToken.approve(emp.address, tokensToLiquidate, { from: liquidator });
+
+    await emp.createLiquidation(
+      sponsor,
+      { rawValue: liquidationPrice.toString() },
+      { rawValue: liquidationPrice.toString() },
+      { rawValue: tokensToLiquidate.toString() },
+      unreachableDeadline,
+      { from: liquidator }
+    );
+  } catch (err) {
+    console.error(err);
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+module.exports = liquidateEMP;

--- a/core/scripts/local/withdrawLiquidationEMP.js
+++ b/core/scripts/local/withdrawLiquidationEMP.js
@@ -1,0 +1,94 @@
+// Withdraws liquidation after it expires without dispute. To be used in testing.
+const { fromWei, toBN } = web3.utils;
+const { LiquidationStatesEnum } = require("../../../common/Enums.js");
+
+// Deployed contract ABI's and addresses we need to fetch.
+const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const argv = require("minimist")(process.argv.slice(), { string: ["emp"] });
+
+// Contracts we need to interact with.
+let emp;
+
+const getWithdrawLiquidationEvent = async (emp, caller) => {
+  const events = await emp.getPastEvents("LiquidationWithdrawn", {
+    fromBlock: 0,
+    filter: { caller: caller }
+  });
+  // Sort descending. Primary sort on block number. Secondary sort on transactionIndex. Tertiary sort on logIndex.
+  // This returns most recent event.
+  events.sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) {
+      return b.blockNumber - a.blockNumber;
+    }
+
+    if (a.transactionIndex !== b.transactionIndex) {
+      return b.transactionIndex - a.transactionIndex;
+    }
+
+    return b.logIndex - a.logIndex;
+  });
+  return events[0];
+};
+
+const withdrawEMP = async callback => {
+  try {
+    const empAddress = argv.emp;
+    if (!empAddress) {
+      console.log('Missing "emp" command line argument, please specify an EMP contract address');
+      return;
+    }
+    emp = await ExpiringMultiParty.at(empAddress);
+    const accounts = await web3.eth.getAccounts();
+    const sponsor = accounts[0];
+    const liquidator = accounts[1];
+    console.log(`Liquidator: ${liquidator}`);
+    console.log(`Sponsor that was liquidated: ${sponsor}`);
+    console.log("Withdrawing liquidation with ID 0");
+    const liquidationId = 0;
+    const liquidations = await emp.getLiquidations(sponsor);
+    const liquidation = liquidations[liquidationId];
+
+    // Check liquidation state
+    if (liquidation.state === "0") {
+      console.log("Liquidation has been deleted");
+      return;
+    }
+    console.group("Liquidation details:");
+    console.log(`- tokens liquidated: ${fromWei(liquidation.tokensOutstanding)}`);
+    console.log(`- collateral liquidated: ${fromWei(liquidation.liquidatedCollateral)}`);
+    console.log(`- liquidation state: ${liquidation.state}`);
+    console.groupEnd();
+    const liquidationState = liquidation.state;
+    if (liquidationState !== LiquidationStatesEnum.PRE_DISPUTE) {
+      console.log(
+        "Liquidation is pending a dispute and cannot be withdrawn with this script. This script is intended to withdraw liquidations that expire without dispute."
+      );
+      return;
+    }
+    const currentContractTime = await emp.getCurrentTime();
+    const liquidationTime = liquidation.liquidationTime;
+    expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
+    const liquidationLiveness = (await expiringMultiPartyCreator.STRICT_WITHDRAWAL_LIVENESS()).toString();
+    const liquidationExpiration = toBN(liquidationTime).add(toBN(liquidationLiveness));
+    console.log(`Current time: ${currentContractTime.toString()}`);
+    console.log(`Liquidation expiration: ${liquidationExpiration.toString()}`);
+
+    // If liquidation has expired, then withdraw.
+    if (liquidationExpiration.gte(toBN(currentContractTime))) {
+      await emp.withdrawLiquidation(liquidationId, sponsor, { from: liquidator });
+      const withdrawEvent = await getWithdrawLiquidationEvent(emp, liquidator);
+      console.log("Withdrew liquidation:", withdrawEvent.returnValues);
+    } else {
+      console.log("Liquidation has not expired yet");
+      return;
+    }
+  } catch (err) {
+    console.error(err);
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+module.exports = withdrawEMP;

--- a/core/scripts/local/withdrawLiquidationEMP.js
+++ b/core/scripts/local/withdrawLiquidationEMP.js
@@ -1,22 +1,34 @@
-// Withdraws liquidation after it expires without dispute. To be used in testing.
-const { fromWei, toBN } = web3.utils;
+/**
+ * @notice Withdraws liquidation as the liquidator on a specified liquidation ID. Therefore this assumes
+ * that the liquidation has expired or has been disputed unsuccessfully.
+ */
+const { fromWei, toBN, utf8ToHex } = web3.utils;
 const { LiquidationStatesEnum } = require("../../../common/Enums.js");
+const { interfaceName } = require("../../utils/Constants");
 
 // Deployed contract ABI's and addresses we need to fetch.
 const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const Finder = artifacts.require("Finder");
+const MockOracle = artifacts.require("MockOracle");
+
 const argv = require("minimist")(process.argv.slice(), { string: ["emp", "id"] });
 
 // Contracts we need to interact with.
 let emp;
+let finder;
+let mockOracle;
 
+/**
+ * @notice Returns most recent LiquidationWithdrawn event.
+ */
 const getWithdrawLiquidationEvent = async (emp, caller) => {
   const events = await emp.getPastEvents("LiquidationWithdrawn", {
     fromBlock: 0,
     filter: { caller: caller }
   });
   // Sort descending. Primary sort on block number. Secondary sort on transactionIndex. Tertiary sort on logIndex.
-  // This returns most recent event.
+  // This sets most recent event at events[0].
   events.sort((a, b) => {
     if (a.blockNumber !== b.blockNumber) {
       return b.blockNumber - a.blockNumber;
@@ -33,59 +45,103 @@ const getWithdrawLiquidationEvent = async (emp, caller) => {
 
 const withdrawEMP = async callback => {
   try {
-    const empAddress = argv.emp;
-    if (!empAddress) {
-      console.log('Missing "emp" command line argument, please specify an EMP contract address');
-      return;
-    }
-    emp = await ExpiringMultiParty.at(empAddress);
+    // Accounts
     const accounts = await web3.eth.getAccounts();
     const sponsor = accounts[0];
     const liquidator = accounts[1];
     console.log(`Liquidator: ${liquidator}`);
     console.log(`Sponsor that was liquidated: ${sponsor}`);
 
-    const liquidationId = argv.id;
+    // Get liquidation details
+    const empAddress = argv.emp;
+    if (!empAddress) {
+      console.log('Missing "emp" command line argument, please specify an EMP contract address');
+      return;
+    }
+    emp = await ExpiringMultiParty.at(empAddress);
+    let liquidationId = argv.id;
     if (!liquidationId) {
-      console.log("Missing 'id' command line argument, this selects which liquidation to withdraw from");
+      console.log(
+        "Missing optional 'id' command line argument, which selects which liquidation to withdraw from. Defaulting to index 0."
+      );
+      liquidationId = 0;
     }
     console.log(`Withdrawing liquidation with ID ${liquidationId}`);
     const liquidations = await emp.getLiquidations(sponsor);
     const liquidation = liquidations[liquidationId];
+    if (!liquidation) {
+      console.log(`Cannot find a liquidation with index ${liquidationId} for sponsor ${sponsor}`);
+      return;
+    }
 
-    // Check liquidation state
-    if (liquidation.state === "0") {
+    // Check if liquidation has been deleted or if liquidator has already withdrawn rewards from a successful dispute.
+    const liquidationState = liquidation.state;
+    if (liquidationState === LiquidationStatesEnum.UNINITIALIZED) {
       console.log("Liquidation has been deleted");
       return;
-    }
-    console.group("Liquidation details:");
-    console.log(`- tokens liquidated: ${fromWei(liquidation.tokensOutstanding)}`);
-    console.log(`- collateral liquidated: ${fromWei(liquidation.liquidatedCollateral)}`);
-    console.log(`- liquidation state: ${liquidation.state}`);
-    console.groupEnd();
-    const liquidationState = liquidation.state;
-    if (liquidationState !== LiquidationStatesEnum.PRE_DISPUTE) {
-      console.log(
-        "Liquidation is pending a dispute and cannot be withdrawn with this script. This script is intended to withdraw liquidations that expire without dispute."
-      );
+    } else if (liquidationState === LiquidationStatesEnum.DISPUTE_SUCCEEDED) {
+      console.log("Dispute succeeded and liquidator has already withdrawn rewards");
       return;
     }
-    const currentContractTime = await emp.getCurrentTime();
-    const liquidationTime = liquidation.liquidationTime;
-    expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
-    const liquidationLiveness = (await expiringMultiPartyCreator.STRICT_WITHDRAWAL_LIVENESS()).toString();
-    const liquidationExpiration = toBN(liquidationTime).add(toBN(liquidationLiveness));
-    console.log(`Current time: ${currentContractTime.toString()}`);
-    console.log(`Liquidation expiration: ${liquidationExpiration.toString()}`);
 
-    // If liquidation has expired, then withdraw.
-    if (liquidationExpiration.gte(toBN(currentContractTime))) {
-      await emp.withdrawLiquidation(liquidationId, sponsor, { from: liquidator });
-      const withdrawEvent = await getWithdrawLiquidationEvent(emp, liquidator);
-      console.log("Withdrew liquidation:", withdrawEvent.returnValues);
-    } else {
-      console.log("Liquidation has not expired yet");
-      return;
+    // Print liquidation details
+    console.group("Liquidation details:");
+    const liquidationTime = liquidation.liquidationTime;
+    console.log(`- tokens liquidated: ${fromWei(liquidation.tokensOutstanding.rawValue)}`);
+    console.log(`- collateral liquidated: ${fromWei(liquidation.liquidatedCollateral.rawValue)}`);
+    console.log(`- liquidation state: ${liquidationState}`);
+    console.log(`- liquidation timestamp: ${liquidationTime}`);
+    console.groupEnd();
+
+    // Liquidation has not been disputed:
+    if (liquidationState === LiquidationStatesEnum.PRE_DISPUTE) {
+      console.log("Liquidation is in the PRE_DISPUTE state, checking whether it has expired");
+      // Check if liquidation has expired
+      const currentContractTime = await emp.getCurrentTime();
+      expiringMultiPartyCreator = await ExpiringMultiPartyCreator.deployed();
+      const liquidationLiveness = (await expiringMultiPartyCreator.STRICT_WITHDRAWAL_LIVENESS()).toString();
+      const liquidationExpiration = toBN(liquidationTime).add(toBN(liquidationLiveness));
+      console.log(`Current time: ${currentContractTime.toString()}`);
+      console.log(`Liquidation expiration: ${liquidationExpiration.toString()}`);
+
+      // Withdraw if liquidation has expired
+      if (toBN(currentContractTime).gte(liquidationExpiration)) {
+        console.log("Liquidation has expired!");
+        await emp.withdrawLiquidation(liquidationId, sponsor, { from: liquidator });
+        const withdrawEvent = await getWithdrawLiquidationEvent(emp, liquidator);
+        console.group("Withdrew liquidation:");
+        console.log(`- Withdrawal amount: ${fromWei(withdrawEvent.returnValues.withdrawalAmount)}`);
+        console.log(`- Liquidation Status: ${withdrawEvent.returnValues.liquidationStatus}`);
+        console.groupEnd();
+      } else {
+        console.log("Liquidation has not expired, cannot withdraw rewards");
+      }
+    }
+    // Liquidation has been disputed:
+    else if (liquidationState === LiquidationStatesEnum.PENDING_DISPUTE) {
+      // Check if the dispute can be resolved.
+      finder = await Finder.deployed();
+      mockOracle = await MockOracle.at(await finder.getImplementationAddress(utf8ToHex(interfaceName.Oracle)));
+      const priceFeedIdentifier = utf8ToHex("ETH/BTC");
+      try {
+        let priceResolution = await mockOracle.getPrice(priceFeedIdentifier, liquidationTime);
+        console.log(`Price has been resolved: ${fromWei(priceResolution)}`);
+
+        // Withdraw rewards. If the liquidator can make this call, then it means that the liquidation dispute has failed.
+        const withdrawResult = await emp.withdrawLiquidation.call(liquidationId, sponsor, { from: liquidator });
+        console.log(`Withdrawing ${fromWei(withdrawResult.rawValue.toString())} collateral tokens`);
+        await emp.withdrawLiquidation(liquidationId, sponsor, { from: liquidator });
+
+        // Read event to determine if dispute succeeded or failed.
+        const withdrawEvent = await getWithdrawLiquidationEvent(emp, liquidator);
+        console.group("Withdrew liquidation:");
+        console.log(`- Withdrawal amount: ${fromWei(withdrawEvent.returnValues.withdrawalAmount)}`);
+        console.log(`- Liquidation Status: ${withdrawEvent.returnValues.liquidationStatus}`);
+        console.groupEnd();
+      } catch (err) {
+        console.error(err);
+        console.log("Liquidation has been disputed but a price has not resolved yet.");
+      }
     }
   } catch (err) {
     console.error(err);

--- a/core/scripts/local/withdrawLiquidationEMP.js
+++ b/core/scripts/local/withdrawLiquidationEMP.js
@@ -5,7 +5,7 @@ const { LiquidationStatesEnum } = require("../../../common/Enums.js");
 // Deployed contract ABI's and addresses we need to fetch.
 const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator");
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
-const argv = require("minimist")(process.argv.slice(), { string: ["emp"] });
+const argv = require("minimist")(process.argv.slice(), { string: ["emp", "id"] });
 
 // Contracts we need to interact with.
 let emp;
@@ -44,8 +44,12 @@ const withdrawEMP = async callback => {
     const liquidator = accounts[1];
     console.log(`Liquidator: ${liquidator}`);
     console.log(`Sponsor that was liquidated: ${sponsor}`);
-    console.log("Withdrawing liquidation with ID 0");
-    const liquidationId = 0;
+
+    const liquidationId = argv.id;
+    if (!liquidationId) {
+      console.log("Missing 'id' command line argument, this selects which liquidation to withdraw from");
+    }
+    console.log(`Withdrawing liquidation with ID ${liquidationId}`);
     const liquidations = await emp.getLiquidations(sponsor);
     const liquidation = liquidations[liquidationId];
 


### PR DESCRIPTION
Apologies for the big PR, but a lot of these changes depend on each other so it was easier for me to develop on the same branch. Originally I was only working on #1499 but made all of these edits along the way. Many of the changes are new helper scripts to test the sponsor CLI with liquidations, disputes, and withdrawing liquidation rewards.

New features/bug fixes:
- BigNumber config is moved to top of `create.js` so that large number strings are not automatically displayed in scientific format. This caused a bug on line 22: `const minPositionSize = BigNumber((await emp.minSponsorTokens()).toString());` which cannot cast scientific-notation string to `BigNumber`.
- Warn user before creating a position if they do not have enough collateral to create their desired new position.
- `currencyUtils.getCurrencySymbol` now attempts to call `.symbol()` on a collateral currency rather than returning a generic "collateral currency" as the collaterl token's symbol. This improves UX. 
- Add contract's current time to sponsor summary. Mostly useful for testing.
- Display token balances for convenience.
- Detect liquidation token amount data from events since this gets deleted after a liquidation is deleted post-withdrawal. 
- Add more specific error messages to `withdrawLiquidation` functionality via the CLI. 
- New helper scripts for testing sponsor CLI.
- Refactor liquidation menus into the same files, dedicated to liquidation logic.

Resolves #1499 