### PR TITLE
Improve liquidator and disputer bot defaults

### DIFF
--- a/disputer/index.js
+++ b/disputer/index.js
@@ -10,7 +10,7 @@ const { MAX_UINT_VAL } = require("../common/Constants");
 const { Disputer } = require("./disputer");
 const { GasEstimator } = require("../financial-templates-lib/helpers/GasEstimator");
 const { ExpiringMultiPartyClient } = require("../financial-templates-lib/clients/ExpiringMultiPartyClient");
-const { createPriceFeed } = require("../financial-templates-lib/price-feed/CreatePriceFeed");
+const { createReferencePriceFeedForEmp } = require("../financial-templates-lib/price-feed/CreatePriceFeed");
 const { Networker } = require("../financial-templates-lib/price-feed/Networker");
 
 // Truffle contracts
@@ -44,7 +44,14 @@ async function run(address, pollingDelay, priceFeedConfig, disputerConfig) {
 
     // Setup price feed.
     const getTime = () => Math.round(new Date().getTime() / 1000);
-    const priceFeed = await createPriceFeed(Logger, web3, new Networker(Logger), getTime, priceFeedConfig);
+    const priceFeed = await createReferencePriceFeedForEmp(
+      Logger,
+      web3,
+      new Networker(Logger),
+      getTime,
+      address,
+      priceFeedConfig
+    );
 
     if (!priceFeed) {
       throw new Error("Price feed config is invalid");
@@ -102,16 +109,12 @@ async function Poll(callback) {
     // Default to 1 minute delay. If set to 0 in env variables then the script will exit after full execution.
     const pollingDelay = process.env.POLLING_DELAY ? Number(process.env.POLLING_DELAY) : 60;
 
-    if (!process.env.PRICE_FEED_CONFIG) {
-      throw new Error(
-        "Bad input arg! Specify a `PRICE_FEED_CONFIG` for price feed config for the disputer bot to use."
-      );
-    }
     // Read price feed configuration from an environment variable. This can be a crypto watch, medianizer or uniswap
-    // price feed Config defines the exchanges to use. EG with medianizer: {"type":"medianizer","pair":"ethbtc",
+    // price feed Config defines the exchanges to use. If not provided then the bot will try and infer a price feed
+    // from the EMP_ADDRESS. EG with medianizer: {"type":"medianizer","pair":"ethbtc",
     // "lookback":7200, "minTimeBetweenUpdates":60,"medianizedFeeds":[{"type":"cryptowatch","exchange":"coinbase-pro"},
     // {"type":"cryptowatch","exchange":"binance"}]}
-    const priceFeedConfig = JSON.parse(process.env.PRICE_FEED_CONFIG);
+    const priceFeedConfig = process.env.PRICE_FEED_CONFIG ? JSON.parse(process.env.PRICE_FEED_CONFIG) : null;
 
     // If there is a disputer config, add it. Else, set to null. This config contains disputeDelay and txnGasLimit. EG:
     // {"disputeDelay":60,"txnGasLimit":9000000}

--- a/disputer/test/index.js
+++ b/disputer/test/index.js
@@ -23,25 +23,23 @@ contract("index.js", function(accounts) {
   let defaultPriceFeedConfig;
 
   before(async function() {
-    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
+    collateralToken = await Token.new("DAI", "DAI", 18, { from: contractCreator });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("UMATEST"));
+    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("ETH/BTC"));
   });
 
   beforeEach(async function() {
-    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
-
     const constructorParams = {
       expirationTimestamp: "12345678900",
       withdrawalLiveness: "1000",
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,
-      priceFeedIdentifier: utf8ToHex("UMATEST"),
-      syntheticName: "Test UMA Token",
-      syntheticSymbol: "UMATEST",
+      priceFeedIdentifier: utf8ToHex("ETH/BTC"),
+      syntheticName: "ETH/BTC synthetic token",
+      syntheticSymbol: "ETH/BTC",
       liquidationLiveness: "1000",
       collateralRequirement: { rawValue: toWei("1.2") },
       disputeBondPct: { rawValue: toWei("0.1") },

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -121,6 +121,14 @@ function slackFormatter(info) {
             }
           });
         }
+      } else if (info[key] == null) {
+        formattedResponse.blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ` • _${key}_: null`
+          }
+        });
       }
     }
     // Add a divider to the end of the message to help distinguish messages in long lists.

--- a/financial-templates-lib/logger/SlackTransport.js
+++ b/financial-templates-lib/logger/SlackTransport.js
@@ -121,6 +121,8 @@ function slackFormatter(info) {
             }
           });
         }
