### PR TITLE
Update bot deployment script to pull config from GCP bucket and check service account

### DIFF
--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -30,7 +30,7 @@ echo "📄 Bot service account found @" $serviceAccountEmail
 echo "🤖 Pulling bot config from GCP bucket"
 
 # Create a temp file to store the config. This will be cleaned up by the OS.
-tempFile=$(mktemp /tmp/UMA.XXXXXXXXX)
+tempFile=$(mktemp -t UMA)
 
 # Copy config files from GCP to the temp file
 gsutil cp gs://bot-configs/$1.env $tempFile

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
 set -e
 
-if [ $# -ne 3 ]; then
-    echo "Incorrect number of arguments supplied! First argument is bot's name. Second argument is path to config file. Third is the service account the bot should run as."
-    echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot ./ethbtc-monitor-bot-env.txt ethbtc-account@project-name.iam.gserviceaccount.com"
+if [ $# -ne 1 ]; then
+    echo "Incorrect number of arguments supplied! First and only argument is bot's name.From this the bot's config and service account will be inferred."
+    echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot"
     exit 1
 fi
 
 echo "Deploying" $1
-echo "Using ENV file:" $2
-echo "Running as Service Account:" $3
-gcloud compute instances create-with-container $1 \
-    --container-image docker.io/umaprotocol/protocol:latest \
-    --container-env-file $2 \
-    --zone northamerica-northeast1-b \
-    --container-restart-policy on-failure \
-    --container-stdin \
-    --service-account $3 \
-    --scopes cloud-platform
+
+paramToServiceAccount=$(echo $1 | cut -d'-' -f 1,3)
+serviceAccountEmail=""
+
+# Loop through all service accounts in GCP and validate that the provided bot name matches to a service account email.
+for serviceAccount in $(gcloud iam service-accounts list --format="value(EMAIL)"); do
+    if [ $paramToServiceAccount == $(echo $serviceAccount | cut -d'@' -f 1) ]; then
+        serviceAccountEmail=$serviceAccount
+    fi
+done
+
+if [ $serviceAccountEmail == "" ]; then
+    echo "Bot name provided does not match to a service account."
+    exit 1
+fi
+
+gsutil cp gs://bot-configs/$1.env ./.tempConfig
+
+echo $serviceAccountEmail

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -2,13 +2,15 @@
 set -e
 
 if [ $# -ne 1 ]; then
-    echo "Incorrect number of arguments supplied! First and only argument is bot's name.From this the bot's config and service account will be inferred."
+    echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config and service account will be inferred."
     echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot"
     exit 1
 fi
 
-echo "Deploying" $1
+echo "🔥Starting deployment script for bot" $1
 
+# Bot names are <identifer>-<network>-<bot-type>. EG: ethbtc-liquidator-mainnet.
+# This cut removes the network as this is not included in a service account. ethbtc-liquidator-mainnet becomes ethbtc-liquidator
 paramToServiceAccount=$(echo $1 | cut -d'-' -f 1,3)
 serviceAccountEmail=""
 
@@ -24,6 +26,23 @@ if [ $serviceAccountEmail == "" ]; then
     exit 1
 fi
 
-gsutil cp gs://bot-configs/$1.env ./.tempConfig
+echo "Bot service account found @ " $serviceAccountEmail
+echo "Pulling bot config from GCP bucket"
 
-echo $serviceAccountEmail
+gsutil cp gs://bot-configs/$1.env ~/.tempUMAConfig
+
+echo "Config has been pulled and placed in your home directory."
+
+echo "🚀Deploying bot to GCP"
+gcloud compute instances create-with-container $1 \
+    --container-image docker.io/umaprotocol/protocol:latest \
+    --container-env-file ~/.tempUMAConfig \
+    --zone northamerica-northeast1-b \
+    --container-restart-policy on-failure \
+    --container-stdin \
+    --service-account $serviceAccountEmail \
+    --scopes cloud-platform
+
+echo "🎉Bot deployed! Removing local config file"
+
+rm ~/.tempUMAConfig


### PR DESCRIPTION
This PR overhalls the `./scripts/bot-deployment/DeployBotGCP.sh` to only take in one parameter: the bots name. From this, the script finds an associated service account and pulls down the relevant bot config file. If either the name provided does not match a service account or there is no config for the name provided then the script will not deploy anything. This ensures that the user always deploys an up to date config and that the associated service account is correct.