### PR TITLE
Move away from EthGasStation to Etherchain for gas estimations

### DIFF
--- a/financial-templates-lib/helpers/GasEstimator.js
+++ b/financial-templates-lib/helpers/GasEstimator.js
@@ -1,8 +1,8 @@
-// This script gets the current recommended `fast` gas price from ethGasStation
+// This script gets the current recommended `fast` gas price from etherchain
 // to inform the Liquidator and dispute bot of a reasonable gas price to use.
 
 const fetch = require("node-fetch");
-const url = "https://ethgasstation.info/json/ethgasAPI.json";
+const url = "https://www.etherchain.org/api/gasPriceOracle";
 
 class GasEstimator {
   /**
@@ -61,9 +61,8 @@ class GasEstimator {
     try {
       const response = await fetch(url);
       const json = await response.json();
-      // The number returned by EthGasStation is a Gwei amount, scaled by 10.
       if (json.fast) {
-        let price = json.fast / 10;
+        let price = json.fast;
         return price;
       } else {
         throw new Error("bad json response");


### PR DESCRIPTION
EthGasStation requires an API key from the 1st of July. This is not a big issue and certainly is not a large development overhead to implement. However, it does introduce the need for _all users_ to include an API key in their config. This burden is very irritating. Alternatively, an API could be hardcoded into the code but this is bad practice and could be used until rate limited. 

Rather than adding in an API key parameter to the `GasEstimator.js` module, this PR changes the module to use a different service to estimate gas. This can be seen [here](https://www.etherchain.org/tools/gasPriceOracle).

Fortunately, etherchain & EthGasStation both return objects of the same structure and so minimum code changes were needed to be made. The only real difference is that EthGasStation scales all prices up by 10 for no apparent reason while etherchain does not do this.

Sample etherchain object: 
```
{"safeLow":"35.9","standard":"41.0","fast":"44.0","fastest":"49.0"}
```

Sample EthGasStation object:
```
{"fast": 460.0, "fastest": 470.0, "safeLow": 360.0, "average": 420.0, "block_time": 10.5, "blockNum": 10315704, "speed": 0.895397210524636, "safeLowWait": 13.8, "avgWait": 3.4, "fastWait": 0.4, "fastestWait": 0.4, "gasPriceRange": {"470": 0.4, "450": 0.5, "430": 1.8, "410": 4.4, "390": 11.6, "370": 13.8, "350": 19.6, "330": 175.0, "310": 175.0, "290": 175.0, "270": 175.0, "250": 175.0, "230": 175.0, "210": 175.0, "190": 175.0, "180": 175.0, "170": 175.0, "160": 175.0, "150": 175.0, "140": 175.0, "130": 175.0, "120": 175.0, "110": 175.0, "100": 175.0, "90": 175.0, "80": 175.0, "70": 175.0, "60": 175.0, "50": 175.0, "40": 175.0, "30": 175.0, "20": 175.0, "10": 175.0, "8": 175.0, "6": 175.0, "4": 175.0, "460": 0.4, "420": 3.4, "360": 13.8}}
```

close #1635