### PR TITLE
Disputer should correctly simulate reward withdrawals

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -197,6 +197,13 @@ class Disputer {
       let withdrawAmount;
       try {
         withdrawAmount = await withdraw.call({ from: this.account });
+        // See: https://github.com/ethereum/solidity/issues/4840 for the reason this fix is necessary.
+        if (
+          withdrawAmount.rawValue.toString() ===
+          "3963877391197344453575983046348115674221700746820753546331534351508065746944"
+        ) {
+          throw new Error("Simulated reward withdrawal failed");
+        }
       } catch (error) {
         this.logger.debug({
           at: "Disputer",

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -1,4 +1,5 @@
 const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
+const { revertWrapper } = require("../common/ContractUtils");
 
 class Disputer {
   /**
@@ -196,12 +197,8 @@ class Disputer {
       // Confirm that dispute has eligible rewards to be withdrawn.
       let withdrawAmount;
       try {
-        withdrawAmount = await withdraw.call({ from: this.account });
-        // See: https://github.com/ethereum/solidity/issues/4840 for the reason this fix is necessary.
-        if (
-          withdrawAmount.rawValue.toString() ===
-          "3963877391197344453575983046348115674221700746820753546331534351508065746944"
-        ) {
+        withdrawAmount = revertWrapper(await withdraw.call({ from: this.account }));
+        if (withdrawAmount === null) {
           throw new Error("Simulated reward withdrawal failed");
         }
       } catch (error) {

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -280,6 +280,13 @@ contract("Disputer.js", function(accounts) {
     await disputer.queryAndDispute();
     assert.equal(spy.callCount, 2); // Two info level events for the two disputes.
 
+    // Before the dispute is resolved, the bot should simulate the withdrawal, determine that it will fail, and
+    // continue to wait.
+    await disputer.queryAndWithdrawRewards();
+
+    // No new info or error logs should appear because no attempted withdrawal should be made.
+    assert.equal(spy.callCount, 2);
+
     // Push a price of 1.3, which should cause sponsor1's dispute to fail and sponsor2's dispute to succeed.
     const liquidationTime = await emp.getCurrentTime();
     await mockOracle.pushPrice(web3.utils.utf8ToHex("UMATEST"), liquidationTime, toWei("1.3"));


### PR DESCRIPTION
Disputer was failing to detect when a withdraw will fail because of an existing [bug](https://github.com/ethereum/solidity/issues/4840) in `solidity`/`web3`.