### PR TITLE
Declare providers using functions to reduce Infura polling

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -37,24 +37,20 @@ function addPublicNetwork(networks, name, networkId) {
   // GCS ManagedSecretProvider network.
   networks[name] = {
     ...options,
-    provider: new ManagedSecretProvider(
-      GckmsConfig,
-      `https://${name}.infura.io/v3/${infuraApiKey}`,
-      0,
-      GckmsConfig.length
-    )
+    provider: () =>
+      new ManagedSecretProvider(GckmsConfig, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, GckmsConfig.length)
   };
 
   // Private key network.
   networks[name + "_privatekey"] = {
     ...options,
-    provider: new HDWalletProvider([privateKey], `https://${name}.infura.io/v3/${infuraApiKey}`)
+    provider: () => new HDWalletProvider([privateKey], `https://${name}.infura.io/v3/${infuraApiKey}`)
   };
 
   // Mnemonic network.
   networks[name + "_mnemonic"] = {
     ...options,
-    provider: new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2)
+    provider: () => new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2)
   };
 
   // Ledger has changed their standard derivation path since this library was created, so we must override the default one.
@@ -66,7 +62,7 @@ function addPublicNetwork(networks, name, networkId) {
   // Normal ledger wallet network.
   networks[name + "_ledger"] = {
     ...options,
-    provider: new LedgerWalletProvider(ledgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
+    provider: () => new LedgerWalletProvider(ledgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
   };
 
   // The default derivation path matches the "legacy" ledger account in Ledger Live.
@@ -77,7 +73,7 @@ function addPublicNetwork(networks, name, networkId) {
   // Legacy ledger wallet network.
   networks[name + "_ledger_legacy"] = {
     ...options,
-    provider: new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
+    provider: () => new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
   };
 }
 
@@ -125,7 +121,7 @@ addLocalNetwork(networks, "test");
 addLocalNetwork(networks, "coverage", { port: 8545, network_id: 1234 });
 
 // MetaMask truffle provider requires a longer timeout so that user has time to point web browser with metamask to localhost:3333
-addLocalNetwork(networks, "metamask", { provider: new MetaMaskTruffleProvider(), networkCheckTimeout: 500000 });
+addLocalNetwork(networks, "metamask", { provider: () => new MetaMaskTruffleProvider(), networkCheckTimeout: 500000 });
 
 addLocalNetwork(networks, "mainnet-fork", { port: 8545, network_id: 1 });
 

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -28,7 +28,7 @@ const gas = undefined; // Defining this as undefined (rather than leaving undefi
 // shell environment.
 function addPublicNetwork(networks, name, networkId) {
   const options = {
-    networkCheckTimeout: 10000,
+    networkCheckTimeout: 500000,
     network_id: networkId,
     gas: gas,
     gasPrice: gasPx
@@ -37,20 +37,34 @@ function addPublicNetwork(networks, name, networkId) {
   // GCS ManagedSecretProvider network.
   networks[name] = {
     ...options,
-    provider: () =>
-      new ManagedSecretProvider(GckmsConfig, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, GckmsConfig.length)
+    provider: function() {
+      console.log(mnemonic);
+      console.log(`https://${name}.infura.io/v3/${infuraApiKey}`);
+      return new ManagedSecretProvider(
+        GckmsConfig,
+        `https://${name}.infura.io/v3/${infuraApiKey}`,
+        0,
+        GckmsConfig.length
+      );
+    }
   };
 
   // Private key network.
   networks[name + "_privatekey"] = {
     ...options,
-    provider: () => new HDWalletProvider([privateKey], `https://${name}.infura.io/v3/${infuraApiKey}`)
+    provider: function() {
+      return new HDWalletProvider([privateKey], `https://${name}.infura.io/v3/${infuraApiKey}`);
+    }
   };
 
   // Mnemonic network.
   networks[name + "_mnemonic"] = {
     ...options,
-    provider: () => new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2)
+    provider: function() {
+      console.log(mnemonic);
+      console.log(`https://${name}.infura.io/v3/${infuraApiKey}`);
+      return new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2);
+    }
   };
 
   // Ledger has changed their standard derivation path since this library was created, so we must override the default one.
@@ -62,7 +76,9 @@ function addPublicNetwork(networks, name, networkId) {
   // Normal ledger wallet network.
   networks[name + "_ledger"] = {
     ...options,
-    provider: () => new LedgerWalletProvider(ledgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
+    provider: function() {
+      return new LedgerWalletProvider(ledgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`);
+    }
   };
 
   // The default derivation path matches the "legacy" ledger account in Ledger Live.
@@ -73,7 +89,9 @@ function addPublicNetwork(networks, name, networkId) {
   // Legacy ledger wallet network.
   networks[name + "_ledger_legacy"] = {
     ...options,
-    provider: () => new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`)
+    provider: function() {
+      return new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`);
+    }
   };
 }
 

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -28,7 +28,7 @@ const gas = undefined; // Defining this as undefined (rather than leaving undefi
 // shell environment.
 function addPublicNetwork(networks, name, networkId) {
   const options = {
-    networkCheckTimeout: 500000,
+    networkCheckTimeout: 10000,
     network_id: networkId,
     gas: gas,
     gasPrice: gasPx
@@ -156,7 +156,15 @@ addLocalNetwork(networks, "test");
 addLocalNetwork(networks, "coverage", { port: 8545, network_id: 1234 });
 
 // MetaMask truffle provider requires a longer timeout so that user has time to point web browser with metamask to localhost:3333
-addLocalNetwork(networks, "metamask", { provider: () => new MetaMaskTruffleProvider(), networkCheckTimeout: 500000 });
+addLocalNetwork(networks, "metamask", {
+  networkCheckTimeout: 500000,
+  provider: function() {
+    if (!this.singletonProvider) {
+      this.singletonProvider = new MetaMaskTruffleProvider();
+    }
+    return this.singletonProvider;
+  }
+});
 
 addLocalNetwork(networks, "mainnet-fork", { port: 8545, network_id: 1 });
 

--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -38,14 +38,15 @@ function addPublicNetwork(networks, name, networkId) {
   networks[name] = {
     ...options,
     provider: function() {
-      console.log(mnemonic);
-      console.log(`https://${name}.infura.io/v3/${infuraApiKey}`);
-      return new ManagedSecretProvider(
-        GckmsConfig,
-        `https://${name}.infura.io/v3/${infuraApiKey}`,
-        0,
-        GckmsConfig.length
-      );
+      if (!this.singletonProvider) {
+        this.singletonProvider = new ManagedSecretProvider(
+          GckmsConfig,
+          `https://${name}.infura.io/v3/${infuraApiKey}`,
+          0,
+          GckmsConfig.length
+        );
+      }
+      return this.singletonProvider;
     }
   };
 
@@ -53,7 +54,10 @@ function addPublicNetwork(networks, name, networkId) {
   networks[name + "_privatekey"] = {
     ...options,
     provider: function() {
-      return new HDWalletProvider([privateKey], `https://${name}.infura.io/v3/${infuraApiKey}`);
+      if (!this.singletonProvider) {
+        this.singletonProvider = new HDWalletProvider([privateKey], `https://${name}.infura.io/v3/${infuraApiKey}`);
+      }
+      return this.singletonProvider;
     }
   };
 
@@ -61,9 +65,10 @@ function addPublicNetwork(networks, name, networkId) {
   networks[name + "_mnemonic"] = {
     ...options,
     provider: function() {
-      console.log(mnemonic);
-      console.log(`https://${name}.infura.io/v3/${infuraApiKey}`);
-      return new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2);
+      if (!this.singletonProvider) {
+        this.singletonProvider = new HDWalletProvider(mnemonic, `https://${name}.infura.io/v3/${infuraApiKey}`, 0, 2);
+      }
+      return this.singletonProvider;
     }
   };
 
@@ -77,7 +82,13 @@ function addPublicNetwork(networks, name, networkId) {
   networks[name + "_ledger"] = {
     ...options,
     provider: function() {
-      return new LedgerWalletProvider(ledgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`);
+      if (!this.singletonProvider) {
+        this.singletonProvider = new LedgerWalletProvider(
+          ledgerOptions,
+          `https://${name}.infura.io/v3/${infuraApiKey}`
+        );
+      }
+      return this.singletonProvider;
     }
   };
 
@@ -90,7 +101,13 @@ function addPublicNetwork(networks, name, networkId) {
   networks[name + "_ledger_legacy"] = {
     ...options,
     provider: function() {
-      return new LedgerWalletProvider(legacyLedgerOptions, `https://${name}.infura.io/v3/${infuraApiKey}`);
+      if (!this.singletonProvider) {
+        this.singletonProvider = new LedgerWalletProvider(
+          legacyLedgerOptions,
+          `https://${name}.infura.io/v3/${infuraApiKey}`
+        );
+      }
+      return this.singletonProvider;
     }
   };
 }


### PR DESCRIPTION
Declaring providers using functions means that all providers will not be constructed on every truffle instantiation. Since the HDWalletProvider seems to poll blocks periodically after its construction, we were previously constructing at least 2 public network providers *per public network* for a total of 8 providers. This means that while running any sort of truffle operation, we had 8 HDWalletProviders constantly polling public networks through infura.

Note: I use a strange singleton construction in this PR because truffle calls the provider constructor method multiple times (6 times on a truffle console initialization). To prevent that from causing over-polling, we only construct the provider on the first call and then return the same provider for all calls after that.