### PR TITLE
Various Daily Reporter Fixes

### DIFF
--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -315,8 +315,8 @@ class GlobalSummaryReporter {
         e => e.liquidationId === event.liquidationId && e.sponsor === event.sponsor
       )[0];
 
-      allTokensDisputed = allTokensDisputed.add(this.toBN(liquidationData.tokensOutstanding.toString()));
-      allCollateralDisputed = allCollateralDisputed.add(this.toBN(liquidationData.lockedCollateral.toString()));
+      allTokensDisputed = allTokensDisputed.add(this.toBN(liquidationData.tokensOutstanding));
+      allCollateralDisputed = allCollateralDisputed.add(this.toBN(liquidationData.lockedCollateral));
       allUniqueDisputes[event.sponsor] = true;
 
       for (let period of periods) {
@@ -332,10 +332,10 @@ class GlobalSummaryReporter {
 
         if (this.isEventInPeriod(event, period)) {
           periodTokensDisputed[period.label] = periodTokensDisputed[period.label].add(
-            this.toBN(liquidationData.tokensOutstanding.toString())
+            this.toBN(liquidationData.tokensOutstanding)
           );
           periodCollateralDisputed[period.label] = periodCollateralDisputed[period.label].add(
-            this.toBN(liquidationData.lockedCollateral.toString())
+            this.toBN(liquidationData.lockedCollateral)
           );
           periodUniqueDisputes[period.label][event.sponsor] = true;
         }

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -485,7 +485,10 @@ class GlobalSummaryReporter {
 
     // - Net collateral deposited into contract:
     let netCollateralWithdrawn = depositData.allCollateralTransferred.sub(withdrawData.allCollateralTransferred);
-    if (!netCollateralWithdrawn.eq(this.toBN(this.totalPfc.toString()))) {
+    if (
+      !netCollateralWithdrawn.lt(this.toBN(this.totalPfc.toString()).add(this.accountingVariance)) &&
+      !netCollateralWithdrawn.gt(this.toBN(this.totalPfc.toString()).sub(this.accountingVariance))
+    ) {
       throw "Net collateral deposited is not equal to current total position collateral + liquidated collateral";
     }
     let netCollateralWithdrawnPeriod = depositData.periodCollateralTransferred["period"].sub(

--- a/reporters/uniswapSubgraphClient.js
+++ b/reporters/uniswapSubgraphClient.js
@@ -26,7 +26,7 @@ function getUniswapClient() {
  * @return query string
  */
 function PAIR_DATA(pairAddress, block) {
-  const blockNumberLag = 3;
+  const blockNumberLag = 5;
   const queryString = block
     ? `
             query pairs {


### PR DESCRIPTION
Now that we have a Mainnet dispute, I was able to test and patch some bugs displaying the Dispute and Final fee stats

Another bug was that we had an accounting check asserting that `netCollateralDeposited == totalPositionCollateral`. However, the RHS of this assertion should be `PfC`. This is a check that total amount of collateral in the contract is consistent with `PfC`, which includes current liquidations that are not captured by `totalPositionCollateral`.

Finally, I increased the Uniswap subgraph delay parameter to 5 blocks because I noticed an error between the latest block in Infura's mainnet node and the graph. This parameter is used so that if we want to get the current data, for example, we will actually be asking the graph to send us data from 5 (previously 3) blocks behind the latest block according to our web3 node. This is to account for the fact that the graph appears to have a delay in making data available.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>