### PR TITLE
Update EMP tutorials to reflect latest `DeployEMP.js` scripts and other helper scripts

### DIFF
--- a/core/scripts/local/AdvanceEMP.js
+++ b/core/scripts/local/AdvanceEMP.js
@@ -1,8 +1,9 @@
 /**
- * This script advances time in all EMP's and the Voting contract forward by some specified amount of seconds (or one hour and one second by default).
+ * @notice This script advances time in all EMP's and the Voting contract forward by some specified amount of seconds.
+ * @dev This assumes that the EMP is using the `MockOracle` on a local network. The default amount of seconds
+ * to advance is 2 hours or 7200 seconds.
  *
- * `truffle exec ./scripts/local/AdvanceEMPTime --time 10`
- * Advances time for all contracts by 10 seconds
+ * Example: `truffle exec ./scripts/local/AdvanceEMP --network test --time 10`
  */
 const { toBN } = web3.utils;
 const argv = require("minimist")(process.argv.slice(), { string: ["time"] });

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -1,13 +1,21 @@
 /**
- * The purpose of this script is to deploy several ExpiringMultiParty financial templates.
- * This involves creating and minting collateral tokens, whitelisting price identifiers,
- * and configuring the contracts to use the mock oracle which is more useful for testing.
+ * @notice The purpose of this script is to deploy an ExpiringMultiParty financial templates.
+ * @dev If you are deploying to a local testnet, set the `--test` flag value to `true` in order to whitelist
+ * the collateral currency, approve the pricefeed identifier, use the `MockOracle` contract as the `Oracle` linked
+ * with the financial contract, creates an initial sponsor position at the minimum collateralization ratio allowed,
+ * and mints collateral tokens to the default sponsor, `accounts[0]`. The testnet version of this script is designed
+ * to be used when testing out the sponsor CLI locally. The Sponsor CLI assumes `accounts[0]` to be the default
+ * sponsor account.
+ * @dev Other helpful scripts to run after this one are:
+ * - `./AdvanceEMP.js`: advances EMP time forward, which is useful when testing withdrawal and liquidation requests.
+ * - `./LiquidateEMP.js`: liquidates the sponsor's position with `accounts[1]` as the liquidator.
+ * - `./DisputeEMP.js`: disputes the default sponsor's liquidations using `accounts[0]` as the disputer.
+ * - `./WithdrawLiquidationEMP.js`: withdraws liquidations from `accounts[1]`, i.e. the liquidator. Withdrawing
+ *    liquidations as the sponsor can be done via the CLI.
+ * - `./PushPriceEMP.js`: "resolves" a pending mock oracle price request with a price.
  *
- * This script is intended to make testing the Sponsor CLI easier.
  *
- * How to run on local testnet: $(npm bin)/truffle exec ./scripts/local/DeployEMP.js --network test --test true
- * - The `--test` flag will deploy a MockOracle, whitelist the collateral currency and the pricefeed identifier,
- *   and create an initial sponsor position.
+ * Example: $(npm bin)/truffle exec ./scripts/local/DeployEMP.js --network test --test true
  */
 const { toWei, utf8ToHex, hexToUtf8 } = web3.utils;
 const { interfaceName } = require("../../utils/Constants.js");

--- a/core/scripts/local/DisputeEMP.js
+++ b/core/scripts/local/DisputeEMP.js
@@ -1,7 +1,8 @@
 /**
- * @notice Dispute a liquidation as the sponsor, which is assumed to be accounts[0].
+ * @notice Dispute a liquidation using `accounts[0]` as the disputer. We can specify which liquidation
+ * ID to dispute by setting the value of the `--id` flag.
  *
- *  Example run: `$(npm bin)/truffle exec ./scripts/local/DisputeEMP.js --network test --emp 0x6E2F1B57AF5C6237B7512b4DdC1FFDE2Fb7F90B9 --id 0`
+ * Example: `$(npm bin)/truffle exec ./scripts/local/DisputeEMP.js --network test --emp 0x6E2F1B57AF5C6237B7512b4DdC1FFDE2Fb7F90B9 --id 0`
  */
 const { toWei, fromWei, toBN } = web3.utils;
 const { LiquidationStatesEnum } = require("../../../common/Enums.js");

--- a/core/scripts/local/PushPriceEMP.js
+++ b/core/scripts/local/PushPriceEMP.js
@@ -1,8 +1,10 @@
 /**
- * @notice Push a price for a mock oracle price request. Designed to be used in testing disputed liquidations.
+ * @notice Push a price for a mock oracle price request. User can specify which pending price request to push a price
+ * for and what price to use. Note that the more recent the price request the higher the index. It is possible
+ * `MockOracle.getPendingQueries` returns already-resolved price requests, so this script will inform you if
+ * the price has been resolved.
  *
- * How to use: $(npm bin)/truffle exec ./scripts/local/PushPriceEMP.js --network test --id 1 --price 1.2
- * - This will push 1.2 as the price for the pending price request at index 1 in the MockOracle
+ * Example: $(npm bin)/truffle exec ./scripts/local/PushPriceEMP.js --network test --id 1 --price 1.2
  */
 const { toWei, fromWei, utf8ToHex, hexToUtf8 } = web3.utils;
 const { interfaceName } = require("../../utils/Constants");

--- a/core/scripts/local/liquidateEMP.js
+++ b/core/scripts/local/liquidateEMP.js
@@ -1,8 +1,9 @@
 /**
- * @notice Liquidates the sponsor's position, where the sponsor is accounts[0] and the liquidator
- * is accounts[1].
+ * @notice Liquidates 1000 tokens of the the sponsor's position, where the sponsor is accounts[0] and the liquidator
+ * is accounts[1]. Useful when paired with the `DeployEMP.js` script which deploys an EMP with a minimum
+ * sponsor position of 1000 tokens.
  *
- * Example run: `$(npm bin)/truffle exec ./scripts/local/LiquidateEMP.js --network test --emp 0x6E2F1B57AF5C6237B7512b4DdC1FFDE2Fb7F90B9`
+ * Example: `$(npm bin)/truffle exec ./scripts/local/LiquidateEMP.js --network test --emp 0x6E2F1B57AF5C6237B7512b4DdC1FFDE2Fb7F90B9`
  */
 const { toWei, fromWei, toBN } = web3.utils;
 const { MAX_UINT_VAL } = require("../../../common/Constants");

--- a/core/scripts/local/withdrawLiquidationEMP.js
+++ b/core/scripts/local/withdrawLiquidationEMP.js
@@ -1,6 +1,9 @@
 /**
- * @notice Withdraws liquidation as the liquidator on a specified liquidation ID. Therefore this assumes
- * that the liquidation has expired or has been disputed unsuccessfully.
+ * @notice Withdraws liquidation as the liquidator on a specified liquidation ID. This requires
+ * that the liquidation has expired or has been disputed unsuccessfully. We can customize which liquidation ID
+ * we withdraw from by setting the value of the `--id` flag.
+ *
+ * Example: `$(npm bin)/truffle exec ./scripts/local/WithdrawLiquidationEMP.js --network test --emp 0x6E2F1B57AF5C6237B7512b4DdC1FFDE2Fb7F90B9 --id 0`
  */
 const { fromWei, toBN, utf8ToHex } = web3.utils;
 const { LiquidationStatesEnum } = require("../../../common/Enums.js");


### PR DESCRIPTION
Reflects new scripts added in #1507  and adds explanations to tutorials about why an initial sponsor position must be created before using the CLI locally and how the `minSponsorTokens` contract parameter affects CLI actions.
 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>