### PR TITLE
Move off of solidity-docgen fork

### DIFF
--- a/ci/docgen.sh
+++ b/ci/docgen.sh
@@ -3,4 +3,4 @@
 # Note: because we've forked the solidity-docgen library, providing the path alias doesn't have an effect. However,
 # once external libraries are supported in v2 and we deprecate our fork, this will allow the docgen to find the
 # openzeppelin directory. See https://github.com/OpenZeppelin/solidity-docgen/issues/24 for progress on that front.
-$(npm bin)/solidity-docgen -i ./core/contracts -t documentation --contract-pages -x adoc -e core/contracts/oracle/test,core/contracts/tokenized-derivative/echidna-tests
+$(npm bin)/solidity-docgen -i ./core/contracts -t documentation -x adoc -e core/contracts/oracle/test,core/contracts/tokenized-derivative/echidna-tests

--- a/documentation/contract.hbs
+++ b/documentation/contract.hbs
@@ -1,5 +1,5 @@
 {{~#*inline "typed-variable-array"~}}
-{{#each .}}[.var-type\]#{{ecb typeName}}#{{#if name}} [.var-name\]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
+{{#each .}}[.var-type]#{{typeName}}#{{#if name}} [.var-name]#{{name}}#{{/if}}{{#unless @last}}, {{/unless}}{{/each}}
 {{~/inline~}}
 
 {{#each linkable}}
@@ -68,7 +68,7 @@
 {{#each modifiers}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#modifier#
+==== `{{name}}({{> typed-variable-array args}})` [.item-kind]#modifier#
 
 {{natspec.userdoc}}
 
@@ -87,7 +87,7 @@ Parameters:
 {{#each functions}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}]` [.item-kind]#{{visibility}}#
+==== `{{name}}({{> typed-variable-array args}}){{#if outputs}} → {{> typed-variable-array outputs}}{{/if}}` [.item-kind]#{{visibility}}#
 
 {{natspec.userdoc}}
 
@@ -106,7 +106,7 @@ Parameters:
 {{#each events}}
 [.contract-item]
 [[{{anchor}}]]
-==== `pass:normal[{{name}}({{> typed-variable-array args}})]` [.item-kind]#event#
+==== `{{name}}({{> typed-variable-array args}})` [.item-kind]#event#
 
 {{natspec.userdoc}}
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "require-context": "^1.1.0",
     "secp256k1": "^3.7.1",
     "sinon": "^9.0.2",
+    "solidity-docgen": "^0.5.3",
     "truffle": "^5.1.14",
     "truffle-assertions": "^0.9.2",
     "web3": "^1.2.4",
@@ -81,9 +82,6 @@
     "winston": "^3.2.1",
     "winston-slack-webhook-transport": "^1.2.1",
     "winston-transport": "^4.3.0"
-  },
-  "optionalDependencies": {
-    "solidity-docgen": "github:UMAprotocol/solidity-docgen#fork-updated"
   },
   "bin": {
     "uma": "./core/scripts/cli/cli_entry.sh"


### PR DESCRIPTION
Required for #1631. `lerna bootstrap` doesn't generate a binary for solidity-docgen when pulled from git. My guess is that this has something to do with post install scripts not being run, but this is as good a reason as any to move away from using our fork.

Most of these changes just flow from the advice from @frangio in #1046.