### PR TITLE
Google Cloud Run deployment script

### DIFF
--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -4,7 +4,7 @@ set -e
 if [ $# -ne 1 ]; then
     echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config and service account will be inferred."
     echo "example: ./DeployBotGCP.sh ethbtc-mainnet-monitor"
-    echo "To view all avalible configs run: gsutil ls gs://bot-configs"
+    echo "To view all available configs run: gsutil ls gs://bot-configs"
     exit 1
 fi
 

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -3,7 +3,8 @@ set -e
 
 if [ $# -ne 1 ]; then
     echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config and service account will be inferred."
-    echo "example: ./DeployBotGCP.sh ethbtc-monitor-bot"
+    echo "example: ./DeployBotGCP.sh ethbtc-mainnet-monitor"
+    echo "To view all avalible configs run: gsutil ls gs://bot-configs"
     exit 1
 fi
 

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -19,9 +19,9 @@ gsutil cp gs://bot-configs/$1.yml $tempFile
 
 echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
 
-# Deploy The bot to GCP using the config file and the service account
 echo "🚀 Deploying cloud run instance to GCP"
 
+# Deploy The bot to GCP using the config file
 gcloud beta run services replace $tempFile \
     --platform managed \
     --region=us-central1

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -45,10 +45,10 @@ echo "⏱  Creating cloud scedular to run the cloud run instance"
 
 # Lastly, creat the scheduler job.
 gcloud scheduler jobs create http $1 \
-    --schedule="0 8 * * *" \
+    --schedule="0 12 * * *" \
     --uri=$cloudRunURL \
     --oidc-service-account-email=$serviceAccountEmail \
     --http-method=get \
-    --description="Daily reporter cron job to send messages at 8am UTC"
+    --description="Daily reporter cron job to send messages at 8am ET"
 
 echo "🎊 Scheduler created!"

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -4,7 +4,7 @@ set -e
 if [ $# -ne 1 ]; then
     echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config will be inferred."
     echo "example: ./DeployBotCR.sh ethbtc-mainnet-reporter"
-    echo "To view all avalible configs run: gsutil ls gs://bot-configs"
+    echo "To view all available configs run: gsutil ls gs://bot-configs"
     exit 1
 fi
 

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -4,6 +4,7 @@ set -e
 if [ $# -ne 1 ]; then
     echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config will be inferred."
     echo "example: ./DeployBotCR.sh ethbtc-mainnet-reporter"
+    echo "To view all avalible configs run: gsutil ls gs://bot-configs"
     exit 1
 fi
 

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ $# -ne 1 ]; then
-    echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config."
+    echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config will be inferred."
     echo "example: ./DeployBotCR.sh ethbtc-mainnet-reporter"
     exit 1
 fi

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config."
+    echo "example: ./DeployBotCR.sh ethbtc-monitor-reporter"
+    exit 1
+fi
+
+echo "🔥 Starting GCP Cloud Run deployment script for bot" $1
+
+echo "🤖 Pulling bot config from GCP bucket"
+
+# Create a temp file to store the config. This will be cleaned up by the OS.
+tempFile=$(mktemp -t UMA)
+
+# Copy config files from GCP to the temp file
+gsutil cp gs://bot-configs/$1.yml $tempFile
+
+echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
+
+# Deploy The bot to GCP using the config file and the service account
+echo "🚀 Deploying cloud run instance to GCP"
+
+gcloud beta run services replace $tempFile \
+    --platform managed \
+    --region=us-central1
+
+echo "🎉 Bot deployed!"
+
+echo "🧭 Fetching cloud run instance URL"
+# Fetch the cloud run URL created for the service
+cloudRunURL=$(gcloud run services describe $1 --platform managed --region us-central1 --format 'value(status.url)')
+
+echo "🛣  Cloud run URL has been pulled as" $cloudRunURL
+
+# Fetch the project ID and use this to construct the default service account.
+# Note1: the default service account email is always <project_number>--compute@developer.gserviceaccount.com
+# Note2: this command assumes that the GCP account account only has 1 project associated with it.
+serviceAccountEmail=$(gcloud projects list --filter="$PROJECT" --format="value(PROJECT_NUMBER)")"-compute@developer.gserviceaccount.com"
+
+echo "📄 Using default service account for project @" $serviceAccountEmail
+
+echo "⏱  Creating cloud scedular to run the cloud run instance"
+
+gcloud scheduler jobs create http $1 \
+    --schedule="0 8 * * *" \
+    --uri=$cloudRunURL \
+    --oidc-service-account-email=$serviceAccountEmail \
+    --http-method=get \
+    --description="Daily reporter cron job to send messages at 8am UTC"
+
+echo "🎊 scheduler created!"

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -15,26 +15,25 @@ echo "🤖 Pulling bot config from GCP bucket"
 # Create a temp file to store the config. This will be cleaned up by the OS.
 tempFile=$(mktemp -t UMA)
 
-# Copy config files from GCP to the temp file
+# Copy config files from GCP to the temp file.
 gsutil cp gs://bot-configs/$1.yml $tempFile
 
 echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
 
 echo "🚀 Deploying cloud run instance to GCP"
 
-# Deploy The bot to GCP using the config file
+# Deploy The bot to GCP using the config file.
 gcloud beta run services replace $tempFile \
     --platform managed \
     --region=us-central1
-
 echo "🎉 Bot deployed!"
 
 echo "🧭 Fetching cloud run instance URL"
-# Fetch the cloud run URL created for the service
+
+# Fetch the cloud run URL created for the service.
 cloudRunURL=$(gcloud run services describe $1 --platform managed --region us-central1 --format 'value(status.url)')
 
 echo "🛣  Cloud run URL has been pulled as" $cloudRunURL
-
 # Fetch the project ID and use this to construct the default service account.
 # Note1: the default service account email is always <project_number>--compute@developer.gserviceaccount.com
 # Note2: this command assumes that the GCP account account only has 1 project associated with it.
@@ -44,6 +43,7 @@ echo "📄 Using default service account for project @" $serviceAccountEmail
 
 echo "⏱  Creating cloud scedular to run the cloud run instance"
 
+# Lastly, creat the scheduler job.
 gcloud scheduler jobs create http $1 \
     --schedule="0 8 * * *" \
     --uri=$cloudRunURL \

--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ $# -ne 1 ]; then
     echo "Incorrect number of arguments supplied! First and only argument is bot's name. From this the bot's config."
-    echo "example: ./DeployBotCR.sh ethbtc-monitor-reporter"
+    echo "example: ./DeployBotCR.sh ethbtc-mainnet-reporter"
     exit 1
 fi
 
@@ -50,4 +50,4 @@ gcloud scheduler jobs create http $1 \
     --http-method=get \
     --description="Daily reporter cron job to send messages at 8am UTC"
 
-echo "🎊 scheduler created!"
+echo "🎊 Scheduler created!"


### PR DESCRIPTION
This PR adds a script to enable google Cloud Run containers to be deployed and creates an associated cloud scheduler. This contains the following steps:
1) Pull down the config file for the bot from the GCP storage bucket.
2) Deploy the Cloud Run instance with the config file
3) Fetch the deployed Cloud Run URL for the new instance.
4) Computes the default service account using the GCP project number
5) Creates a scheduler job with the associated URL and service account to run the Cloud Run instance daily @ 8AM UTC.