### PR TITLE
Patch winston slack logger

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -153,7 +153,7 @@ class Disputer {
         tx: receipt.transactionHash,
         sponsor: receipt.events.LiquidationDisputed.returnValues.sponsor,
         liquidator: receipt.events.LiquidationDisputed.returnValues.liquidator,
-        id: receipt.events.LiquidationDisputed.returnValues.disputeId,
+        id: receipt.events.LiquidationDisputed.returnValues.liquidationId,
         disputeBondPaid: receipt.events.LiquidationDisputed.returnValues.disputeBondAmount
       };
       this.logger.info({

--- a/financial-templates-lib/logger/Logger.js
+++ b/financial-templates-lib/logger/Logger.js
@@ -62,7 +62,7 @@ const Logger = winston.createLogger({
     winston.format.json()
   ),
   transports,
-  exitOnError: false
+  exitOnError: true
 });
 
 module.exports = {

--- a/financial-templates-lib/logger/Logger.js
+++ b/financial-templates-lib/logger/Logger.js
@@ -62,7 +62,7 @@ const Logger = winston.createLogger({
     winston.format.json()
   ),
   transports,
-  exitOnError: true
+  exitOnError: false
 });
 
 module.exports = {

--- a/financial-templates-lib/logger/PagerDutyTransport.js
+++ b/financial-templates-lib/logger/PagerDutyTransport.js
@@ -18,7 +18,7 @@ module.exports = class PagerDutyTransport extends Transport {
   async log(info, callback) {
     try {
       // If the message has markdown then add it and the bot-identifer field. Else put the whole info object as a string
-      const logMessage = info.mrkdwn ? info.mrkdwn + info["bot-identifier"] : JSON.stringify(info);
+      const logMessage = info.mrkdwn ? info.mrkdwn + `\n${info["bot-identifier"]}` : JSON.stringify(info);
 
       await this.pd.incidents.createIncident(this.fromEmail, {
         incident: {
@@ -35,7 +35,6 @@ module.exports = class PagerDutyTransport extends Transport {
           }
         }
       });
-      callback();
     } catch (error) {
       console.error("PagerDuty error", error);
     }

--- a/financial-templates-lib/logger/PagerDutyTransport.js
+++ b/financial-templates-lib/logger/PagerDutyTransport.js
@@ -17,6 +17,9 @@ module.exports = class PagerDutyTransport extends Transport {
 
   async log(info, callback) {
     try {
+      // If the message has markdown then add it and the bot-identifer field. Else put the whole info object as a string
+      const logMessage = info.mrkdwn ? info.mrkdwn + info["bot-identifier"] : JSON.stringify(info);
+
       await this.pd.incidents.createIncident(this.fromEmail, {
         incident: {
           type: "incident",
@@ -28,7 +31,7 @@ module.exports = class PagerDutyTransport extends Transport {
           urgency: info.level == "warn" ? "low" : "high", // If level is warn then urgency is low. If level is error then urgency is high.
           body: {
             type: "incident_body",
-            details: info.mrkdwn ? info.mrkdwn : JSON.stringify(info) // If the message has markdown then add it. Else put the whole info object.
+            details: logMessage
           }
         }
       });

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -26,120 +26,123 @@ const SlackHook = require("winston-slack-webhook-transport");
 const { createEtherscanLinkMarkdown } = require("../../common/FormattingUtils");
 
 function slackFormatter(info) {
-  if (!("level" in info) || !("at" in info) || !("message" in info)) {
-    console.error("WINSTON INCORRECTLY CONFIGURED IN MESSAGE", info);
+  try {
+    if (!("level" in info) || !("at" in info) || !("message" in info)) throw "WINSTON MESSAGE INCORRECTLY CONFIGURED";
+
+    // Each part of the slack response is a separate block with markdown text within it.
+    // All slack responses start with the heading level and where the message came from.
+    let formattedResponse = {
+      // If the bot contains an identifier flag it should be included in the heading.
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `[${info.level}] *${info["bot-identifier"]}* (${info.at})⭢${info.message}\n`
+          }
+        }
+      ]
+    };
+    // All messages from winston come in as a Json object. The loop below expands this object and adds mrkdwn sections
+    // for each key value pair with a bullet point. If the section is an object then it was passed containing multiple
+    // sub points. This is also expanded as a sub indented section.
+    console.log("IN spread", info);
+    for (const key in info) {
+      // these keys have been printed in the previous block.
+      if (key == "at" || key == "level" || key == "message" || key == "bot-identifier") {
+        continue;
+      }
+      // If the key is `mrkdwn` then simply return only the markdown as the txt object. This assumes all formatting has
+      // been applied in the bot itself. For example the monitor bots which conform to strict formatting rules.
+      if (key == "mrkdwn") {
+        formattedResponse.blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ` ${info[key]}`
+          }
+        });
+      }
+      // If the value in the message is an object then spread each key value pair within the object.
+      else if (typeof info[key] === "object" && info[key] !== null) {
+        formattedResponse.blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ` • _${key}_:\n`
+          }
+        });
+        // For each key value pair within the object, spread the object out for formatting.
+        for (const subKey in info[key]) {
+          // If the length of the value is 66 then we know this is a transaction hash. Format accordingly.
+          if (info[key][subKey].length == 66) {
+            formattedResponse.blocks[
+              formattedResponse.blocks.length - 1
+            ].text.text += `    - _tx_: ${createEtherscanLinkMarkdown(info[key][subKey])}\n`;
+          }
+          // If the length of the value is 42 then we know this is an address. Format accordingly.
+          else if (info[key][subKey].length == 42) {
+            formattedResponse.blocks[
+              formattedResponse.blocks.length - 1
+            ].text.text += `    - _${subKey}_: ${createEtherscanLinkMarkdown(info[key][subKey])}\n`;
+          }
+          // If the value within the object itself is an object we dont want to spread it any further. Rather,
+          // convert the object to a string and print it along side it's key value pair.
+          else if (typeof info[key][subKey] === "object" && info[key][subKey] !== null) {
+            formattedResponse.blocks[
+              formattedResponse.blocks.length - 1
+            ].text.text += `    - _${subKey}_: ${JSON.stringify(info[key][subKey])}\n`;
+            // Else if not a address, transaction or object then print as ` - key: value`
+          } else {
+            formattedResponse.blocks[
+              formattedResponse.blocks.length - 1
+            ].text.text += `    - _${subKey}_: ${info[key][subKey]}\n`;
+          }
+        }
+        // Else, if the input is not an object then print the values as key value pairs. First check for addresses or txs
+      } else if (info[key]) {
+        // like with the previous level, if there is a value that is a transaction or an address format accordingly
+        if (info[key].length == 66) {
+          formattedResponse.blocks[
+            formattedResponse.blocks.length - 1
+          ].text.text += ` • _tx_: ${createEtherscanLinkMarkdown(info[key])}\n`;
+        }
+        // If the length of the value is 42 then we know this is an address. Format accordingly.
+        else if (info[key].length == 42) {
+          formattedResponse.blocks[
+            formattedResponse.blocks.length - 1
+          ].text.text += ` • _${key}_: ${createEtherscanLinkMarkdown(info[key])}\n`;
+        } else {
+          formattedResponse.blocks.push({
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: ` • _${key}_: ${info[key]}\n`
+            }
+          });
+        }
+      }
+    }
+    // Add a divider to the end of the message to help distinguish messages in long lists.
+    formattedResponse.blocks.push({
+      type: "divider"
+    });
+    return formattedResponse;
+  } catch (error) {
     return {
       blocks: [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: "*incorrectly formatted winston message!*"
+            text: `*Something went wrong in the winston formatter!*\n\nError:${error}\n\nlogInfo:${JSON.stringify(
+              info
+            )}`
           }
         }
       ]
     };
   }
