### PR TITLE
Pull EMP parameters from parent in monitor bot

### DIFF
--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -13,7 +13,7 @@ class BalanceMonitor {
   //   syntheticThreshold: x2,
   //   etherThreshold: x3 },
   // ...]
-  constructor(logger, tokenBalanceClient, botsToMonitor) {
+  constructor(logger, tokenBalanceClient, botsToMonitor, empProps) {
     this.logger = logger;
 
     // Instance of the tokenBalanceClient to read account balances from last change update.
@@ -23,14 +23,10 @@ class BalanceMonitor {
     // Bot addresses and thresholds to monitor.
     this.botsToMonitor = botsToMonitor;
 
+    // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId.
+    this.empProps = empProps;
+
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
-
-    // TODO: replace this with a fetcher that pulls the actual collateral token symbol
-    this.collateralCurrencySymbol = "DAI";
-    this.syntheticCurrencySymbol = "ETHBTC";
-
-    // TODO: pull this into the parent client
-    this.networkId = 1;
   }
 
   // Queries all bot ballance for collateral, synthetic and ether against specified thresholds
@@ -52,7 +48,7 @@ class BalanceMonitor {
             bot,
             bot.collateralThreshold,
             this.client.getCollateralBalance(bot.address),
-            this.collateralCurrencySymbol,
+            this.empProps.collateralCurrencySymbol,
             "collateral"
           )
         });
@@ -65,7 +61,7 @@ class BalanceMonitor {
             bot,
             bot.syntheticThreshold,
             this.client.getSyntheticBalance(bot.address),
-            this.syntheticCurrencySymbol,
+            this.empProps.syntheticCurrencySymbol,
             "synthetic"
           )
         });