+        // Else, if the value from the key value pair is null still show the key in the log. For example if a param is
+        // logged but empty we still want to see the key.
       } else if (info[key] == null) {
         formattedResponse.blocks.push({
           type: "section",

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -229,7 +229,6 @@ async function createReferencePriceFeedForEmp(logger, web3, networker, getTime, 
   if (empAddress) {
     emp = getEmpAtAddress(web3, empAddress);
     _identifier = web3.utils.hexToUtf8(await emp.methods.priceIdentifier().call());
-    console.log("_identifier", _identifier);
   } else if (identifier) {
     _identifier = identifier;
   } else {

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -197,6 +197,16 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
       { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
     ]
+  },
+  "COMP/USD": {
+    type: "medianizer",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "compusd" },
+      { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
+      { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
+    ]
   }
 };
 
@@ -219,6 +229,7 @@ async function createReferencePriceFeedForEmp(logger, web3, networker, getTime, 
   if (empAddress) {
     emp = getEmpAtAddress(web3, empAddress);
     _identifier = web3.utils.hexToUtf8(await emp.methods.priceIdentifier().call());
+    console.log("_identifier", _identifier);
   } else if (identifier) {
     _identifier = identifier;
   } else {
@@ -226,6 +237,14 @@ async function createReferencePriceFeedForEmp(logger, web3, networker, getTime, 
   }
 
   const defaultConfig = defaultConfigs[_identifier];
+
+  logger.debug({
+    at: "createReferencePriceFeedForEmp",
+    message: "Inferred default config from identifier or EMP address",
+    empAddress,
+    identifier: _identifier,
+    defaultConfig
+  });
 
   // Infer lookback from liquidation liveness.
   if (emp) {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -10,7 +10,7 @@ const { toBN } = web3.utils;
 const { Liquidator } = require("./liquidator");
 const { GasEstimator } = require("../financial-templates-lib/helpers/GasEstimator");
 const { ExpiringMultiPartyClient } = require("../financial-templates-lib/clients/ExpiringMultiPartyClient");
-const { createPriceFeed } = require("../financial-templates-lib/price-feed/CreatePriceFeed");
+const { createReferencePriceFeedForEmp } = require("../financial-templates-lib/price-feed/CreatePriceFeed");
 const { Networker } = require("../financial-templates-lib/price-feed/Networker");
 
 // Truffle contracts
@@ -45,7 +45,15 @@ async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
 
     // Setup price feed.
     const getTime = () => Math.round(new Date().getTime() / 1000);
-    const priceFeed = await createPriceFeed(Logger, web3, new Networker(Logger), getTime, priceFeedConfig);
+
+    const priceFeed = await createReferencePriceFeedForEmp(
+      Logger,
+      web3,
+      new Networker(Logger),
+      getTime,
+      address,
+      priceFeedConfig
+    );
 
     if (!priceFeed) {
       throw new Error("Price feed config is invalid");
@@ -116,17 +124,12 @@ async function Poll(callback) {
     // Default to 1 minute delay. If set to 0 in env variables then the script will exit after full execution.
     const pollingDelay = process.env.POLLING_DELAY ? Number(process.env.POLLING_DELAY) : 60;
 
-    if (!process.env.PRICE_FEED_CONFIG) {
-      throw new Error(
-        "Bad input arg! Specify an `PRICE_FEED_CONFIG` for the location of the expiring Multi Party within your environment variables."
-      );
-    }
-
     // Read price feed configuration from an environment variable. This can be a crypto watch, medianizer or uniswap
-    // price feed Config defines the exchanges to use. EG with medianizer: {"type":"medianizer","pair":"ethbtc",
+    // price feed Config defines the exchanges to use. If not provided then the bot will try and infer a price feed
+    // from the EMP_ADDRESS. EG with medianizer: {"type":"medianizer","pair":"ethbtc",
     // "lookback":7200, "minTimeBetweenUpdates":60,"medianizedFeeds":[{"type":"cryptowatch","exchange":"coinbase-pro"},
     // {"type":"cryptowatch","exchange":"binance"}]}
-    const priceFeedConfig = JSON.parse(process.env.PRICE_FEED_CONFIG);
+    const priceFeedConfig = process.env.PRICE_FEED_CONFIG ? JSON.parse(process.env.PRICE_FEED_CONFIG) : null;
 
     // If there is a disputer config, add it. Else, set to null. This config contains crThreshold,liquidationDeadline,
     // liquidationMinPrice, txnGasLimit & logOverrides. Example config:

--- a/liquidator/test/index.js
+++ b/liquidator/test/index.js
@@ -24,11 +24,11 @@ contract("index.js", function(accounts) {
   let defaultPriceFeedConfig;
 
   before(async function() {
-    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
+    collateralToken = await Token.new("DAI", "DAI", 18, { from: contractCreator });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("UMATEST"));
+    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("ETH/BTC"));
   });
 
   beforeEach(async function() {
@@ -38,9 +38,9 @@ contract("index.js", function(accounts) {
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,
-      priceFeedIdentifier: utf8ToHex("UMATEST"),
-      syntheticName: "Test UMA Token",
-      syntheticSymbol: "UMATEST",
+      priceFeedIdentifier: utf8ToHex("ETH/BTC"),
+      syntheticName: "ETH/BTC synthetic token",
+      syntheticSymbol: "ETH/BTC",
       liquidationLiveness: "1000",
       collateralRequirement: { rawValue: toWei("1.2") },
       disputeBondPct: { rawValue: toWei("0.1") },
@@ -76,11 +76,11 @@ contract("index.js", function(accounts) {
     } catch (err) {
       errorThrown = true;
     }
-    assert.isFalse(errorThrown);
 
     const collateralAllowance = await collateralToken.allowance(contractCreator, emp.address);
     assert.equal(collateralAllowance.toString(), MAX_UINT_VAL);
     const syntheticAllowance = await syntheticToken.allowance(contractCreator, emp.address);
     assert.equal(syntheticAllowance.toString(), MAX_UINT_VAL);
+    assert.isFalse(errorThrown);
   });
 });


### PR DESCRIPTION
This PR makes the liquidator and disputer bot easier to start up and run. After this change, the `PRICE_FEED_CONFIG` object variable has become optional. If it is not included then the bot will attempt to infer the config from a pre-defined default config list. If it is included, then the bot will join the default with the inferred config using the `createReferencePriceFeedForEmp` added by @nicholaspai yesterday.

This PR is part 1 of 2 for issue #1617. This PR covers the liquidator and disputer bots. A follow-up PR will be for the monitor and reporter bots.