### PR TITLE
Add price override parameters to liquidator and dispute bots

### DIFF
--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -66,7 +66,7 @@ class Disputer {
 
   // Queries disputable liquidations and disputes any that were incorrectly liquidated. If `disputerOverridePrice` is
   // provided then the disputer will ignore the price feed and use the override price instead for all undisputed liquidations.
-  async queryAndDispute(disputerOverridePrice = null) {
+  async queryAndDispute(disputerOverridePrice) {
     this.logger.debug({
       at: "Disputer",
       message: "Checking for any disputable liquidations"

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -143,7 +143,7 @@ async function Poll(callback) {
     // If there is a DISPUTER_OVERRIDE_PRICE environment variable then the disputer will disregard the price from the
     // price feed and preform disputes at this override price. Use with caution as wrong input could cause invalid disputes.
     const disputerOverridePrice = process.env.DISPUTER_OVERRIDE_PRICE;
-    
+
     await run(Logger, process.env.EMP_ADDRESS, pollingDelay, priceFeedConfig, disputerConfig, disputerOverridePrice);
   } catch (error) {
     Logger.error({

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -24,10 +24,10 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  *     mode which will exit after the loop.
  * @param {Object} priceFeedConfig Configuration to construct the price feed object.
  * @param {Object} [disputerConfig] Configuration to construct the disputer.
- * @param {String} [disputerOverridePrice] String encoded BigNumber to override the disputer price feed.
+ * @param {String} [disputerOverridePrice] String representing a Wei number to override the disputer price feed.
  * @return None or throws an Error.
  */
-async function run(address, pollingDelay, priceFeedConfig, disputerConfig, disputerOverridePrice = null) {
+async function run(address, pollingDelay, priceFeedConfig, disputerConfig, disputerOverridePrice) {
   try {
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -24,7 +24,7 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  *     mode which will exit after the loop.
  * @param {Object} priceFeedConfig Configuration to construct the price feed object.
  * @param {Object} [disputerConfig] Configuration to construct the disputer.
- * @param {String} [disputerOverridePrice] String representing a Wei number to override the disputer price feed.
+ * @param {String} [disputerOverridePrice] Optional String representing a Wei number to override the disputer price feed.
  * @return None or throws an Error.
  */
 async function run(address, pollingDelay, priceFeedConfig, disputerConfig, disputerOverridePrice) {

--- a/disputer/test/Disputer.js
+++ b/disputer/test/Disputer.js
@@ -413,5 +413,46 @@ contract("Disputer.js", function(accounts) {
       assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
       assert.equal((await emp.getLiquidations(sponsor1))[0].disputer, disputeBot);
     });
+
+    it("Can provide an override price to disputer", async function() {
+      // sponsor1 creates a position with 130 units of collateral, creating 100 synthetic tokens.
+      await emp.create({ rawValue: toWei("130") }, { rawValue: toWei("100") }, { from: sponsor1 });
+
+      // The liquidator creates a position to have synthetic tokens.
+      await emp.create({ rawValue: toWei("1000") }, { rawValue: toWei("500") }, { from: liquidator });
+
+      // The sponsor1 submits a valid withdrawal request of withdrawing 5e18 collateral. This places their
+      // position at collateral of 125 and debt of 100.
+      await emp.requestWithdrawal({ rawValue: toWei("5") }, { from: sponsor1 });
+
+      // Next, we will create an invalid liquidation to liquidate the whole position.
+      await emp.createLiquidation(
+        sponsor1,
+        { rawValue: "0" },
+        { rawValue: toWei("1.75") }, // Price high enough to initiate the liquidation
+        { rawValue: toWei("100") },
+        unreachableDeadline,
+        { from: liquidator }
+      );
+
+      // Say the price feed reports a price of 1 USD per token. This makes the liquidation invalid and the disputer should
+      // dispute the liquidation: 125/(100*1.0)=1.25 CR -> Position was collateralized and invalid liquidation.
+      priceFeedMock.setHistoricalPrice(toBN(toWei("1")));
+
+      // However, say disputer operator has provided an override price of 1.2 USD per token. This makes the liquidation
+      // valid and the disputer should do nothing: 125/(100*1.2)=1.0
+      await disputer.queryAndDispute(toWei("1.2"));
+      assert.equal(spy.callCount, 0); // 0 info level logs should be sent as no dispute.
+      assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
+
+      // Next assume that the override price is in fact 1 USD per token. At this price point the liquidation is now
+      // invalid that the disputer should try dispute the tx.
+      await disputer.queryAndDispute(toWei("1.0"));
+      assert.equal(spy.callCount, 1); // 1 info level logs should be sent for the dispute
+      assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PENDING_DISPUTE);
+
+      // The disputeBot should be the disputer in sponsor1  liquidations.
+      assert.equal((await emp.getLiquidations(sponsor1))[0].disputer, disputeBot);
+    });
   });
 });

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -24,7 +24,7 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  *     mode which will exit after the loop.
  * @param {Object} priceFeedConfig Configuration to construct the price feed object.
  * @param {Object} [liquidatorConfig] Configuration to construct the liquidator.
- * @param {String} [liquidatorOverridePrice] String representing a Wei number to override the liquidator price feed.
+ * @param {String} [liquidatorOverridePrice] Optional String representing a Wei number to override the liquidator price feed.
  * @return None or throws an Error.
  */
 async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig, liquidatorOverridePrice) {

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -24,10 +24,10 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  *     mode which will exit after the loop.
  * @param {Object} priceFeedConfig Configuration to construct the price feed object.
  * @param {Object} [liquidatorConfig] Configuration to construct the liquidator.
- * @param {String} [liquidatorOverridePrice] String encoded BigNumber to override the liquidator price feed.
+ * @param {String} [liquidatorOverridePrice] String representing a Wei number to override the liquidator price feed.
  * @return None or throws an Error.
  */
-async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig, liquidatorOverridePrice = null) {
+async function run(address, pollingDelay, priceFeedConfig, liquidatorConfig, liquidatorOverridePrice) {
   try {
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -168,7 +168,14 @@ async function Poll(callback) {
     // price feed and preform liquidations at this override price. Use with caution as wrong input could cause invalid liquidations.
     const liquidatorOverridePrice = process.env.LIQUIDATOR_OVERRIDE_PRICE;
 
-    await run(Logger, process.env.EMP_ADDRESS, pollingDelay, priceFeedConfig, liquidatorConfig, liquidatorOverridePrice);
+    await run(
+      Logger,
+      process.env.EMP_ADDRESS,
+      pollingDelay,
+      priceFeedConfig,
+      liquidatorConfig,
+      liquidatorOverridePrice
+    );
   } catch (error) {
     Logger.error({
       at: "Liquidator#index",

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -133,6 +133,7 @@ async function Poll(callback) {
     // If there is a disputer config, add it. Else, set to null. This config contains crThreshold,liquidationDeadline,
     // liquidationMinPrice, txnGasLimit & logOverrides. Example config:
     // {"crThreshold":0.02,  -> Liquidate if a positions collateral falls more than this % below the min CR requirement
+    //   "liquidationDeadline":300, -> Aborts if the transaction is mined this amount of time after the last update
     //   "liquidationMinPrice":0, -> Aborts if the amount of collateral in the position per token is below this ratio
     //   "txnGasLimit":9000000 -> Gas limit to set for sending on-chain transactions.
     //   "logOverrides":{"positionLiquidated":"warn"}} -> override specific events log levels.

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -115,7 +115,7 @@ class Liquidator {
   // Queries underCollateralized positions and performs liquidations against any under collateralized positions.
   // If `maxTokensToLiquidateWei` is not passed in, then the bot will only attempt to liquidate the full position.
   // If liquidatorOverridePrice is provided then the liquidator bot will override the price feed with this input price.
-  async queryAndLiquidate(maxTokensToLiquidateWei, liquidatorOverridePrice = null) {
+  async queryAndLiquidate(maxTokensToLiquidateWei, liquidatorOverridePrice) {
     await this.update();
 
     // If an override is provided, use that price. Else, get the latest price from the price feed.

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -114,10 +114,12 @@ class Liquidator {
 
   // Queries underCollateralized positions and performs liquidations against any under collateralized positions.
   // If `maxTokensToLiquidateWei` is not passed in, then the bot will only attempt to liquidate the full position.
-  async queryAndLiquidate(maxTokensToLiquidateWei) {
+  // If liquidatorOverridePrice is provided then the liquidator bot will override the price feed with this input price.
+  async queryAndLiquidate(maxTokensToLiquidateWei, liquidatorOverridePrice = null) {
     await this.update();
 
-    const price = this.priceFeed.getCurrentPrice();
+    // If an override is provided, use that price. Else, get the latest price from the price feed.
+    const price = liquidatorOverridePrice ? this.toBN(liquidatorOverridePrice) : this.priceFeed.getCurrentPrice();
 
     if (!price) {
       this.logger.warn({
@@ -146,6 +148,7 @@ class Liquidator {
     this.logger.debug({
       at: "Liquidator",
       message: "Checking for under collateralized positions",
+      liquidatorOverridePrice: liquidatorOverridePrice ? liquidatorOverridePrice.toString() : null,
       inputPrice: price.toString(),
       scaledPrice: scaledPrice.toString(),
       empCRRatio: this.empCRRatio.toString(),

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -841,8 +841,6 @@ contract("Liquidator.js", function(accounts) {
     });
 
     it("Can correctly override price feed input", async function() {
-      liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0]);
-
       // sponsor1 creates a position with 115 units of collateral, creating 100 synthetic tokens.
       await emp.create({ rawValue: toWei("115") }, { rawValue: toWei("100") }, { from: sponsor1 });
 

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -19,7 +19,6 @@ const {
   spyLogIncludes,
   spyLogLevel
 } = require("../../financial-templates-lib/logger/SpyTransport");
-// const { assert } = require("sinon");
 
 // Contracts and helpers
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");

--- a/liquidator/test/Liquidator.js
+++ b/liquidator/test/Liquidator.js
@@ -19,6 +19,7 @@ const {
   spyLogIncludes,
   spyLogLevel
 } = require("../../financial-templates-lib/logger/SpyTransport");
+// const { assert } = require("sinon");
 
 // Contracts and helpers
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
@@ -48,6 +49,7 @@ contract("Liquidator.js", function(accounts) {
   let spyLogger;
 
   let liquidatorConfig;
+  let liquidatorOverridePrice;
 
   before(async function() {
     collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
@@ -752,6 +754,48 @@ contract("Liquidator.js", function(accounts) {
       await liquidator.queryAndLiquidate();
       assert.equal(spy.callCount, 1); // 1 log events after liquidation query.
       assert.equal(lastSpyLogLevel(spy), "warn"); // most recent log level should be "warn"
+    });
+
+    it("Can correctly override price feed input", async function() {
+      liquidator = new Liquidator(spyLogger, empClient, gasEstimator, priceFeedMock, accounts[0]);
+
+      // sponsor1 creates a position with 115 units of collateral, creating 100 synthetic tokens.
+      await emp.create({ rawValue: toWei("115") }, { rawValue: toWei("100") }, { from: sponsor1 });
+
+      // sponsor2 creates a position with 118 units of collateral, creating 100 synthetic tokens.
+      await emp.create({ rawValue: toWei("125") }, { rawValue: toWei("100") }, { from: sponsor2 });
+
+      // liquidatorBot creates a position to have synthetic tokens to pay off debt upon liquidation.
+      await emp.create({ rawValue: toWei("1000") }, { rawValue: toWei("500") }, { from: liquidatorBot });
+
+      // specify an override price of 0.5e18.
+      liquidatorOverridePrice = toWei("0.5");
+      // At a price point of 1 sponsor 1 is undercollateralized and sponsor 2 is overcollateralized. However, there
+      // is an override price present at 0.5. At this price point neither position is undercollateralized and so
+      // there should be no liquidation events generated from the liquidation call.
+      priceFeedMock.setCurrentPrice(toBN(toWei("1")));
+      assert.equal(spy.callCount, 0); // No log events before liquidation query
+
+      // Next, call the `queryAndLiquidate` function with the override price. The `null` param is for
+      // `maxTokensToLiquidateWei` which null will attempt to liquidate the full position, if undercollateralized.
+      await liquidator.queryAndLiquidate(null, liquidatorOverridePrice);
+      assert.equal(spy.callCount, 0); // still no liquidation events generated as price override is set to 0.5.
+
+      let liquidationObject = await emp.getLiquidations(sponsor1);
+      // There should be no liquidation's created.
+      assert.equal(liquidationObject.length, 0);
+
+      // Specifying a new override price that places one of the positions undercollateralized should initiate a liquidation.
+      // This should again be independent of the price feed.
+      priceFeedMock.setCurrentPrice(toBN(toWei("0.5"))); // set the price feed to something that should not create a liquidation.
+
+      liquidatorOverridePrice = toWei("1.0"); // specify an override price of 1.0e18. This should place sponsor 1 underwater.
+      await liquidator.queryAndLiquidate(null, liquidatorOverridePrice);
+      assert.equal(spy.callCount, 1); // This should initiate the liquidation event and so there should be 1 log.
+
+      liquidationObject = await emp.getLiquidations(sponsor1);
+      // There should be one liquidation created.
+      assert.equal(liquidationObject.length, 1);
     });
   });
 });


### PR DESCRIPTION
This pull request adds the ability for the bot operator to provide a `DISPUTER_OVERRIDE_PRICE` or `LIQUIDATOR_OVERRIDE_PRICE` to override the default price feed when choosing the preform liquidations or disputes.

Resolves #1448 
Resolves #1702