@@ -90,7 +86,7 @@ class BalanceMonitor {
     return (
       bot.name +
       " (" +
-      createEtherscanLinkMarkdown(bot.address, this.networkId) +
+      createEtherscanLinkMarkdown(bot.address, this.empProps.networkId) +
       ") " +
       tokenName +
       " balance is less than " +

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -31,7 +31,7 @@ class CRMonitor {
 
     // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId.
     this.empProps = empProps;
-    
+
     // Helper functions from web3.
     this.toBN = this.web3.utils.toBN;
     this.toWei = this.web3.utils.toWei;

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -15,7 +15,7 @@ class CRMonitor {
    *                  ...];
    * @param {Object} priceFeed offchain price feed used to track the token price.
    */
-  constructor(logger, expiringMultiPartyClient, walletsToMonitor, priceFeed) {
+  constructor(logger, expiringMultiPartyClient, walletsToMonitor, priceFeed, empProps) {
     this.logger = logger;
 
     this.empClient = expiringMultiPartyClient;
@@ -29,12 +29,8 @@ class CRMonitor {
 
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
 
-    // TODO: replace this with a fetcher that pulls the actual collateral token symbol
-    this.collateralCurrencySymbol = "DAI";
-    this.syntheticCurrencySymbol = "ETHBTC";
-
-    // TODO: pull this into the parent client
-    this.networkId = 1;
+    // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId.
+    this.empProps = empProps;
   }
 
   // Queries all monitored wallet ballance for collateralization ratio against a given threshold.
@@ -93,13 +89,13 @@ class CRMonitor {
         const mrkdwn =
           wallet.name +
           " (" +
-          createEtherscanLinkMarkdown(wallet.address, this.networkId) +
+          createEtherscanLinkMarkdown(wallet.address, this.empProps.networkId) +
           ") collateralization ratio has dropped to " +
           this.formatDecimalString(positionCR.muln(100)) + // Scale up the CR threshold by 100 to become a percentage
           "% which is below the " +
           wallet.crAlert * 100 +
           "% threshold. Current value of " +
-          this.syntheticCurrencySymbol +
+          this.empProps.syntheticCurrencySymbol +
           " is " +
           this.formatDecimalString(price) +
           ". The collateralization requirement is " +

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -1,7 +1,7 @@
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
 
 class ContractMonitor {
-  constructor(logger, expiringMultiPartyEventClient, contractMonitorConfigObject, priceFeed) {
+  constructor(logger, expiringMultiPartyEventClient, contractMonitorConfigObject, priceFeed, empProps) {
     this.logger = logger;
 
     // Bot and ecosystem accounts to monitor. Will inform the console logs when events are detected from these accounts.
@@ -22,15 +22,9 @@ class ContractMonitor {
     this.lastDisputeSettlementBlockNumber = 0;
     this.lastNewSponsorBlockNumber = 0;
 
-    // Contract constants
-    // TODO: replace this with an actual query to the collateral currency symbol
-    this.collateralCurrencySymbol = "DAI";
-    this.syntheticCurrencySymbol = "ETHBTC";
+    // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId
+    this.empProps = empProps;
 
-    // TODO: pull this into the parent client
-    this.networkId = 1;
-
-    // TODO: get the decimals of the collateral currency and use this to scale the output appropriately for non 1e18 colat
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
   }
 
@@ -76,18 +70,18 @@ class ContractMonitor {
       // New sponsor alert: [ethereum address if third party, or “UMA” if it’s our bot]
       // created X tokens backed by Y collateral.  [etherscan link to txn]
       const mrkdwn =
-        createEtherscanLinkMarkdown(event.sponsor, this.networkId) +
+        createEtherscanLinkMarkdown(event.sponsor, this.empProps.networkId) +
         (isMonitoredBot ? " (Monitored liquidator or disputer bot)" : "") +
         " created " +
         this.formatDecimalString(event.tokenAmount) +
         " " +
-        this.syntheticCurrencySymbol +
+        this.empProps.syntheticCurrencySymbol +
         " backed by " +
         this.formatDecimalString(event.collateralAmount) +
         " " +
-        this.collateralCurrencySymbol +
+        this.empProps.collateralCurrencySymbol +
         ". tx: " +
-        createEtherscanLinkMarkdown(event.transactionHash, this.networkId);
+        createEtherscanLinkMarkdown(event.transactionHash, this.empProps.networkId);
 
       this.logger.info({
         at: "ContractMonitor",
@@ -140,22 +134,22 @@ class ContractMonitor {
       // initiated liquidation for for [x][collateral currency]of sponsor collateral
       // backing[n] tokens - sponsor collateralization was[y] %.  [etherscan link to txn]
       const mrkdwn =
-        createEtherscanLinkMarkdown(event.liquidator, this.networkId) +
+        createEtherscanLinkMarkdown(event.liquidator, this.empProps.networkId) +
         (this.monitoredLiquidators.indexOf(event.liquidator) != -1 ? " (Monitored liquidator bot)" : "") +
         " initiated liquidation for " +
         this.formatDecimalString(event.liquidatedCollateral) +
         " " +
-        this.collateralCurrencySymbol +
+        this.empProps.collateralCurrencySymbol +
         " of sponsor " +
-        createEtherscanLinkMarkdown(event.sponsor, this.networkId) +
+        createEtherscanLinkMarkdown(event.sponsor, this.empProps.networkId) +
         " collateral backing " +
         this.formatDecimalString(event.tokensOutstanding) +
         " " +
-        this.syntheticCurrencySymbol +
+        this.empProps.syntheticCurrencySymbol +
         " tokens. Sponsor collateralization was " +
         collateralizationString +
         "%. tx: " +
-        createEtherscanLinkMarkdown(event.transactionHash, this.networkId);
+        createEtherscanLinkMarkdown(event.transactionHash, this.empProps.networkId);
 
       this.logger.info({
         at: "ContractMonitor",
@@ -183,17 +177,17 @@ class ContractMonitor {
       // Dispute alert: [ethereum address if third party, or “UMA” if it’s our bot]
       // initiated dispute [etherscan link to txn]
       const mrkdwn =
-        createEtherscanLinkMarkdown(event.disputer, this.networkId) +
+        createEtherscanLinkMarkdown(event.disputer, this.empProps.networkId) +
         (this.monitoredDisputers.indexOf(event.disputer) != -1 ? " (Monitored dispute bot)" : "") +
         " initiated dispute against liquidator " +
-        createEtherscanLinkMarkdown(event.liquidator, this.networkId) +
+        createEtherscanLinkMarkdown(event.liquidator, this.empProps.networkId) +
         (this.monitoredLiquidators.indexOf(event.liquidator) != -1 ? " (Monitored liquidator bot)" : "") +
         " with a dispute bond of " +
         this.formatDecimalString(event.disputeBondAmount) +
         " " +
-        this.collateralCurrencySymbol +
+        this.empProps.collateralCurrencySymbol +
         ". tx: " +
-        createEtherscanLinkMarkdown(event.transactionHash, this.networkId);
+        createEtherscanLinkMarkdown(event.transactionHash, this.empProps.networkId);
 
       this.logger.info({
         at: "ContractMonitor",
@@ -225,15 +219,15 @@ class ContractMonitor {
       // it’s our bot]has resolved as [success or failed] [etherscan link to txn]
       const mrkdwn =
         "Dispute between liquidator " +
-        createEtherscanLinkMarkdown(event.liquidator, this.networkId) +
+        createEtherscanLinkMarkdown(event.liquidator, this.empProps.networkId) +
         (this.monitoredLiquidators.indexOf(event.liquidator) != -1 ? "(Monitored liquidator bot)" : "") +
         " and disputer " +
-        createEtherscanLinkMarkdown(event.disputer, this.networkId) +
+        createEtherscanLinkMarkdown(event.disputer, this.empProps.networkId) +
         (this.monitoredDisputers.indexOf(event.disputer) != -1 ? "(Monitored dispute bot)" : "") +
         " has been resolved as " +
         (event.disputeSucceeded == true ? "success" : "failed") +
         ". tx: " +
-        createEtherscanLinkMarkdown(event.transactionHash, this.networkId);
+        createEtherscanLinkMarkdown(event.transactionHash, this.empProps.networkId);
       this.logger.info({
         at: "ContractMonitor",
         message: "Dispute Settlement Alert 👮‍♂️!",

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -10,7 +10,7 @@ class SyntheticPegMonitor {
    * @param {Object} medianizerPriceFeed Module used to query the median price among selected price feeds.
    * @param {Object} [config] Contains fields with which constructor will attempt to override defaults.
    */
-  constructor(logger, web3, uniswapPriceFeed, medianizerPriceFeed, config) {
+  constructor(logger, web3, uniswapPriceFeed, medianizerPriceFeed, config, empProps) {
     this.logger = logger;
 
     // Instance of price feeds used to check for deviation of synthetic token price.
@@ -19,13 +19,9 @@ class SyntheticPegMonitor {
 
     this.web3 = web3;
 
-    // Contract constants
-    // TODO: replace this with an actual query to the collateral currency symbol
-    this.collateralCurrencySymbol = "DAI";
-    this.syntheticCurrencySymbol = "ETHBTC";
-    this.pricefeedIdentifierName = "ETHBTC/DAI";
+    // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId.
+    this.empProps = empProps;
 
-    // TODO: get the decimals of the collateral currency and use this to scale the output appropriately for non 1e18 colat
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
 
     // Default config settings. SyntheticPegMonitor deployer can override these settings by passing in new
@@ -90,7 +86,7 @@ class SyntheticPegMonitor {
         message: "Synthetic off peg alert 😵",
         mrkdwn:
           "Synthetic token " +
-          this.syntheticCurrencySymbol +
+          this.empProps.syntheticCurrencySymbol +
           " is trading at " +
           this.formatDecimalString(uniswapTokenPrice) +
           " on Uniswap. Target price is " +
@@ -143,7 +139,7 @@ class SyntheticPegMonitor {
         message: "High peg price volatility alert 🌋",
         mrkdwn:
           "Latest updated " +
-          this.pricefeedIdentifierName +
+          this.empProps.priceIdentifier +
           " price is " +
           this.formatDecimalString(pricefeedLatestPrice) +
           ". Price moved " +
@@ -196,7 +192,7 @@ class SyntheticPegMonitor {
         message: "High synthetic price volatility alert 🌋",
         mrkdwn:
           "Latest updated " +
-          this.pricefeedIdentifierName +
+          this.empProps.priceIdentifier +
           " price is " +
           this.formatDecimalString(pricefeedLatestPrice) +
           ". Price moved " +

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -63,7 +63,7 @@ async function run(
     const syntheticTokenAddress = await emp.tokenCurrency();
     const syntheticToken = await ExpandedERC20.at(syntheticTokenAddress);
 
-    // Generate EMP properties to inform logs in modules like the token symbols.
+    // Generate EMP properties to inform monitor modules of important info like token symbols and price identifier.
     const empProps = {
       collateralCurrencySymbol: await collateralToken.symbol(),
       syntheticCurrencySymbol: await syntheticToken.symbol(),

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -71,8 +71,6 @@ async function run(
       networkId: await web3.eth.net.getId()
     };
 
-    console.log("EMPPROPOS", empProps);
-
     // Setup medianizer price feed.
     const getTime = () => Math.round(new Date().getTime() / 1000);
     const medianizerPriceFeed = await createPriceFeed(

--- a/monitors/test/BalanceMonitor.js
+++ b/monitors/test/BalanceMonitor.js
@@ -43,8 +43,7 @@ contract("BalanceMonitor.js", function(accounts) {
       Token.abi,
       web3,
       collateralToken.address,
-      syntheticToken.address,
-      10
+      syntheticToken.address
     );
 
     // Create two bot objects to monitor a liquidator bot with a lot of tokens and Eth and a disputer with less.
@@ -65,7 +64,14 @@ contract("BalanceMonitor.js", function(accounts) {
       }
     ];
 
-    balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, botMonitorObject);
+    const empProps = {
+      collateralCurrencySymbol: await collateralToken.symbol(),
+      syntheticCurrencySymbol: await syntheticToken.symbol(),
+      priceIdentifier: "ETH/BTC",
+      networkId: await web3.eth.net.getId()
+    };
+
+    balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, botMonitorObject, empProps);
 
     // setup the positions to the initial happy state.
     // Liquidator threshold is 10000 for both collateral and synthetic so mint a bit more to start above this

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -1,4 +1,4 @@
-const { toWei, toBN } = web3.utils;
+const { toWei, toBN, hexToUtf8 } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
 const { interfaceName } = require("../../core/utils/Constants.js");
@@ -62,10 +62,10 @@ contract("ContractMonitor.js", function(accounts) {
   const spy = sinon.spy();
 
   before(async function() {
-    collateralToken = await Token.new("Dai Stable coin", "Dai", 18, { from: tokenSponsor });
+    collateralToken = await Token.new("Dai Stable coin", "DAI", 18, { from: tokenSponsor });
 
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(web3.utils.utf8ToHex("UMATEST"));
+    await identifierWhitelist.addSupportedIdentifier(web3.utils.utf8ToHex("ETH/BTC"));
 
     // Create a mockOracle and finder. Register the mockOracle with the finder.
     finder = await Finder.deployed();
@@ -88,9 +88,9 @@ contract("ContractMonitor.js", function(accounts) {
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,
       timerAddress: Timer.address,
-      priceFeedIdentifier: web3.utils.utf8ToHex("UMATEST"),
+      priceFeedIdentifier: web3.utils.utf8ToHex("ETH/BTC"),
       syntheticName: "Test UMA Token",
-      syntheticSymbol: "UMATEST",
+      syntheticSymbol: "ETHBTC",
       liquidationLiveness: "10",
       collateralRequirement: { rawValue: toWei("1.5") },
       disputeBondPct: { rawValue: toWei("0.1") },
@@ -113,9 +113,16 @@ contract("ContractMonitor.js", function(accounts) {
     // Define a configuration object. In this config only monitor one liquidator and one disputer.
     const contractMonitorConfig = { monitoredLiquidators: [liquidator], monitoredDisputers: [disputer] };
 
-    contractMonitor = new ContractMonitor(spyLogger, eventClient, contractMonitorConfig, priceFeedMock);
-
     syntheticToken = await Token.at(await emp.tokenCurrency());
+
+    const empProps = {
+      collateralCurrencySymbol: await collateralToken.symbol(),
+      syntheticCurrencySymbol: await syntheticToken.symbol(),
+      priceIdentifier: hexToUtf8(await emp.priceIdentifier()),
+      networkId: await web3.eth.net.getId()
+    };
+
+    contractMonitor = new ContractMonitor(spyLogger, eventClient, contractMonitorConfig, priceFeedMock, empProps);
 
     await collateralToken.addMember(1, tokenSponsor, {
       from: tokenSponsor
@@ -307,7 +314,7 @@ contract("ContractMonitor.js", function(accounts) {
     // Push a price such that the dispute fails and ensure the resolution reports correctly. Sponsor1 has 50 units of
     // debt and 150 units of collateral. price of 2.5: 150 / (50 * 2.5) = 120% => undercollateralized
     let disputePrice = toWei("2.5");
-    await mockOracle.pushPrice(web3.utils.utf8ToHex("UMATEST"), liquidationTime, disputePrice);
+    await mockOracle.pushPrice(web3.utils.utf8ToHex("ETH/BTC"), liquidationTime, disputePrice);
 
     // Withdraw from liquidation to settle the dispute event.
     const txObject1 = await emp.withdrawLiquidation("0", sponsor1, { from: liquidator });
@@ -350,7 +357,7 @@ contract("ContractMonitor.js", function(accounts) {
     // Push a price such that the dispute succeeds and ensure the resolution reports correctly. Sponsor2 has 45 units of
     // debt and 175 units of collateral. price of 2.0: 175 / (45 * 2) = 194% => sufficiently collateralized
     disputePrice = toWei("2.0");
-    await mockOracle.pushPrice(web3.utils.utf8ToHex("UMATEST"), liquidationTime, disputePrice);
+    await mockOracle.pushPrice(web3.utils.utf8ToHex("ETH/BTC"), liquidationTime, disputePrice);
 
     // Withdraw from liquidation to settle the dispute event.
     const txObject2 = await emp.withdrawLiquidation("0", sponsor2, { from: sponsor2 });

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -40,12 +40,21 @@ contract("SyntheticPegMonitor", function(accounts) {
       syntheticPegMonitorConfig = {
         deviationAlertThreshold: 0.2 // Any deviation larger than 0.2 should fire an alert
       };
+
+      const empProps = {
+        collateralCurrencySymbol: "DAI",
+        syntheticCurrencySymbol: "ETHBTC",
+        priceIdentifier: "ETH/BTC",
+        networkId: await web3.eth.net.getId()
+      };
+
       syntheticPegMonitor = new SyntheticPegMonitor(
         spyLogger,
         web3,
         uniswapPriceFeedMock,
         medianizerPriceFeedMock,
-        syntheticPegMonitorConfig
+        syntheticPegMonitorConfig,
+        empProps
       );
     });
 
@@ -132,12 +141,20 @@ contract("SyntheticPegMonitor", function(accounts) {
         // correctly by Logger.
         volatilityAlertThreshold: 0.3
       };
+
+      const empProps = {
+        collateralCurrencySymbol: "DAI",
+        syntheticCurrencySymbol: "ETHBTC",
+        priceIdentifier: "ETH/BTC",
+        networkId: await web3.eth.net.getId()
+      };
       syntheticPegMonitor = new SyntheticPegMonitor(
         spyLogger,
         web3,
         uniswapPriceFeedMock,
         medianizerPriceFeedMock,
-        syntheticPegMonitorConfig
+        syntheticPegMonitorConfig,
+        empProps
       );
     });
 


### PR DESCRIPTION
This PR refactors the monitor bot to pull the 1) `collateralCurrencySymbol` 2) `syntheticCurrencySymbol` 3) `priceIdentifierName` and 4) `networkId` from the base monitor instance.

Close: #1417