### PR TITLE
Make Hub and Spoke implementation stateful of last block query

### DIFF
--- a/common/globalTruffleConfig.js
+++ b/common/globalTruffleConfig.js
@@ -24,7 +24,7 @@ const privateKey = process.env.PRIVATE_KEY
   : "0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709";
 
 // Fallback to a backup non-prod API key.
-const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "9317010b1b6343558b7eff9d25934f38";
+const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "e34138b2db5b496ab5cc52319d2f0299";
 const customNodeUrl = process.env.CUSTOM_NODE_URL;
 let singletonProvider;
 

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -8,10 +8,10 @@ class ExpiringMultiPartyEventClient {
    * @param {Object} empAbi Expiring Multi Party truffle ABI object to create a contract instance.
    * @param {Object} web3 Web3 provider from truffle instance.
    * @param {String} empAddress Ethereum address of the EMP contract deployed on the current network.
-   * @param {Integer} latestBlockNumber Offset block number to index events from.
+   * @param {Integer} startingBlockNumber Offset block number to index events from.
    * @return None or throws an Error.
    */
-  constructor(logger, empAbi, web3, empAddress, latestBlockNumber = 0) {
+  constructor(logger, empAbi, web3, empAddress, startingBlockNumber = 0, endingBlockNumber = null) {
     this.logger = logger;
     this.web3 = web3;
 
@@ -34,7 +34,10 @@ class ExpiringMultiPartyEventClient {
     this.settleExpiredPositionEvents = [];
 
     // First block number to begin searching for events after.
-    this.firstBlockToSearch = latestBlockNumber;
+    this.firstBlockToSearch = startingBlockNumber;
+
+    // Last block number to end the searching for events at.
+    this.lastBlockToSearchUntil = endingBlockNumber;
     this.lastUpdateTimestamp = 0;
   }
   // Delete all events within the client
@@ -107,15 +110,17 @@ class ExpiringMultiPartyEventClient {
   }
 
   async update() {
-    const currentBlockNumber = await this.web3.eth.getBlockNumber();
-    // TODO(#1540): For efficiency, we should only pass through `fromBlock` to `toBlock` once and check for
-    // all of the relevant events along the way.
+    // The last block to search is either the value specified in the constructor (useful in serverless mode) or is the
+    // latest block number (if running in loop mode).
+    const lastBlockToSearch = this.lastBlockToSearchUntil
+      ? this.lastBlockToSearchUntil
+      : await this.web3.eth.getBlockNumber();
 
     // Look for events on chain from the previous seen block number to the current block number.
     // Liquidation events
     const liquidationEventsObj = await this.emp.getPastEvents("LiquidationCreated", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
 
     // Liquidation events.
@@ -135,7 +140,7 @@ class ExpiringMultiPartyEventClient {
     // Dispute events.
     const disputeEventsObj = await this.emp.getPastEvents("LiquidationDisputed", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of disputeEventsObj) {
       this.disputeEvents.push({
@@ -152,7 +157,7 @@ class ExpiringMultiPartyEventClient {
     // Dispute settlement events.
     const disputeSettlementEventsObj = await this.emp.getPastEvents("DisputeSettled", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of disputeSettlementEventsObj) {
       this.disputeSettlementEvents.push({
@@ -170,7 +175,7 @@ class ExpiringMultiPartyEventClient {
     // Create events.
     const createEventsObj = await this.emp.getPastEvents("PositionCreated", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of createEventsObj) {
       this.createEvents.push({
@@ -185,7 +190,7 @@ class ExpiringMultiPartyEventClient {
     // NewSponsor events mapped against PositionCreated events to determine size of new positions created.
     const newSponsorEventsObj = await this.emp.getPastEvents("NewSponsor", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of newSponsorEventsObj) {
       // Every transaction that emits a NewSponsor event must also emit a PositionCreated event.
@@ -205,7 +210,7 @@ class ExpiringMultiPartyEventClient {
     // Deposit events.
     const depositEventsObj = await this.emp.getPastEvents("Deposit", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of depositEventsObj) {
       this.depositEvents.push({
@@ -219,7 +224,7 @@ class ExpiringMultiPartyEventClient {
     // Withdraw events.
     const withdrawEventsObj = await this.emp.getPastEvents("Withdrawal", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of withdrawEventsObj) {
       this.withdrawEvents.push({
@@ -233,7 +238,7 @@ class ExpiringMultiPartyEventClient {
     // Redeem events.
     const redeemEventsObj = await this.emp.getPastEvents("Redeem", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of redeemEventsObj) {
       this.redeemEvents.push({
@@ -248,7 +253,7 @@ class ExpiringMultiPartyEventClient {
     // Regular fee events.
     const regularFeeEventsObj = await this.emp.getPastEvents("RegularFeesPaid", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of regularFeeEventsObj) {
       this.regularFeeEvents.push({
@@ -262,7 +267,7 @@ class ExpiringMultiPartyEventClient {
     // Final fee events.
     const finalFeeEventsObj = await this.emp.getPastEvents("FinalFeesPaid", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of finalFeeEventsObj) {
       this.finalFeeEvents.push({
@@ -275,7 +280,7 @@ class ExpiringMultiPartyEventClient {
     // Liquidation withdrawn events.
     const liquidationWithdrawnEventsObj = await this.emp.getPastEvents("LiquidationWithdrawn", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of liquidationWithdrawnEventsObj) {
       this.liquidationWithdrawnEvents.push({
@@ -290,7 +295,7 @@ class ExpiringMultiPartyEventClient {
     // Settle expired position events.
     const settleExpiredPositionEventsObj = await this.emp.getPastEvents("SettleExpiredPosition", {
       fromBlock: this.firstBlockToSearch,
-      toBlock: currentBlockNumber
+      toBlock: lastBlockToSearch
     });
     for (let event of settleExpiredPositionEventsObj) {
       this.settleExpiredPositionEvents.push({
@@ -303,7 +308,7 @@ class ExpiringMultiPartyEventClient {
     }
 
     // Add 1 to current block so that we do not double count the last block number seen.
-    this.firstBlockToSearch = currentBlockNumber + 1;
+    this.firstBlockToSearch = lastBlockToSearch + 1;
 
     this.lastUpdateTimestamp = await this.emp.methods.getCurrentTime().call();
     this.logger.debug({

--- a/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyEventClient.js
@@ -9,6 +9,7 @@ class ExpiringMultiPartyEventClient {
    * @param {Object} web3 Web3 provider from truffle instance.
    * @param {String} empAddress Ethereum address of the EMP contract deployed on the current network.
    * @param {Integer} startingBlockNumber Offset block number to index events from.
+   * @param {Integer} endingBlockNumber Termination block number to index events until. If not defined runs to `latest`.
    * @return None or throws an Error.
    */
   constructor(logger, empAbi, web3, empAddress, startingBlockNumber = 0, endingBlockNumber = null) {

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -104,7 +104,7 @@ async function run(
       web3,
       emp.address,
       eventsFromBlockNumber,
-      eventsToBlockNumber
+      endingBlock
     );
     const contractMonitor = new ContractMonitor(
       Logger,

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -41,6 +41,7 @@ async function run(
   address,
   pollingDelay,
   startingBlock,
+  endingBlock,
   botMonitorObject,
   walletMonitorObject,
   contractMonitorObject,
@@ -57,6 +58,7 @@ async function run(
       empAddress: address,
       pollingDelay,
       startingBlock,
+      endingBlock,
       botMonitorObject,
       walletMonitorObject,
       contractMonitorObject,
@@ -91,16 +93,18 @@ async function run(
     );
 
     // 1. Contract state monitor.
-    // Start the event client by looking from the provided block number. If param set to null then use the latest
-    // block number. Else, use the param number to start the search from.
-    const eventsFromBlock = startingBlock ? startingBlock : (await web3.eth.getBlock("latest")).number;
+    // Start the event client by looking from the provided `startingBlock` number to the provided `endingBlock` number.
+    // If param are sets to null then use the latest block number for the `eventsFromBlockNumber` and leave the
+    // `endingBlock` as null in the client constructor. The client will then query up until the `latest` block.
+    const eventsFromBlockNumber = startingBlock ? startingBlock : (await web3.eth.getBlock("latest")).number;
 
     const empEventClient = new ExpiringMultiPartyEventClient(
       Logger,
       ExpiringMultiParty.abi,
       web3,
       emp.address,
-      eventsFromBlock
+      eventsFromBlockNumber,
+      eventsToBlockNumber
     );
     const contractMonitor = new ContractMonitor(
       Logger,
@@ -210,6 +214,10 @@ async function Poll(callback) {
     // set then default to null which indicates that the bot should start at the current block number.
     const startingBlock = process.env.STARTING_BLOCK_NUMBER;
 
+    // Block number to search for events to. If set, acts to limit from where the monitor bot will search for events up
+    // until. If not set the default to null which indicates that the bot should search up to 'latests'.
+    const endingBlock = process.env.ENDING_BLOCK_NUMBER;
+
     if (
       !process.env.BOT_MONITOR_OBJECT ||
       !process.env.WALLET_MONITOR_OBJECT ||
@@ -267,6 +275,7 @@ async function Poll(callback) {
       process.env.EMP_ADDRESS,
       pollingDelay,
       startingBlock,
+      endingBlock,
       botMonitorObject,
       walletMonitorObject,
       contractMonitorObject,

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -29,6 +29,8 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  *     mode which will exit after the loop.
  * @param {Number} startingBlock Offset block number to define where the monitor bot should start searching for events
  *     from. If 0 will look for all events back to deployment of the EMP. If set to null uses current block number.
+ * @param {Number} endingBlock Termination block number to define where the monitor bot should end searching for events.
+ *     If `null` then will search up until the latest block number in each loop.
  * @param {Object} botMonitorObject Configuration to construct the balance monitor module.
  * @param {Object} walletMonitorObject Configuration to construct the collateralization ratio monitor module.
  * @param {Object} contractMonitorObject Configuration to construct the contract monitor module.
@@ -94,8 +96,9 @@ async function run(
 
     // 1. Contract state monitor.
     // Start the event client by looking from the provided `startingBlock` number to the provided `endingBlock` number.
-    // If param are sets to null then use the latest block number for the `eventsFromBlockNumber` and leave the
-    // `endingBlock` as null in the client constructor. The client will then query up until the `latest` block.
+    // If param are sets to null then use the `latest` block number for the `eventsFromBlockNumber` and leave the
+    // `endingBlock` as null in the client constructor. The client will then query up until the `latest` block on every
+    // loop and update this variable accordingly on each iteration.
     const eventsFromBlockNumber = startingBlock ? startingBlock : (await web3.eth.getBlock("latest")).number;
 
     const empEventClient = new ExpiringMultiPartyEventClient(
@@ -215,7 +218,7 @@ async function Poll(callback) {
     const startingBlock = process.env.STARTING_BLOCK_NUMBER;
 
     // Block number to search for events to. If set, acts to limit from where the monitor bot will search for events up
-    // until. If not set the default to null which indicates that the bot should search up to 'latests'.
+    // until. If not set the default to null which indicates that the bot should search up to 'latest'.
     const endingBlock = process.env.ENDING_BLOCK_NUMBER;
 
     if (

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@antora/cli": "^2.1.2",
     "@antora/site-generator-default": "^2.1.2",
     "@awaitjs/express": "^0.3.0",
+    "@google-cloud/datastore": "^6.0.0",
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/logging-winston": "^3.0.6",
     "@google-cloud/storage": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "express": "^4.17.1",
     "ganache-cli": "^6.7.0",
     "gmail-send": "^1.2.14",
+    "google-auth-library": "^6.0.2",
     "graphql-request": "^1.8.2",
     "inquirer": "^7.0.4",
     "lodash.startcase": "^4.4.0",

--- a/reporters/cloud-run-scripts/CloudResponse.js
+++ b/reporters/cloud-run-scripts/CloudResponse.js
@@ -40,19 +40,17 @@ app.post("/", async (req, res) => {
 
     const execResponse = await execShellCommand(req.body.cloudRunCommand, processedEnvironmentVariables);
     // TODO: refactor this to send a more graceful winston log.
-    console.log("error:", execResponse.error);
-    console.log("stdout:", execResponse.stdout);
-    console.log("stderr:", execResponse.stderr);
+    console.log("execResponse:", execResponse);
 
     if (execResponse.error) {
       console.log("Process exited with error");
-      throw execResponse.error;
+      throw execResponse;
     }
     console.log("Process exited with no error");
 
-    res.status(200).send({ message: "Process exited correctly!", error: null });
-  } catch (error) {
-    res.status(400).send({ message: "Process exited with error!", error: error });
+    res.status(200).send({ message: "Process exited correctly!", execResponse: execResponse });
+  } catch (execResponse) {
+    res.status(400).send({ message: "Process exited with error!", execResponse: execResponse });
   }
 });
 

--- a/reporters/cloud-run-scripts/CloudResponse.js
+++ b/reporters/cloud-run-scripts/CloudResponse.js
@@ -1,54 +1,68 @@
+/**
+ * @notice This script enables Google Cloud Run functions to execute any arbitrary command from the UMA docker container.
+ * Cloud Run provides a privileged REST endpoint that can be called to spin up a Docker container. This endpoint is
+ * expected to respond on PORT. Upon receiving a request, this script executes a child process and responds to the
+ * REST query with the output of the process execution. The REST query sent to the API is expected to be a POST
+ * with a body formatted as: {"cloudRunCommand":<some-command-to-run>, environmentVariables: <env-variable-object>}
+ * the some-command-to-run is any execution process. For example to run the monitor bot this could be set to:
+ * { "cloudRunCommand":"npx truffle exec ../monitors/index.js --network mainnet_mnemonic" }. `environmentVariables` is
+ * optional. If included the child process will have additional parameters appended with these params.
+ */
+
 const express = require("express");
 const app = express();
 app.use(express.json()); // Enables json to be parsed by the express process.
-const { exec } = require("child_process");
+const exec = require("child_process").exec;
 
-app.post("/", (req, res) => {
-  console.log("Executing GCP Cloud Run API");
-  if (!req.body.cloudRunCommand) {
-    res.status(400).send({
-      message: "ERROR: Body missing json cloudRunCommand!"
-    });
-    throw "ERROR: Missing cloudRunCommand";
-  }
-
-  // Iterate over the provided environment variables and ensure that they are all strings. This enables json configs
-  // to be passed in the req body and then set as environment variables in the child_process as a string
-  let processedEnvironmentVariables = {};
-
-  if (req.body.environmentVariables) {
-    Object.keys(req.body.environmentVariables).forEach(key => {
-      // All env variables must be a string. If they are not a string (int, object ect) convert them to a string.
-      processedEnvironmentVariables[key] =
-        typeof req.body.environmentVariables[key] == "string"
-          ? req.body.environmentVariables[key]
-          : JSON.stringify(req.body.environmentVariables[key]);
-    });
-  }
-
-  // Run the command from the request body. Note this assumes that the process is running from the /core directory.
-  // Include the environment variables. Having both ...process.env and ...processedEnvironmentVariables acts to combined
-  // the existing env variables with those passed in from the req.
-  exec(
-    req.body.cloudRunCommand,
-    { env: { ...process.env, ...processedEnvironmentVariables } },
-    (error, stdout, stderr) => {
-      if (error !== null) {
-        console.error(`exec error: ${error}stderr: ${stderr}`);
-        res.status(400).send({
-          message: "ERROR executing process!",
-          stdout,
-          stderr,
-          error
-        });
-      } else {
-        console.error(`stdout: ${stdout}`);
-        res.status(200).send({ message: "Process executed correctly!", stdout, stderr, error: null });
-      }
+app.post("/", async (req, res) => {
+  try {
+    console.log("Executing GCP Cloud Run API Call");
+    if (!req.body.cloudRunCommand) {
+      res.status(400).send({
+        message: "ERROR: Body missing json cloudRunCommand!"
+      });
+      throw "ERROR: Missing cloudRunCommand";
     }
-  );
+
+    // Iterate over the provided environment variables and ensure that they are all strings. This enables json configs
+    // to be passed in the req body and then set as environment variables in the child_process as a string
+    let processedEnvironmentVariables = {};
+
+    if (req.body.environmentVariables) {
+      Object.keys(req.body.environmentVariables).forEach(key => {
+        // All env variables must be a string. If they are not a string (int, object ect) convert them to a string.
+        processedEnvironmentVariables[key] =
+          typeof req.body.environmentVariables[key] == "string"
+            ? req.body.environmentVariables[key]
+            : JSON.stringify(req.body.environmentVariables[key]);
+      });
+    }
+
+    const execResponse = await execShellCommand(req.body.cloudRunCommand, processedEnvironmentVariables);
+    // TODO: refactor this to send a more graceful winston log.
+    console.log("error:", execResponse.error);
+    console.log("stdout:", execResponse.stdout);
+    console.log("stderr:", execResponse.stderr);
+
+    if (execResponse.error) {
+      console.log("Process exited with error");
+      throw execResponse.error;
+    }
+    console.log("Process exited with no error");
+
+    res.status(200).send({ message: "Process exited correctly!", error: null });
+  } catch (error) {
+    res.status(400).send({ message: "Process exited with error!", error: error });
+  }
 });
 
+function execShellCommand(cmd, inputEnv) {
+  return new Promise((resolve, reject) => {
+    exec(cmd, { env: { ...process.env, ...inputEnv } }, (error, stdout, stderr) => {
+      resolve({ error, stdout, stderr });
+    });
+  });
+}
 const port = process.env.PORT || 8080;
 app.listen(port, () => {
   console.log("Listening on port", port);

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -1,0 +1,143 @@
+/**
+ * @notice This script reads in a global configuration file stored on GCP buckets and executes parallel Cloud Run
+ * instances for each configured bot. This enables one global config file to define all bot instances. This drastically
+ * simplifying the devops and management overhead for spinning up new instances as this can be done by simply updating
+ * a config file. This script is designed to be run within a GCP Cloud Run (or cloud function) environment with a
+ * permissioned service account to pull config objects from GCP buckets and execute Cloud Run functions.
+ * This script assumes the caller is providing a HTTP POST with a body formatted as:
+ * {"bucket":"<config-bucket>","configFile":"<config-file-name>"}
+ *
+ * If you want to run it in your local environment, you need to do the following configuration changes:
+ * 1) Set the environment variable PROTOCOL_RUNNER_URL to point to your remote cloud run instance URL.
+ * 2) To access service accounts you need to configure your local environment with the associated config file. Go to:
+ * https://console.cloud.google.com/apis/credentials/serviceaccountkey and generate a json config file. Save this to
+ * a safe place. Then, set the environment variable GOOGLE_APPLICATION_CREDENTIALS to point to this config file.
+ * 3) Once this is done the script can be started by running: node ../reporters/cloud-run-scripts/CloudRunnerHub.js
+ * This will start a restful API server on PORT (default 8080).
+ * 4) call the restful query using CURL as:
+ * curl -X POST -H 'Content-type: application/json' --data '{"bucket":"bot-configs","configFile":"global-bot-config.json"}' https://localhost:8080
+ */
+
+// TODO: add integration tests between this CloudRunnerHub and CloudResponse.
+
+const express = require("express");
+const app = express();
+app.use(express.json()); // Enables json to be parsed by the express process.
+require("dotenv").config();
+const fetch = require("node-fetch");
+const { URL } = require("url");
+
+// GCP helpers
+const { GoogleAuth } = require("google-auth-library");
+const auth = new GoogleAuth();
+const { Storage } = require("@google-cloud/storage");
+const storage = new Storage();
+
+// Helpers
+// TODO integrate with winston logger.
+// const { Logger, waitForLogger } = require("../../financial-templates-lib/logger/Logger");
+
+app.post("/", async (req, res) => {
+  try {
+    console.log("Running Cloud runner hub query");
+    if (!process.env.PROTOCOL_RUNNER_URL) {
+      throw new Error("Bad environment! Specify a `PROTOCOL_RUNNER_URL` to point to the a cloud run instance");
+    }
+    // The cloud runner hub should have a configured URL to define the remote instance to boot.
+    const protocolRunnerUrl = process.env.PROTOCOL_RUNNER_URL;
+
+    // Validate the post request has both the `bucket` and `configFile` params.
+    if (!req.body.bucket || !req.body.configFile) {
+      res.status(400).send({
+        message: "ERROR: Body missing json bucket or file parameters!"
+      });
+      throw new Error("ERROR: Body missing json bucket or file parameters!");
+    }
+
+    // Get the config file from the GCP bucket
+    const configObject = await _fetchConfigObject(req.body.bucket, req.body.configFile);
+    console.log("configObject", configObject);
+
+    // Loop over all config objects in the config file and for each append a call promise to the promiseArray.
+    let promiseArray = [];
+    for (const botName in configObject) {
+      const botConfig = configObject[botName];
+      console.log("Appending to promise array", botName); // TODO: refine this logging with a winston log
+      promiseArray.push(_executeCloudRun(protocolRunnerUrl, botConfig));
+    }
+
+    // Loop through promise array and submit all in parallel. `allSettled` does not fail early if a promise is rejected.
+    const results = await Promise.allSettled(promiseArray);
+    console.log(results); // TODO: refine this logging with a winston log
+
+    // Validate that the promises returned correctly. If ANY have error, then catch them and throw them all together.
+    let thrownErrors = [];
+    results.forEach(result => {
+      if (result.status == "rejected") {
+        thrownErrors.push(result);
+      }
+    });
+
+    if (thrownErrors.length > 0) {
+      throw thrownErrors;
+    }
+
+    // If no errors and got to this point correctly then return a 200 success status.
+    res.status(200).send({ message: "All calls returned correctly", error: null });
+  } catch (error) {
+    console.log("error", error);
+    res.status(400).send({ message: "One or more calls failed with error", error: error });
+  }
+});
+
+// Fetch a `file` from a GCP `bucket`. This function uses a readStream which is converted into a buffer such that the
+// config file does not need to first be downloaded from the bucket. This will use the local service account.
+const _fetchConfigObject = async (bucket, file) => {
+  const requestPromise = new Promise((resolve, reject) => {
+    let buf = "";
+    storage
+      .bucket(bucket)
+      .file(file)
+      .createReadStream()
+      .on("data", d => (buf += d))
+      .on("end", () => resolve(buf))
+      .on("error", e => reject(e));
+  });
+
+  return JSON.parse(await requestPromise);
+};
+
+// Execute a Cloud Run Post command on a given `url` with a provided json `body`. The local service account must
+// be permissioned to execute this command.
+const _executeCloudRun = async (url, body) => {
+  const targetAudience = new URL(url).origin;
+
+  const client = await auth.getIdTokenClient(targetAudience);
+  const res = await client.request({
+    url: url,
+    method: "post",
+    data: body
+  });
+  return res.data;
+};
+
+// Execute a post query on a arbitrary `url` with a given json `body. Used to test the hub script locally.
+// TODO: wire this in for unit testing.
+async function _postJson(url, body) {
+  console.log("b", JSON.stringify(body));
+  const response = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-type": "application/json",
+      Accept: "application/json",
+      "Accept-Charset": "utf-8"
+    }
+  });
+  return await response.json(); // extract JSON from the http response
+}
+
+const port = process.env.PORT || 8080;
+app.listen(port, () => {
+  console.log("Listening on port", port);
+});

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -32,7 +32,7 @@ const { GoogleAuth } = require("google-auth-library"); // Used to get authentica
 const auth = new GoogleAuth();
 const { Storage } = require("@google-cloud/storage"); // Used to get global config objects to parameterize bots.
 const storage = new Storage();
-const { Datastore } = require("@google-cloud/datastore"); // used to read/write the last block number the monitor used.
+const { Datastore } = require("@google-cloud/datastore"); // Used to read/write the last block number the monitor used.
 const datastore = new Datastore();
 
 // Web3 instance to get current block numbers of polling loops.

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -35,6 +35,9 @@ const storage = new Storage();
 const { Datastore } = require("@google-cloud/datastore"); // used to read/write the last block number the monitor used.
 const datastore = new Datastore();
 
+// Web3 instance to get current block numbers of polling loops.
+const Web3 = require("web3");
+
 // Helpers
 // TODO integrate with winston logger.
 // const { Logger, waitForLogger } = require("../../financial-templates-lib/logger/Logger");
@@ -42,12 +45,6 @@ const datastore = new Datastore();
 app.post("/", async (req, res) => {
   try {
     console.log("Running Cloud runner hub query");
-    if (!process.env.PROTOCOL_RUNNER_URL) {
-      throw new Error("Bad environment! Specify a `PROTOCOL_RUNNER_URL` to point to the a cloud run instance");
-    }
-    // The cloud runner hub should have a configured URL to define the remote instance to boot.
-    const protocolRunnerUrl = process.env.PROTOCOL_RUNNER_URL;
-
     // Validate the post request has both the `bucket` and `configFile` params.
     if (!req.body.bucket || !req.body.configFile) {
       res.status(400).send({
@@ -58,19 +55,30 @@ app.post("/", async (req, res) => {
 
     // Get the config file from the GCP bucket
     const configObject = await _fetchConfigObject(req.body.bucket, req.body.configFile);
-    console.log("configObject", configObject);
+
+    // Fetch the last block number this given config file queried the blockchain at.
+    const lastQueriedBlockNumber = await _getLastQueriedBlockNumber(req.body.configFile);
+
+    // Get the latest block number. The query will run from the last queried block number to the latest block number.
+    const latestBlockNumber = await _getLatestBlockNumber();
+
+    // Save the current latest block number to the remote config. This will be the used as the "lastQueriedBlockNumber"
+    // in the next iteration when the hub is called again.
+    await _saveQueriedBlockNumber(req.body.configFile, latestBlockNumber);
 
     // Loop over all config objects in the config file and for each append a call promise to the promiseArray.
     let promiseArray = [];
     for (const botName in configObject) {
-      const botConfig = configObject[botName];
+      const botConfig = appendStartEndBlockVariables(configObject[botName], lastQueriedBlockNumber, latestBlockNumber);
       console.log("Appending to promise array", botName); // TODO: refine this logging with a winston log
-      promiseArray.push(_executeCloudRun(protocolRunnerUrl, botConfig));
+      // TODO: when running locally we can execute a JSON call to a local restful API. Refactor this for intergration tests.
+      // promiseArray.push(_postJson(process.env.PROTOCOL_RUNNER_URL, botConfig));
+      promiseArray.push(_executeCloudRun(process.env.PROTOCOL_RUNNER_URL, botConfig));
     }
 
     // Loop through promise array and submit all in parallel. `allSettled` does not fail early if a promise is rejected.
     const results = await Promise.allSettled(promiseArray);
-    console.log(results); // TODO: refine this logging with a winston log
+    console.log(JSON.stringify(results)); // TODO: refine this logging with a winston log
 
     // Validate that the promises returned correctly. If ANY have error, then catch them and throw them all together.
     let thrownErrors = [];
@@ -145,13 +153,25 @@ async function _getLastQueriedBlockNumber(configIdentifier) {
   const key = datastore.key(["BlockNumberLog", configIdentifier]);
   const [dataField] = await datastore.get(key);
 
-  return dataField;
+  if (dataField == undefined) return 0;
+  return dataField.blockNumber;
+}
+
+async function _getLatestBlockNumber() {
+  const web3 = new Web3(process.env.CUSTOM_NODE_URL);
+  return await web3.eth.getBlockNumber();
+}
+
+function appendStartEndBlockVariables(config, lastQueriedBlockNumber, latestBlockNumber) {
+  // The starting block number should be one block after the last queried block number to not double report that block.
+  config.environmentVariables["STARTING_BLOCK_NUMBER"] = lastQueriedBlockNumber + 1;
+  config.environmentVariables["ENDING_BLOCK_NUMBER"] = latestBlockNumber;
+  return config;
 }
 
 // Execute a post query on a arbitrary `url` with a given json `body. Used to test the hub script locally.
 // TODO: wire this in for unit testing.
 async function _postJson(url, body) {
-  console.log("b", JSON.stringify(body));
   const response = await fetch(url, {
     method: "POST",
     body: JSON.stringify(body),
@@ -167,4 +187,8 @@ async function _postJson(url, body) {
 const port = process.env.PORT || 8080;
 app.listen(port, () => {
   console.log("Listening on port", port);
+  // The cloud runner hub should have a configured URL to define the remote instance & a local node URL to boot.
+  if (!process.env.PROTOCOL_RUNNER_URL || !process.env.CUSTOM_NODE_URL) {
+    throw new Error("Bad environment! Specify a `PROTOCOL_RUNNER_URL` to point to the a cloud run instance");
+  }
 });

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -157,11 +157,13 @@ async function _getLastQueriedBlockNumber(configIdentifier) {
   return dataField.blockNumber;
 }
 
+// Get the latest block number from `CUSTOM_NODE_URL`. Used to update the `lastSeenBlockNumber` after each run.
 async function _getLatestBlockNumber() {
   const web3 = new Web3(process.env.CUSTOM_NODE_URL);
   return await web3.eth.getBlockNumber();
 }
 
+// Add additional environment variables for a given config file. Used to attach starting and ending block numbers.
 function appendStartEndBlockVariables(config, lastQueriedBlockNumber, latestBlockNumber) {
   // The starting block number should be one block after the last queried block number to not double report that block.
   config.environmentVariables["STARTING_BLOCK_NUMBER"] = lastQueriedBlockNumber + 1;

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -192,6 +192,8 @@ app.listen(port, () => {
   console.log("Listening on port", port);
   // The cloud runner hub should have a configured URL to define the remote instance & a local node URL to boot.
   if (!process.env.PROTOCOL_RUNNER_URL || !process.env.CUSTOM_NODE_URL) {
-    throw new Error("Bad environment! Specify a `PROTOCOL_RUNNER_URL` to point to the a cloud run instance");
+    throw new Error(
+      "Bad environment! Specify a `PROTOCOL_RUNNER_URL` & `CUSTOM_NODE_URL` to point to the a cloud run instance and Ethereum node"
+    );
   }
 });

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -153,7 +153,8 @@ async function _getLastQueriedBlockNumber(configIdentifier) {
   const key = datastore.key(["BlockNumberLog", configIdentifier]);
   const [dataField] = await datastore.get(key);
 
-  if (dataField == undefined) return 0;
+  // If the data field is undefined then this is the first time the hub is run. Therefore return the latest block number.
+  if (dataField == undefined) return await this._getLatestBlockNumber();
   return dataField.blockNumber;
 }
 

--- a/reporters/cloud-run-scripts/CloudRunnerHub.js
+++ b/reporters/cloud-run-scripts/CloudRunnerHub.js
@@ -69,7 +69,7 @@ app.post("/", async (req, res) => {
     // Loop over all config objects in the config file and for each append a call promise to the promiseArray.
     let promiseArray = [];
     for (const botName in configObject) {
-      const botConfig = appendStartEndBlockVariables(configObject[botName], lastQueriedBlockNumber, latestBlockNumber);
+      const botConfig = appendBlockNumberEnvVars(configObject[botName], lastQueriedBlockNumber, latestBlockNumber);
       console.log("Appending to promise array", botName); // TODO: refine this logging with a winston log
       // TODO: when running locally we can execute a JSON call to a local restful API. Refactor this for intergration tests.
       // promiseArray.push(_postJson(process.env.PROTOCOL_RUNNER_URL, botConfig));
@@ -164,7 +164,7 @@ async function _getLatestBlockNumber() {
 }
 
 // Add additional environment variables for a given config file. Used to attach starting and ending block numbers.
-function appendStartEndBlockVariables(config, lastQueriedBlockNumber, latestBlockNumber) {
+function appendBlockNumberEnvVars(config, lastQueriedBlockNumber, latestBlockNumber) {
   // The starting block number should be one block after the last queried block number to not double report that block.
   config.environmentVariables["STARTING_BLOCK_NUMBER"] = lastQueriedBlockNumber + 1;
   config.environmentVariables["ENDING_BLOCK_NUMBER"] = latestBlockNumber;


### PR DESCRIPTION
This PR modifies the Cloud Run hub to "remember" the last block number it ran from. This is done by querying the last block number the hub saw at the start of the loop and then using this parameter as the `STARTING_BLOCK_NUMBER` for the bots. The hub then uses the current block number as the `ENDING_BLOCK_NUMBER`. At the same time the bot records the current observed block number as the last seen block number, ensuring that for the next loop of the hub execution the time has progressed without skipping any blocks.

This ensures that the bots query events from the `STARTING_BLOCK_NUMBER` until the `ENDING_BLOCK_NUMBER`, representing the discrete-time steps the hub has seen.

In order to accommodate this functionality, the `ExpiringMultiPartyEventClient.js` was modified to take in this new ending block number parameter to define up until where the client should search.

As with other changes made to the bots, these parameters are totally optional. If the user running the bot elects to not provide `STARTING_BLOCK_NUMBER` then the bot will start at the current latest block. Likewise, if the user chooses to not provide `ENDING_BLOCK_NUMBER` then the bot will always run to `latest` on every loop. This means that the normal "looping" behavior of the bots is not affected.

On relevant implementation details, this PR makes use of GCPs Datastore to store block numbers. This can be viewed from the GCP dashboard as follows:
![image](https://user-images.githubusercontent.com/12886084/85864818-4ad2f100-b7c5-11ea-9628-5539bdb8b47f.png)

Each config file will have it's own unique entry in GCP Datastore. This enables different config & Hubs to operate in conjunction with one another. For example, we might elect to run a hub and spoke for a test net. This would create a key value pair in GCP Datastore with the key `global-bot-config-testing.json` for the `global-bot-config-testing.json` config file. There would be a second entry in the DB for the main net config, named `global-bot-config.json` which would store the main net latest block number.

close #1640