### PR TITLE
Liquidator bot caller has option to partially liquidate positions

### DIFF
--- a/financial-templates-lib/logger/SpyTransport.js
+++ b/financial-templates-lib/logger/SpyTransport.js
@@ -18,10 +18,20 @@ class SpyTransport extends Transport {
 // Helper function used by unit tests to check if the last message sent to winston contains a particular string value.
 // Caller feeds in the spy instance and the value to check.
 function lastSpyLogIncludes(spy, value) {
-  // Sinon's getCall(n) function returns values sent in the nth call to the spy. Check both the mrkdown and message sent.
+  // Sinon's getCall(n) function returns values sent in the nth (zero-indexed) call to the spy. Check both the mrkdown and message sent.
   const lastReturnedArgMrkdwn = spy.getCall(-1).lastArg.mrkdwn.toString();
   const lastReturnedArgMessage = spy.getCall(-1).lastArg.message.toString();
-  return lastReturnedArgMrkdwn.indexOf(value) != -1 || lastReturnedArgMessage.indexOf(value) != -1;
+  return lastReturnedArgMrkdwn.indexOf(value) !== -1 || lastReturnedArgMessage.indexOf(value) !== -1;
+}
+
+function spyLogIncludes(spy, messageIndex, value) {
+  // Sinon's getCall(n) function returns values sent in the nth (zero-indexed) call to the spy.
+  return (
+    spy
+      .getCall(messageIndex)
+      .lastArg.message.toString()
+      .indexOf(value) !== -1
+  );
 }
 
 // Helper function used by unit tests to get the most recent log level.
@@ -29,4 +39,8 @@ function lastSpyLogLevel(spy) {
   return spy.getCall(-1).lastArg.level.toString();
 }
 
-module.exports = { SpyTransport, lastSpyLogIncludes, lastSpyLogLevel };
+function spyLogLevel(spy, messageIndex) {
+  return spy.getCall(messageIndex).lastArg.level.toString();
+}
+
+module.exports = { SpyTransport, lastSpyLogIncludes, spyLogIncludes, lastSpyLogLevel, spyLogLevel };

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -84,7 +84,8 @@ async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
     }
 
     while (true) {
-      await liquidator.queryAndLiquidate();
+      const currentSyntheticBalance = await syntheticToken.balanceOf(accounts[0]);
+      await liquidator.queryAndLiquidate(currentSyntheticBalance);
       await liquidator.queryAndWithdrawRewards();
 
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -198,7 +198,7 @@ class Liquidator {
       if (tokensToLiquidate.isZero()) {
         this.logger.error({
           at: "Liquidator",
-          message: "Cannot liquidate position: not enough synthetic to initiate liquidation✋",
+          message: "Position size is equal to the minimum: not enough synthetic to initiate full liquidation✋",
           sponsor: position.sponsor,
           inputPrice: scaledPrice.toString(),
           position: position,
@@ -208,6 +208,21 @@ class Liquidator {
           error: new Error("Refusing to liquidate 0 tokens")
         });
         continue;
+      }
+
+      // Send an alert if the bot is going to submit a partial liquidation instead of a full liquidation.
+      if (tokensToLiquidate.lt(this.toBN(position.numTokens))) {
+        this.logger.error({
+          at: "Liquidator",
+          message: "Submitting a partial liquidation: not enough synthetic to initiate full liquidation⚠️",
+          sponsor: position.sponsor,
+          inputPrice: scaledPrice.toString(),
+          position: position,
+          minLiquidationPrice: this.liquidationMinPrice,
+          maxLiquidationPrice: maxCollateralPerToken.toString(),
+          tokensToLiquidate: tokensToLiquidate.toString(),
+          maxTokensToLiquidateWei: maxTokensToLiquidateWei.toString()
+        });
       }
 
       // Create the liquidation transaction.
@@ -226,7 +241,7 @@ class Liquidator {
         this.logger.error({
           at: "Liquidator",
           message:
-            "Cannot liquidate position: not enough synthetic (or large enough approval) to initiate liquidation✋",
+            "Failed to liquidate position: not enough synthetic (or large enough approval) to initiate liquidation❌",
           sponsor: position.sponsor,
           inputPrice: scaledPrice.toString(),
           position: position,

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -190,7 +190,11 @@ class Liquidator {
         tokensToLiquidate = this.toBN(position.numTokens);
       }
 
-      // If `tokensToLiquidate` is 0, then skip this liquidation.
+      // If `tokensToLiquidate` is 0, then skip this liquidation. Due to the if-statement branching above, `tokensToLiquidate == 0`
+      // is only possible if the `positionTokensAboveMinimum == 0` && `maxTokensToLiquidate < position.numTokens`. In other words,
+      // the bot cannot liquidate the full position size, but the full position size is at the minimum sponsor threshold. Therefore, the
+      // bot can liquidate 0 tokens. The smart contracts should disallow this, but a/o June 2020 this behavior is allowed so we should block it
+      // client-side.
       if (tokensToLiquidate.isZero()) {
         this.logger.error({
           at: "Liquidator",


### PR DESCRIPTION
My implementation of this feature changes `queryAndLiquidate()` to take in one parameter `tokenBalanceWei` which is the max amount of tokens it will try to liquidate. It will use this figure to either liquidate the full position, the full balance (in a partial liquidation), or the full balance minus some amount to account for the min sponsor size.

I tested with the bots also:
1. Liquidator has 175 tokens, full position to be liquidated is 350 tokens:
![Screen Shot 2020-06-24 at 14 31 02](https://user-images.githubusercontent.com/9457025/85613459-e3cc0580-b627-11ea-9624-d34210ac6533.png)

2. Sponsor [requests to withdraw all collateral](https://kovan.etherscan.io/tx/0xb8d7eda0590d9eb8c4510e97eee333e581e4f4b2034eb502364f3334590332ef#eventlog), making it clearly undercollateralized
![Screen Shot 2020-06-24 at 14 32 14](https://user-images.githubusercontent.com/9457025/85613508-f34b4e80-b627-11ea-8b0a-7a4a0af52599.png)

3. Liquidator bot [partially liquidates](https://kovan.etherscan.io/tx/0x4777962c5ceeaa15bb75fec6f25f4fa3b713503cffda960e875f79d000e0458a#eventlog) what it can
![Screen Shot 2020-06-24 at 14 33 38](https://user-images.githubusercontent.com/9457025/85613546-ff371080-b627-11ea-8370-7f4b21b8637a.png)

4. Monitor catches liquidation
![Screen Shot 2020-06-24 at 14 39 07](https://user-images.githubusercontent.com/9457025/85614019-7f5d7600-b628-11ea-8f72-0990ae46db4b.png)

Resolves #1655 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>