### PR TITLE
Refine logging levels to enable overrides and disable logic

### DIFF
--- a/disputer/index.js
+++ b/disputer/index.js
@@ -30,15 +30,13 @@ async function run(address, pollingDelay, priceFeedConfig, disputerConfig) {
   try {
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
-    const logObject = {
+    Logger[pollingDelay === 0 ? "debug" : "info"]({
       at: "Disputer#index",
       message: "Disputer started🔎",
       empAddress: address,
       pollingDelay,
       priceFeedConfig
-    };
-    if (pollingDelay === 0) Logger.debug(logObject);
-    else Logger.info(logObject);
+    });
 
     // Setup web3 accounts an contract instance
     const accounts = await web3.eth.getAccounts();
@@ -117,7 +115,7 @@ async function Poll(callback) {
 
     // If there is a disputer config, add it. Else, set to null. This config contains disputeDelay and txnGasLimit. EG:
     // {"disputeDelay":60,"txnGasLimit":9000000}
-    const disputerConfig = process.env.DISPUTER_CONFIG ? process.env.DISPUTER_CONFIG : null;
+    const disputerConfig = process.env.DISPUTER_CONFIG ? JSON.parse(process.env.DISPUTER_CONFIG) : null;
 
     await run(process.env.EMP_ADDRESS, pollingDelay, priceFeedConfig, disputerConfig);
   } catch (error) {

--- a/financial-templates-lib/logger/SpyTransport.js
+++ b/financial-templates-lib/logger/SpyTransport.js
@@ -24,4 +24,9 @@ function lastSpyLogIncludes(spy, value) {
   return lastReturnedArgMrkdwn.indexOf(value) != -1 || lastReturnedArgMessage.indexOf(value) != -1;
 }
 
-module.exports = { SpyTransport, lastSpyLogIncludes };
+// Helper function used by unit tests to get the most recent log level.
+function lastSpyLogLevel(spy) {
+  return spy.getCall(-1).lastArg.level.toString();
+}
+
+module.exports = { SpyTransport, lastSpyLogIncludes, lastSpyLogLevel };

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -130,8 +130,12 @@ async function Poll(callback) {
     const priceFeedConfig = JSON.parse(process.env.PRICE_FEED_CONFIG);
 
     // If there is a disputer config, add it. Else, set to null. This config contains crThreshold,liquidationDeadline,
-    // liquidationMinPrice and txnGasLimit. EG: {"crThreshold":0.02,"liquidationDeadline":300,"liquidationMinPrice":0,
-    // "txnGasLimit":9000000}
+    // liquidationMinPrice, txnGasLimit & logOverrides. Example config:
+    // {"crThreshold":0.02,  -> Liquidate if a positions collateral falls more than this % below the min CR requirement
+    //   "liquidationDeadline":300, -> Aborts if the transaction is mined this amount of time after the last update
+    //   "liquidationMinPrice":0, -> Aborts if the amount of collateral in the position per token is below this ratio
+    //   "txnGasLimit":9000000 -> Gas limit to set for sending on-chain transactions.
+    //   "logOverrides":{"positionLiquidated":"warn"}} -> override specific events log levels.
     const liquidatorConfig = process.env.LIQUIDATOR_CONFIG ? JSON.parse(process.env.LIQUIDATOR_CONFIG) : null;
 
     const portNumber = 8888;

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -31,7 +31,7 @@ async function run(address, pollingDelay, priceFeedConfig, monitorPort, liquidat
   try {
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
-    const logObject = {
+    Logger[pollingDelay === 0 ? "debug" : "info"]({
       at: "Liquidator#index",
       message: "Liquidator started 🌊",
       empAddress: address,
@@ -39,9 +39,7 @@ async function run(address, pollingDelay, priceFeedConfig, monitorPort, liquidat
       priceFeedConfig,
       liquidatorConfig,
       monitorPort
-    };
-    if (pollingDelay === 0) Logger.debug(logObject);
-    else Logger.info(logObject);
+    });
 
     // Setup web3 accounts an contract instance.
     const accounts = await web3.eth.getAccounts();
@@ -134,7 +132,7 @@ async function Poll(callback) {
     // If there is a disputer config, add it. Else, set to null. This config contains crThreshold,liquidationDeadline,
     // liquidationMinPrice and txnGasLimit. EG: {"crThreshold":0.02,"liquidationDeadline":300,"liquidationMinPrice":0,
     // "txnGasLimit":9000000}
-    const liquidatorConfig = process.env.LIQUIDATOR_CONFIG ? process.env.LIQUIDATOR_CONFIG : null;
+    const liquidatorConfig = process.env.LIQUIDATOR_CONFIG ? JSON.parse(process.env.LIQUIDATOR_CONFIG) : null;
 
     const portNumber = 8888;
 

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -13,7 +13,7 @@ const { GasEstimator } = require("../../financial-templates-lib/helpers/GasEstim
 const { PriceFeedMock } = require("../../financial-templates-lib/test/price-feed/PriceFeedMock");
 
 // Custom winston transport module to monitor winston log outputs
-const { SpyTransport } = require("../../financial-templates-lib/logger/SpyTransport");
+const { SpyTransport, lastSpyLogLevel } = require("../../financial-templates-lib/logger/SpyTransport");
 
 // Contracts and helpers
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
@@ -503,6 +503,41 @@ contract("Liquidator.js", function(accounts) {
       // Sponsor2 should have all their collateral left and no liquidations.
       assert.deepStrictEqual(await emp.getLiquidations(sponsor2), []);
       assert.equal((await emp.getCollateral(sponsor2)).rawValue, toWei("118"));
+    });
+    it("Cannot set invalid alerting overrides", async function() {
+      // Create an invalid log level override. This should be rejected.
+
+      let errorThrown;
+      try {
+        liquidatorConfig = { logOverrides: { positionLiquidated: "not a valid log level" } };
+        liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
+        errorThrown = false;
+      } catch (err) {
+        errorThrown = true;
+      }
+      assert.isTrue(errorThrown);
+    });
+
+    it("Overriding threshold correctly effects generated logs", async function() {
+      // Liquidation events normally are `info` level. This override should change the value to `warn` which can be
+      // validated after the log is generated.
+      liquidatorConfig = { logOverrides: { positionLiquidated: "warn" } };
+      liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
+
+      // sponsor1 creates a position with 115 units of collateral, creating 100 synthetic tokens.
+      await emp.create({ rawValue: toWei("115") }, { rawValue: toWei("100") }, { from: sponsor1 });
+
+      // sponsor2 creates a position with 118 units of collateral, creating 100 synthetic tokens.
+      await emp.create({ rawValue: toWei("118") }, { rawValue: toWei("100") }, { from: sponsor2 });
+
+      // liquidatorBot creates a position to have synthetic tokens to pay off debt upon liquidation.
+      await emp.create({ rawValue: toWei("1000") }, { rawValue: toWei("500") }, { from: liquidatorBot });
+
+      priceFeedMock.setCurrentPrice(toBN(toWei("1")));
+      assert.equal(spy.callCount, 0); // No log events before liquidation query
+      await liquidator.queryAndLiquidate();
+      assert.equal(spy.callCount, 1); // 1 log events after liquidation query.
+      assert.equal(lastSpyLogLevel(spy), "warn"); // most recent log level should be "warn"
     });
   });
 });

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -505,10 +505,9 @@ contract("Liquidator.js", function(accounts) {
       assert.equal((await emp.getCollateral(sponsor2)).rawValue, toWei("118"));
     });
     it("Cannot set invalid alerting overrides", async function() {
-      // Create an invalid log level override. This should be rejected.
-
       let errorThrown;
       try {
+        // Create an invalid log level override. This should be rejected.
         liquidatorConfig = { logOverrides: { positionLiquidated: "not a valid log level" } };
         liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0], liquidatorConfig);
         errorThrown = false;

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -2,7 +2,6 @@
 // 2) liquidations are submitted, 3) liquidations are disputed or 4) disputes are resolved.
 
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
-const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
 
 class ContractMonitor {
   /**
@@ -49,8 +48,6 @@ class ContractMonitor {
     // Helper functions from web3.
     this.toWei = this.web3.utils.toWei;
     this.toBN = this.web3.utils.toBN;
-
-    const defaultConfig = {};
   }
 
   // Calculate the collateralization Ratio from the collateral, token amount and token price

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -2,6 +2,7 @@
 // 2) liquidations are submitted, 3) liquidations are disputed or 4) disputes are resolved.
 
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
+const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
 
 class ContractMonitor {
   /**
@@ -48,6 +49,8 @@ class ContractMonitor {
     // Helper functions from web3.
     this.toWei = this.web3.utils.toWei;
     this.toBN = this.web3.utils.toBN;
+
+    const defaultConfig = {};
   }
 
   // Calculate the collateralization Ratio from the collateral, token amount and token price

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -38,10 +38,10 @@ class SyntheticPegMonitor {
     const defaultConfig = {
       deviationAlertThreshold: {
         // `deviationAlertThreshold`: Error threshold used to compare observed and expected token prices.
-        // if the deviation in token price exceeds this value an alert is fired.
+        // if the deviation in token price exceeds this value an alert is fired. If set to zero then fire no logs.
         value: 0.2,
         isValid: x => {
-          return x < 100 && x > 0;
+          return x < 100 && x >= 0;
         }
       },
       volatilityWindow: {
@@ -67,8 +67,9 @@ class SyntheticPegMonitor {
   }
 
   // Compares synthetic price on Uniswap with pegged price on medianizer price feed and fires a message
-  // if the synythetic price deviates too far from the peg.
+  // if the synythetic price deviates too far from the peg. If deviationAlertThreshold == 0 then do nothing.
   async checkPriceDeviation() {
+    if (this.deviationAlertThreshold == 0) return; // return early if the threshold is zero.
     // Get the latest prices from the two price feeds.
     const uniswapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
     const cryptoWatchTokenPrice = this.medianizerPriceFeed.getCurrentPrice();

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -51,7 +51,7 @@ async function run(
   try {
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
-    const logObject = {
+    Logger[pollingDelay === 0 ? "debug" : "info"]({
       at: "Monitor#index",
       message: "Monitor started 🕵️‍♂️",
       empAddress: address,
@@ -63,9 +63,7 @@ async function run(
       syntheticPegMonitorObject,
       uniswapPriceFeedConfig,
       medianizerPriceFeedConfig
-    };
-    if (pollingDelay === 0) Logger.debug(logObject);
-    else Logger.info(logObject);
+    });
 
     // 0. Setup EMP and token instances to monitor.
     const emp = await ExpiringMultiParty.at(address);

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -134,7 +134,7 @@ contract("SyntheticPegMonitor", function(accounts) {
 
     it("Does not track price deviation if threshold set to zero", async function() {
       syntheticPegMonitorConfig = {
-        deviationAlertThreshold: 0 // No alerts should be fired, irrespective of the current price.
+        deviationAlertThreshold: 0 // No alerts should be fired, irrespective of the current price deviation.
       };
 
       syntheticPegMonitor = new SyntheticPegMonitor(


### PR DESCRIPTION
Due to [UMIP-5](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-5.md) we require the ability to change logging levels for specific events as well as change the behavior in some monitors. 

To accommodate this requirement, this PR introduces a new optional config setting that can be passed into bots. **This config object is currently only applied to the liquidator bot specifically for the `liquidationEvent` log.** An example log override object is shown below:
```
LIQUIDATOR_CONFIG={"logOverrides":{"positionLiquidated":"warn"}}
```
This config will override the position liquidated log from its default `info` to a `warn` level event.

In future, we can choose to add additional overrides as needed. For example, we might want to have a log override in the monitor for specific actions or for a dispute event. 

This PR also changes the `SyntheticPegMonitor` to accept a `deviationAlertThreshold` of 0 to indicate that no alerts should be fired for a given deviation.