### PR TITLE
Stringify CryptoWatch API response for error logs

### DIFF
--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -111,7 +111,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       this.logger.error({
         at: "CryptoWatchPriceFeed",
         message: "Could not parse ohlc result🚨",
-        error: new Error(ohlcResponse)
+        error: new Error(JSON.stringify(ohlcResponse))
       });
       return;
     }
@@ -157,7 +157,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
         at: "CryptoWatchPriceFeed",
         message: "Could not parse price result🚨",
         priceUrl,
-        error: new Error(priceResponse)
+        error: new Error(JSON.stringify(priceResponse))
       });
       return;
     }


### PR DESCRIPTION
Currently, when we fail to parse Cryptowatch's API response, we send the response object as an error via `new Error(priceResponse)`, however we should stringify this so that we can see the error. See below for what the current error log looks like:
![Screen Shot 2020-06-24 at 14 41 29](https://user-images.githubusercontent.com/9457025/85614348-cd727980-b628-11ea-8d38-1fb6adabe960.png)

Signed-off-by: Nick Pai <npai.nyc@gmail.com>