### PR TITLE
Fix staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,3 +225,6 @@ workflows:
           requires:
             - dapp_test
             - test
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,3 @@ workflows:
           requires:
             - dapp_test
             - test
-          filters:
-            branches:
-              only: master

--- a/scripts/deploy_docs.sh
+++ b/scripts/deploy_docs.sh
@@ -22,7 +22,7 @@ shift
 
 # Build the docs site.
 echo "Building docs site locally."
-npm install
+npx lerna bootstrap
 ./scripts/build_docs_site.sh
 
 # Prepare for gcloud deploy.


### PR DESCRIPTION
This PR uses lerna to install dependencies in the docs build script. This fixes the problem in the ci staging deployment, where npm was initiating a full reinstall requiring additional system dependencies that were not present in that docker container.

Note: this was tested by temporarily enabling the deploy_to_staging job to be run in the ci for this PR. That test worked, so I reverted that config update.