### PR TITLE
Enhance how Liquidator/Disputer bot handle null prices returned from pricefeed

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -117,6 +117,14 @@ class Disputer {
       const disputeTime = parseInt(disputeableLiquidation.liquidationTime.toString());
       const inputPrice = this.priceFeed.getHistoricalPrice(disputeTime).toString();
 
+      if (!inputPrice) {
+        this.logger.warn({
+          at: "Disputer",
+          message: "Cannot dispute: price feed returned invalid value"
+        });
+        return;
+      }
+
       this.logger.debug({
         at: "Disputer",
         message: "Disputing liquidation",

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -171,6 +171,10 @@ contract("Disputer.js", function(accounts) {
       { from: liquidator }
     );
 
+    // Try disputing before any mocked prices are set, simulating a situation where the pricefeed
+    // fails to return a price. The disputer should fail gracefully.
+    await disputer.queryAndDispute();
+
     // Start with a mocked price of 1.75 usd per token.
     // This makes all sponsors undercollateralized, meaning no disputes are issued.
     priceFeedMock.setHistoricalPrice(toBN(toWei("1.75")));

--- a/financial-templates-lib/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyClient.js
@@ -33,6 +33,14 @@ class ExpiringMultiPartyClient {
   // result this function will return positions that are undercollateralized due to too little collateral or a withdrawal
   // that, if passed, would make the position undercollateralized.
   getUnderCollateralizedPositions = tokenRedemptionValue => {
+    if (!tokenRedemptionValue) {
+      this.logger.debug({
+        at: "ExpiringMultiPartyClient",
+        message: "Invalid params for getUnderCollateralizedPositions",
+        tokenRedemptionValue
+      });
+      return [];
+    }
     return this.positions.filter(position => {
       const collateralNetWithdrawal = this.web3.utils
         .toBN(position.amountCollateral)
@@ -58,6 +66,15 @@ class ExpiringMultiPartyClient {
   // Whether the given undisputed `liquidation` (`getUndisputedLiquidations` returns an array of `liquidation`s) is disputable.
   // `tokenRedemptionValue` should be the redemption value at `liquidation.time`.
   isDisputable = (liquidation, tokenRedemptionValue) => {
+    if (!liquidation || !liquidation.numTokens || !liquidation.amountCollateral || !tokenRedemptionValue) {
+      this.logger.debug({
+        at: "ExpiringMultiPartyClient",
+        message: "Invalid params for isDisputable",
+        liquidation,
+        tokenRedemptionValue
+      });
+      return false;
+    }
     return !this._isUnderCollateralized(liquidation.numTokens, liquidation.amountCollateral, tokenRedemptionValue);
   };
 

--- a/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
@@ -435,4 +435,51 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
     await client.update();
     assert.deepStrictEqual([], client.getDisputedLiquidations().sort());
   });
+
+  describe("Unit tests: isDisputable", function() {
+    beforeEach(async function() {
+      await client.update();
+    });
+
+    it("Liquidation is disputable", async function() {
+      const liquidationMock = {
+        numTokens: toWei("1"),
+        amountCollateral: toWei("2")
+      };
+      const tokenRedemptionValue = toWei("1");
+      assert.isTrue(await client.isDisputable(liquidationMock, tokenRedemptionValue));
+    });
+
+    it("Liquidation is not disputable", async function() {
+      const liquidationMock = {
+        numTokens: toWei("1"),
+        amountCollateral: toWei("2")
+      };
+      const tokenRedemptionValue = toWei("2");
+      assert.isFalse(await client.isDisputable(liquidationMock, tokenRedemptionValue));
+    });
+
+    it("Missing liquidation object: Liquidation is not disputable", async function() {
+      const tokenRedemptionValue = toWei("2");
+      assert.isFalse(await client.isDisputable(null, tokenRedemptionValue));
+    });
+
+    it("Missing TRV: Liquidation is not disputable", async function() {
+      const liquidationMock = {
+        numTokens: toWei("1"),
+        amountCollateral: toWei("2")
+      };
+      assert.isFalse(await client.isDisputable(liquidationMock, null));
+    });
+  });
+
+  describe("Unit tests: getUnderCollateralizedPositions", function() {
+    beforeEach(async function() {
+      await client.update();
+    });
+
+    it("Missing TRV: returns empty array", async function() {
+      assert.deepEqual(await client.getUnderCollateralizedPositions(null), []);
+    });
+  });
 });


### PR DESCRIPTION
- Handles gracefully `null` prices from pricefeed in bot clients
- EMPClient (a bot dependency) handles `null` TRV parameters for `isDisputable` and `getUndercollateralizedPositions` calls
- Unit tests for EMPClient

Signed-off-by: Nick Pai <npai.nyc@gmail.com>