### PR TITLE
Add simple script for creating a GCP cloud Scheduler with a json body

### DIFF
--- a/scripts/bot-deployment/DeployJsonScheduler.sh
+++ b/scripts/bot-deployment/DeployJsonScheduler.sh
@@ -1,4 +1,4 @@
-if [ $# -ne 5 ]; then
+if [ $# -ne 6 ]; then
     echo "Incorrect number of arguments supplied! arguments are:"
     echo "1) Scheduler name"
     echo "2) Schedular cron time"

--- a/scripts/bot-deployment/DeployJsonScheduler.sh
+++ b/scripts/bot-deployment/DeployJsonScheduler.sh
@@ -1,26 +1,28 @@
 if [ $# -ne 5 ]; then
     echo "Incorrect number of arguments supplied! arguments are:"
     echo "1) Scheduler name"
-    echo "2) Target HTTP URL"
-    echo "3) Scheduler service account"
-    echo "4) HTTP JSON body"
-    echo "5) Scheduler description"
+    echo "2) Schedular cron time"
+    echo "3) Target HTTP URL"
+    echo "4) Scheduler service account"
+    echo "5) HTTP JSON body"
+    echo "6) Scheduler description"
     exit 1
 fi
 
 echo "🔥 Creating scheduler with the following params:"
 echo "Scheduler Name:" $1
-echo "Target HTTP URL:" $2
-echo "Service Account:" $3
-echo "HTTP JSON body:" $4
-echo "Scheduler description:" $5
+echo "Schedular cron time" $2
+echo "Target HTTP URL:" $3
+echo "Service Account:" $4
+echo "HTTP JSON body:" $5
+echo "Scheduler description:" $6
 
 gcloud scheduler jobs create http $1 \
-    --schedule="0 12 * * *" \
-    --uri=$2 \
-    --oidc-service-account-email=$3 \
+    --schedule="$2" \
+    --uri=$3 \
+    --oidc-service-account-email=$4 \
     --http-method=post \
-    --message-body=$4 \
+    --message-body=$5 \
     --headers="Authorization=key=AUTHKEY, Content-Type=application/json" \
-    --description="$5"
+    --description="$6"
 echo "🎊 Scheduler created!"

--- a/scripts/bot-deployment/DeployJsonScheduler.sh
+++ b/scripts/bot-deployment/DeployJsonScheduler.sh
@@ -1,0 +1,26 @@
+if [ $# -ne 5 ]; then
+    echo "Incorrect number of arguments supplied! arguments are:"
+    echo "1) Scheduler name"
+    echo "2) Target HTTP URL"
+    echo "3) Scheduler service account"
+    echo "4) HTTP JSON body"
+    echo "5) Scheduler description"
+    exit 1
+fi
+
+echo "🔥 Creating scheduler with the following params:"
+echo "Scheduler Name:" $1
+echo "Target HTTP URL:" $2
+echo "Service Account:" $3
+echo "HTTP JSON body:" $4
+echo "Scheduler description:" $5
+
+gcloud scheduler jobs create http $1 \
+    --schedule="0 12 * * *" \
+    --uri=$2 \
+    --oidc-service-account-email=$3 \
+    --http-method=post \
+    --message-body=$4 \
+    --headers="Authorization=key=AUTHKEY, Content-Type=application/json" \
+    --description="$5"
+echo "🎊 Scheduler created!"


### PR DESCRIPTION
This simple script is a subset of the functionality in [DeployReporterCR.sh](https://github.com/UMAprotocol/protocol/blob/a9bcb653b70e5615d4a3c6e75845746ae7b26624/scripts/bot-deployment/DeployReporterCR.sh). The point of this script is to make a cloud scheduler POST object that can accept JSON as the body. Importantly **this functionality is NOT exposed in the GCP dashboard** and so you have to make JSON body post scheduler calls from the CLI. 

Once the full hub and spoke implementation is done we should need to only use this script when creating new scheduler cadences. For example if we want a new daily reporter that logs every 6 hours, we would use this script. Otherwise, in the ideal case, there will only be 1 scheduler for each polling frequency.