### PR TITLE
Add delta column to daily reporter, showing difference between current and previous period

### DIFF
--- a/common/FormattingUtils.js
+++ b/common/FormattingUtils.js
@@ -43,7 +43,7 @@ const formatWei = (num, web3) => {
 
 // Formats the input to round to decimalPlaces number of decimals if the number has a magnitude larger than 1 and fixes
 // precision to minPrecision if the number has a magnitude less than 1.
-const formatWithMaxDecimals = (num, decimalPlaces, minPrecision, roundUp) => {
+const formatWithMaxDecimals = (num, decimalPlaces, minPrecision, roundUp, showSign) => {
   if (roundUp) {
     BigNumber.set({ ROUNDING_MODE: BigNumber.ROUND_UP });
   } else {
@@ -51,6 +51,7 @@ const formatWithMaxDecimals = (num, decimalPlaces, minPrecision, roundUp) => {
   }
 
   const fullPrecisionFloat = BigNumber(num);
+  const positiveSign = showSign && fullPrecisionFloat.gt(0) ? "+" : "";
   let fixedPrecisionFloat;
   // Convert back to BN to truncate any trailing 0s that the toFixed() output would print. If the number is equal to or larger than
   // 1 then truncate to `decimalPlaces` number of decimal places. EG 999.999 -> 999.99 with decimalPlaces=2 If the number
@@ -67,12 +68,12 @@ const formatWithMaxDecimals = (num, decimalPlaces, minPrecision, roundUp) => {
   // This puts commas in the thousands places, but only before the decimal point.
   const fixedPrecisionFloatParts = fixedPrecisionFloat.split(".");
   fixedPrecisionFloatParts[0] = fixedPrecisionFloatParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  return fixedPrecisionFloatParts.join(".");
+  return positiveSign + fixedPrecisionFloatParts.join(".");
 };
 
-const createFormatFunction = (web3, numDisplayedDecimals, minDisplayedPrecision) => {
+const createFormatFunction = (web3, numDisplayedDecimals, minDisplayedPrecision, showSign = false) => {
   return valInWei =>
-    formatWithMaxDecimals(formatWei(valInWei, web3), numDisplayedDecimals, minDisplayedPrecision, false);
+    formatWithMaxDecimals(formatWei(valInWei, web3), numDisplayedDecimals, minDisplayedPrecision, false, showSign);
 };
 
 // Generate an etherscan link prefix. If a networkId is provided then the URL will point to this network. Else, assume mainnet.
@@ -106,6 +107,15 @@ function createEtherscanLinkMarkdown(hex, networkId = 1) {
   else if (hex.length == 42) return `<${createEtherscanLinkFromtx(networkId)}address/${hex}|${shortURLString}>`;
 }
 
+function addSign(number) {
+  if (Number(number) > 0) {
+    return `+${number}`;
+  } else {
+    // Number strings already print the '-' sign for negative numbers.
+    return `${number}`;
+  }
+}
+
 module.exports = {
   formatDateShort,
   formatDate,
@@ -115,5 +125,6 @@ module.exports = {
   createFormatFunction,
   createEtherscanLinkFromtx,
   createShortHexString,
-  createEtherscanLinkMarkdown
+  createEtherscanLinkMarkdown,
+  addSign
 };

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -1,4 +1,4 @@
-const { createFormatFunction, formatDateShort, formatWithMaxDecimals } = require("../common/FormattingUtils");
+const { createFormatFunction, formatDateShort, formatWithMaxDecimals, addSign } = require("../common/FormattingUtils");
 const { revertWrapper } = require("../common/ContractUtils");
 const { ZERO_ADDRESS } = require("../common/Constants");
 const { averageBlockTimeSeconds } = require("../common/TimeUtils");
@@ -39,6 +39,7 @@ class GlobalSummaryReporter {
     this.oracleContract = oracle;
 
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
+    this.formatDecimalStringWithSign = createFormatFunction(this.web3, 2, 4, true);
   }
 
   async update() {
@@ -53,6 +54,8 @@ class GlobalSummaryReporter {
       this.currentBlockNumber - (await this._getLookbackTimeInBlocks(this.endDateOffsetSeconds));
     this.startBlockNumberForPeriod =
       this.endBlockNumberForPeriod - (await this._getLookbackTimeInBlocks(this.periodLengthSeconds));
+    this.startBlockNumberForPreviousPeriod =
+      this.startBlockNumberForPeriod - (await this._getLookbackTimeInBlocks(this.periodLengthSeconds));
     this.startBlockTimestamp = (await this.web3.eth.getBlock(this.startBlockNumberForPeriod)).timestamp;
     this.endBlockTimestamp = (await this.web3.eth.getBlock(this.endBlockNumberForPeriod)).timestamp;
     this.periodLabelInHours = `${formatDateShort(this.startBlockTimestamp)} to ${formatDateShort(
@@ -173,99 +176,161 @@ class GlobalSummaryReporter {
     // - Lifetime # of unique sponsors.
     const uniqueSponsors = {};
     const periodUniqueSponsors = {};
+    const prevPeriodUniqueSponsors = {};
     const currentUniqueSponsors = this.empClient.getAllPositions();
     for (let event of this.newSponsorEvents) {
       uniqueSponsors[event.sponsor] = true;
       if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
         periodUniqueSponsors[event.sponsor] = true;
       }
+      if (
+        event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+        event.blockNumber < this.startBlockNumberForPeriod
+      ) {
+        prevPeriodUniqueSponsors[event.sponsor] = true;
+      }
     }
     allSponsorStatsTable["# of unique sponsors"] = {
       cumulative: Object.keys(uniqueSponsors).length,
       current: Object.keys(currentUniqueSponsors).length,
-      [this.periodLabelInHours]: Object.keys(periodUniqueSponsors).length
+      [this.periodLabelInHours]: Object.keys(periodUniqueSponsors).length,
+      ["delta from prev. period"]: addSign(
+        Object.keys(periodUniqueSponsors).length - Object.keys(prevPeriodUniqueSponsors).length
+      )
     };
 
     // - Cumulative collateral deposited into contract
     let collateralDeposited = this.toBN("0");
     let collateralDepositedPeriod = this.toBN("0");
+    let collateralDepositedPrevPeriod = this.toBN("0");
     for (let event of this.collateralDepositEvents) {
       collateralDeposited = collateralDeposited.add(this.toBN(event.returnValues.value));
       if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
         collateralDepositedPeriod = collateralDepositedPeriod.add(this.toBN(event.returnValues.value));
       }
+      if (
+        event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+        event.blockNumber < this.startBlockNumberForPeriod
+      ) {
+        collateralDepositedPrevPeriod = collateralDepositedPrevPeriod.add(this.toBN(event.returnValues.value));
+      }
     }
     allSponsorStatsTable["collateral deposited"] = {
       cumulative: this.formatDecimalString(collateralDeposited),
       [this.periodLabelInHours]: this.formatDecimalString(collateralDepositedPeriod),
-      current: this.formatDecimalString(this.totalPositionCollateral)
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+        collateralDepositedPeriod.sub(collateralDepositedPrevPeriod)
+      )
     };
 
     // - Cumulative collateral withdrawn from contract
     let collateralWithdrawn = this.toBN("0");
     let collateralWithdrawnPeriod = this.toBN("0");
+    let collateralWithdrawnPrevPeriod = this.toBN("0");
     for (let event of this.collateralWithdrawEvents) {
       collateralWithdrawn = collateralWithdrawn.add(this.toBN(event.returnValues.value));
       if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
         collateralWithdrawnPeriod = collateralWithdrawnPeriod.add(this.toBN(event.returnValues.value));
       }
+      if (
+        event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+        event.blockNumber < this.startBlockNumberForPeriod
+      ) {
+        collateralWithdrawnPrevPeriod = collateralWithdrawnPrevPeriod.add(this.toBN(event.returnValues.value));
+      }
     }
     allSponsorStatsTable["collateral withdrawn"] = {
       cumulative: this.formatDecimalString(collateralWithdrawn),
-      [this.periodLabelInHours]: this.formatDecimalString(collateralWithdrawnPeriod)
+      [this.periodLabelInHours]: this.formatDecimalString(collateralWithdrawnPeriod),
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+        collateralWithdrawnPeriod.sub(collateralWithdrawnPrevPeriod)
+      )
     };
 
     // - Net collateral deposited into contract:
     let netCollateralWithdrawn = collateralDeposited.sub(collateralWithdrawn);
+    if (!netCollateralWithdrawn.eq(this.toBN(this.totalPositionCollateral.toString()))) {
+      throw "Net collateral deposited is not equal to current total position collateral";
+    }
     let netCollateralWithdrawnPeriod = collateralDepositedPeriod.sub(collateralWithdrawnPeriod);
+    let netCollateralWithdrawnPrevPeriod = collateralDepositedPrevPeriod.sub(collateralWithdrawnPrevPeriod);
     allSponsorStatsTable["net collateral deposited"] = {
       cumulative: this.formatDecimalString(netCollateralWithdrawn),
-      [this.periodLabelInHours]: this.formatDecimalString(netCollateralWithdrawnPeriod)
+      [this.periodLabelInHours]: this.formatDecimalString(netCollateralWithdrawnPeriod),
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+        netCollateralWithdrawnPeriod.sub(netCollateralWithdrawnPrevPeriod)
+      )
     };
 
     // - Tokens minted: tracked via Create events.
     let tokensMinted = this.toBN("0");
     let tokensMintedPeriod = this.toBN("0");
+    let tokensMintedPrevPeriod = this.toBN("0");
     for (let event of this.createEvents) {
       tokensMinted = tokensMinted.add(this.toBN(event.tokenAmount));
       if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
         tokensMintedPeriod = tokensMintedPeriod.add(this.toBN(event.tokenAmount));
       }
+      if (
+        event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+        event.blockNumber < this.startBlockNumberForPeriod
+      ) {
+        tokensMintedPrevPeriod = tokensMintedPrevPeriod.add(this.toBN(event.tokenAmount));
+      }
     }
     allSponsorStatsTable["tokens minted"] = {
       cumulative: this.formatDecimalString(tokensMinted),
       [this.periodLabelInHours]: this.formatDecimalString(tokensMintedPeriod),
-      current: this.formatDecimalString(this.totalTokensOutstanding)
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(tokensMintedPrevPeriod.sub(tokensMintedPeriod))
     };
 
     // - Tokens burned
     let tokensBurned = this.toBN("0");
     let tokensBurnedPeriod = this.toBN("0");
+    let tokensBurnedPrevPeriod = this.toBN("0");
     for (let event of this.syntheticBurnedEvents) {
       tokensBurned = tokensBurned.add(this.toBN(event.returnValues.value));
       if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
         tokensBurnedPeriod = tokensBurnedPeriod.add(this.toBN(event.returnValues.value));
       }
+      if (
+        event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+        event.blockNumber < this.startBlockNumberForPeriod
+      ) {
+        tokensBurnedPrevPeriod = tokensBurnedPrevPeriod.add(this.toBN(event.returnValues.value));
+      }
     }
     allSponsorStatsTable["tokens burned"] = {
       cumulative: this.formatDecimalString(tokensBurned),
-      [this.periodLabelInHours]: this.formatDecimalString(tokensBurnedPeriod)
+      [this.periodLabelInHours]: this.formatDecimalString(tokensBurnedPeriod),
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(tokensBurnedPeriod.sub(tokensBurnedPrevPeriod))
     };
 
     // - Net tokens minted:
     let netTokensMinted = tokensMinted.sub(tokensBurned);
+    if (!netTokensMinted.eq(this.toBN(this.totalTokensOutstanding.toString()))) {
+      throw "Net tokens minted is not equal to current tokens outstanding";
+    }
     let netTokensMintedPeriod = tokensMintedPeriod.sub(tokensBurnedPeriod);
+    let netTokensMintedPrevPeriod = tokensMintedPrevPeriod.sub(tokensBurnedPrevPeriod);
     allSponsorStatsTable["net tokens minted"] = {
       cumulative: this.formatDecimalString(netTokensMinted),
-      [this.periodLabelInHours]: this.formatDecimalString(netTokensMintedPeriod)
+      [this.periodLabelInHours]: this.formatDecimalString(netTokensMintedPeriod),
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+        netTokensMintedPeriod.sub(netTokensMintedPrevPeriod)
+      )
     };
 
     // - GCR (collateral / tokens outstanding):
     let currentCollateral = this.toBN(this.totalPositionCollateral.toString());
+    let prevPeriodCollateral = currentCollateral.sub(netCollateralWithdrawnPeriod);
     let currentTokensOutstanding = this.toBN(this.totalTokensOutstanding.toString());
+    let prevPeriodTokensOutstanding = currentTokensOutstanding.sub(netTokensMintedPeriod);
     let currentGCR = currentCollateral.mul(this.toBN(this.toWei("1"))).div(currentTokensOutstanding);
+    let prevGCR = prevPeriodCollateral.mul(this.toBN(this.toWei("1"))).div(prevPeriodTokensOutstanding);
     allSponsorStatsTable["GCR - collateral / # tokens outstanding"] = {
-      current: this.formatDecimalString(currentGCR)
+      current: this.formatDecimalString(currentGCR),
+      ["delta from prev. period"]: this.formatDecimalStringWithSign(currentGCR.sub(prevGCR))
     };
 
     // - GCR (collateral / TRV):
@@ -310,22 +375,36 @@ class GlobalSummaryReporter {
     const endPeriodTokenData = (
       await uniswapClient.request(queries.PAIR_DATA(uniswapPairAddress, this.endBlockNumberForPeriod))
     ).pairs[0];
+    const startPrevPeriodTokenData = (
+      await uniswapClient.request(queries.PAIR_DATA(uniswapPairAddress, this.startBlockNumberForPreviousPeriod))
+    ).pairs[0];
 
     const tradeCount = parseInt(allTokenData.txCount);
     const periodTradeCount = parseInt(endPeriodTokenData.txCount) - parseInt(startPeriodTokenData.txCount);
+    const prevPeriodTradeCount = parseInt(startPeriodTokenData.txCount) - parseInt(startPrevPeriodTokenData.txCount);
 
     const volumeTokenLabel = uniswapPairDetails.inverted ? "volumeToken1" : "volumeToken0";
     const tradeVolumeTokens = parseFloat(allTokenData[volumeTokenLabel]);
     const periodTradeVolumeTokens =
       parseFloat(endPeriodTokenData[volumeTokenLabel]) - parseFloat(startPeriodTokenData[volumeTokenLabel]);
+    const prevPeriodTradeVolumeTokens =
+      parseFloat(startPeriodTokenData[volumeTokenLabel]) - parseFloat(startPrevPeriodTokenData[volumeTokenLabel]);
 
     allTokenStatsTable["# trades in Uniswap"] = {
       cumulative: tradeCount,
-      [this.periodLabelInHours]: periodTradeCount
+      [this.periodLabelInHours]: periodTradeCount,
+      ["delta from prev. period"]: addSign(periodTradeCount - prevPeriodTradeCount)
     };
     allTokenStatsTable["volume of trades in Uniswap in # of tokens"] = {
       cumulative: formatWithMaxDecimals(tradeVolumeTokens, 2, 4, false),
-      [this.periodLabelInHours]: formatWithMaxDecimals(periodTradeVolumeTokens, 2, 4, false)
+      [this.periodLabelInHours]: formatWithMaxDecimals(periodTradeVolumeTokens, 2, 4, false),
+      ["delta from prev. period"]: formatWithMaxDecimals(
+        periodTradeVolumeTokens - prevPeriodTradeVolumeTokens,
+        2,
+        4,
+        false,
+        true
+      )
     };
 
     // Get token holder stats.
@@ -344,10 +423,13 @@ class GlobalSummaryReporter {
 
     let uniqueLiquidations = {};
     let uniqueLiquidationsPeriod = {};
+    let uniqueLiquidationsPrevPeriod = {};
     let tokensLiquidated = this.toBN("0");
     let tokensLiquidatedPeriod = this.toBN("0");
+    let tokensLiquidatedPrevPeriod = this.toBN("0");
     let collateralLiquidated = this.toBN("0");
     let collateralLiquidatedPeriod = this.toBN("0");
+    let collateralLiquidatedPrevPeriod = this.toBN("0");
 
     if (this.liquidationEvents.length === 0) {
       console.log(dim("\tNo liquidation events found for this EMP."));
@@ -363,20 +445,37 @@ class GlobalSummaryReporter {
           collateralLiquidatedPeriod = collateralLiquidatedPeriod.add(this.toBN(event.lockedCollateral));
           uniqueLiquidationsPeriod[event.sponsor] = true;
         }
+        if (
+          event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+          event.blockNumber < this.startBlockNumberForPeriod
+        ) {
+          tokensLiquidatedPrevPeriod = tokensLiquidatedPrevPeriod.add(this.toBN(event.tokensOutstanding));
+          collateralLiquidatedPrevPeriod = collateralLiquidatedPrevPeriod.add(this.toBN(event.lockedCollateral));
+          uniqueLiquidationsPrevPeriod[event.sponsor] = true;
+        }
       }
       allLiquidationStatsTable = {
         ["# of liquidations"]: {
           cumulative: Object.keys(uniqueLiquidations).length,
-          [this.periodLabelInHours]: Object.keys(uniqueLiquidationsPeriod).length
+          [this.periodLabelInHours]: Object.keys(uniqueLiquidationsPeriod).length,
+          ["delta from prev. period"]: addSign(
+            Object.keys(uniqueLiquidationsPeriod).length - Object.keys(uniqueLiquidationsPrevPeriod).length
+          )
         },
         ["tokens liquidated"]: {
           cumulative: this.formatDecimalString(tokensLiquidated),
-          [this.periodLabelInHours]: this.formatDecimalString(tokensLiquidatedPeriod)
+          [this.periodLabelInHours]: this.formatDecimalString(tokensLiquidatedPeriod),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+            tokensLiquidatedPeriod.sub(tokensLiquidatedPrevPeriod)
+          )
         },
         ["collateral liquidated"]: {
           cumulative: this.formatDecimalString(collateralLiquidated),
           [this.periodLabelInHours]: this.formatDecimalString(collateralLiquidatedPeriod),
-          current: this.formatDecimalString(this.collateralLockedInLiquidations)
+          current: this.formatDecimalString(this.collateralLockedInLiquidations),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+            collateralLiquidatedPeriod.sub(collateralLiquidatedPrevPeriod)
+          )
         }
       };
 
@@ -389,10 +488,13 @@ class GlobalSummaryReporter {
 
     let uniqueDisputes = {};
     let uniqueDisputesPeriod = {};
+    let uniqueDisputesPrevPeriod = {};
     let tokensDisputed = this.toBN("0");
     let tokensDisputedPeriod = this.toBN("0");
+    let tokensDisputedPrevPeriod = this.toBN("0");
     let collateralDisputed = this.toBN("0");
     let collateralDisputedPeriod = this.toBN("0");
+    let collateralDisputedPrevPeriod = this.toBN("0");
     let disputesResolved = {};
 
     if (this.disputeEvents.length === 0) {
@@ -407,9 +509,17 @@ class GlobalSummaryReporter {
         collateralDisputed = collateralDisputed.add(this.toBN(liquidationData.lockedCollateral));
         uniqueDisputes[event.sponsor] = true;
         if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
-          tokensDisputedDaily = tokensDisputedPeriod.add(this.toBN(liquidationData.tokensOutstanding));
-          collateralDisputedDaily = collateralDisputedPeriod.add(this.toBN(liquidationData.lockedCollateral));
+          tokensDisputedPeriod = tokensDisputedPeriod.add(this.toBN(liquidationData.tokensOutstanding));
+          collateralDisputedPeriod = collateralDisputedPeriod.add(this.toBN(liquidationData.lockedCollateral));
           uniqueDisputesPeriod[event.sponsor] = true;
+        }
+        if (
+          event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+          event.blockNumber < this.startBlockNumberForPeriod
+        ) {
+          tokensDisputedPrevPeriod = tokensDisputedPrevPeriod.add(this.toBN(liquidationData.tokensOutstanding));
+          collateralDisputedPrevPeriod = collateralDisputedPrevPeriod.add(this.toBN(liquidationData.lockedCollateral));
+          uniqueDisputesPrevPeriod[event.sponsor] = true;
         }
 
         // Create list of resolved prices for disputed liquidations.
@@ -439,15 +549,24 @@ class GlobalSummaryReporter {
       allDisputeStatsTable = {
         ["# of disputes"]: {
           cumulative: Object.keys(uniqueDisputes).length,
-          [this.periodLabelInHours]: Object.keys(uniqueDisputesPeriod).length
+          [this.periodLabelInHours]: Object.keys(uniqueDisputesPeriod).length,
+          ["delta from prev. period"]: addSign(
+            Object.keys(uniqueDisputesPeriod).length - Object.keys(uniqueDisputesPrevPeriod).length
+          )
         },
         ["tokens disputed"]: {
           cumulative: this.formatDecimalString(tokensDisputed),
-          [this.periodLabelInHours]: this.formatDecimalString(tokensDisputedPeriod)
+          [this.periodLabelInHours]: this.formatDecimalString(tokensDisputedPeriod),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+            tokensDisputedPeriod.sub(tokensDisputedPrevPeriod)
+          )
         },
         ["collateral disputed"]: {
           cumulative: this.formatDecimalString(collateralDisputed),
-          [this.periodLabelInHours]: this.formatDecimalString(collateralDisputedPeriod)
+          [this.periodLabelInHours]: this.formatDecimalString(collateralDisputedPeriod),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+            collateralDisputedPeriod.sub(collateralDisputedPrevPeriod)
+          )
         }
       };
 
@@ -464,10 +583,13 @@ class GlobalSummaryReporter {
 
     let regularFeesPaid = this.toBN("0");
     let regularFeesPaidPeriod = this.toBN("0");
+    let regularFeesPaidPrevPeriod = this.toBN("0");
     let lateFeesPaid = this.toBN("0");
     let lateFeesPaidPeriod = this.toBN("0");
+    let lateFeesPaidPrevPeriod = this.toBN("0");
     let finalFeesPaid = this.toBN("0");
     let finalFeesPaidPeriod = this.toBN("0");
+    let finalFeesPaidPrevPeriod = this.toBN("0");
 
     if (this.regularFeeEvents.length === 0) {
       console.log(dim("\tNo regular fee events found for this EMP."));
@@ -478,6 +600,13 @@ class GlobalSummaryReporter {
         if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
           regularFeesPaidPeriod = regularFeesPaidPeriod.add(this.toBN(event.regularFee));
           lateFeesPaidPeriod = lateFeesPaidPeriod.add(this.toBN(event.lateFee));
+        }
+        if (
+          event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+          event.blockNumber < this.startBlockNumberForPeriod
+        ) {
+          regularFeesPaidPrevPeriod = regularFeesPaidPrevPeriod.add(this.toBN(event.regularFee));
+          lateFeesPaidPrevPeriod = lateFeesPaidPrevPeriod.add(this.toBN(event.lateFee));
         }
       }
     }
@@ -490,6 +619,12 @@ class GlobalSummaryReporter {
         if (event.blockNumber >= this.startBlockNumberForPeriod && event.blockNumber < this.endBlockNumberForPeriod) {
           finalFeesPaidPeriod = finalFeesPaidPeriod.add(this.toBN(event.amount));
         }
+        if (
+          event.blockNumber >= this.startBlockNumberForPreviousPeriod &&
+          event.blockNumber < this.startBlockNumberForPeriod
+        ) {
+          finalFeesPaidPrevPeriod = finalFeesPaidPrevPeriod.add(this.toBN(event.amount));
+        }
       }
     }
 
@@ -497,15 +632,22 @@ class GlobalSummaryReporter {
       allDvmStatsTable = {
         ["final fees paid to store"]: {
           cumulative: this.formatDecimalString(finalFeesPaid),
-          [this.periodLabelInHours]: this.formatDecimalString(finalFeesPaidPeriod)
+          [this.periodLabelInHours]: this.formatDecimalString(finalFeesPaidPeriod),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+            finalFeesPaidPeriod.sub(finalFeesPaidPrevPeriod)
+          )
         },
         ["ongoing regular fees paid to store"]: {
           cumulative: this.formatDecimalString(regularFeesPaid),
-          [this.periodLabelInHours]: this.formatDecimalString(regularFeesPaidPeriod)
+          [this.periodLabelInHours]: this.formatDecimalString(regularFeesPaidPeriod),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+            regularFeesPaidPeriod.sub(regularFeesPaidPrevPeriod)
+          )
         },
         ["ongoing late fees paid to store"]: {
           cumulative: this.formatDecimalString(lateFeesPaid),
-          [this.periodLabelInHours]: this.formatDecimalString(lateFeesPaidPeriod)
+          [this.periodLabelInHours]: this.formatDecimalString(lateFeesPaidPeriod),
+          ["delta from prev. period"]: this.formatDecimalStringWithSign(lateFeesPaidPeriod.sub(lateFeesPaidPrevPeriod))
         }
       };
 

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -194,7 +194,7 @@ class GlobalSummaryReporter {
       cumulative: Object.keys(uniqueSponsors).length,
       current: Object.keys(currentUniqueSponsors).length,
       [this.periodLabelInHours]: Object.keys(periodUniqueSponsors).length,
-      ["delta from prev. period"]: addSign(
+      ["Δ from prev. period"]: addSign(
         Object.keys(periodUniqueSponsors).length - Object.keys(prevPeriodUniqueSponsors).length
       )
     };
@@ -218,7 +218,7 @@ class GlobalSummaryReporter {
     allSponsorStatsTable["collateral deposited"] = {
       cumulative: this.formatDecimalString(collateralDeposited),
       [this.periodLabelInHours]: this.formatDecimalString(collateralDepositedPeriod),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(
         collateralDepositedPeriod.sub(collateralDepositedPrevPeriod)
       )
     };
@@ -242,7 +242,7 @@ class GlobalSummaryReporter {
     allSponsorStatsTable["collateral withdrawn"] = {
       cumulative: this.formatDecimalString(collateralWithdrawn),
       [this.periodLabelInHours]: this.formatDecimalString(collateralWithdrawnPeriod),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(
         collateralWithdrawnPeriod.sub(collateralWithdrawnPrevPeriod)
       )
     };
@@ -257,7 +257,7 @@ class GlobalSummaryReporter {
     allSponsorStatsTable["net collateral deposited"] = {
       cumulative: this.formatDecimalString(netCollateralWithdrawn),
       [this.periodLabelInHours]: this.formatDecimalString(netCollateralWithdrawnPeriod),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(
         netCollateralWithdrawnPeriod.sub(netCollateralWithdrawnPrevPeriod)
       )
     };
@@ -281,7 +281,7 @@ class GlobalSummaryReporter {
     allSponsorStatsTable["tokens minted"] = {
       cumulative: this.formatDecimalString(tokensMinted),
       [this.periodLabelInHours]: this.formatDecimalString(tokensMintedPeriod),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(tokensMintedPrevPeriod.sub(tokensMintedPeriod))
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(tokensMintedPrevPeriod.sub(tokensMintedPeriod))
     };
 
     // - Tokens burned
@@ -303,7 +303,7 @@ class GlobalSummaryReporter {
     allSponsorStatsTable["tokens burned"] = {
       cumulative: this.formatDecimalString(tokensBurned),
       [this.periodLabelInHours]: this.formatDecimalString(tokensBurnedPeriod),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(tokensBurnedPeriod.sub(tokensBurnedPrevPeriod))
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(tokensBurnedPeriod.sub(tokensBurnedPrevPeriod))
     };
 
     // - Net tokens minted:
@@ -316,9 +316,7 @@ class GlobalSummaryReporter {
     allSponsorStatsTable["net tokens minted"] = {
       cumulative: this.formatDecimalString(netTokensMinted),
       [this.periodLabelInHours]: this.formatDecimalString(netTokensMintedPeriod),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(
-        netTokensMintedPeriod.sub(netTokensMintedPrevPeriod)
-      )
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(netTokensMintedPeriod.sub(netTokensMintedPrevPeriod))
     };
 
     // - GCR (collateral / tokens outstanding):
@@ -330,7 +328,7 @@ class GlobalSummaryReporter {
     let prevGCR = prevPeriodCollateral.mul(this.toBN(this.toWei("1"))).div(prevPeriodTokensOutstanding);
     allSponsorStatsTable["GCR - collateral / # tokens outstanding"] = {
       current: this.formatDecimalString(currentGCR),
-      ["delta from prev. period"]: this.formatDecimalStringWithSign(currentGCR.sub(prevGCR))
+      ["Δ from prev. period"]: this.formatDecimalStringWithSign(currentGCR.sub(prevGCR))
     };
 
     // - GCR (collateral / TRV):
@@ -393,12 +391,12 @@ class GlobalSummaryReporter {
     allTokenStatsTable["# trades in Uniswap"] = {
       cumulative: tradeCount,
       [this.periodLabelInHours]: periodTradeCount,
-      ["delta from prev. period"]: addSign(periodTradeCount - prevPeriodTradeCount)
+      ["Δ from prev. period"]: addSign(periodTradeCount - prevPeriodTradeCount)
     };
     allTokenStatsTable["volume of trades in Uniswap in # of tokens"] = {
       cumulative: formatWithMaxDecimals(tradeVolumeTokens, 2, 4, false),
       [this.periodLabelInHours]: formatWithMaxDecimals(periodTradeVolumeTokens, 2, 4, false),
-      ["delta from prev. period"]: formatWithMaxDecimals(
+      ["Δ from prev. period"]: formatWithMaxDecimals(
         periodTradeVolumeTokens - prevPeriodTradeVolumeTokens,
         2,
         4,
@@ -458,14 +456,14 @@ class GlobalSummaryReporter {
         ["# of liquidations"]: {
           cumulative: Object.keys(uniqueLiquidations).length,
           [this.periodLabelInHours]: Object.keys(uniqueLiquidationsPeriod).length,
-          ["delta from prev. period"]: addSign(
+          ["Δ from prev. period"]: addSign(
             Object.keys(uniqueLiquidationsPeriod).length - Object.keys(uniqueLiquidationsPrevPeriod).length
           )
         },
         ["tokens liquidated"]: {
           cumulative: this.formatDecimalString(tokensLiquidated),
           [this.periodLabelInHours]: this.formatDecimalString(tokensLiquidatedPeriod),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(
             tokensLiquidatedPeriod.sub(tokensLiquidatedPrevPeriod)
           )
         },
@@ -473,7 +471,7 @@ class GlobalSummaryReporter {
           cumulative: this.formatDecimalString(collateralLiquidated),
           [this.periodLabelInHours]: this.formatDecimalString(collateralLiquidatedPeriod),
           current: this.formatDecimalString(this.collateralLockedInLiquidations),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(
             collateralLiquidatedPeriod.sub(collateralLiquidatedPrevPeriod)
           )
         }
@@ -550,21 +548,19 @@ class GlobalSummaryReporter {
         ["# of disputes"]: {
           cumulative: Object.keys(uniqueDisputes).length,
           [this.periodLabelInHours]: Object.keys(uniqueDisputesPeriod).length,
-          ["delta from prev. period"]: addSign(
+          ["Δ from prev. period"]: addSign(
             Object.keys(uniqueDisputesPeriod).length - Object.keys(uniqueDisputesPrevPeriod).length
           )
         },
         ["tokens disputed"]: {
           cumulative: this.formatDecimalString(tokensDisputed),
           [this.periodLabelInHours]: this.formatDecimalString(tokensDisputedPeriod),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(
-            tokensDisputedPeriod.sub(tokensDisputedPrevPeriod)
-          )
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(tokensDisputedPeriod.sub(tokensDisputedPrevPeriod))
         },
         ["collateral disputed"]: {
           cumulative: this.formatDecimalString(collateralDisputed),
           [this.periodLabelInHours]: this.formatDecimalString(collateralDisputedPeriod),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(
             collateralDisputedPeriod.sub(collateralDisputedPrevPeriod)
           )
         }
@@ -633,21 +629,19 @@ class GlobalSummaryReporter {
         ["final fees paid to store"]: {
           cumulative: this.formatDecimalString(finalFeesPaid),
           [this.periodLabelInHours]: this.formatDecimalString(finalFeesPaidPeriod),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(
-            finalFeesPaidPeriod.sub(finalFeesPaidPrevPeriod)
-          )
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(finalFeesPaidPeriod.sub(finalFeesPaidPrevPeriod))
         },
         ["ongoing regular fees paid to store"]: {
           cumulative: this.formatDecimalString(regularFeesPaid),
           [this.periodLabelInHours]: this.formatDecimalString(regularFeesPaidPeriod),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(
             regularFeesPaidPeriod.sub(regularFeesPaidPrevPeriod)
           )
         },
         ["ongoing late fees paid to store"]: {
           cumulative: this.formatDecimalString(lateFeesPaid),
           [this.periodLabelInHours]: this.formatDecimalString(lateFeesPaidPeriod),
-          ["delta from prev. period"]: this.formatDecimalStringWithSign(lateFeesPaidPeriod.sub(lateFeesPaidPrevPeriod))
+          ["Δ from prev. period"]: this.formatDecimalStringWithSign(lateFeesPaidPeriod.sub(lateFeesPaidPrevPeriod))
         }
       };
 

--- a/reporters/SponsorReporter.js
+++ b/reporters/SponsorReporter.js
@@ -73,7 +73,7 @@ class SponsorReporter {
 
   async generateSponsorsTable() {
     await this.update();
-    console.log(italic("- All current token sponsors within the spesified EMP are printed"));
+    console.log(italic("- All current token sponsors within the specified EMP are printed"));
 
     // For all positions current open in the UMA ecosystem, generate a table.
     const allPositions = this.empClient.getAllPositions();

--- a/reporters/uniswapSubgraphClient.js
+++ b/reporters/uniswapSubgraphClient.js
@@ -16,16 +16,17 @@ function getUniswapClient() {
 }
 
 /**
- * @notice Return query to get pair data for uniswap pair @ `pairAddress` up to `block`-2 height. Default block height
- * is latest block available in subgraph.
- * @dev We subtract block height conservatively by 2 because we have observed a delay between the latest network block # (i.e. web3.eth.getBlockNumber),
+ * @notice Return query to get pair data for uniswap pair @ `pairAddress` up to `block`-3 height. Default block height
+ * is latest block available in subgraph. This should not be assumed to be the latest mined block for the network,
+ * which might be higher than the latest block available in the subgraph.
+ * @dev We subtract from the `block` height conservatively because we have observed a delay between the latest network block # (i.e. web3.eth.getBlockNumber),
  * and the latest block number available in the Uniswap subgraph.
  * @param {String} pairAddress Address of uniswap pair
  * @param {[Integer]} block Highest block number to query data from.
  * @return query string
  */
 function PAIR_DATA(pairAddress, block) {
-  const blockNumberLag = 2;
+  const blockNumberLag = 3;
   const queryString = block
     ? `
             query pairs {


### PR DESCRIPTION
I'm not sure this is the most intuitive way to display it, but I'm trying to show the difference between the value in the "period" column versus the previous period, which is the same length as the default "period" but shifted back by one `PERIOD_LENGTH`.

- add helper format modules to add signs to numbers
- remove **current** "net tokens minted" and "net collateral deposited" stats and replace with in-code accounting assertions to make sure they equal `totalTokensOutstanding` and `totalPositionCollateral`, respectively
- fix typos in dispute stats

Resolves #1610 

Example of new delta column:
![Screen Shot 2020-06-16 at 15 39 04](https://user-images.githubusercontent.com/9457025/84820368-88769380-afe7-11ea-85cc-0dddf6f1d730.png)


Signed-off-by: Nick Pai <npai.nyc@gmail.com>