### PR TITLE
Handle bad historical price response from CryptoWatch

### DIFF
--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -47,14 +47,23 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       return undefined;
     }
 
-    // If first element in `historicalPricePeriods` data is invalid, return null.
-    if (!this.historicalPricePeriods[0] || !this.historicalPricePeriods[0].openTime) {
+    // Set first price period in `historicalPricePeriods` to first non-null price.
+    let firstPricePeriod;
+    for (let p in this.historicalPricePeriods) {
+      if (this.historicalPricePeriods[p] && this.historicalPricePeriods[p].openTime) {
+        firstPricePeriod = this.historicalPricePeriods[p];
+        break;
+      }
+    }
+
+    // If there are no valid price periods, return null.
+    if (!firstPricePeriod) {
       return null;
     }
 
     // If the time is before the first piece of data in the set, return null because
     // the price is before the lookback window.
-    if (time < this.historicalPricePeriods[0].openTime) {
+    if (time < firstPricePeriod.openTime) {
       return null;
     }
 

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -47,6 +47,11 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       return undefined;
     }
 
+    // If first element in `historicalPricePeriods` data is invalid, return null.
+    if (!this.historicalPricePeriods[0] || !this.historicalPricePeriods[0].openTime) {
+      return null;
+    }
+
     // If the time is before the first piece of data in the set, return null because
     // the price is before the lookback window.
     if (time < this.historicalPricePeriods[0].openTime) {

--- a/financial-templates-lib/test/price-feed/PriceFeedMock.js
+++ b/financial-templates-lib/test/price-feed/PriceFeedMock.js
@@ -22,7 +22,7 @@ class PriceFeedMock extends PriceFeedInterface {
   // a price for a specific timestamp if found in this array.
   setHistoricalPrices(historicalPrices) {
     historicalPrices.forEach(_price => {
-      if (isNaN(_price.timestamp) || !_price.price) {
+      if (isNaN(_price.timestamp)) {
         throw "Invalid historical price => [{timestamp, price}]";
       }
 

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -247,6 +247,9 @@ class SyntheticPegMonitor {
   // Find difference between minimum and maximum prices for given pricefeed from `lookback` seconds in the past
   // until `mostRecentTime`. Returns volatility as (max - min)/min %. Also Identifies the direction volatility movement.
   _calculateHistoricalVolatility(pricefeed, mostRecentTime, lookback) {
+    // TODO: If the historical price @ `mostRecentTime` is not available, go backwards until you find a most recent timestamp that works.
+    // This method should ideally only return null if there are no valid historical prices between `mostRecentTime` and `mostRecentTime-lookback`.
+
     // Set max and min to latest price to start.
     let min = pricefeed.getHistoricalPrice(mostRecentTime);
     let max = min;

--- a/monitors/test/SyntheticPegMonitor.js
+++ b/monitors/test/SyntheticPegMonitor.js
@@ -184,8 +184,9 @@ contract("SyntheticPegMonitor", function(accounts) {
     });
 
     it("Calculate price volatility returns expected values", async function() {
-      // Inject prices into pricefeed.
+      // Inject prices into pricefeed. Null prices are ignored.
       const historicalPrices = [
+        { timestamp: 99, price: null },
         { timestamp: 100, price: toBN(toWei("10")) },
         { timestamp: 101, price: toBN(toWei("11")) },
         { timestamp: 102, price: toBN(toWei("12")) },
@@ -193,7 +194,9 @@ contract("SyntheticPegMonitor", function(accounts) {
         { timestamp: 104, price: toBN(toWei("14")) },
         { timestamp: 105, price: toBN(toWei("15")) },
         { timestamp: 106, price: toBN(toWei("16")) },
-        { timestamp: 107, price: toBN(toWei("17")) }
+        { timestamp: 107, price: null },
+        { timestamp: 108, price: toBN(toWei("17")) },
+        { timestamp: 109, price: null }
       ];
       medianizerPriceFeedMock.setHistoricalPrices(historicalPrices);
 
@@ -233,7 +236,7 @@ contract("SyntheticPegMonitor", function(accounts) {
       // Test when volatility window is smaller than the amount of historical prices. The last update time is 106,
       // so this should read the volatility from timestamps [106, 105, 104, 103, 102]. The min/max should be 12/16,
       // and the volatility should be (4 / 12 = 0.3333) or 33%.
-      medianizerPriceFeedMock.setLastUpdateTime(106);
+      medianizerPriceFeedMock.setLastUpdateTime(107);
       assert.equal(
         syntheticPegMonitor
           ._calculateHistoricalVolatility(medianizerPriceFeedMock, 106, volatilityWindow)


### PR DESCRIPTION
This error arose from a call to `getHistoricalPrice` from `SyntheticPegMonitor` and crashed the monitor:
![Screen Shot 2020-06-28 at 00 31 30](https://user-images.githubusercontent.com/9457025/85937971-cf616480-b8d6-11ea-822c-0be2fd4a9274.png)

There are two things should address this issue
1. `CryptoWatchPriceFeed` should make sure that invalid `this.historicalPricePeriods[x]` are handled correctly.
2. `SyntheticPegMonitor` uses `getHistoricalPrice` to compute historical volatility, but it currently will return `volatility = null` if `getHistoricalPrice(mostRecentTime)===null`. Instead, it should prepare for this error and just use the other price data points within the price window to compute historical vol.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>