### PR TITLE
Add lerna and yarn workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 build
 bridge.log
 package-lock.json
+yarn.lock
 .coverage_contracts
 .coverage
 coverage

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,6 @@
+{
+  "packages": [],
+  "npmClient": "yarn",
+  "useWorkspaces": true,
+  "version": "independent"
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "protocol",
   "version": "0.1.0",
   "description": "UMA Protocol Smart Contracts",
+  "private": true,
   "scripts": {
     "lint": "npm run eslint && npm run prettier -- --list-different",
     "lint-fix": "npm run eslint -- --fix && npm run prettier -- --write",
@@ -94,5 +95,6 @@
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix"
-  }
+  },
+  "workspaces": []
 }


### PR DESCRIPTION
Right now, these are just alternative ways of running `npm install`:
```
yarn
```
or 
```
lerna bootstrap
```

This will allow us to slowly add packages that will be managed by lerna.