### PR TITLE
Update missing step in liquidator tutorial

### DIFF
--- a/documentation/synthetic_tokens/tutorials/liquidation.md
+++ b/documentation/synthetic_tokens/tutorials/liquidation.md
@@ -42,8 +42,11 @@ Before starting this tutorial you need to clone repo, install the dependencies a
 git clone https://github.com/UMAprotocol/protocol.git
 cd ./protocol
 
-# Install dependencies & compile the contracts
+# Install dependencies
 npm install
+
+# Navigate into the core directory & compile contracts
+cd ./core
 npx truffle compile
 ```
 


### PR DESCRIPTION
There's a missing instruction to navigate into the core folder before running `npx truffle compile`. Since the root folder doesn't have a `truffle-config.js`, this will fail. Thus I have added an extra step to ` cd core` before running the compile step.