### PR TITLE
Update tutorial with yCOMP EMP address

### DIFF
--- a/documentation/synthetic_tokens/tutorials/mint_tokens_via_etherscan.md
+++ b/documentation/synthetic_tokens/tutorials/mint_tokens_via_etherscan.md
@@ -10,7 +10,7 @@ The token minting contract needs approval to transfer the collateral currency (D
 
 1. Go to the [Write Contract Tab](https://etherscan.io/address/0x6b175474e89094c44da98b954eedeac495271d0f#writeContract) on the [DAI](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f) contract page.
 2. Search for the `approve` function.
-3. For the first argument, pass in the address of the token minting contract (for ETHBTC on mainnet it is `0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944`).
+3. For the first argument, pass in the address of the token minting contract (for ETHBTC it is `0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944`, for yCOMP it is `0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1`).
 4. For the second argument, pass in the maximum amount of collateral you intend to supply or alternatively any sufficiently high number.
    - This will be in units of Wei; use this [converter](http://eth-converter.com/).
    - For example, 100 DAI would be a value of `100000000000000000000`.
@@ -39,7 +39,7 @@ To compute that, we need the true total collateral amount, and this we get from 
 
 These instructions will compute for the GCR:
 
-1. Go to the Read Contract Tab on the token minting contract page (for ETHBTC click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#readContract)).
+1. Go to the Read Contract Tab on the token minting contract page (for ETHBTC click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#readContract), for yCOMP click [here](https://etherscan.io/address/0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1#readContract)).
 2. Search for the `cumulativeFeeMultiplier` function and observe the number there. This is in units of Wei so you will again need to convert it back into a human-readable number with the converter above. For example, a value of `1000000000000000000` would equate to **a multiplier with the value of `1`**.
 
    ![multiplier](mint_multiplier.png)
@@ -56,9 +56,9 @@ These instructions will compute for the GCR:
 
 ### Minimum number of tokens to mint
 
-There is a setting in the contract that defines the minimum number of tokens your position must have. For ETHBTC, this value is set at 1000 tokens, but if you wanted to confirm this on Etherscan, you can follow these instructions:
+There is a setting in the contract that defines the minimum number of tokens your position must have. For ETHBTC this value is set at 1000 tokens and for yCOMP it is 1 token, but if you wanted to confirm this on Etherscan, you can follow these instructions:
 
-1. Go to the Read Contract Tab on the token minting contract page (for ETHBTC, click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#readContract)).
+1. Go to the Read Contract Tab on the token minting contract page (for ETHBTC click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#readContract), for yCOMP click [here](https://etherscan.io/address/0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1#readContract)).
 2. Search for the `minSponsorTokens` function and observe the number there. In this example, a value of `1000000000000000000000` or **`1000` tokens when converted from Wei**.
 
    ![min sponsor tokens](mint_min_sponsor_tokens.png)
@@ -73,9 +73,9 @@ Assuming we want to mint 1000 tokens, that would mean we need **`1000 * GCR (~0.
 
 ## Minting the actual tokens
 
-Finally, we are ready to mint the actual synthetic tokens. You might want to add a bit more collateral than the minimum to prevent yourself from being liquidated (the minimum collateralization ratio for ETHBTC is 120%). In this example, we will put in 40 DAI.
+Finally, we are ready to mint the actual synthetic tokens. You might want to add a bit more collateral than the minimum to prevent yourself from being liquidated (the minimum collateralization ratio is 120% for ETHBTC and 150% for yCOMP). In this example, we will put in 40 DAI.
 
-1. Go to the Write Contract Tab on the token minting contract page (for ETHBTC, click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#writeContract)).
+1. Go to the Write Contract Tab on the token minting contract page (for ETHBTC click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#writeContract), for yCOMP click [here](https://etherscan.io/address/0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1#writeContract)).
 2. Search for the `create` function.
 3. For the first argument, input the collateral amount in Wei wrapped in double-quotes and square brackets. For example, 40 DAI of collateral would mean inputting `[“40000000000000000000”]`.
 4. For the second argument, input the number of tokens (in Wei) that you want to mint, and wrap it in double-quotes with square brackets just like above.
@@ -90,7 +90,7 @@ Finally, we are ready to mint the actual synthetic tokens. You might want to add
 
 Now that we have minted our tokens, let’s check the smart contract to make sure it’s keeping tracking of our tokens and collateral properly.
 
-1. Go to the Read Contract Tab on the token minting contract page (for ETHBTC, click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#readContract)).
+1. Go to the Read Contract Tab on the token minting contract page (for ETHBTC click [here](https://etherscan.io/address/0x3f2d9edd9702909cf1f8c4237b7c4c5931f9c944#readContract), for yCOMP click [here](https://etherscan.io/address/0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1#readContract)).
 2. Search for the `positions` function.
 3. Paste in your address into the textbox and hit Query.
 4. You should see something like the following:
@@ -101,6 +101,6 @@ From this, we can conclude that we have successfully minted 1000 tokens with 40 
 
 ## What next?
 
-Now that you have minted your tokens, you need to make sure that it stays collateralized as the value of the underlying moves (e.g. the ETH to BTC ratio). You can do this with the Sponsor [CLI tool](./using_the_uma_sponsor_cli_tool.md) that helps you manage your position. In the future, we might provide a dapp frontend for your convenience. Let us know on our Discord if you want to see this.
+Now that you have minted your tokens, you need to make sure that it stays collateralized as the value of the underlying moves (e.g. the ETH to BTC ratio, or the price of COMP). You can do this with the Sponsor [CLI tool](./using_the_uma_sponsor_cli_tool.md) that helps you manage your position. In the future, we might provide a dapp frontend for your convenience. Let us know on our Discord if you want to see this.
 
-And don’t forget that, in order to get short exposure, you have to actually sell these tokens rather than just hold onto them. For example, you can trade ETHBTC tokens on Uniswap [here](https://uniswap.exchange/swap?inputCurrency=0x6b175474e89094c44da98b954eedeac495271d0f&outputCurrency=0x6d002a834480367fb1a1dc5f47e82fde39ec2c42). These ETHBTC tokens will expire on August 1st, 2020 (and become redeemable by anyone). So make sure to keep that in mind as well.
+In order to get short exposure, don't forget to sell these tokens rather than hold onto them (the idea is that you can buy them cheaper on the market later on to unwind your position). For example, you can trade ETHBTC tokens on Uniswap [here](https://uniswap.exchange/swap?inputCurrency=0x6b175474e89094c44da98b954eedeac495271d0f&outputCurrency=0x6d002a834480367fb1a1dc5f47e82fde39ec2c42). The tokens in the example above will expire on August 1st, 2020 (and become redeemable by anyone), so make sure to keep that in mind as well.

--- a/documentation/synthetic_tokens/tutorials/mint_tokens_via_etherscan.md
+++ b/documentation/synthetic_tokens/tutorials/mint_tokens_via_etherscan.md
@@ -101,6 +101,6 @@ From this, we can conclude that we have successfully minted 1000 tokens with 40 
 
 ## What next?
 
-Now that you have minted your tokens, you need to make sure that it stays collateralized as the value of the underlying moves (e.g. the ETH to BTC ratio, or the price of COMP). You can do this with the Sponsor [CLI tool](./using_the_uma_sponsor_cli_tool.md) that helps you manage your position. In the future, we might provide a dapp frontend for your convenience. Let us know on our Discord if you want to see this.
+Now that you have minted your tokens, you need to make sure that it stays collateralized as the value of the underlying moves (e.g. the ETH to BTC ratio, or the price of COMP in USD). You can do this with the Sponsor [CLI tool](./using_the_uma_sponsor_cli_tool.md) that helps you manage your position. In the future, we might provide a dapp frontend for your convenience. Let us know on our Discord if you want to see this.
 
 In order to get short exposure, don't forget to sell these tokens rather than hold onto them (the idea is that you can buy them cheaper on the market later on to unwind your position). For example, you can trade ETHBTC tokens on Uniswap [here](https://uniswap.exchange/swap?inputCurrency=0x6b175474e89094c44da98b954eedeac495271d0f&outputCurrency=0x6d002a834480367fb1a1dc5f47e82fde39ec2c42). The tokens in the example above will expire on August 1st, 2020 (and become redeemable by anyone), so make sure to keep that in mind as well.


### PR DESCRIPTION
Fixes #1676 

Tutorial should be a little friendlier towards people who want to mint yCOMP now.

I would still like to see:

1. A mention of the "community-developed" frontend so ppl can double check their GCR calculations (but I understand why we might want to leave this out).
2. A link to the Uniswap market for yCOMP, which as of right now is yet to be created. I can pre-compute it but I don't want that to hold up this PR.