### PR TITLE
Add correct collateralization ratio throughout CLI tool

### DIFF
--- a/core/scripts/cli/sponsor/create.js
+++ b/core/scripts/cli/sponsor/create.js
@@ -24,7 +24,9 @@ const create = async (web3, artifacts, emp, hasExistingPosition) => {
     // When creating the globally first position, we wouldn't have a GCR. Therefore, creating that position is a
     // different flow that isn't currently part of this tool.
     console.log("Error: This tool does not currently support creating the chosen market's first position");
-    return;
+
+    // No creation occurred.
+    return false;
   }
 
   const input = await inquirer.prompt({
@@ -66,7 +68,9 @@ const create = async (web3, artifacts, emp, hasExistingPosition) => {
         userCollateralBalance
       )} ${requiredCollateralSymbol}`
     );
-    return;
+
+    // No creation occurred.
+    return false;
   }
 
   const confirmation = await inquirer.prompt({
@@ -99,7 +103,13 @@ const create = async (web3, artifacts, emp, hasExistingPosition) => {
       totalTransactions
     );
     // TODO: Add link to uniswap and bolded messaging.
+
+    // Indicates that the user successfully created tokens.
+    return true;
   }
+
+  // No creation occurred.
+  return false;
 };
 
 module.exports = create;

--- a/core/scripts/cli/sponsor/deposit.js
+++ b/core/scripts/cli/sponsor/deposit.js
@@ -47,7 +47,13 @@ const deposit = async (web3, artifacts, emp) => {
       transactionNum,
       totalTransactions
     );
+
+    // Indicates that the sponsor successfully made a deposit.
+    return true;
   }
+
+  // Indicates that no deposit was made.
+  return false;
 };
 
 module.exports = deposit;

--- a/core/scripts/cli/sponsor/redeem.js
+++ b/core/scripts/cli/sponsor/redeem.js
@@ -72,7 +72,13 @@ const redeem = async (web3, artifacts, emp) => {
     if (isWeth) {
       await unwrapToEth(web3, artifacts, emp, exactCollateral, transactionNum, totalTransactions);
     }
+
+    // User successfully redeemed.
+    return true;
   }
+
+  // No redemption occurred.
+  return false;
 };
 
 module.exports = redeem;

--- a/core/scripts/cli/sponsor/showMarketDetails.js
+++ b/core/scripts/cli/sponsor/showMarketDetails.js
@@ -1,5 +1,4 @@
 const inquirer = require("inquirer");
-const winston = require("winston");
 const getDefaultAccount = require("../wallet/getDefaultAccount");
 const create = require("./create");
 const redeem = require("./redeem");
@@ -9,16 +8,13 @@ const transfer = require("./transfer");
 const { viewLiquidationDetailsMenu } = require("./viewLiquidationDetails");
 const { getLiquidationEvents } = require("./liquidationUtils");
 const { getIsWeth, getCurrencySymbol } = require("./currencyUtils.js");
-const { createReferencePriceFeedForEmp } = require("../../../../financial-templates-lib/price-feed/CreatePriceFeed.js");
-const { Networker } = require("../../../../financial-templates-lib/price-feed/Networker.js");
-const { computeCollateralizationRatio } = require("../../../../common/EmpUtils.js");
+const { getCollateralizationRatio } = require("./marketUtils.js");
 const { createFormatFunction } = require("../../../../common/FormattingUtils.js");
 
 const showMarketDetails = async (web3, artifacts, emp) => {
   const ExpandedERC20 = artifacts.require("ExpandedERC20");
   const { fromWei, toBN } = web3.utils;
   const sponsorAddress = await getDefaultAccount(web3);
-  let collateral = (await emp.getCollateral(sponsorAddress)).toString();
   const collateralCurrency = await ExpandedERC20.at(await emp.collateralCurrency());
   const syntheticCurrency = await ExpandedERC20.at(await emp.tokenCurrency());
   const collateralSymbol = await getCurrencySymbol(web3, artifacts, collateralCurrency);
@@ -28,56 +24,32 @@ const showMarketDetails = async (web3, artifacts, emp) => {
   const printSponsorSummary = async sponsorAddress => {
     console.group("Summary of your position:");
 
+    const collateral = (await emp.getCollateral(sponsorAddress)).toString();
+
     if (collateral !== "0") {
       const position = await emp.positions(sponsorAddress);
       const isWeth = await getIsWeth(web3, artifacts, collateralCurrency);
       const collateralSymbol = await getCurrencySymbol(web3, artifacts, collateralCurrency);
-
-      // TODO: potentially generalize this for use elsewhere in the CLI tool.
-      const getCollateralizationRatio = async () => {
-        let priceFeed;
-        try {
-          priceFeed = await createReferencePriceFeedForEmp(
-            winston.createLogger({ silent: true }),
-            web3,
-            new Networker(),
-            () => Math.floor(Date.now() / 1000),
-            emp.address
-          );
-        } catch (error) {
-          // Ignore error
-        }
-
-        if (!priceFeed) {
-          return "Unknown";
-        }
-
-        await priceFeed.update();
-        const currentPrice = priceFeed.getCurrentPrice();
-
-        if (!currentPrice) {
-          return "Unknown";
-        }
-
-        const collateralizationRatio = await computeCollateralizationRatio(
-          web3,
-          currentPrice,
-          toBN(collateral.toString()),
-          toBN(position.tokensOutstanding.toString())
-        );
-        const format = createFormatFunction(web3, 2, 4, false);
-        return format(collateralizationRatio.muln(100)) + "%";
-      };
+      const collateralRequirement = await emp.collateralRequirement();
+      const format = createFormatFunction(web3, 2, 4, false);
 
       const getDateStringReadable = contractTime => {
         return new Date(Number(contractTime.toString() * 1000)).toString();
       };
 
+      const collateralizationRatioFieldString = `Collateralization ratio (min ${format(
+        collateralRequirement.muln(100)
+      )}%)`;
       console.table({
         "Current contract time": getDateStringReadable(await emp.getCurrentTime()),
         "Tokens you've minted": fromWei(position.tokensOutstanding.toString()),
         "Deposited collateral": fromWei(collateral) + (isWeth ? " ETH" : " " + collateralSymbol),
-        "Collateralization ratio": await getCollateralizationRatio(),
+        [collateralizationRatioFieldString]: await getCollateralizationRatio(
+          web3,
+          emp.address,
+          collateral,
+          position.tokensOutstanding
+        ),
         "Collateral pending/available to withdraw": fromWei(position.withdrawalRequestAmount.toString()),
         "Pending transfer request": position.transferPositionRequestPassTimestamp.toString() !== "0" ? "Yes" : "No"
       });
@@ -102,6 +74,7 @@ const showMarketDetails = async (web3, artifacts, emp) => {
   let actions = {};
   let message = "What would you like to do?";
 
+  const collateral = (await emp.getCollateral(sponsorAddress)).toString();
   if (collateral === "0") {
     // Sponsor doesn't have a position.
     actions = {
@@ -159,29 +132,35 @@ const showMarketDetails = async (web3, artifacts, emp) => {
     choices: Object.values(actions)
   };
   const input = (await inquirer.prompt(prompt))["choice"];
+
+  let shouldShowPositionInfo = false;
   switch (input) {
     case actions.viewLiquidations:
       await viewLiquidationDetailsMenu(web3, artifacts, emp, liquidationEvents);
       break;
     case actions.create:
-      await create(web3, artifacts, emp, collateral !== "0");
+      shouldShowPositionInfo = await create(web3, artifacts, emp, collateral !== "0");
       break;
     case actions.redeem:
-      await redeem(web3, artifacts, emp);
+      shouldShowPositionInfo = await redeem(web3, artifacts, emp);
       break;
     case actions.withdraw:
-      await withdraw(web3, artifacts, emp);
+      shouldShowPositionInfo = await withdraw(web3, artifacts, emp);
       break;
     case actions.deposit:
-      await deposit(web3, artifacts, emp);
+      shouldShowPositionInfo = await deposit(web3, artifacts, emp);
       break;
     case actions.transfer:
-      await transfer(web3, emp);
+      shouldShowPositionInfo = await transfer(web3, emp);
       break;
     case actions.back:
       return;
     default:
       console.log("unimplemented state");
+  }
+
+  if (shouldShowPositionInfo) {
+    await printSponsorSummary(sponsorAddress);
   }
 };
 

--- a/core/scripts/cli/sponsor/transfer.js
+++ b/core/scripts/cli/sponsor/transfer.js
@@ -17,7 +17,11 @@ const transfer = async (web3, emp) => {
     });
     if (confirmation["confirm"]) {
       await submitTransaction(web3, async () => await emp.cancelTransferPosition(), "Cancelling pending transfer");
+      // Transfer was successfully cancelled.
+      return true;
     }
+    // Transfer wasn't cancelled.
+    return false;
   };
 
   // Execute pending transfer.
@@ -33,7 +37,9 @@ const transfer = async (web3, emp) => {
       console.log(
         `Target address already has ${fromWei(targetCollateral)} WETH. Can only transfer to an owner without a position`
       );
-      return;
+
+      // No transfer occurred.
+      return false;
     }
 
     const confirmation = await inquirer.prompt({
@@ -43,7 +49,13 @@ const transfer = async (web3, emp) => {
     });
     if (confirmation["confirm"]) {
       await emp.transferPositionPassedRequest(input["address"]);
+
+      // Transfer was executed.
+      return true;
     }
+
+    // No transfer occurred.
+    return false;
   };
 
   // First check if user has a transfer request pending.
@@ -68,10 +80,11 @@ const transfer = async (web3, emp) => {
       const input = (await inquirer.prompt(prompt))["choice"];
       switch (input) {
         case "Cancel Pending Transfer":
-          await cancelTransfer();
-          break;
+          // Propogate the boolean up.
+          return await cancelTransfer();
         case "Back":
-          return;
+          // No cancellation occurred.
+          return false;
         default:
           console.log("unimplemented state");
       }
@@ -104,13 +117,12 @@ const transfer = async (web3, emp) => {
       const input = (await inquirer.prompt(prompt))["choice"];
       switch (input) {
         case "Execute Pending Transfer":
-          await executeTransfer();
-          break;
+          return await executeTransfer();
         case "Cancel Pending Transfer":
-          await cancelTransfer();
-          break;
+          return await cancelTransfer();
         case "Back":
-          return;
+          // No transaction was sent.
+          return false;
         default:
           console.log("unimplemented state");
       }
@@ -136,8 +148,14 @@ const transfer = async (web3, emp) => {
       console.log(
         `Transfer requested. Come back in ${transferLivenessInMinutes} minutes to execute your transfer to another sponsor address.`
       );
+
+      // Request was sent.
+      return true;
     }
   }
+
+  // No transaction was sent.
+  return false;
 };
 
 module.exports = transfer;


### PR DESCRIPTION
This PR does a few things:
- It reprints the current position information after every sponsor transaction to effectively provide an updated collateralization ratio after each transaction.
- It corrects the strange "collateralization ratio" computation we were using in the Withdraw handler of the CLI tool.

Fixes #1529.