### PR TITLE
CLI needs to construct salt the same way that dApp does

### DIFF
--- a/common/VotingUtils.js
+++ b/common/VotingUtils.js
@@ -4,8 +4,9 @@ const {
   deriveKeyPairFromSignatureTruffle,
   deriveKeyPairFromSignatureMetamask
 } = require("./Crypto");
-const { getKeyGenMessage, computeTopicHash, computeVoteHash } = require("./EncryptionHelper");
+const { getKeyGenMessage, computeVoteHash } = require("./EncryptionHelper");
 const { BATCH_MAX_COMMITS, BATCH_MAX_RETRIEVALS, BATCH_MAX_REVEALS } = require("./Constants");
+const { getRandomUnsignedInt } = require("./Random.js");
 
 const argv = require("minimist")(process.argv.slice());
 
@@ -47,7 +48,7 @@ const getVotingRoles = (account, voting, designatedVoting) => {
  */
 const constructCommitment = async (request, roundId, web3, price, signingAccount, votingAccount) => {
   const priceWei = web3.utils.toWei(price.toString());
-  const salt = web3.utils.toBN(web3.utils.randomHex(32));
+  const salt = getRandomUnsignedInt().toString();
   const hash = computeVoteHash({
     price: priceWei,
     salt,
@@ -101,7 +102,7 @@ const constructReveal = async (request, roundId, web3, signingAccount, votingCon
     identifier: request.identifier,
     time: request.time,
     price: vote.price.toString(),
-    salt: web3.utils.hexToNumberString("0x" + vote.salt.toString())
+    salt: vote.salt
   };
 };
 

--- a/core/scripts/cli/cli.js
+++ b/core/scripts/cli/cli.js
@@ -4,6 +4,7 @@ const sponsor = require("./sponsor");
 const style = require("./textStyle");
 const wallet = require("./wallet");
 const admin = require("./admin.js");
+const vote = require("./vote");
 
 const ACTIONS = {
   wallet: "Wallet",
@@ -42,10 +43,7 @@ async function run() {
         await wallet(web3, artifacts);
         break;
       case ACTIONS.vote:
-        console.log(
-          `${style.help(`Voting through the CLI is currently unstable due to incompatible encryption/decryption
-           between browser and Node.js, please use the dApp at vote.umaproject.org instead.`)}`
-        );
+        await vote(web3, artifacts);
         break;
       case ACTIONS.sponsor:
         await sponsor(web3, artifacts);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "bip39": "^3.0.2",
     "chalk-pipe": "^3.0.0",
     "dotenv": "^6.2.0",
-    "eth-crypto": "^1.3.4",
+    "eth-crypto": "^1.6.0",
     "express": "^4.17.1",
     "ganache-cli": "^6.7.0",
     "gmail-send": "^1.2.14",


### PR DESCRIPTION
Currently: 
- dApp's salt is type Decimal, while CLI's salt is type Hex.

Solution:
- CLI needs to `toString()` its salt to be a decimal.

I also upgraded the [eth-crypto](https://github.com/pubkey/eth-crypto) dependency but this did not affect the encryption/decryption process.  

I tested and verified using the 8 possible commit-reveal user flows on the `test` network:
- Commit on dApp, reveal on CLI
- Commit on dApp, reveal on dApp
- Commit on CLI, reveal on dApp
- Commit on CLI, reveal on CLI
- Commit on dApp, reveal on CLI w/ 2Key contract
- Commit on dApp, reveal on dApp w/ 2Key contract
- Commit on CLI, reveal on dApp w/ 2Key contract
- Commit on CLI, reveal on CLI w/ 2Key contract

Resolves #1472 

Signed-off-by: Nick Pai <npai.nyc@gmail.com>