### PR TITLE
Whitelisting collateral Address

### DIFF
--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -14,6 +14,7 @@ const ExpiringMultiPartyCreator = artifacts.require("ExpiringMultiPartyCreator")
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const Finder = artifacts.require("Finder");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const AddressWhitelist = artifacts.require("AddressWhitelist");
 const MockOracle = artifacts.require("MockOracle");
 const Token = artifacts.require("ExpandedERC20");
 const Registry = artifacts.require("Registry");
@@ -28,6 +29,7 @@ let emp;
 let syntheticToken;
 let mockOracle;
 let identifierWhitelist;
+let collateralTokenWhitelist;
 let registry;
 let expiringMultiPartyCreator;
 
@@ -42,6 +44,9 @@ const deployEMP = async callback => {
 
     // Use Dai as the collateral token.
     collateralToken = await TestnetERC20.deployed();
+    identifierWhitelist = await IdentifierWhitelist.deployed();
+    collateralTokenWhitelist = await AddressWhitelist.at(await expiringMultiPartyCreator.collateralTokenWhitelist());
+    await collateralTokenWhitelist.addToWhitelist(collateralToken.address);
 
     if (argv.mock_dvm) {
       // Create a mockOracle and finder. Register the mockOracle with the finder.

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -245,6 +245,7 @@ contract("scripts/Voting.js", function(accounts) {
 
     // The vote should have been committed.
     let result = await votingSystem.runIteration(USE_PROD_LOGS);
+    console.log("result", result);
     assert.equal(result.batches, 1);
     assert.equal(result.updates.length, 1);
     assert.equal(result.skipped.length, 0);

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -245,7 +245,6 @@ contract("scripts/Voting.js", function(accounts) {
 
     // The vote should have been committed.
     let result = await votingSystem.runIteration(USE_PROD_LOGS);
-    console.log("result", result);
     assert.equal(result.batches, 1);
     assert.equal(result.updates.length, 1);
     assert.equal(result.skipped.length, 0);


### PR DESCRIPTION
I was trying out the [UMA sponsor tool](https://docs.umaproject.org/uma/synthetic_tokens/using_the_uma_sponsor_cli_tool.html) and had an error because `DeployEMP.js` didn't whitelist the collateral token first

```bash
/uma/protocol/core$ $(npm bin)/truffle exec scripts/local/DeployEMP.js --network=test
Using network 'test'.
                                               
Error: Returned error: VM Exception while processing transaction: revert Collateral is not whitelisted
    at deployEMP (/uma/protocol/core/scripts/local/DeployEMP.js:70:73)

```

This PR fixes this issue

**possible improvement** : I'm guessing this is a test network only option. so it'd make sense to check the network before whitelisting.