### PR TITLE
Multiple Fixes to dApp reward retrieval

### DIFF
--- a/common/Enums.js
+++ b/common/Enums.js
@@ -26,9 +26,17 @@ const PositionStatesEnum = {
   EXPIRED_PRICE_RECEIVED: "2"
 };
 
+const PriceRequestStatusEnum = {
+  NOT_REQUESTED: "0",
+  ACTIVE: "1",
+  RESOLVED: "2",
+  FUTURE: "3"
+};
+
 module.exports = {
   RegistryRolesEnum,
   VotePhasesEnum,
   LiquidationStatesEnum,
-  PositionStatesEnum
+  PositionStatesEnum,
+  PriceRequestStatusEnum
 };

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -119,7 +119,7 @@ function RetrieveRewards({ votingAccount }) {
       return MAX_UINT_VAL;
     } else {
       // This section will produce an array of roundIds that should be queried for unclaimed rewards.
-      const defaultLookback = 7; // Default lookback is 10 rounds.
+      const defaultLookback = 7; // Default lookback is 7 rounds (2 weeks).
 
       // Window length should be the lookback or currentRoundId (so the numbers don't go below 0), whichever is smaller.
       const windowLength = Math.min(currentRoundId, defaultLookback);

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -21,7 +21,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 
   const { send, status } = useCacheSend("Voting", "retrieveRewards");
 
-  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceRequests == null) {
+  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || !priceRequests) {
     // Requests haven't been completed.
     return { ready: false, status };
   } else {
@@ -175,6 +175,8 @@ function RetrieveRewards({ votingAccount }) {
       const status = statuses[i];
       priceRequest.lastRound = status.lastVotingRound;
       if (status.status === PriceRequestStatusEnum.RESOLVED) {
+        // Note: this method needs to be called "from" the Governor contract since it's approved to "use" the DVM.
+        // Otherwise, it will revert.
         priceRequest.resolvedPrice = call("Voting", "getPrice", priceRequest.identifier, priceRequest.time, {
           from: governorAddress
         });

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -21,7 +21,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 
   const { send, status } = useCacheSend("Voting", "retrieveRewards");
 
-  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceRequests === null) {
+  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceRequests === undefined) {
     // Requests haven't been completed.
     return { ready: false, status };
   } else {
@@ -153,7 +153,7 @@ function RetrieveRewards({ votingAccount }) {
   // Get auxillary information about all price requests that were revealed.
   const priceRequests = useCacheCall(["Voting"], call => {
     if (!revealedVoteEvents) {
-      return null;
+      return undefined;
     }
 
     const priceRequests = revealedVoteEvents.map(event => {
@@ -168,7 +168,7 @@ function RetrieveRewards({ votingAccount }) {
     const statuses = call("Voting", "getPriceRequestStatuses", priceRequests);
 
     if (!statuses) {
-      return null;
+      return undefined;
     }
 
     // Pulls down the price for every resolved request. If the request wasn't resolved, the resolved price isn't
@@ -190,7 +190,7 @@ function RetrieveRewards({ votingAccount }) {
       }
     }
 
-    return done ? priceRequests : null;
+    return done ? priceRequests : undefined;
   });
 
   // Construct the claim rewards transaction.

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -62,6 +62,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
         // Reveal happened in the same round as the price resolution: definitely a retrievable reward.
         oldestUnclaimedRound = Math.min(oldestUnclaimedRound, revealRound);
         voteState.didReveal = true;
+        voteState.priceResolutionRound = revealRound;
       }
     }
 
@@ -74,11 +75,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
     const toRetrieve = [];
     const maxBatchRetrievals = BATCH_MAX_RETRIEVALS;
     for (const [key, voteState] of Object.entries(state)) {
-      if (
-        !voteState.retrievedRewards &&
-        voteState.priceResolutionRound === oldestUnclaimedRound.toString() &&
-        voteState.didReveal
-      ) {
+      if (voteState.priceResolutionRound === oldestUnclaimedRound.toString() && voteState.didReveal) {
         // If this is an eligible reward for the oldest round, extract the information and push it into the retrieval array.
         const [identifier, time] = key.split("|");
         toRetrieve.push({ identifier: web3.utils.utf8ToHex(identifier), time: time });
@@ -100,7 +97,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 }
 
 function RetrieveRewards({ votingAccount }) {
-  const { useCacheCall, useCacheEvents } = drizzleReactHooks.useDrizzle();
+  const { drizzle, useCacheCall, useCacheEvents } = drizzleReactHooks.useDrizzle();
   const classes = useTableStyles();
 
   const currentRoundId = useCacheCall("Voting", "getCurrentRoundId");

--- a/voter-dapp/src/RetrieveRewards.js
+++ b/voter-dapp/src/RetrieveRewards.js
@@ -21,7 +21,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
 
   const { send, status } = useCacheSend("Voting", "retrieveRewards");
 
-  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || !priceRequests) {
+  if (retrievedRewardsEvents === undefined || revealedVoteEvents === undefined || priceRequests === null) {
     // Requests haven't been completed.
     return { ready: false, status };
   } else {
@@ -55,6 +55,8 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, revealedVoteEvents, price
       const revealRound = event.returnValues.roundId.toString();
       const votedPrice = event.returnValues.price.toString();
 
+      // Note: must check that the reveal round matches the resolution round of the price request because the correct
+      // vote during the wrong round doesn't earn any rewards.
       if (
         !voteState.retrievedRewards &&
         priceRequest.lastRound.toString() === revealRound &&
@@ -117,7 +119,9 @@ function RetrieveRewards({ votingAccount }) {
       return MAX_UINT_VAL;
     } else {
       // This section will produce an array of roundIds that should be queried for unclaimed rewards.
-      const defaultLookback = 7; // Default lookback is 7 rounds (2 weeks).
+      // Default lookback is 7 rounds (2 weeks). Rewards currently expire after 2 weeks, so there should be no reason for
+      // a user to need a longer lookback.
+      const defaultLookback = 7;
 
       // Window length should be the lookback or currentRoundId (so the numbers don't go below 0), whichever is smaller.
       const windowLength = Math.min(currentRoundId, defaultLookback);


### PR DESCRIPTION
1. Fixes #1695.
2. Fixes #1683.

I've tested this locally in ganache, but likely haven't covered *all* edge cases. Please suggest test cases that should be run if you can think of any interesting ones.

Note: this does not handle prevent users from erroneously attempting to retrieve rewards that are expired. However, the default reward retrieval lookback was updated to not show expired rewards by default. This should be fixed in a separate PR.