### PR TITLE
Add price script to get median historical price

### DIFF
--- a/core/scripts/local/getMedianHistoricalPrice.js
+++ b/core/scripts/local/getMedianHistoricalPrice.js
@@ -40,20 +40,6 @@ const defaultConfigs = {
 
 async function getMedianHistoricalPrice(callback) {
   try {
-    // Function to get the current time.
-    const getTime = () => Math.round(new Date().getTime() / 1000);
-
-    // If user specified a timestamp, then use it, otherwise default to the current time.
-    let queryTime;
-    if (!argv.time) {
-      queryTime = getTime();
-      console.log(
-        `Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): ${queryTime}`
-      );
-    } else {
-      queryTime = argv.time;
-    }
-
     // If user did not specify an identifier, provide a default value.
     let queryIdentifier;
     if (!argv.identifier) {
@@ -68,12 +54,26 @@ async function getMedianHistoricalPrice(callback) {
     let pricefeedConfig;
     if (!defaultConfigs[queryIdentifier]) {
       throw new Error(
-        `Identifier '${queryIdentifier}' not found in defaultConfigs object. Please add to the object to continue. Current available identifiers are [ ${JSON.stringify(
+        `Identifier '${queryIdentifier}' not found in defaultConfigs object. Please add to the object to continue. Current available identifiers are ${JSON.stringify(
           Object.keys(defaultConfigs)
-        )} ].`
+        )}.`
       );
     } else {
       pricefeedConfig = defaultConfigs[queryIdentifier];
+    }
+
+    // Function to get the current time.
+    const getTime = () => Math.round(new Date().getTime() / 1000);
+
+    // If user specified a timestamp, then use it, otherwise default to the current time.
+    let queryTime;
+    if (!argv.time) {
+      queryTime = getTime();
+      console.log(
+        `Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): ${queryTime}`
+      );
+    } else {
+      queryTime = argv.time;
     }
 
     // Create and update a new Medianizer price feed.

--- a/core/scripts/local/getMedianHistoricalPrice.js
+++ b/core/scripts/local/getMedianHistoricalPrice.js
@@ -1,0 +1,102 @@
+/**
+ * @notice This is an example script demonstrating how to get a historical median price at a specific timestamp.
+ * It could be used for example to query a price before committing a vote for a DVM price request.
+ * We provide default configurations for querying median prices on specific markets across some exchanges and markets.
+ * This script should serve as a template for constructing other historical median queries.
+ *  *
+ * @dev How to run: $(npm bin)/truffle exec ./scripts/local/GetMedianHistoricalPrice.js --network mainnet --identifier <PRICE-FEED IDENTIFIER> --time <TIMESTAMP IN SECONDS>
+ */
+const { fromWei } = web3.utils;
+const { createPriceFeed } = require("../../../financial-templates-lib/price-feed/CreatePriceFeed");
+const { Networker } = require("../../../financial-templates-lib/price-feed/Networker");
+const winston = require("winston");
+const argv = require("minimist")(process.argv.slice(), { string: ["identifier", "time"] });
+
+// Pricefeed default configurations to pass into Medianizer price feed. Medianizer returns the median price across specified
+// `medianizedFeeds`.
+const defaultConfigs = {
+  "ETH/BTC": {
+    type: "medianizer",
+    pair: "ethbtc",
+    lookback: 604800,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro" },
+      { type: "cryptowatch", exchange: "binance" },
+      { type: "cryptowatch", exchange: "bitstamp" }
+    ]
+  },
+  COMPUSD: {
+    type: "medianizer",
+    lookback: 604800,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "compusd" },
+      { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
+      { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
+    ]
+  }
+};
+
+async function getMedianHistoricalPrice(callback) {
+  try {
+    // Function to get the current time.
+    const getTime = () => Math.round(new Date().getTime() / 1000);
+
+    // If user specified a timestamp, then use it, otherwise default to the current time.
+    let queryTime;
+    if (!argv.time) {
+      queryTime = getTime();
+      console.log(
+        `Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): ${queryTime}`
+      );
+    } else {
+      queryTime = argv.time;
+    }
+
+    // If user did not specify an identifier, provide a default value.
+    let queryIdentifier;
+    if (!argv.identifier) {
+      queryIdentifier = Object.keys(defaultConfigs)[0];
+      console.log(`Optional '--identifier' flag not specified, defaulting to: ${queryIdentifier}`);
+    } else {
+      queryIdentifier = argv.identifier;
+    }
+    queryIdentifier = queryIdentifier.toUpperCase();
+
+    // Get configuration object from identifier.
+    let pricefeedConfig;
+    if (!defaultConfigs[queryIdentifier]) {
+      throw new Error(
+        `Identifier '${queryIdentifier}' not found in defaultConfigs object. Please add to the object to continue. Current available identifiers are [ ${JSON.stringify(
+          Object.keys(defaultConfigs)
+        )} ].`
+      );
+    } else {
+      pricefeedConfig = defaultConfigs[queryIdentifier];
+    }
+
+    // Create and update a new Medianizer price feed.
+    let dummyLogger = winston.createLogger({
+      silent: true
+    });
+    const medianizerPriceFeed = await createPriceFeed(
+      dummyLogger,
+      web3,
+      new Networker(dummyLogger),
+      getTime,
+      pricefeedConfig
+    );
+    await medianizerPriceFeed.update();
+
+    // Get a price.
+    const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime);
+    console.log(`${queryIdentifier} price @ ${queryTime} = ${fromWei(queryPrice.toString())}`);
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+}
+
+module.exports = getMedianHistoricalPrice;

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -175,6 +175,31 @@ async function createUniswapPriceFeedForEmp(logger, web3, networker, getTime, em
   return await createPriceFeed(logger, web3, networker, getTime, { ...defaultConfig, ...userConfig });
 }
 
+// Default price feed configs for currently approved identifiers.
+const defaultConfigs = {
+  "ETH/BTC": {
+    type: "medianizer",
+    pair: "ethbtc",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro" },
+      { type: "cryptowatch", exchange: "binance" },
+      { type: "cryptowatch", exchange: "bitstamp" }
+    ]
+  },
+  COMPUSD: {
+    type: "medianizer",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "compusd" },
+      { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
+      { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
+    ]
+  }
+};
+
 /**
  * Create a reference price feed for the EMP. Note: this is the price feed that the token is tracking.
  * @param {Object} winston logger.
@@ -182,42 +207,31 @@ async function createUniswapPriceFeedForEmp(logger, web3, networker, getTime, em
  * @param {Object} networker object that the price feed may use to make REST calls.
  * @param {Function} function to get the current time.
  * @param {String} string representing the address of the EMP contract.
- * @param {Object} optional config to override the defaults for this reference feed.
+ * @param {Object=} config (optional) to override the defaults for this reference feed.
+ * @param {String=} identifier (optional) allows caller to choose which default price feed config to use. Required only if the caller does not pass in an `empAddress`
  * @return {Object} an instance of PriceFeedInterface that can be used to get the reference price.
  */
-async function createReferencePriceFeedForEmp(logger, web3, networker, getTime, empAddress, config) {
-  const emp = getEmpAtAddress(web3, empAddress);
+async function createReferencePriceFeedForEmp(logger, web3, networker, getTime, empAddress, config, identifier) {
+  // Automatically detect identifier from passed in EMP address or use `identifier`.
+  let _identifier;
+  let emp;
+
+  if (empAddress) {
+    emp = getEmpAtAddress(web3, empAddress);
+    _identifier = web3.utils.hexToUtf8(await emp.methods.priceIdentifier().call());
+  } else if (identifier) {
+    _identifier = identifier;
+  } else {
+    throw new Error("createReferencePriceFeedForEmp: Must pass in an `empAddress` or an `identifier`");
+  }
+
+  const defaultConfig = defaultConfigs[_identifier];
 
   // Infer lookback from liquidation liveness.
-  const lookback = Number((await emp.methods.liquidationLiveness().call()).toString());
-
-  // TODO: maybe move this default config to a better location.
-  const defaultConfigs = {
-    "ETH/BTC": {
-      type: "medianizer",
-      pair: "ethbtc",
-      lookback,
-      minTimeBetweenUpdates: 60,
-      medianizedFeeds: [
-        { type: "cryptowatch", exchange: "coinbase-pro" },
-        { type: "cryptowatch", exchange: "binance" },
-        { type: "cryptowatch", exchange: "bitstamp" }
-      ]
-    },
-    COMPUSD: {
-      type: "medianizer",
-      lookback: 7200,
-      minTimeBetweenUpdates: 60,
-      medianizedFeeds: [
-        { type: "cryptowatch", exchange: "coinbase-pro", pair: "compusd" },
-        { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
-        { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
-      ]
-    }
-  };
-
-  const identifier = web3.utils.hexToUtf8(await emp.methods.priceIdentifier().call());
-  const defaultConfig = defaultConfigs[identifier];
+  if (emp) {
+    const lookback = Number((await emp.methods.liquidationLiveness().call()).toString());
+    Object.assign(defaultConfig, { lookback });
+  }
 
   let combinedConfig;
   if (defaultConfig && config) {

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -363,6 +363,8 @@ contract("CreatePriceFeed.js", function(accounts) {
 
     assert.isTrue(priceFeed != null);
     assert.equal(priceFeed.priceFeeds[0].minTimeBetweenUpdates, 5);
+
+    // Check that the default `lookback` property is overridden.
     assert.equal(priceFeed.priceFeeds[0].lookback, 1000);
   });
 


### PR DESCRIPTION
Sample script for getting a median historical price. Uses default price config objects and allows user to specify an `identifier` and `time`.

Example runs:

- Getting a historical price:
```
$(npm bin)/truffle exec ./scripts/local/getMedianHistoricalPrice.js --network mainnet --identifier eth/btc --time 1592952360

ETH/BTC price @ 1592952360 = 0.02525
```

- Requesting an invalid identifier:
```
$(npm bin)/truffle exec ./scripts/local/getMedianHistoricalPrice.js --network mainnet --identifier compusdt

Error: Identifier 'COMPUSDT' not found in defaultConfigs object. Please add to the object to continue. Current available identifiers are ["ETH/BTC","COMPUSD"].
```

- Not specifying a time and defaulting to current time:
```
$(npm bin)/truffle exec ./scripts/local/getMedianHistoricalPrice.js --network mainnet --identifier compusd

Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): 1593196708
COMPUSD price @ 1593196708 = 256.07
```

- Not specifying an identifier and defaulting to one of the supported identifiers:
```
$(npm bin)/truffle exec ./scripts/local/getMedianHistoricalPrice.js --network mainnet                    

Using network 'mainnet'.

Optional '--identifier' flag not specified, defaulting to: ETH/BTC
Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): 1593196739
ETH/BTC price @ 1593196739 = 0.025088
```

Resolves #1685 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>