### PR TITLE
Change bot configurations to take in consistantly scale variables

### DIFF
--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -40,9 +40,9 @@ class Liquidator {
         // then it will be liquidated. For example: If the minimum collateralization ratio is 120% and the TRV is 100,
         // then the minimum collateral requirement is 120. However, if `crThreshold = 0.02`, then the minimum
         // collateral requirement is 120 * (1-0.02) = 117.6, or 2% below 120.
-        value: toWei("0.02"),
+        value: 0.02,
         isValid: x => {
-          return toBN(x).lt(toBN(toWei("1"))) && toBN(x).gte(toBN("0"));
+          return x < 1 && x >= 0;
         }
       },
       liquidationDeadline: {
@@ -101,14 +101,14 @@ class Liquidator {
 
     // The `price` is a BN that is used to determine if a position is liquidatable. The higher the
     // `price` value, the more collateral that the position is required to have to be correctly collateralized.
-    // Therefore, we add a buffer by deriving a `scaledPrice` from (`1 - crThreshold` * `price`)
-    const scaledPrice = fromWei(price.mul(toBN(toWei("1")).sub(toBN(this.crThreshold))));
+    // Therefore, we add a buffer by deriving scaledPrice = price * (1 - crThreshold)
+    const scaledPrice = fromWei(price.mul(toBN(toWei("1")).sub(toBN(toWei(this.crThreshold.toString())))));
     this.logger.debug({
       at: "Liquidator",
       message: "Scaling down collateral threshold for liquidations",
       inputPrice: price.toString(),
       scaledPrice: scaledPrice.toString(),
-      crThreshold: this.crThreshold.toString()
+      crThreshold: this.crThreshold
     });
 
     this.logger.debug({

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -120,7 +120,7 @@ contract("Liquidator.js", function(accounts) {
 
     // Create a new instance of the liquidator to test
     liquidatorConfig = {
-      crThreshold: toWei("0")
+      crThreshold: 0
     };
     liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
   });
@@ -435,7 +435,7 @@ contract("Liquidator.js", function(accounts) {
       let errorThrown;
       try {
         liquidatorConfig = {
-          crThreshold: toWei("1")
+          crThreshold: 1
         };
         liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
         errorThrown = false;
@@ -449,7 +449,7 @@ contract("Liquidator.js", function(accounts) {
       let errorThrown;
       try {
         liquidatorConfig = {
-          crThreshold: toWei("-0.02")
+          crThreshold: -0.02
         };
         liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
         errorThrown = false;
@@ -461,7 +461,7 @@ contract("Liquidator.js", function(accounts) {
 
     it("Sets `crThreshold` to 2%", async function() {
       liquidatorConfig = {
-        crThreshold: toWei("0.02")
+        crThreshold: 0.02
       };
       liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
 

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -11,7 +11,7 @@ class CRMonitor {
    *                 must be given:
    *                 [{ name: "Market Making bot",
    *                    address: "0x12345",
-   *                    crAlert: 150 },
+   *                    crAlert: 1.50 }, // Note 150% is represented as 1.5
    *                  ...];
    * @param {Object} priceFeed offchain price feed used to track the token price.
    */
@@ -87,9 +87,9 @@ class CRMonitor {
           " (" +
           createEtherscanLinkMarkdown(this.web3, wallet.address) +
           ") collateralization ratio has dropped to " +
-          this.formatDecimalString(positionCR) +
+          this.formatDecimalString(positionCR.muln(100)) + // Scale up the CR threshold by 100 to become a percentage
           "% which is below the " +
-          wallet.crAlert +
+          wallet.crAlert * 100 +
           "% threshold. Current value of " +
           this.syntheticCurrencySymbol +
           " is " +
@@ -121,9 +121,8 @@ class CRMonitor {
     return this.web3.utils.toBN(value).lt(this.web3.utils.toBN(threshold));
   }
 
-  // TODO: refactor this out into a separate utility function
   // Calculate the collateralization Ratio from the collateral, token amount and token price
-  // This is cr = [collateral / (tokensOutstanding * price)] * 100
+  // This is cr = collateral / (tokensOutstanding * price)
   _calculatePositionCRPercent = (collateral, tokensOutstanding, tokenPrice) => {
     if (collateral == 0) {
       return 0;
@@ -135,9 +134,7 @@ class CRMonitor {
       .toBN(collateral)
       .mul(this.web3.utils.toBN(this.web3.utils.toWei("1")))
       .mul(this.web3.utils.toBN(this.web3.utils.toWei("1")))
-      .div(this.web3.utils.toBN(tokensOutstanding).mul(this.web3.utils.toBN(tokenPrice)))
-      .muln(100)
-      .toString();
+      .div(this.web3.utils.toBN(tokensOutstanding).mul(this.web3.utils.toBN(tokenPrice)));
   };
 }
 

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -31,14 +31,13 @@ class SyntheticPegMonitor {
     // Default config settings. SyntheticPegMonitor deployer can override these settings by passing in new
     // values via the `config` input object. The `isValid` property is a function that should be called
     // before resetting any config settings. `isValid` must return a Boolean.
-    const { toBN, toWei } = this.web3.utils;
     const defaultConfig = {
       deviationAlertThreshold: {
         // `deviationAlertThreshold`: Error threshold used to compare observed and expected token prices.
         // if the deviation in token price exceeds this value an alert is fired.
-        value: this.web3.utils.toBN(this.web3.utils.toWei("0.2")),
+        value: 0.2,
         isValid: x => {
-          return toBN(x).lte(toBN(toWei("100"))) && toBN(x).gte(toBN("0"));
+          return x < 100 && x > 0;
         }
       },
       volatilityWindow: {
@@ -50,9 +49,9 @@ class SyntheticPegMonitor {
       },
       volatilityAlertThreshold: {
         // `volatilityAlertThreshold`: Error threshold for pricefeed's price volatility over `volatilityWindow`.
-        value: this.web3.utils.toBN(this.web3.utils.toWei("0.05")),
+        value: 0.05,
         isValid: x => {
-          return toBN(x).lte(toBN(toWei("100"))) && toBN(x).gt(toBN("0"));
+          return x < 100 && x > 0;
         }
       }
     };
@@ -84,7 +83,7 @@ class SyntheticPegMonitor {
     }
     const deviationError = this._calculateDeviationError(uniswapTokenPrice, cryptoWatchTokenPrice);
     // If the percentage error is greater than (gt) the threshold send a message.
-    if (deviationError.gt(this.web3.utils.toBN(this.deviationAlertThreshold))) {
+    if (deviationError.gt(this.web3.utils.toBN(this.web3.utils.toWei(this.deviationAlertThreshold.toString())))) {
       this.logger.error({
         at: "SyntheticPegMonitor",
         message: "Synthetic off peg alert 😵",
@@ -130,7 +129,7 @@ class SyntheticPegMonitor {
     }
 
     // If the volatility percentage is greater than (gt) the threshold send a message.
-    if (pricefeedVolatility.gt(this.web3.utils.toBN(this.volatilityAlertThreshold))) {
+    if (pricefeedVolatility.gt(this.web3.utils.toBN(this.web3.utils.toWei(this.volatilityAlertThreshold.toString())))) {
       this.logger.error({
         at: "SyntheticPegMonitor",
         message: "High peg price volatility alert 🌋",
@@ -144,7 +143,7 @@ class SyntheticPegMonitor {
           "% over the last " +
           formatHours(this.volatilityWindow) +
           " hour(s). Threshold is " +
-          this.formatDecimalString(this.web3.utils.toBN(this.volatilityAlertThreshold).muln(100)) +
+          this.formatDecimalString(this.volatilityAlertThreshold * 100) +
           " %."
       });
     }
@@ -176,7 +175,7 @@ class SyntheticPegMonitor {
     }
 
     // If the volatility percentage is greater than (gt) the threshold send a message.
-    if (pricefeedVolatility.gt(this.web3.utils.toBN(this.volatilityAlertThreshold))) {
+    if (pricefeedVolatility.gt(this.web3.utils.toBN(this.web3.utils.toWei(this.volatilityAlertThreshold.toString())))) {
       this.logger.error({
         at: "SyntheticPegMonitor",
         message: "High synthetic price volatility alert 🌋",
@@ -190,7 +189,7 @@ class SyntheticPegMonitor {
           "% over the last " +
           formatHours(this.volatilityWindow) +
           " hour(s). Threshold is " +
-          this.formatDecimalString(this.web3.utils.toBN(this.volatilityAlertThreshold).muln(100)) +
+          this.formatDecimalString(this.volatilityAlertThreshold * 100) +
           " %."
       });
     }

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -38,7 +38,7 @@ contract("SyntheticPegMonitor", function(accounts) {
     beforeEach(async function() {
       // Tested module that uses the two price feeds.
       syntheticPegMonitorConfig = {
-        deviationAlertThreshold: toBN(toWei("0.2")) // Any deviation larger than 0.2 should fire an alert
+        deviationAlertThreshold: 0.2 // Any deviation larger than 0.2 should fire an alert
       };
       syntheticPegMonitor = new SyntheticPegMonitor(
         spyLogger,
@@ -121,7 +121,7 @@ contract("SyntheticPegMonitor", function(accounts) {
         volatilityWindow: 3650,
         // Not divisible by 3600 in order to test that "volatility window in hours" is printed
         // correctly by Logger.
-        volatilityAlertThreshold: toBN(toWei("0.3"))
+        volatilityAlertThreshold: 0.3
       };
       syntheticPegMonitor = new SyntheticPegMonitor(
         spyLogger,


### PR DESCRIPTION
This PR refactors the bots configuration variables to all take in consistently scaled numbers. Before this PR there were multiple ways of representing percentages in configs. `crAlert` in `WALLET_MONITOR_OBJECT` for example was represented by `140` but `volatilityAlertThreshold` in `SYNTHETIC_PEG_MONITOR_OBJECT` was represented as `200000000000000000`. This PR changes the scaling of configurations to all follows one common standard. 

This standard is as follows: 
1) All currency terms are expressed in their number of significant figures; 1 Ether threshold, for example, is represented as 1000000000000000000 (1e18). If a token has less significant figures then it is represented with it's native number of units. 1 USDC, therefore, would be 1000000 (1e6).
2) All non-currency parameters are represented as their _actual_ value, with no scaling applied. A time delay of an hour in seconds is 3600. 
3) Percentages are represented as decimals in native scaling. eg 140% is represented as 1.4 and 20% is represented as 0.2.