### PR TITLE
Fix volitility alert message

### DIFF
--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -50,7 +50,7 @@ const slackFormatter = info => {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `[${info.level}] *${info["bot-identifier"]}* (${info.at}) ⭢ ${info.message}\n`
+          text: `[${info.level}] *${info["bot-identifier"]}* (${info.at})⭢${info.message}\n`
         }
       }
     ]

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -95,7 +95,7 @@ class SyntheticPegMonitor {
     if (deviationError.abs().gt(this.toBN(this.toWei(this.deviationAlertThreshold.toString())))) {
       this.logger.warn({
         at: "SyntheticPegMonitor",
-        message: "Synthetic off peg 😵",
+        message: "Synthetic off peg alert 😵",
         mrkdwn:
           "Synthetic token " +
           this.empProps.syntheticCurrencySymbol +
@@ -144,7 +144,7 @@ class SyntheticPegMonitor {
     if (pricefeedVolatility.abs().gt(this.toBN(this.toWei(this.volatilityAlertThreshold.toString())))) {
       this.logger.warn({
         at: "SyntheticPegMonitor",
-        message: "High peg price volatility 🌋",
+        message: "Peg price volatility alert 🌋",
         mrkdwn:
           "Latest updated " +
           this.empProps.priceIdentifier +
@@ -193,7 +193,7 @@ class SyntheticPegMonitor {
     if (pricefeedVolatility.abs().gt(this.toBN(this.toWei(this.volatilityAlertThreshold.toString())))) {
       this.logger.warn({
         at: "SyntheticPegMonitor",
-        message: "High synthetic price volatility 🌋",
+        message: "Synthetic price volatility alert 🌋",
         mrkdwn:
           "Latest updated " +
           this.empProps.priceIdentifier +

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -95,7 +95,7 @@ class SyntheticPegMonitor {
     if (deviationError.abs().gt(this.toBN(this.toWei(this.deviationAlertThreshold.toString())))) {
       this.logger.warn({
         at: "SyntheticPegMonitor",
-        message: "Synthetic off peg alert 😵",
+        message: "Synthetic off peg 😵",
         mrkdwn:
           "Synthetic token " +
           this.empProps.syntheticCurrencySymbol +
@@ -144,7 +144,7 @@ class SyntheticPegMonitor {
     if (pricefeedVolatility.abs().gt(this.toBN(this.toWei(this.volatilityAlertThreshold.toString())))) {
       this.logger.warn({
         at: "SyntheticPegMonitor",
-        message: "High peg price volatility alert 🌋",
+        message: "High peg price volatility 🌋",
         mrkdwn:
           "Latest updated " +
           this.empProps.priceIdentifier +
@@ -155,8 +155,8 @@ class SyntheticPegMonitor {
           "% over the last " +
           formatHours(this.volatilityWindow) +
           " hour(s). Threshold is " +
-          this.formatDecimalString(this.volatilityAlertThreshold * 100) +
-          " %."
+          this.volatilityAlertThreshold * 100 +
+          "%."
       });
     }
   };
@@ -193,7 +193,7 @@ class SyntheticPegMonitor {
     if (pricefeedVolatility.abs().gt(this.toBN(this.toWei(this.volatilityAlertThreshold.toString())))) {
       this.logger.warn({
         at: "SyntheticPegMonitor",
-        message: "High synthetic price volatility alert 🌋",
+        message: "High synthetic price volatility 🌋",
         mrkdwn:
           "Latest updated " +
           this.empProps.priceIdentifier +
@@ -204,8 +204,8 @@ class SyntheticPegMonitor {
           "% over the last " +
           formatHours(this.volatilityWindow) +
           " hour(s). Threshold is " +
-          this.formatDecimalString(this.volatilityAlertThreshold * 100) +
-          " %."
+          this.volatilityAlertThreshold * 100 +
+          "%."
       });
     }
   };

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -99,7 +99,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1.25")));
       await syntheticPegMonitor.checkPriceDeviation();
       assert.equal(spy.callCount, 1); // There should be one message sent at this point.
-      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic off peg"));
       assert.isTrue(lastSpyLogIncludes(spy, "1.25")); // uniswap price
       assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
       assert.isTrue(lastSpyLogIncludes(spy, "25.00")); // percentage error
@@ -115,7 +115,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("0.7")));
       await syntheticPegMonitor.checkPriceDeviation();
       assert.equal(spy.callCount, 2); // There should be one message sent at this point.
-      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic off peg"));
       assert.isTrue(lastSpyLogIncludes(spy, "0.7000")); // uniswap price
       assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
       assert.isTrue(lastSpyLogIncludes(spy, "-30.00")); // percentage error (note negative sign)
@@ -125,7 +125,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("0.025678"))); // Note 5 units of precision provided.
       await syntheticPegMonitor.checkPriceDeviation();
       assert.equal(spy.callCount, 3); // There should be one message sent at this point.
-      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic off peg"));
       assert.isTrue(lastSpyLogIncludes(spy, "0.02567")); // uniswap price (note: 4 units of precision)
       assert.isTrue(lastSpyLogIncludes(spy, "0.02111")); // expected price (note: 4 units of precision)
       assert.isTrue(lastSpyLogIncludes(spy, "21.63")); // percentage error
@@ -249,36 +249,40 @@ contract("SyntheticPegMonitor", function(accounts) {
       medianizerPriceFeedMock.setLastUpdateTime(104);
       await syntheticPegMonitor.checkPegVolatility();
       assert.equal(spy.callCount, 1);
-      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility"));
       assert.isTrue(lastSpyLogIncludes(spy, "14.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "40.00")); // actual volatility
+      assert.isTrue(lastSpyLogIncludes(spy, "30")); // volatility threshold parameter
 
       uniswapPriceFeedMock.setLastUpdateTime(104);
       await syntheticPegMonitor.checkSyntheticVolatility();
       assert.equal(spy.callCount, 2);
-      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility"));
       assert.isTrue(lastSpyLogIncludes(spy, "14.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "40.00")); // actual volatility
+      assert.isTrue(lastSpyLogIncludes(spy, "30")); // volatility threshold parameter
 
       // Correctly reports negative volatility. The last 4 sets of time series data move in the opposite direction.
       // Logger should correctly report the negative swing.
       medianizerPriceFeedMock.setLastUpdateTime(108);
       await syntheticPegMonitor.checkPegVolatility();
       assert.equal(spy.callCount, 3);
-      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility"));
       assert.isTrue(lastSpyLogIncludes(spy, "10.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "-40.00")); // actual volatility (note the negative sign)
+      assert.isTrue(lastSpyLogIncludes(spy, "30")); // volatility threshold parameter
 
       uniswapPriceFeedMock.setLastUpdateTime(108);
       await syntheticPegMonitor.checkSyntheticVolatility();
       assert.equal(spy.callCount, 4);
-      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility"));
       assert.isTrue(lastSpyLogIncludes(spy, "10.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "-40.00")); // actual volatility
+      assert.isTrue(lastSpyLogIncludes(spy, "30")); // volatility threshold parameter
     });
 
     it("Stress testing with a lot of historical price data points", async function() {
@@ -293,12 +297,12 @@ contract("SyntheticPegMonitor", function(accounts) {
       medianizerPriceFeedMock.setLastUpdateTime(historicalPrices.length - 1);
       uniswapPriceFeedMock.setLastUpdateTime(historicalPrices.length - 1);
 
-      // There should be one alert emitted for each pricefeed.
+      // There should be one emitted for each pricefeed.
       // Max price will be 9999, min price will be (9999-3650+1) = 6350.
       // Vol will be 3649/6350 = 57.46%
       await syntheticPegMonitor.checkPegVolatility();
       assert.equal(spy.callCount, 1);
-      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility"));
       assert.isTrue(lastSpyLogIncludes(spy, "9,999.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "57.46")); // actual volatility
@@ -306,7 +310,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       // uniswapPriceFeedMock.setLastUpdateTime(104);
       await syntheticPegMonitor.checkSyntheticVolatility();
       assert.equal(spy.callCount, 2);
-      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility alert"));
+      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility"));
       assert.isTrue(lastSpyLogIncludes(spy, "9,999.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "57.46")); // actual volatility

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -99,7 +99,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("1.25")));
       await syntheticPegMonitor.checkPriceDeviation();
       assert.equal(spy.callCount, 1); // There should be one message sent at this point.
-      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic off peg"));
+      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "1.25")); // uniswap price
       assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
       assert.isTrue(lastSpyLogIncludes(spy, "25.00")); // percentage error
@@ -115,7 +115,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("0.7")));
       await syntheticPegMonitor.checkPriceDeviation();
       assert.equal(spy.callCount, 2); // There should be one message sent at this point.
-      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic off peg"));
+      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "0.7000")); // uniswap price
       assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // expected price
       assert.isTrue(lastSpyLogIncludes(spy, "-30.00")); // percentage error (note negative sign)
@@ -125,7 +125,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setCurrentPrice(toBN(toWei("0.025678"))); // Note 5 units of precision provided.
       await syntheticPegMonitor.checkPriceDeviation();
       assert.equal(spy.callCount, 3); // There should be one message sent at this point.
-      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic off peg"));
+      assert.isTrue(lastSpyLogIncludes(spy, "off peg alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "0.02567")); // uniswap price (note: 4 units of precision)
       assert.isTrue(lastSpyLogIncludes(spy, "0.02111")); // expected price (note: 4 units of precision)
       assert.isTrue(lastSpyLogIncludes(spy, "21.63")); // percentage error
@@ -249,7 +249,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       medianizerPriceFeedMock.setLastUpdateTime(104);
       await syntheticPegMonitor.checkPegVolatility();
       assert.equal(spy.callCount, 1);
-      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Peg price volatility alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "14.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "40.00")); // actual volatility
@@ -258,7 +258,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setLastUpdateTime(104);
       await syntheticPegMonitor.checkSyntheticVolatility();
       assert.equal(spy.callCount, 2);
-      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic price volatility alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "14.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "40.00")); // actual volatility
@@ -269,7 +269,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       medianizerPriceFeedMock.setLastUpdateTime(108);
       await syntheticPegMonitor.checkPegVolatility();
       assert.equal(spy.callCount, 3);
-      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Peg price volatility alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "10.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "-40.00")); // actual volatility (note the negative sign)
@@ -278,7 +278,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       uniswapPriceFeedMock.setLastUpdateTime(108);
       await syntheticPegMonitor.checkSyntheticVolatility();
       assert.equal(spy.callCount, 4);
-      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic price volatility alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "10.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "-40.00")); // actual volatility
@@ -297,12 +297,12 @@ contract("SyntheticPegMonitor", function(accounts) {
       medianizerPriceFeedMock.setLastUpdateTime(historicalPrices.length - 1);
       uniswapPriceFeedMock.setLastUpdateTime(historicalPrices.length - 1);
 
-      // There should be one emitted for each pricefeed.
+      // There should be one alert emitted for each pricefeed.
       // Max price will be 9999, min price will be (9999-3650+1) = 6350.
       // Vol will be 3649/6350 = 57.46%
       await syntheticPegMonitor.checkPegVolatility();
       assert.equal(spy.callCount, 1);
-      assert.isTrue(lastSpyLogIncludes(spy, "peg price volatility"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Peg price volatility alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "9,999.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "57.46")); // actual volatility
@@ -310,7 +310,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       // uniswapPriceFeedMock.setLastUpdateTime(104);
       await syntheticPegMonitor.checkSyntheticVolatility();
       assert.equal(spy.callCount, 2);
-      assert.isTrue(lastSpyLogIncludes(spy, "synthetic price volatility"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Synthetic price volatility alert"));
       assert.isTrue(lastSpyLogIncludes(spy, "9,999.00")); // latest pricefeed price
       assert.isTrue(lastSpyLogIncludes(spy, "1.01")); // volatility window in hours (i.e. 3650/3600)
       assert.isTrue(lastSpyLogIncludes(spy, "57.46")); // actual volatility


### PR DESCRIPTION
This PR makes three small changes to the synthetic monitor bot:
1) remove the word "High" from volatility alerts as this is redundant and causes the line to wrap 
2) removes white space around the `⭢` in the log message to decrease the line length and
3) removes number formatting on threshold values in the synthetic monitor.

Note that the line length wrapping is a slack restriction and enforces the same length parameters on all devices/platforms, irrespective of how wide the screen is. This change is to ensure that all messages are on one line for consistency.

The previous slack message looked as follows:
![image](https://user-images.githubusercontent.com/12886084/84642480-d2367f80-aefc-11ea-94af-5de49ba28ae2.png)

After this PR looks as follows:
![image](https://user-images.githubusercontent.com/12886084/84642496-d793ca00-aefc-11ea-9822-00a403f81719.png)

close #1606