### PR TITLE
Enable option for daily reporter to send output to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ app.yaml
 
 # environment-specific values pulled by dotenv package
 .env
+
+# Logs created by reporter module
+dailyreport.log

--- a/common/StreamUtils.js
+++ b/common/StreamUtils.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+
+/**
+ * @notice Redirects the process.stdout stream to a file.
+ * @param {String} logFilePath Relative path to file to redirect output to.
+ * @return Stream object (https://nodejs.org/api/stream.html#stream_stream)
+ */
+const redirectStdOutToFile = logFilePath => {
+  try {
+    const stream = fs.createWriteStream(logFilePath);
+    process.stdout.write = stream.write.bind(stream);
+    return stream;
+  } catch (err) {
+    console.error("Something failed when redirecting process.stdout to file", err);
+  }
+};
+
+module.exports = {
+  redirectStdOutToFile
+};


### PR DESCRIPTION
The high-level context is that we want the daily reporter script (`$(npm bin)/truffle exec ../reporters/index.js --network mainnet`) to send output to a Slack log. The script should be callable by a downstream cron job.

The first step that I am working on is to redirect all `console.log` output (which sends data to the `process.stdout` stream) to a file. We want to do this because it minimizes code churn in `reporters/` and we want to take advantage of the nicely formatted `console.table` display for tabled data. The follow-up feature would be to upload this file to Slack.

So far, I've created a function `redirectStdOutToFile` that when called redirects all `process.stdout` data to a specified file. `/reporters/index.js` will call `redirectStdOutToFile` before instructing the reporters to print their reports to `stdout`, wait for those async reports to end, signal to the file stream that it should expect no further data, and finally exit the process once that signal is sent.

This all works, but the output sent to the file stream is ugly/unusable in its current form, which indicates that the terminal application/shell does a fair amount of processing on the `stdout` data:

[example output](https://gist.github.com/nicholaspai/fb8fe52f84f93e29497b04e4891f6da6)

Part of #1564 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>