### PR TITLE
Make CryptoWatch api key optional

### DIFF
--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -6,7 +6,7 @@ const Uniswap = require("../../core/build/contracts/Uniswap.json");
 
 async function createPriceFeed(logger, web3, networker, getTime, config) {
   if (config.type === "cryptowatch") {
-    const requiredFields = ["apiKey", "exchange", "pair", "lookback", "minTimeBetweenUpdates"];
+    const requiredFields = ["exchange", "pair", "lookback", "minTimeBetweenUpdates"];
 
     if (isMissingField(config, requiredFields, logger)) {
       return null;

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -3,7 +3,7 @@ const { PriceFeedInterface } = require("./PriceFeedInterface");
 // An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
 class CryptoWatchPriceFeed extends PriceFeedInterface {
   // Constructs the CryptoWatchPriceFeed.
-  // apiKey the CW API key. Note: these API keys are rate-limited.
+  // apiKey optional CW API key. Note: these API keys are rate-limited.
   // exchange a string identifier for the echange to pull prices from. This should be the identifier used to
   //          identify the exchange in CW's REST API.
   // pair a string representation of the pair the price feed is tracking. This pair should be available on the

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -93,10 +93,10 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     // See https://docs.cryptowat.ch/rest-api/markets/ohlc for how this url is constructed.
     const ohlcUrl = [
-      `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?`,
-      `afer=${earliestHistoricalTimestamp}&`,
-      `periods=${this.ohlcPeriod}&`,
-      `apikey=${this.apiKey}`
+      `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc`,
+      `?after=${earliestHistoricalTimestamp}`,
+      `&periods=${this.ohlcPeriod}`,
+      this.apiKey ? `&apiKey=${this.apiKey}` : ""
     ].join("");
 
     const ohlcResponse = await this.networker.getJson(ohlcUrl);
@@ -141,7 +141,9 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       });
 
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
-    const priceUrl = `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price?apikey=${this.apiKey}`;
+    const priceUrl =
+      `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price` +
+      (this.apiKey ? `?apiKey=${this.apiKey}` : "");
     const priceResponse = await this.networker.getJson(priceUrl);
     if (!ohlcResponse || !priceResponse.result || !priceResponse.result.price) {
       this.logger.error({

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -61,6 +61,21 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validCryptoWatchFeed.getTime(), getTime());
   });
 
+  it("Valid CryptoWatch config without apiKey", async function() {
+    const config = {
+      type: "cryptowatch",
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates
+    };
+
+    const validCryptoWatchFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isTrue(validCryptoWatchFeed instanceof CryptoWatchPriceFeed);
+    assert.equal(validCryptoWatchFeed.apiKey, undefined);
+  });
+
   it("Invalid CryptoWatch config", async function() {
     const validConfig = {
       type: "cryptowatch",
@@ -71,7 +86,6 @@ contract("CreatePriceFeed.js", function(accounts) {
       minTimeBetweenUpdates
     };
 
-    assert.equal(await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, apiKey: undefined }), null);
     assert.equal(
       await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, exchange: undefined }),
       null

--- a/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -166,4 +166,25 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), originalMockTime);
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice().toString(), toWei("1.5"));
   });
+
+  it("apiKey present", async function() {
+    networker.getJsonReturns = [...validResponses];
+    await cryptoWatchPriceFeed.update();
+
+    assert.deepStrictEqual(networker.getJsonInputs, [
+      "https://api.cryptowat.ch/markets/test-exchange/test-pair/price?apiKey=test-api-key",
+      "https://api.cryptowat.ch/markets/test-exchange/test-pair/ohlc?after=1588376460&periods=60&apiKey=test-api-key"
+    ]);
+  });
+
+  it("apiKey absent", async function() {
+    cryptoWatchPriceFeed.apiKey = undefined;
+    networker.getJsonReturns = [...validResponses];
+    await cryptoWatchPriceFeed.update();
+
+    assert.deepStrictEqual(networker.getJsonInputs, [
+      "https://api.cryptowat.ch/markets/test-exchange/test-pair/price",
+      "https://api.cryptowat.ch/markets/test-exchange/test-pair/ohlc?after=1588376460&periods=60"
+    ]);
+  });
 });


### PR DESCRIPTION
You don't have to have an API key to make API requests to cryptowatch. For convenience (especially for those using the tutorials), I think it makes sense to make it an optional parameter.

This will also be useful when integrating it into the sponsor cli tool.

Related to #1529.