### PR TITLE
Fix date-label and GCR bugs in Daily Reporter

### DIFF
--- a/common/FormattingUtils.js
+++ b/common/FormattingUtils.js
@@ -9,6 +9,7 @@ const BigNumber = require("bignumber.js");
 // +-1e500.
 BigNumber.set({ ROUNDING_MODE: 2, RANGE: 500, EXPONENTIAL_AT: 500 });
 
+// Given a timestamp in seconds, returns the date in the format: "MM/DD/YYYY"
 const formatDateShort = timestampInSeconds => {
   const date = new Date(parseInt(Number(timestampInSeconds) * 1000));
   return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;

--- a/common/FormattingUtils.js
+++ b/common/FormattingUtils.js
@@ -11,7 +11,7 @@ BigNumber.set({ ROUNDING_MODE: 2, RANGE: 500, EXPONENTIAL_AT: 500 });
 
 const formatDateShort = timestampInSeconds => {
   const date = new Date(parseInt(Number(timestampInSeconds) * 1000));
-  return `${date.getMonth()}/${date.getDate()}/${date.getFullYear()}`;
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 };
 
 const formatDate = (timestampInSeconds, web3) => {

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -31,7 +31,7 @@ class GlobalSummaryReporter {
 
     this.web3 = this.empEventClient.web3;
     this.toBN = this.web3.utils.toBN;
-    this.toWei = this.web3.utils.toBN;
+    this.toWei = this.web3.utils.toWei;
 
     this.empContract = this.empEventClient.emp;
     this.collateralContract = collateralToken;


### PR DESCRIPTION
- Need to account for `Date.getMonth()` returning **zero-based** month integer.
- `this.toWei` was incorrectly set to `this.web3.utils.toBN`