### PR TITLE
Add unit tests documenting what happens when you call `createLiquidation()` with `maxTokensToLiquidate = 0`

### DIFF
--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -1231,6 +1231,89 @@ contract("Liquidatable", function(accounts) {
   });
 
   describe("Weird Edge cases", () => {
+    it("Liquidating 0 tokens always results in a successful Dispute", async () => {
+      // TODO: Liquidations for 0 tokens should be blocked but they are not. They will harmlessly always cause a successful dispute because
+      // the TRV and requiredCollateral calculations both equal 0. The liquidator and disputer will each pay final fee payments, and the dispute will always succeed.
+      // Withdrawing rewards sends a final fee payment back to the disputer. So in summary, a liquidator will be charged a final fee
+      // for sending a liquidation of 0 tokens. The downside is that this sends a useless price request and the liquidation will never be deleted
+      // since the Liquidator and Sponsor cannot withdraw 0 rewards.
+
+      // Set a final fee to see what assets get transferred in this useless liquidation.
+      await store.setFinalFee(collateralToken.address, { rawValue: finalFeeAmount.toString() });
+
+      // Create position.
+      await liquidationContract.create(
+        { rawValue: amountOfCollateral.toString() },
+        { rawValue: amountOfSynthetic.toString() },
+        { from: sponsor }
+      );
+
+      // Mint liquidator enough tokens to pay the final fee.
+      await collateralToken.mint(liquidator, finalFeeAmount, { from: contractDeployer });
+
+      // Liquidator does not need any synthetic tokens to initiate this liquidation.
+      assert.equal((await syntheticToken.balanceOf(liquidator)).toString(), "0");
+
+      // Request a 0 token liquidation.
+      const createLiquidationResult = await liquidationContract.createLiquidation(
+        sponsor,
+        { rawValue: "0" },
+        { rawValue: pricePerToken.toString() },
+        { rawValue: "0" },
+        unreachableDeadline,
+        { from: liquidator }
+      );
+
+      // Liquidator should have 0 balance remaining after paying the final fee bond.
+      assert.equal((await collateralToken.balanceOf(liquidator)).toString(), "0");
+
+      // Liquidated collateral and tokens both equal 0.
+      truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
+        return (
+          ev.sponsor == sponsor,
+          ev.liquidator == liquidator,
+          ev.liquidationId == 0,
+          ev.tokensOutstanding == "0",
+          ev.lockedCollateral == "0",
+          ev.liquidatedCollateral == "0"
+        );
+      });
+
+      // Disputer started with (dispute-bond + final-fee) amount of collateral.
+      assert.equal((await collateralToken.balanceOf(disputer)).toString(), disputeBond.add(finalFeeAmount));
+
+      // Dispute the liquidation.
+      await liquidationContract.dispute(liquidationParams.liquidationId, sponsor, { from: disputer });
+
+      // The disputer should only have paid the
+      // final fee since the dispute bond will be 0.
+      assert.equal((await collateralToken.balanceOf(disputer)).toString(), disputeBond);
+
+      // Here's the interesting part: even at an extremely low price (i.e. 0), where the required collateral is extremely low (i.e. 0),
+      // the dispute will always be successful. This is because the required collateral is (TRV * CR) = 0 because tokensOutstanding = 0.
+      // So regardless, the liquidated collateral will always be enough to cover the required collateral (even if the liquidated collateral is
+      // also 0 in this case).
+      const liquidationTime = await liquidationContract.getCurrentTime();
+      await mockOracle.pushPrice(priceFeedIdentifier, liquidationTime, "0");
+
+      // Disputer reward is 0 since TRV = 0, so disputer gets back their final fee bond.
+      await liquidationContract.withdrawLiquidation(liquidationParams.liquidationId, sponsor, { from: disputer });
+      assert.equal((await collateralToken.balanceOf(disputer)).toString(), disputeBond.add(finalFeeAmount));
+
+      // Liquidator reward is 0 so this call will revert since the liquidator cannot get withdraw anything.
+      assert(
+        await didContractThrow(
+          liquidationContract.withdrawLiquidation(liquidationParams.liquidationId, sponsor, { from: liquidator })
+        )
+      );
+
+      // Sponsor gets back nothing since collateral and TRV = 0 and this call will also revert.
+      assert(
+        await didContractThrow(
+          liquidationContract.withdrawLiquidation(liquidationParams.liquidationId, sponsor, { from: sponsor })
+        )
+      );
+    });
     it("Dispute rewards should not add to over 100% of TRV", async () => {
       // Deploy liquidation contract and set global params.
       // Set the add of the dispute rewards to be >= 100 %

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -1232,7 +1232,7 @@ contract("Liquidatable", function(accounts) {
 
   describe("Weird Edge cases", () => {
     it("Liquidating 0 tokens always results in a successful Dispute", async () => {
-      // TODO: Liquidations for 0 tokens should be blocked but they are not. They will harmlessly always cause a successful dispute because
+      // Liquidations for 0 tokens should be blocked but they are not. They will harmlessly always cause a successful dispute because
       // the TRV and requiredCollateral calculations both equal 0. The liquidator and disputer will each pay final fee payments, and the dispute will always succeed.
       // Withdrawing rewards sends a final fee payment back to the disputer. So in summary, a liquidator will be charged a final fee
       // for sending a liquidation of 0 tokens. The downside is that this sends a useless price request and the liquidation will never be deleted


### PR DESCRIPTION
This unit test verifies this action as harmless. These are the takeaways:
- Dispute always succeeds because the `requiredCollateral = (tokensOutstanding * settlementPrice * collateralRequirement) = 0`. Even though the liquidated collateral is 0, 0 >= 0 in the check for `isDisputeSuccessful = Boolean(liquidatedCollateral >= requiredCollateral)`. 
- Because dispute succeeds, liquidator pays final fee. This is good behavior since the liquidator initiated a useless price request.
- The disputer can call `withdrawLiquidationRewards()` after the dispute resolves to get back their final fee bond.
- The liquidator and sponsor both cannot call `withdrawLiquidationRewards()` because the contract does not allow them to withdraw 0 rewards.
- The unfortunate side effect is that the liquidation data object can never be deleted since not all parties can "withdraw"

Resolves #1671 

Signed-off-by: Nick Pai <npai.nyc@gmail.com>