### PR TITLE
Add prod deployment to ci

### DIFF
--- a/ci/deploy_to_staging.sh
+++ b/ci/deploy_to_staging.sh
@@ -21,11 +21,19 @@ gcloud auth activate-service-account --key-file=$GCLOUD_FNAME
 gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
 gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 
-# Copy the staging config into the voter-dapp dir
-gsutil cp gs://staging-deployment-configuration/voter-app.yaml voter-dapp/app.yaml
+# Pull down dapp configs.
+gsutil cp gs://dapp-configs/staging-voter-app.yaml voter-dapp/
+gsutil cp gs://dapp-configs/prod-voter-app.yaml voter-dapp/
 
-# Deploy voter dapp
-./scripts/deploy_dapp.sh voter-dapp voter-dapp/app.yaml -q
+# Deploy voter dapp to staging. This will immediately update the service to point traffic to this version.
+./scripts/deploy_dapp.sh voter-dapp voter-dapp/staging-voter-app.yaml -q
+
+# Upload a new prod version. --no-promote means that traffic will not be migrated to this version.
+# That will be done manually through the release process.
+./scripts/deploy_dapp.sh voter-dapp voter-dapp/prod-voter-app.yaml -q --no-promote
+
+# Clean up dapp configs
+rm -rf voter-dapp/staging-voter-app.yaml voter-dapp/prod-voter-app.yaml
 
 # Deploy docs
 ./scripts/deploy_docs.sh documentation/gae_app.yaml -q


### PR DESCRIPTION
This adds the prod deployment to ci. The prod versions that ci deploys *will not* receive traffic until they are manually promoted in GAE. This will allow for a manual release process.

Note: despite these versions not receiving traffic, they are still available at URLs like the following:
```
https://[VERSION_ID]-dot-[SERVICE_NAME]-dot-[PROJECT_NAME].df.r.appspot.com]
```

This could allow us to do prod tests against specific versions before releasing them.