### PR TITLE
Cloud run deployment script branching logic

### DIFF
--- a/scripts/bot-deployment/DeployReporterCR.sh
+++ b/scripts/bot-deployment/DeployReporterCR.sh
@@ -22,7 +22,8 @@ echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
 
 echo "🚀 Deploying cloud run instance to GCP"
 
-# Deploy The bot to GCP using the config file.
+# Deploy The bot to GCP using the config file. If the deployed GCP cloud run instance already exists then this will
+# replace it with the latest config file. Else, this will create a new cloud run instance.
 gcloud beta run services replace $tempFile \
     --platform managed \
     --region=us-central1
@@ -41,14 +42,33 @@ serviceAccountEmail=$(gcloud projects list --filter="$PROJECT" --format="value(P
 
 echo "📄 Using default service account for project @" $serviceAccountEmail
 
-echo "⏱  Creating cloud scedular to run the cloud run instance"
+# Lastly, creat the scheduler job. This will either create a new schedular job (if it does not exist already)
+# or will update the existing job with the provided configuration.
+schedularExists=0
+for serviceAccount in $(gcloud scheduler jobs list --format="value(ID)"); do
+    if [ $1 == $serviceAccount ]; then
+        schedularExists=1
+    fi
+done
 
-# Lastly, creat the scheduler job.
-gcloud scheduler jobs create http $1 \
-    --schedule="0 12 * * *" \
-    --uri=$cloudRunURL \
-    --oidc-service-account-email=$serviceAccountEmail \
-    --http-method=get \
-    --description="Daily reporter cron job to send messages at 8am ET"
+if [ $schedularExists == 0 ]; then
+    echo "⏱  Creating new cloud scheduler to run the cloud run instance"
+    gcloud scheduler jobs create http $1 \
+        --schedule="0 12 * * *" \
+        --uri=$cloudRunURL \
+        --oidc-service-account-email=$serviceAccountEmail \
+        --http-method=get \
+        --description="Daily reporter cron job to send messages at 8am ET"
+    echo "🎊 Scheduler created!"
+fi
 
-echo "🎊 Scheduler created!"
+if [ $schedularExists == 1 ]; then
+    echo "⏱  Updating existing cloud scheduler to run the cloud run instance"
+    gcloud scheduler jobs update http $1 \
+        --schedule="0 12 * * *" \
+        --uri=$cloudRunURL \
+        --oidc-service-account-email=$serviceAccountEmail \
+        --http-method=get \
+        --description="Daily reporter cron job to send messages at 8am ET"
+    echo "🎊 Scheduler updated!"
+fi


### PR DESCRIPTION
This PR adds branching logic to the Daily reporter cloud run script to facilitate either creating a new or updating an existing cloud run cron job based on the list of other deployed jobs. 

close #1597