### PR TITLE
Fix false positive liquidator and disputer "index.js" tests

### DIFF
--- a/disputer/test/index.js
+++ b/disputer/test/index.js
@@ -13,6 +13,11 @@ const TokenFactory = artifacts.require("TokenFactory");
 const Timer = artifacts.require("Timer");
 const UniswapMock = artifacts.require("UniswapMock");
 
+// Custom winston transport module to monitor winston log outputs
+const winston = require("winston");
+const sinon = require("sinon");
+const { SpyTransport, spyLogLevel } = require("../../financial-templates-lib/logger/SpyTransport");
+
 contract("index.js", function(accounts) {
   const contractCreator = accounts[0];
 
@@ -21,6 +26,9 @@ contract("index.js", function(accounts) {
   let uniswap;
 
   let defaultPriceFeedConfig;
+
+  let spy;
+  let spyLogger;
 
   before(async function() {
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
@@ -31,6 +39,13 @@ contract("index.js", function(accounts) {
   });
 
   beforeEach(async function() {
+    // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston logs.
+    spy = sinon.spy(); // Create a new spy for each test.
+    spyLogger = winston.createLogger({
+      level: "info",
+      transports: [new SpyTransport({ level: "info" }, { spy: spy })]
+    });
+
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
 
     const constructorParams = {
@@ -68,18 +83,18 @@ contract("index.js", function(accounts) {
     await uniswap.setPrice(toWei("1"), toWei("1"));
   });
 
-  it("Completes one iteration without throwing an error", async function() {
-    let errorThrown;
-    try {
-      await Poll.run(emp.address, 0, defaultPriceFeedConfig);
-      errorThrown = false;
-    } catch (err) {
-      console.error(err);
-      errorThrown = true;
-    }
-    assert.isFalse(errorThrown);
+  it("Allowances are set", async function() {
+    await Poll.run(spyLogger, emp.address, 0, defaultPriceFeedConfig);
 
     const collateralAllowance = await collateralToken.allowance(contractCreator, emp.address);
     assert.equal(collateralAllowance.toString(), MAX_UINT_VAL);
+  });
+
+  it("Completes one iteration without logging any errors", async function() {
+    await Poll.run(spyLogger, emp.address, 0, defaultPriceFeedConfig);
+
+    for (let i = 0; i < spy.callCount; i++) {
+      assert.notEqual(spyLogLevel(spy, i), "error");
+    }
   });
 });

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -19,6 +19,7 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
 
 /**
  * @notice Continuously attempts to liquidate positions in the EMP contract.
+ * @param {Object} logger Module responsible for sending logs.
  * @param {String} address Contract address of the EMP.
  * @param {Number} pollingDelay The amount of seconds to wait between iterations. If set to 0 then running in serverless
  *     mode which will exit after the loop.
@@ -26,11 +27,11 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  * @param {Object} [liquidatorConfig] Configuration to construct the liquidator.
  * @return None or throws an Error.
  */
-async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
+async function run(logger, address, pollingDelay, priceFeedConfig, liquidatorConfig) {
   try {
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
-    Logger[pollingDelay === 0 ? "debug" : "info"]({
+    logger[pollingDelay === 0 ? "debug" : "info"]({
       at: "Liquidator#index",
       message: "Liquidator started 🌊",
       empAddress: address,
@@ -45,16 +46,16 @@ async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
 
     // Setup price feed.
     const getTime = () => Math.round(new Date().getTime() / 1000);
-    const priceFeed = await createPriceFeed(Logger, web3, new Networker(Logger), getTime, priceFeedConfig);
+    const priceFeed = await createPriceFeed(logger, web3, new Networker(logger), getTime, priceFeedConfig);
 
     if (!priceFeed) {
       throw new Error("Price feed config is invalid");
     }
 
     // Client and liquidator bot
-    const empClient = new ExpiringMultiPartyClient(Logger, ExpiringMultiParty.abi, web3, emp.address);
-    const gasEstimator = new GasEstimator(Logger);
-    const liquidator = new Liquidator(Logger, empClient, gasEstimator, priceFeed, accounts[0], liquidatorConfig);
+    const empClient = new ExpiringMultiPartyClient(logger, ExpiringMultiParty.abi, web3, emp.address);
+    const gasEstimator = new GasEstimator(logger);
+    const liquidator = new Liquidator(logger, empClient, gasEstimator, priceFeed, accounts[0], liquidatorConfig);
 
     // The EMP requires approval to transfer the liquidator's collateral and synthetic tokens in order to liquidate
     // a position. We'll set this once to the max value and top up whenever the bot's allowance drops below MAX_INT / 2.
@@ -66,7 +67,7 @@ async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
       const collateralApprovalTx = await collateralToken.approve(empClient.empAddress, MAX_UINT_VAL, {
         from: accounts[0]
       });
-      Logger.info({
+      logger.info({
         at: "Liquidator#index",
         message: "Approved EMP to transfer unlimited collateral tokens 💰",
         collateralApprovalTx: collateralApprovalTx.transactionHash
@@ -76,7 +77,7 @@ async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
       const syntheticApprovalTx = await syntheticToken.approve(empClient.empAddress, MAX_UINT_VAL, {
         from: accounts[0]
       });
-      Logger.info({
+      logger.info({
         at: "Liquidator#index",
         message: "Approved EMP to transfer unlimited synthetic tokens 💰",
         collateralApprovalTx: syntheticApprovalTx.transactionHash
@@ -90,18 +91,18 @@ async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig) {
 
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (pollingDelay === 0) {
-        await waitForLogger(Logger);
+        await waitForLogger(logger);
         break;
       }
       await delay(Number(pollingDelay));
     }
   } catch (error) {
-    Logger.error({
+    logger.error({
       at: "Liquidator#index",
       message: "Liquidator polling error🚨",
       error: typeof error === "string" ? new Error(error) : error
     });
-    await waitForLogger(Logger);
+    await waitForLogger(logger);
   }
 }
 
@@ -137,7 +138,7 @@ async function Poll(callback) {
     //   "logOverrides":{"positionLiquidated":"warn"}} -> override specific events log levels.
     const liquidatorConfig = process.env.LIQUIDATOR_CONFIG ? JSON.parse(process.env.LIQUIDATOR_CONFIG) : null;
 
-    await run(process.env.EMP_ADDRESS, pollingDelay, priceFeedConfig, liquidatorConfig);
+    await run(Logger, process.env.EMP_ADDRESS, pollingDelay, priceFeedConfig, liquidatorConfig);
   } catch (error) {
     Logger.error({
       at: "Liquidator#index",


### PR DESCRIPTION
Like #1704 these tests should check for "error"-level winston logs, not whether any errors are thrown. In fact, errors should not be thrown because they are caught by a root try-catch.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>