### PR TITLE
NewSponsor events monitor + fixing bot error-catching bugs that I ran into

### DIFF
--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -100,16 +100,24 @@ class ExpiringMultiPartyEventClient {
       });
     }
 
-    // New sponsor events
+    // NewSponsor events mapped against PositionCreated events to determine size of new positions created.
     const newSponsorEventsObj = await this.emp.getPastEvents("NewSponsor", {
       fromBlock: this.lastBlockNumberSeen,
       toBlock: currentBlockNumber
     });
     for (let event of newSponsorEventsObj) {
+      // Every transaction that emits a NewSponsor event must also emit a PositionCreated event.
+      const positionCreatedEventObj = await this.emp.getPastEvents("PositionCreated", {
+        fromBlock: event.blockNumber,
+        toBlock: event.blockNumber
+      });
+
       this.newSponsorEvents.push({
         transactionHash: event.transactionHash,
         blockNumber: event.blockNumber,
-        sponsor: event.returnValues.sponsor
+        sponsor: event.returnValues.sponsor,
+        collateralAmount: positionCreatedEventObj[0].returnValues.collateralAmount,
+        tokenAmount: positionCreatedEventObj[0].returnValues.tokenAmount
       });
     }
 

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -48,7 +48,7 @@ class ExpiringMultiPartyEventClient {
     // Look for events on chain from the previous seen block number to the current block number.
     // Liquidation events
     const liquidationEventsObj = await this.emp.getPastEvents("LiquidationCreated", {
-      fromBlock: this.lastBlockNumberSeen + 1,
+      fromBlock: this.lastBlockNumberSeen,
       toBlock: currentBlockNumber
     });
 
@@ -67,7 +67,7 @@ class ExpiringMultiPartyEventClient {
 
     // Dispute events
     const disputeEventsObj = await this.emp.getPastEvents("LiquidationDisputed", {
-      fromBlock: this.lastBlockNumberSeen + 1,
+      fromBlock: this.lastBlockNumberSeen,
       toBlock: currentBlockNumber
     });
     for (let event of disputeEventsObj) {
@@ -84,7 +84,7 @@ class ExpiringMultiPartyEventClient {
 
     // Dispute settlement events
     const disputeSettlementEventsObj = await this.emp.getPastEvents("DisputeSettled", {
-      fromBlock: this.lastBlockNumberSeen + 1,
+      fromBlock: this.lastBlockNumberSeen,
       toBlock: currentBlockNumber
     });
     for (let event of disputeSettlementEventsObj) {
@@ -102,7 +102,7 @@ class ExpiringMultiPartyEventClient {
 
     // New sponsor events
     const newSponsorEventsObj = await this.emp.getPastEvents("NewSponsor", {
-      fromBlock: this.lastBlockNumberSeen + 1,
+      fromBlock: this.lastBlockNumberSeen,
       toBlock: currentBlockNumber
     });
     for (let event of newSponsorEventsObj) {
@@ -113,7 +113,9 @@ class ExpiringMultiPartyEventClient {
       });
     }
 
-    this.lastBlockNumberSeen = currentBlockNumber;
+    // Add 1 so that we do not double-count the actual last block number seen.
+    this.lastBlockNumberSeen = currentBlockNumber + 1;
+
     this.lastUpdateTimestamp = await this.emp.methods.getCurrentTime().call();
     this.logger.debug({
       at: "ExpiringMultiPartyEventClient",

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -16,8 +16,8 @@ class ExpiringMultiPartyEventClient {
     this.disputeSettlementEvents = [];
     this.newSponsorEvents = [];
 
-    // Last block number seen by the client.
-    this.lastBlockNumberSeen = 0;
+    // First block number to begin searching for events after.
+    this.firstBlockToSearch = 0;
     this.lastUpdateTimestamp = 0;
   }
   // Delete all events within the client
@@ -48,7 +48,7 @@ class ExpiringMultiPartyEventClient {
     // Look for events on chain from the previous seen block number to the current block number.
     // Liquidation events
     const liquidationEventsObj = await this.emp.getPastEvents("LiquidationCreated", {
-      fromBlock: this.lastBlockNumberSeen,
+      fromBlock: this.firstBlockToSearch,
       toBlock: currentBlockNumber
     });
 
@@ -67,7 +67,7 @@ class ExpiringMultiPartyEventClient {
 
     // Dispute events
     const disputeEventsObj = await this.emp.getPastEvents("LiquidationDisputed", {
-      fromBlock: this.lastBlockNumberSeen,
+      fromBlock: this.firstBlockToSearch,
       toBlock: currentBlockNumber
     });
     for (let event of disputeEventsObj) {
@@ -84,7 +84,7 @@ class ExpiringMultiPartyEventClient {
 
     // Dispute settlement events
     const disputeSettlementEventsObj = await this.emp.getPastEvents("DisputeSettled", {
-      fromBlock: this.lastBlockNumberSeen,
+      fromBlock: this.firstBlockToSearch,
       toBlock: currentBlockNumber
     });
     for (let event of disputeSettlementEventsObj) {
@@ -102,7 +102,7 @@ class ExpiringMultiPartyEventClient {
 
     // NewSponsor events mapped against PositionCreated events to determine size of new positions created.
     const newSponsorEventsObj = await this.emp.getPastEvents("NewSponsor", {
-      fromBlock: this.lastBlockNumberSeen,
+      fromBlock: this.firstBlockToSearch,
       toBlock: currentBlockNumber
     });
     for (let event of newSponsorEventsObj) {
@@ -121,8 +121,8 @@ class ExpiringMultiPartyEventClient {
       });
     }
 
-    // Add 1 so that we do not double-count the actual last block number seen.
-    this.lastBlockNumberSeen = currentBlockNumber + 1;
+    // Add 1 to current block so that we do not double count the last block number seen.
+    this.firstBlockToSearch = currentBlockNumber + 1;
 
     this.lastUpdateTimestamp = await this.emp.methods.getCurrentTime().call();
     this.logger.debug({

--- a/financial-templates-lib/test/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/test/clients/ExpiringMultiPartyEventClient.js
@@ -121,17 +121,23 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
         {
           transactionHash: newSponsorTxObj1.tx,
           blockNumber: newSponsorTxObj1.receipt.blockNumber,
-          sponsor: sponsor1
+          sponsor: sponsor1,
+          collateralAmount: toWei("10"),
+          tokenAmount: toWei("50")
         },
         {
           transactionHash: newSponsorTxObj2.tx,
           blockNumber: newSponsorTxObj2.receipt.blockNumber,
-          sponsor: sponsor2
+          sponsor: sponsor2,
+          collateralAmount: toWei("100"),
+          tokenAmount: toWei("45")
         },
         {
           transactionHash: newSponsorTxObj3.tx,
           blockNumber: newSponsorTxObj3.receipt.blockNumber,
-          sponsor: liquidator
+          sponsor: liquidator,
+          collateralAmount: toWei("500"),
+          tokenAmount: toWei("200")
         }
       ],
       client.getAllNewSponsorEvents()
@@ -147,7 +153,9 @@ contract("ExpiringMultiPartyEventClient.js", function(accounts) {
         {
           transactionHash: newSponsorTxObj4.tx,
           blockNumber: newSponsorTxObj4.receipt.blockNumber,
-          sponsor: sponsor3
+          sponsor: sponsor3,
+          collateralAmount: toWei("10"),
+          tokenAmount: toWei("1")
         }
       ],
       client.getAllNewSponsorEvents()

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -42,8 +42,7 @@ class CRMonitor {
     if (!price) {
       this.logger.warn({
         at: "CRMonitor",
-        message: "Cannot compute wallet collateralization ratio because price feed returned invalid value",
-        price: price.toString()
+        message: "Cannot compute wallet collateralization ratio because price feed returned invalid value"
       });
       return;
     }

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -67,14 +67,14 @@ class ContractMonitor {
       // Check if new sponsor is UMA bot.
       const isLiquidatorBot = this.monitoredLiquidators.indexOf(event.sponsor);
       const isDisputerBot = this.monitoredDisputers.indexOf(event.sponsor);
-      const isUMABot = Boolean(isLiquidatorBot != -1 || isDisputerBot != -1);
+      const isMonitoredBot = Boolean(isLiquidatorBot != -1 || isDisputerBot != -1);
 
       // Sample message:
       // New sponsor alert: [ethereum address if third party, or “UMA” if it’s our bot]
       // created X tokens backed by Y collateral.  [etherscan link to txn]
       const mrkdwn =
         createEtherscanLinkMarkdown(this.web3, event.sponsor) +
-        (isUMABot ? " (Monitored liquidator or disputer bot)" : "") +
+        (isMonitoredBot ? " (Monitored liquidator or disputer bot)" : "") +
         " created " +
         this.formatDecimalString(event.tokenAmount) +
         " " +

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -20,6 +20,7 @@ class ContractMonitor {
     this.lastLiquidationBlockNumber = 0;
     this.lastDisputeBlockNumber = 0;
     this.lastDisputeSettlementBlockNumber = 0;
+    this.lastNewSponsorBlockNumber = 0;
 
     // Contract constants
     // TODO: replace this with an actual query to the collateral currency symbol
@@ -47,6 +48,56 @@ class ContractMonitor {
     }
     return eventArray[eventArray.length - 1].blockNumber;
   }
+
+  // Quries NewSponsor events since the latest query marked by `lastNewSponsorBlockNumber`.
+  checkForNewSponsors = async () => {
+    this.logger.debug({
+      at: "ContractMonitor",
+      message: "Checking for new sponsor events",
+      lastNewSponsorBlockNumber: this.lastNewSponsorBlockNumber
+    });
+
+    // Get the latest new sponsor information.
+    let latestNewSponsorEvents = this.empEventClient.getAllNewSponsorEvents();
+
+    // Get events that are newer than the last block number we've seen
+    let newSponsorEvents = latestNewSponsorEvents.filter(event => event.blockNumber > this.lastLiquidationBlockNumber);
+
+    for (let event of newSponsorEvents) {
+      // Check if new sponsor is UMA bot.
+      const isLiquidatorBot = this.monitoredLiquidators.indexOf(event.sponsor);
+      const isDisputerBot = this.monitoredDisputers.indexOf(event.sponsor);
+      const isUMABot = Boolean(isLiquidatorBot != -1 || isDisputerBot != -1);
+
+      // Get sponsor position details.
+      const collateralAmount = await this.empContract.methods.getCollateral(event.sponsor).call();
+      const tokenAmount = (await this.empContract.methods.positions(event.sponsor).call()).tokensOutstanding();
+
+      // Sample message:
+      // New sponsor alert: [ethereum address if third party, or “UMA” if it’s our bot]
+      // created X tokens backed by Y collateral.  [etherscan link to txn]
+      const mrkdwn =
+        createEtherscanLinkMarkdown(this.web3, event.sponsor) +
+        (isUMABot ? " (Monitored liquidator or disputer bot)" : "") +
+        " created " +
+        this.formatDecimalString(tokenAmount) +
+        " " +
+        this.syntheticCurrencySymbol +
+        " backed by " +
+        this.formatDecimalString(collateralAmount) +
+        " " +
+        this.collateralCurrencySymbol +
+        ". tx: " +
+        createEtherscanLinkMarkdown(this.web3, event.transactionHash);
+
+      this.logger.info({
+        at: "ContractMonitor",
+        message: "New Sponsor Alert 🧙‍♂️!",
+        mrkdwn: mrkdwn
+      });
+    }
+    this.lastNewSponsorBlockNumber = this.getLastSeenBlockNumber(latestNewSponsorEvents);
+  };
 
   // Queries disputable liquidations and disputes any that were incorrectly liquidated.
   checkForNewLiquidations = async () => {

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -61,17 +61,13 @@ class ContractMonitor {
     let latestNewSponsorEvents = this.empEventClient.getAllNewSponsorEvents();
 
     // Get events that are newer than the last block number we've seen
-    let newSponsorEvents = latestNewSponsorEvents.filter(event => event.blockNumber > this.lastLiquidationBlockNumber);
+    let newSponsorEvents = latestNewSponsorEvents.filter(event => event.blockNumber > this.lastNewSponsorBlockNumber);
 
     for (let event of newSponsorEvents) {
       // Check if new sponsor is UMA bot.
       const isLiquidatorBot = this.monitoredLiquidators.indexOf(event.sponsor);
       const isDisputerBot = this.monitoredDisputers.indexOf(event.sponsor);
       const isUMABot = Boolean(isLiquidatorBot != -1 || isDisputerBot != -1);
-
-      // Get sponsor position details.
-      const collateralAmount = await this.empContract.methods.getCollateral(event.sponsor).call();
-      const tokenAmount = (await this.empContract.methods.positions(event.sponsor).call()).tokensOutstanding;
 
       // Sample message:
       // New sponsor alert: [ethereum address if third party, or “UMA” if it’s our bot]
@@ -80,11 +76,11 @@ class ContractMonitor {
         createEtherscanLinkMarkdown(this.web3, event.sponsor) +
         (isUMABot ? " (Monitored liquidator or disputer bot)" : "") +
         " created " +
-        this.formatDecimalString(tokenAmount) +
+        this.formatDecimalString(event.tokenAmount) +
         " " +
         this.syntheticCurrencySymbol +
         " backed by " +
-        this.formatDecimalString(collateralAmount) +
+        this.formatDecimalString(event.collateralAmount) +
         " " +
         this.collateralCurrencySymbol +
         ". tx: " +

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -71,7 +71,7 @@ class ContractMonitor {
 
       // Get sponsor position details.
       const collateralAmount = await this.empContract.methods.getCollateral(event.sponsor).call();
-      const tokenAmount = (await this.empContract.methods.positions(event.sponsor).call()).tokensOutstanding();
+      const tokenAmount = (await this.empContract.methods.positions(event.sponsor).call()).tokensOutstanding;
 
       // Sample message:
       // New sponsor alert: [ethereum address if third party, or “UMA” if it’s our bot]
@@ -92,7 +92,7 @@ class ContractMonitor {
 
       this.logger.info({
         at: "ContractMonitor",
-        message: "New Sponsor Alert 🧙‍♂️!",
+        message: "New Sponsor Alert 🐣!",
         mrkdwn: mrkdwn
       });
     }

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -66,6 +66,16 @@ class SyntheticPegMonitor {
     const uniswapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
     const cryptoWatchTokenPrice = this.medianizerPriceFeed.getCurrentPrice();
 
+    if (!uniswapTokenPrice || !cryptoWatchTokenPrice) {
+      this.logger.warn({
+        at: "SyntheticPegMonitor",
+        message: "Unable to get price",
+        uniswapTokenPrice: uniswapTokenPrice ? uniswapTokenPrice.toString() : null,
+        cryptoWatchTokenPrice: cryptoWatchTokenPrice ? cryptoWatchTokenPrice.toString() : null
+      });
+      return;
+    }
+
     this.logger.debug({
       at: "SyntheticPegMonitor",
       message: "Checking price deviation",
@@ -73,15 +83,6 @@ class SyntheticPegMonitor {
       cryptoWatchTokenPrice: cryptoWatchTokenPrice.toString()
     });
 
-    if (!uniswapTokenPrice || !cryptoWatchTokenPrice) {
-      this.logger.warn({
-        at: "SyntheticPegMonitor",
-        message: "Unable to get price",
-        uniswapTokenPrice: uniswapTokenPrice.toString(),
-        cryptoWatchTokenPrice: cryptoWatchTokenPrice.toString()
-      });
-      return;
-    }
     const deviationError = this._calculateDeviationError(uniswapTokenPrice, cryptoWatchTokenPrice);
     // If the percentage error is greater than (gt) the threshold send a message.
     if (deviationError.gt(this.web3.utils.toBN(this.deviationAlertThreshold))) {
@@ -107,7 +108,21 @@ class SyntheticPegMonitor {
   checkPegVolatility = async () => {
     const pricefeed = this.medianizerPriceFeed;
 
-    const { pricefeedVolatility, pricefeedLatestPrice, min, max } = await this._checkPricefeedVolatility(pricefeed);
+    const volData = await this._checkPricefeedVolatility(pricefeed);
+
+    if (!volData) {
+      this.logger.warn({
+        at: "SyntheticPegMonitor",
+        message: "Unable to get volatility data",
+        pricefeed: "Medianizer"
+      });
+      return;
+    }
+
+    const pricefeedVolatility = volData.pricefeedVolatility;
+    const pricefeedLatestPrice = volData.pricefeedLatestPrice;
+    const min = volData.min;
+    const max = volData.max;
 
     this.logger.debug({
       at: "SyntheticPegMonitor",
@@ -117,17 +132,6 @@ class SyntheticPegMonitor {
       minPrice: min.toString(),
       maxPrice: max.toString()
     });
-
-    if (!pricefeedVolatility || !pricefeedLatestPrice) {
-      this.logger.warn({
-        at: "SyntheticPegMonitor",
-        message: "Unable to get price",
-        pricefeed: "Medianizer",
-        pricefeedVolatility: pricefeedVolatility.toString(),
-        pricefeedLatestPrice: pricefeedLatestPrice.toString()
-      });
-      return;
-    }
 
     // If the volatility percentage is greater than (gt) the threshold send a message.
     if (pricefeedVolatility.gt(this.web3.utils.toBN(this.volatilityAlertThreshold))) {
@@ -153,7 +157,21 @@ class SyntheticPegMonitor {
   checkSyntheticVolatility = async () => {
     const pricefeed = this.uniswapPriceFeed;
 
-    const { pricefeedVolatility, pricefeedLatestPrice, min, max } = await this._checkPricefeedVolatility(pricefeed);
+    const volData = await this._checkPricefeedVolatility(pricefeed);
+
+    if (!volData) {
+      this.logger.warn({
+        at: "SyntheticPegMonitor",
+        message: "Unable to get volatility data",
+        pricefeed: "Uniswap"
+      });
+      return;
+    }
+
+    const pricefeedVolatility = volData.pricefeedVolatility;
+    const pricefeedLatestPrice = volData.pricefeedLatestPrice;
+    const min = volData.min;
+    const max = volData.max;
 
     this.logger.debug({
       at: "SyntheticPegMonitor",
@@ -163,17 +181,6 @@ class SyntheticPegMonitor {
       minPrice: min.toString(),
       maxPrice: max.toString()
     });
-
-    if (!pricefeedVolatility || !pricefeedLatestPrice) {
-      this.logger.warn({
-        at: "SyntheticPegMonitor",
-        message: "Unable to get price",
-        pricefeed: "Uniswap",
-        pricefeedVolatility: pricefeedVolatility.toString(),
-        pricefeedLatestPrice: pricefeedLatestPrice.toString()
-      });
-      return;
-    }
 
     // If the volatility percentage is greater than (gt) the threshold send a message.
     if (pricefeedVolatility.gt(this.web3.utils.toBN(this.volatilityAlertThreshold))) {
@@ -201,20 +208,20 @@ class SyntheticPegMonitor {
     // Get all historical prices from `volatilityWindow` seconds before the last update time and
     // record the minimum and maximum.
     const latestTime = pricefeed.getLastUpdateTime();
-    const { volatility: pricefeedVolatility, min, max } = this._calculateHistoricalVolatility(
-      pricefeed,
-      latestTime,
-      this.volatilityWindow
-    );
+    const volData = this._calculateHistoricalVolatility(pricefeed, latestTime, this.volatilityWindow);
+    if (!volData) {
+      return null;
+    }
+
     // @dev: This is not `getCurrentTime` in order to enforce that the volatility calculation is counting back from precisely the
     // same timestamp as the "latest price". This would prevent inaccurate volatility readings where `currentTime` differs from `lastUpdateTime`.
     const pricefeedLatestPrice = pricefeed.getHistoricalPrice(latestTime);
 
     return {
-      pricefeedVolatility,
+      pricefeedVolatility: volData.volatility,
       pricefeedLatestPrice,
-      min,
-      max
+      min: volData.min,
+      max: volData.max
     };
   };
 

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -126,7 +126,7 @@ async function run(
       await contractMonitor.checkForNewDisputeEvents();
       // 1.d Check for new disputeSettlements
       await contractMonitor.checkForNewDisputeSettlementEvents();
-      // 1.3 Check for new sponsor positions created
+      // 1.e Check for new sponsor positions created
       await contractMonitor.checkForNewSponsors();
 
       // 2.  Wallet Balance monitor

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -126,6 +126,8 @@ async function run(
       await contractMonitor.checkForNewDisputeEvents();
       // 1.d Check for new disputeSettlements
       await contractMonitor.checkForNewDisputeSettlementEvents();
+      // 1.3 Check for new sponsor positions created
+      await contractMonitor.checkForNewSponsors();
 
       // 2.  Wallet Balance monitor
       // 2.a Update the client
@@ -156,6 +158,7 @@ async function run(
       }
     }
   } catch (error) {
+    console.error(error);
     Logger.error({
       at: "Monitor#index",
       message: "Monitor polling error. Monitor crashed🚨",

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -158,7 +158,6 @@ async function run(
       }
     }
   } catch (error) {
-    console.error(error);
     Logger.error({
       at: "Monitor#index",
       message: "Monitor polling error. Monitor crashed🚨",

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -33,6 +33,7 @@ contract("ContractMonitor.js", function(accounts) {
   const disputer = accounts[2];
   const sponsor1 = accounts[3];
   const sponsor2 = accounts[4];
+  const sponsor3 = accounts[5];
 
   const zeroAddress = "0x0000000000000000000000000000000000000000";
   const unreachableDeadline = MAX_UINT_VAL;
@@ -54,6 +55,9 @@ contract("ContractMonitor.js", function(accounts) {
   // re-used variables
   let expirationTime;
   let constructorParams;
+
+  // Keep track of new sponsor transactions for testing `checkForNewSponsors` method.
+  let newSponsorTxn;
 
   const spy = sinon.spy();
 
@@ -106,7 +110,7 @@ contract("ContractMonitor.js", function(accounts) {
     eventClient = new ExpiringMultiPartyEventClient(spyLogger, ExpiringMultiParty.abi, web3, emp.address);
     priceFeedMock = new PriceFeedMock();
     // accounts[1] is liquidator bot to monitor and accounts[2] is dispute bot to monitor.
-    contractMonitor = new ContractMonitor(spyLogger, eventClient, [accounts[1]], [accounts[2]], priceFeedMock);
+    contractMonitor = new ContractMonitor(spyLogger, eventClient, [liquidator], [disputer], priceFeedMock);
 
     syntheticToken = await Token.at(await emp.tokenCurrency());
 
@@ -115,7 +119,7 @@ contract("ContractMonitor.js", function(accounts) {
     });
 
     //   Bulk mint and approve for all wallets
-    for (let i = 1; i < 5; i++) {
+    for (let i = 1; i < 6; i++) {
       await collateralToken.mint(accounts[i], toWei("100000000"), {
         from: tokenSponsor
       });
@@ -130,9 +134,43 @@ contract("ContractMonitor.js", function(accounts) {
     // Create positions for the sponsors, liquidator and disputer
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("50") }, { from: sponsor1 });
     await emp.create({ rawValue: toWei("175") }, { rawValue: toWei("45") }, { from: sponsor2 });
-    await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("400") }, { from: liquidator });
+    newSponsorTxn = await emp.create({ rawValue: toWei("1500") }, { rawValue: toWei("400") }, { from: liquidator });
   });
 
+  it("Winston correctly emits new sponsor message", async function() {
+    // Update the eventClient and check it has the new sponsor event stored correctly
+    await eventClient.update();
+
+    // Check for new sponsor events
+    await contractMonitor.checkForNewSponsors();
+
+    // Ensure that the spy correctly captured the new sponsor events key information.
+    // Should contain etherscan addresses for the sponsor and transaction
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${liquidator}`));
+    assert.isTrue(lastSpyLogIncludes(spy, "(Monitored liquidator or disputer bot)")); // The address that initiated the liquidation is a monitored address
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newSponsorTxn.tx}`));
+
+    // should contain the correct position information.
+    assert.isTrue(lastSpyLogIncludes(spy, "400.00")); // New tokens created
+    assert.isTrue(lastSpyLogIncludes(spy, "1,500.00")); // Collateral amount
+
+    // Create another position
+    const txObject1 = await emp.create(
+      { rawValue: toWei("10") },
+      { rawValue: toWei("1.5") },
+      { from: sponsor3 } // not a monitored address
+    );
+
+    await eventClient.update();
+
+    // check for new sponsor events and check the winston messages sent to the spy
+    await contractMonitor.checkForNewSponsors();
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor3}`));
+    assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator or disputer bot bot)"));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, "1.50")); // New tokens created
+    assert.isTrue(lastSpyLogIncludes(spy, "10.00")); // Collateral amount
+  });
   it("Winston correctly emits liquidation message", async function() {
     // Create liquidation to liquidate sponsor2 from sponsor1
     const txObject1 = await emp.createLiquidation(


### PR DESCRIPTION
Adds `NewSponsor` event tracker to `ExpiringMultiPartyEventClient`.

Fixes bug in this client that sets `this.lastBlockNumberSeen = currentBlock` to `this.lastBlockNumberSeen = currentBlock + 1` so that events in the last block are not double-counted.

Fix bugs in `CRMonitor` and `SyntheticPegMonitor` that attempt to print values from an `undefined` object in cases where the monitors fail to fetch pricefeed data.

Example slack message for `NewSponsor` monitor:
![Screen Shot 2020-05-26 at 11 19 47](https://user-images.githubusercontent.com/9457025/82919044-83bc4380-9f43-11ea-8f31-c380aff80826.png)


Resolves #1506