### PR TITLE
Add events to EMPEventClient that we will need to query to create Daily Report

### DIFF
--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -198,6 +198,33 @@ class ExpiringMultiPartyEventClient {
       });
     }
 
+    // Regular fee events
+    const regularFeeEventsObj = await this.emp.getPastEvents("RegularFeesPaid", {
+      fromBlock: this.firstBlockToSearch,
+      toBlock: currentBlockNumber
+    });
+    for (let event of regularFeeEventsObj) {
+      this.regularFeeEvents.push({
+        transactionHash: event.transactionHash,
+        blockNumber: event.blockNumber,
+        regularFee: event.returnValues.regularFee,
+        lateFee: event.returnValues.lateFee
+      });
+    }
+
+    // Final fee events
+    const finalFeeEventsObj = await this.emp.getPastEvents("FinalFeesPaid", {
+      fromBlock: this.firstBlockToSearch,
+      toBlock: currentBlockNumber
+    });
+    for (let event of finalFeeEventsObj) {
+      this.finalFeeEvents.push({
+        transactionHash: event.transactionHash,
+        blockNumber: event.blockNumber,
+        amount: event.returnValues.amount
+      });
+    }
+
     // Add 1 to current block so that we do not double count the last block number seen.
     this.firstBlockToSearch = currentBlockNumber + 1;
 

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -65,6 +65,9 @@ class ExpiringMultiPartyEventClient {
 
   update = async () => {
     const currentBlockNumber = await this.web3.eth.getBlockNumber();
+    // TODO(#1540): For efficiency, we should only pass through `fromBlock` to `toBlock` once and check for
+    // all of the relevant events along the way.
+
     // Look for events on chain from the previous seen block number to the current block number.
     // Liquidation events
     const liquidationEventsObj = await this.emp.getPastEvents("LiquidationCreated", {

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -155,6 +155,49 @@ class ExpiringMultiPartyEventClient {
       });
     }
 
+    // Deposit events
+    const depositEventsObj = await this.emp.getPastEvents("Deposit", {
+      fromBlock: this.firstBlockToSearch,
+      toBlock: currentBlockNumber
+    });
+    for (let event of depositEventsObj) {
+      this.depositEvents.push({
+        transactionHash: event.transactionHash,
+        blockNumber: event.blockNumber,
+        sponsor: event.returnValues.sponsor,
+        collateralAmount: event.returnValues.collateralAmount
+      });
+    }
+
+    // Withdraw events
+    const withdrawEventsObj = await this.emp.getPastEvents("Withdrawal", {
+      fromBlock: this.firstBlockToSearch,
+      toBlock: currentBlockNumber
+    });
+    for (let event of withdrawEventsObj) {
+      this.withdrawEvents.push({
+        transactionHash: event.transactionHash,
+        blockNumber: event.blockNumber,
+        sponsor: event.returnValues.sponsor,
+        collateralAmount: event.returnValues.collateralAmount
+      });
+    }
+
+    // Redeem events
+    const redeemEventsObj = await this.emp.getPastEvents("Redeem", {
+      fromBlock: this.firstBlockToSearch,
+      toBlock: currentBlockNumber
+    });
+    for (let event of redeemEventsObj) {
+      this.redeemEvents.push({
+        transactionHash: event.transactionHash,
+        blockNumber: event.blockNumber,
+        sponsor: event.returnValues.sponsor,
+        collateralAmount: event.returnValues.collateralAmount,
+        tokenAmount: event.returnValues.tokenAmount
+      });
+    }
+
     // Add 1 to current block so that we do not double count the last block number seen.
     this.firstBlockToSearch = currentBlockNumber + 1;
 


### PR DESCRIPTION
Adds event tracking for:
- `Deposit`
- `Create`
- `Withdrawal`
- `Redeem`
- `RegularFeesPaid`
- `FinalFeePaid`

Refactors the `NewSponsor` event tracking to cross-reference `Create` events and track collateral/tokens transferred