### PR TITLE
GCP deploy script: delete instance before deploying

### DIFF
--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -39,7 +39,7 @@ gsutil cp gs://bot-configs/$1.env $tempFile
 echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
 
 # Check if there is an existing instance. If there is, then we will delete it to clear space for the new one.
-existingImages=$(gcloud compute instances list --filter $1 --limit 1 | grep $1)
+existingImages=$(gcloud compute instances list --filter $1 --limit 1)
 if [[ "$existingImages" == *"$1"* ]]; then
     echo "♻️  Deleting old bot.  ⚠️  Deleting an instance can take some time, please be patient.  ⚠️"
     

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -38,6 +38,15 @@ gsutil cp gs://bot-configs/$1.env $tempFile
 
 echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
 
+# Delete existing instance to clear space for new instance. This will prompt the user to confirm y/N if they want
+# to delete the instance. 
+# TODO: Check if an image exists before attempting to delete it via "gcloud compute instances list --filter $1"
+echo "♻️  Deleting old bot.  ⚠️  Deleting an instance can take some time, please be patient.  ⚠️"
+gcloud compute instances delete $1 \
+    --zone northamerica-northeast1-b
+
+echo "🎇  Old bot has been deleted!"
+
 # Deploy The bot to GCP using the config file and the service account
 echo "🚀 Deploying bot to GCP"
 gcloud compute instances create-with-container $1 \

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -38,14 +38,17 @@ gsutil cp gs://bot-configs/$1.env $tempFile
 
 echo "✍️  Config has been pulled and placed in a temp directory" $tempFile
 
-# Delete existing instance to clear space for new instance. This will prompt the user to confirm y/N if they want
-# to delete the instance. 
-# TODO: Check if an image exists before attempting to delete it via "gcloud compute instances list --filter $1"
-echo "♻️  Deleting old bot.  ⚠️  Deleting an instance can take some time, please be patient.  ⚠️"
-gcloud compute instances delete $1 \
-    --zone northamerica-northeast1-b
+# Check if there is an existing instance. If there is, then we will delete it to clear space for the new one.
+existingImages=$(gcloud compute instances list --filter $1 --limit 1 | grep $1)
+if [[ "$existingImages" == *"$1"* ]]; then
+    echo "♻️  Deleting old bot.  ⚠️  Deleting an instance can take some time, please be patient.  ⚠️"
+    
+    # This will prompt the user to confirm y/N if they want o delete the instance. 
+    gcloud compute instances delete $1 \
+        --zone northamerica-northeast1-b
 
-echo "🎇  Old bot has been deleted!"
+    echo "🎇  Old bot has been deleted!"
+fi
 
 # Deploy The bot to GCP using the config file and the service account
 echo "🚀 Deploying bot to GCP"

--- a/scripts/bot-deployment/DeployBotGCP.sh
+++ b/scripts/bot-deployment/DeployBotGCP.sh
@@ -43,9 +43,9 @@ existingImages=$(gcloud compute instances list --filter $1 --limit 1)
 if [[ "$existingImages" == *"$1"* ]]; then
     echo "♻️  Deleting old bot.  ⚠️  Deleting an instance can take some time, please be patient.  ⚠️"
     
-    # This will prompt the user to confirm y/N if they want o delete the instance. 
     gcloud compute instances delete $1 \
-        --zone northamerica-northeast1-b
+        --zone northamerica-northeast1-b \
+        --quiet
 
     echo "🎇  Old bot has been deleted!"
 fi


### PR DESCRIPTION
Currently we cannot deploy a new GCP instance via this script before manually deleting the existing one. This automates the deletion process by first checking whether an image exists already and subsequently deleting it if so.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>