### PR TITLE
Add CR requirement, estimated price at liquidation time, and max disputable price to ContractMonitor reporting of liquidation events

### DIFF
--- a/common/FormattingUtils.js
+++ b/common/FormattingUtils.js
@@ -45,10 +45,10 @@ const formatWithMaxDecimals = (num, decimalPlaces, minPrecision, roundUp) => {
 
   const fullPrecisionFloat = BigNumber(num);
   let fixedPrecisionFloat;
-  // Convert back to BN to truncate any trailing 0s that the toFixed() output would print. If the number is larger than
+  // Convert back to BN to truncate any trailing 0s that the toFixed() output would print. If the number is equal to or larger than
   // 1 then truncate to `decimalPlaces` number of decimal places. EG 999.999 -> 999.99 with decimalPlaces=2 If the number
   // is less than 1 then truncate to minPrecision precision. EG: 0.0022183471 -> 0.002218 with minPrecision=4
-  if (fullPrecisionFloat.abs().gt(BigNumber(1))) {
+  if (fullPrecisionFloat.abs().gte(BigNumber(1))) {
     fixedPrecisionFloat = BigNumber(fullPrecisionFloat)
       .toFixed(decimalPlaces)
       .toString();

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -209,7 +209,7 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "150.00")); // locked collateral amount of 150
     assert.isTrue(lastSpyLogIncludes(spy, "50.00")); // tokens liquidated
     assert.isTrue(lastSpyLogIncludes(spy, "150.00%")); // cr requirement %
-    assert.isTrue(lastSpyLogIncludes(spy, "1.000")); // estimated price at liquidation time
+    assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // estimated price at liquidation time
     assert.isTrue(lastSpyLogIncludes(spy, "1.86")); // maximum price for liquidation to be disputable
 
     // Liquidate another position and ensure the Contract monitor emits the correct params
@@ -234,7 +234,7 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "175.00")); // liquidated & locked collateral: 175
     assert.isTrue(lastSpyLogIncludes(spy, "45.00")); // tokens liquidated
     assert.isTrue(lastSpyLogIncludes(spy, "150.00%")); // cr requirement %
-    assert.isTrue(lastSpyLogIncludes(spy, "1.000")); // estimated price at liquidation time
+    assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // estimated price at liquidation time
     assert.isTrue(lastSpyLogIncludes(spy, "2.59")); // maximum price for liquidation to be disputable
   });
   it("Winston correctly emits dispute events", async function() {

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -207,6 +207,10 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "280.00%")); // expected collateralization ratio of 280%
     assert.isTrue(lastSpyLogIncludes(spy, "140.00")); // liquidated collateral amount of 150 - 10
     assert.isTrue(lastSpyLogIncludes(spy, "150.00")); // locked collateral amount of 150
+    assert.isTrue(lastSpyLogIncludes(spy, "50.00")); // tokens liquidated
+    assert.isTrue(lastSpyLogIncludes(spy, "150.00%")); // cr requirement %
+    assert.isTrue(lastSpyLogIncludes(spy, "1.000")); // estimated price at liquidation time
+    assert.isTrue(lastSpyLogIncludes(spy, "1.86")); // maximum price for liquidation to be disputable
 
     // Liquidate another position and ensure the Contract monitor emits the correct params
     const txObject2 = await emp.createLiquidation(
@@ -228,6 +232,10 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.tx}`));
     assert.isTrue(lastSpyLogIncludes(spy, "388.88%")); // expected collateralization ratio: 175 / (45 * 1) = 388.88%
     assert.isTrue(lastSpyLogIncludes(spy, "175.00")); // liquidated & locked collateral: 175
+    assert.isTrue(lastSpyLogIncludes(spy, "45.00")); // tokens liquidated
+    assert.isTrue(lastSpyLogIncludes(spy, "150.00%")); // cr requirement %
+    assert.isTrue(lastSpyLogIncludes(spy, "1.000")); // estimated price at liquidation time
+    assert.isTrue(lastSpyLogIncludes(spy, "2.59")); // maximum price for liquidation to be disputable
   });
   it("Winston correctly emits dispute events", async function() {
     // Create liquidation to dispute.


### PR DESCRIPTION
New proposed message for each liquidation detected by `ContractMonitor`:

```
{
    at: 'ContractMonitor',
    message: 'Liquidation Alert 🧙‍♂️!',
    mrkdwn: "<https://etherscan.io/address/0x887f4CB8F229ABf9F7808c78e3f57b4E674349da|0x887...4349d> (Monitored liquidator bot) initiated liquidation for 150.00 (liquidated collateral = 140.00) DAI of sponsor <https://etherscan.io/address/0xE405e4cb525857202324171c008Ec947C6742a6A|0xE40...742a6> collateral backing 50.00 ETHBTC tokens. Sponsor collateralization ('liquidatedCollateral / tokensOutsanding') was 280.00%, using 1.000 as the estimated price at liquidation time. With a collateralization requirement of 150.00%, this liquidation would be disputable at a price below 1.86. tx: <https://etherscan.io/tx/0x78b38f1481b88bc596274e5dea885649c8b239afd1b45d4ac67b7a21549665bf|0x78b...9665b>",
    level: 'info',
 
```
Signed-off-by: Nick Pai <npai.nyc@gmail.com>