### PR TITLE
Programmatically verify file upload success for daily report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ app.yaml
 
 # environment-specific values pulled by dotenv package
 .env
+
+# daily reporter temp files.
+response.json
+*daily-report.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY . ./
 
 # Install dependencies and compile contracts.
 RUN apt-get update
-RUN apt-get install -y libudev-dev libusb-1.0-0-dev
+RUN apt-get install -y libudev-dev libusb-1.0-0-dev jq
 RUN npm install
 RUN scripts/buildContracts.sh
 

--- a/reporters/SendSlackReport.sh
+++ b/reporters/SendSlackReport.sh
@@ -41,7 +41,12 @@ if [ "$uploadSuccess" = true ] ; then
 else
     error=$(cat $responseFileName | jq '.error')
     echo "Failed to upload file! Error description:" $error
+    rm $fileName
+    exit 1
 fi
 
 echo "Cleaning up and removing files"
 rm $fileName
+
+# Exit with success state
+exit 0

--- a/reporters/SendSlackReport.sh
+++ b/reporters/SendSlackReport.sh
@@ -26,8 +26,20 @@ message_title=$date" Daily Report"
 pathToFile="./"$fileName
 
 # Send a curl command to upload the file along with a message to the channel.
+# We'll store the response data in a file to verify that it was uploaded properly.
 echo "Sending file as slack message"
-curl https://slack.com/api/files.upload -F token="${SLACK_TOKEN}" -F channels="${SLACK_CHANNEL}" -F title="${message_title}" -F fileName="${fileName}" -F file=@"${pathToFile}"
+responseFile="response.json"
+curl https://slack.com/api/files.upload -F token="${SLACK_TOKEN}" -F channels="${SLACK_CHANNEL}" -F title="${message_title}" -F fileName="${fileName}" -F file=@"${pathToFile}" > $responseFile
 
-echo "Cleaning up and removing file"
+# Verify that the 'ok' property of the response data is "true".
+uploadSuccess=$(cat $responseFile | jq '.ok')
+if [ "$uploadSuccess" = true ] ; then
+    echo 'File upload succeeded!'
+else
+    echo 'File upload failed!'
+    # Do something here
+fi
+
+echo "Cleaning up and removing files"
 rm $fileName
+rm $responseFile


### PR DESCRIPTION
[Slack API](https://api.slack.com/methods/files.upload) is expected to respond `{ok:true,...}` if the upload was successful, we can verify that. We'll print out file type and size if successful.

New dockerfile requirement:
- Installs [jq](https://stedolan.github.io/jq/) which is `sed` for JSON data

Other update
- Add report to `.gitignore` in case they are not properly deleted (i.e. if script stops for whatever reason)
- log response.json in a local file we can use to debug

Signed-off-by: Nick Pai <npai.nyc@gmail.com>