### PR TITLE
Handle gas station API failures more gracefully

### DIFF
--- a/financial-templates-lib/helpers/GasEstimator.js
+++ b/financial-templates-lib/helpers/GasEstimator.js
@@ -2,8 +2,24 @@
 // to inform the Liquidator and dispute bot of a reasonable gas price to use.
 
 const fetch = require("node-fetch");
+// Etherchain expected response structure:
+// {
+//   "safeLow": "25.0",
+//   "standard": "30.0",
+//   "fast": "35.0",
+//   "fastest": "39.6"
+// }
 const url = "https://www.etherchain.org/api/gasPriceOracle";
-// Etherscan API limits 1 request every 3 seconds without passing in an API key.
+// Etherscan API limits 1 request every 3 seconds without passing in an API key. Expected response structure:
+// {
+//   "status": "1",
+//   "message": "OK-Missing/Invalid API Key, rate limit of 1/3sec applied",
+//   "result": {
+//       "LastBlock": "10330323",
+//       "SafeGasPrice": "30",
+//       "ProposeGasPrice": "41"
+//   }
+// }
 const backupUrl = "https://api.etherscan.io/api?module=gastracker&action=gasoracle";
 
 class GasEstimator {
@@ -80,8 +96,8 @@ class GasEstimator {
       try {
         const responseBackup = await fetch(backupUrl);
         const jsonBackup = await responseBackup.json();
-        if (jsonBackup.SafeGasPrice) {
-          return jsonBackup.fast;
+        if (jsonBackup.result && jsonBackup.result.SafeGasPrice) {
+          return jsonBackup.SafeGasPrice;
         } else {
           throw new Error("Etherscan API: bad json response");
         }

--- a/financial-templates-lib/helpers/GasEstimator.js
+++ b/financial-templates-lib/helpers/GasEstimator.js
@@ -97,7 +97,7 @@ class GasEstimator {
         const responseBackup = await fetch(backupUrl);
         const jsonBackup = await responseBackup.json();
         if (jsonBackup.result && jsonBackup.result.SafeGasPrice) {
-          return jsonBackup.SafeGasPrice;
+          return jsonBackup.result.SafeGasPrice;
         } else {
           throw new Error("Etherscan API: bad json response");
         }


### PR DESCRIPTION
Changelog:
- Change Logger level for GasEstimator errors from `error` to `debug` so that if an external API fails (like Etherchain did recently), then it won't keep sending Pagerduty/Slack alerts.
- Add a backup API, etherscan, to fall back to before falling back on default value.
- Update default gas price to be conservatively higher, in line with current safe gas prices of ~50

Questions for @chrismaree @mrice32 :
- Should I make the logs level `debug` or `info`? Note that `info` would print to Slack (but not PagerDuty)

Resolves #1663 