### PR TITLE
Monitor logs to differentiate between liquidatedCollateral and locked collateral

### DIFF
--- a/financial-templates-lib/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyClient.js
@@ -58,7 +58,7 @@ class ExpiringMultiPartyClient {
   // Whether the given undisputed `liquidation` (`getUndisputedLiquidations` returns an array of `liquidation`s) is disputable.
   // `tokenRedemptionValue` should be the redemption value at `liquidation.time`.
   isDisputable = (liquidation, tokenRedemptionValue) => {
-    return !this._isUnderCollateralized(liquidation.numTokens, liquidation.amountCollateral, tokenRedemptionValue);
+    return !this._isUnderCollateralized(liquidation.numTokens, liquidation.liquidatedCollateral, tokenRedemptionValue);
   };
 
   // Returns an array of sponsor addresses.
@@ -101,7 +101,8 @@ class ExpiringMultiPartyClient {
           sponsor: liquidation.sponsor,
           id: id.toString(),
           numTokens: liquidation.tokensOutstanding.toString(),
-          amountCollateral: liquidation.liquidatedCollateral.toString(),
+          liquidatedCollateral: liquidation.liquidatedCollateral.toString(),
+          lockedCollateral: liquidation.lockedCollateral.toString(),
           liquidationTime: liquidation.liquidationTime,
           liquidator: liquidation.liquidator,
           disputer: liquidation.disputer

--- a/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
@@ -184,7 +184,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         sponsor: sponsor2,
         id: liquidationId.toString(),
         numTokens: toWei("45"),
-        amountCollateral: toWei("100"),
+        liquidatedCollateral: toWei("100"),
+        lockedCollateral: toWei("100"),
         liquidationTime: (await emp.getCurrentTime()).toString(),
         liquidator: sponsor1,
         disputer: zeroAddress
@@ -307,6 +308,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
 
     await emp.create({ rawValue: toWei("150") }, { rawValue: toWei("100") }, { from: sponsor1 });
     await syntheticToken.transfer(liquidator, toWei("100"), { from: sponsor1 });
+    await emp.requestWithdrawal({ rawValue: toWei("10") }, { from: sponsor1 });
 
     // Create a new liquidation for account[0]'s position.
     await emp.createLiquidation.call(
@@ -336,7 +338,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           id: "0",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
-          amountCollateral: toWei("150"),
+          liquidatedCollateral: toWei("140"), // This should `lockedCollateral` reduced by requested withdrawal amount
+          lockedCollateral: toWei("150"),
           liquidator: liquidator,
           disputer: zeroAddress
         }
@@ -360,7 +363,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           id: "0",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
-          amountCollateral: toWei("150"),
+          liquidatedCollateral: toWei("140"),
+          lockedCollateral: toWei("150"),
           liquidator: liquidator,
           disputer: zeroAddress
         }
@@ -418,7 +422,8 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
           id: "0",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
-          amountCollateral: toWei("150"),
+          liquidatedCollateral: toWei("150"),
+          lockedCollateral: toWei("150"),
           liquidator: liquidator,
           disputer: sponsor1
         }

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -140,8 +140,10 @@ class ContractMonitor {
         createEtherscanLinkMarkdown(this.web3, event.liquidator) +
         (this.monitoredLiquidators.indexOf(event.liquidator) != -1 ? " (Monitored liquidator bot)" : "") +
         " initiated liquidation for " +
+        this.formatDecimalString(event.lockedCollateral) +
+        " (liquidated collateral = " +
         this.formatDecimalString(event.liquidatedCollateral) +
-        " " +
+        ") " +
         this.collateralCurrencySymbol +
         " of sponsor " +
         createEtherscanLinkMarkdown(this.web3, event.sponsor) +
@@ -149,7 +151,7 @@ class ContractMonitor {
         this.formatDecimalString(event.tokensOutstanding) +
         " " +
         this.syntheticCurrencySymbol +
-        " tokens. Sponsor collateralization was " +
+        " tokens. Sponsor collateralization (based on 'liquidated' not 'locked' collateral) was " +
         collateralizationString +
         "%. tx: " +
         createEtherscanLinkMarkdown(this.web3, event.transactionHash);


### PR DESCRIPTION
Current slack logs do not make it clear whether liquidated collateral is the `liquidatedCollateral` or the `lockedCollateral`:

Liquidator bot's logs print `amountCollateral`, which I broke down into `liquidatedCollateral` and `lockedCollateral`:
![Screen Shot 2020-06-02 at 16 33 49](https://user-images.githubusercontent.com/9457025/83567033-f2267600-a4ee-11ea-80fc-b3f9d59f1215.png)

ContractMonitor's logs display only `liquidatedCollateral`:
![Screen Shot 2020-06-02 at 16 33 58](https://user-images.githubusercontent.com/9457025/83567065-023e5580-a4ef-11ea-9654-a6614a634512.png)


Signed-off-by: Nick Pai <npai.nyc@gmail.com>