-
-  // Each part of the slack response is a separate block with markdown text within it.
-  // All slack responses start with the heading level and where the message came from.
-  let formattedResponse = {
-    // If the bot contains an identifier flag it should be included in the heading.
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `[${info.level}] *${info["bot-identifier"]}* (${info.at})⭢${info.message}\n`
-        }
-      }
-    ]
-  };
-
-  // All messages from winston come in as a Json object. The loop below expands this object and adds mrkdwn sections
-  // for each key value pair with a bullet point. If the section is an object then it was passed containing multiple
-  // sub points. This is also expanded as a sub indented section.
-  for (const key in info) {
-    // these keys have been printed in the previous block.
-    if (key == "at" || key == "level" || key == "message" || key == "bot-identifier") {
-      continue;
-    }
-    // If the key is `mrkdwn` then simply return only the markdown as the txt object. This assumes all formatting has
-    // been applied in the bot itself. For example the monitor bots which conform to strict formatting rules.
-    if (key == "mrkdwn") {
-      formattedResponse.blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: ` ${info[key]}`
-        }
-      });
-    }
-    // If the value in the message is an object then spread each key value pair within the object.
-    else if (typeof info[key] === "object" && info[key] !== null) {
-      formattedResponse.blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: ` • _${key}_:\n`
-        }
-      });
-      // For each key value pair within the object, spread the object out for formatting.
-      for (const subKey in info[key]) {
-        // If the length of the value is 66 then we know this is a transaction hash. Format accordingly.
-        if (info[key][subKey].length == 66) {
-          formattedResponse.blocks[
-            formattedResponse.blocks.length - 1
-          ].text.text += `    - _tx_: ${createEtherscanLinkMarkdown(info[key][subKey])}\n`;
-        }
-        // If the length of the value is 42 then we know this is an address. Format accordingly.
-        else if (info[key][subKey].length == 42) {
-          formattedResponse.blocks[
-            formattedResponse.blocks.length - 1
-          ].text.text += `    - _${subKey}_: ${createEtherscanLinkMarkdown(info[key][subKey])}\n`;
-        }
-        // If the value within the object itself is an object we dont want to spread it any further. Rather,
-        // convert the object to a string and print it along side it's key value pair.
-        else if (typeof info[key][subKey] === "object" && info[key][subKey] !== null) {
-          formattedResponse.blocks[
-            formattedResponse.blocks.length - 1
-          ].text.text += `    - _${subKey}_: ${JSON.stringify(info[key][subKey])}\n`;
-          // Else if not a address, transaction or object then print as ` - key: value`
-        } else {
-          formattedResponse.blocks[
-            formattedResponse.blocks.length - 1
-          ].text.text += `    - _${subKey}_: ${info[key][subKey]}\n`;
-        }
-      }
-      // Else, if the input is not an object then print the values as key value pairs. First check for addresses or txs
-    } else if (info[key]) {
-      // like with the previous level, if there is a value that is a transaction or an address format accordingly
-      if (info[key].length == 66) {
-        formattedResponse.blocks[
-          formattedResponse.blocks.length - 1
-        ].text.text += ` • _tx_: ${createEtherscanLinkMarkdown(info[key])}\n`;
-      }
-      // If the length of the value is 42 then we know this is an address. Format accordingly.
-      else if (info[key].length == 42) {
-        formattedResponse.blocks[
-          formattedResponse.blocks.length - 1
-        ].text.text += ` • _${key}_: ${createEtherscanLinkMarkdown(info[key])}\n`;
-      } else {
-        formattedResponse.blocks.push({
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: ` • _${key}_: ${info[key]}\n`
-          }
-        });
-      }
-    }
-  }
-  // Add a divider to the end of the message to help distinguish messages in long lists.
-  formattedResponse.blocks.push({
-    type: "divider"
-  });
-  return formattedResponse;
 }
 
 function createSlackTransport(webHookUrl) {

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -46,7 +46,6 @@ function slackFormatter(info) {
     // All messages from winston come in as a Json object. The loop below expands this object and adds mrkdwn sections
     // for each key value pair with a bullet point. If the section is an object then it was passed containing multiple
     // sub points. This is also expanded as a sub indented section.
-    console.log("IN spread", info);
     for (const key in info) {
       // these keys have been printed in the previous block.
       if (key == "at" || key == "level" || key == "message" || key == "bot-identifier") {

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -27,7 +27,8 @@ const { createEtherscanLinkMarkdown } = require("../../common/FormattingUtils");
 
 function slackFormatter(info) {
   try {
-    if (!("level" in info) || !("at" in info) || !("message" in info)) throw "WINSTON MESSAGE INCORRECTLY CONFIGURED";
+    if (!("level" in info) || !("at" in info) || !("message" in info))
+      throw new Error("WINSTON MESSAGE INCORRECTLY CONFIGURED");
 
     // Each part of the slack response is a separate block with markdown text within it.
     // All slack responses start with the heading level and where the message came from.


### PR DESCRIPTION
While testing the kovan disputer bot in preparation for a main net test I came across a bug in the slack transport that produced the following error:
![image](https://user-images.githubusercontent.com/12886084/85404154-d5fe7d80-b55e-11ea-8347-62a6a7d0c228.png)

This error meant that **no slack message was sent and the bot hung**. The dispute event was fired correctly & pager duty did correctly catch this but it is still a pretty bad bug that it broke the bot and caused the system to freeze with no logs to slack.

This error was as a result of a previously undetected typo in the disputer bot-message string apon creating a dispute. Specifically the id field for a dispute was identified as `disputeId`, where it should have been specified as `liquidationId`. As a result of PR [1527](https://github.com/UMAprotocol/protocol/pull/1527) this implementation became brittle which made the `undefined` value from the incorrect key-value throw this error. 

As a result, this PR patches this typo and also refines the `slackFormatter` function. Now, if a critical error is hit during the `slackFormatter` it will be gracefully caught and logged to another slack message. An example of an error filled slack object is shown below:

![image](https://user-images.githubusercontent.com/12886084/85404763-b9af1080-b55f-11ea-8af5-ef4c84e832d2.png)
