### PR TITLE
Add details about resolved price requests to ContractMonitor's logs about Dispute Settlements

### DIFF
--- a/monitors/index.js
+++ b/monitors/index.js
@@ -21,6 +21,7 @@ const { SyntheticPegMonitor } = require("./SyntheticPegMonitor");
 // Truffle contracts artifacts.
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const ExpandedERC20 = artifacts.require("ExpandedERC20");
+const Voting = artifacts.require("Voting");
 
 /**
  * @notice Continuously attempts to monitor contract positions and reports based on monitor modules.
@@ -77,6 +78,7 @@ async function run(
     const collateralToken = await ExpandedERC20.at(collateralTokenAddress);
     const syntheticTokenAddress = await emp.tokenCurrency();
     const syntheticToken = await ExpandedERC20.at(syntheticTokenAddress);
+    const votingContract = await Voting.deployed();
 
     // Generate EMP properties to inform monitor modules of important info like token symbols and price identifier.
     const empProps = {
@@ -116,7 +118,8 @@ async function run(
       empEventClient,
       contractMonitorObject,
       medianizerPriceFeed,
-      empProps
+      empProps,
+      votingContract
     );
 
     // 2. Balance monitor to inform if monitored addresses drop below critical thresholds.

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -386,7 +386,7 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // This liquidator is not monitored
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor2}`)); // disputer address
     assert.isFalse(lastSpyLogIncludes(spy, "(Monitored dispute bot)")); // This disputer is not monitored
-    assert.isTrue(lastSpyLogIncludes(spy, "success")); // the disputed was successful based on settlement price
+    assert.isTrue(lastSpyLogIncludes(spy, "succeeded")); // the disputed was successful based on settlement price
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.tx}`));
   });
 });

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -122,7 +122,14 @@ contract("ContractMonitor.js", function(accounts) {
       networkId: await web3.eth.net.getId()
     };
 
-    contractMonitor = new ContractMonitor(spyLogger, eventClient, contractMonitorConfig, priceFeedMock, empProps);
+    contractMonitor = new ContractMonitor(
+      spyLogger,
+      eventClient,
+      contractMonitorConfig,
+      priceFeedMock,
+      empProps,
+      mockOracle
+    );
 
     await collateralToken.addMember(1, tokenSponsor, {
       from: tokenSponsor
@@ -319,15 +326,11 @@ contract("ContractMonitor.js", function(accounts) {
       from: disputer
     });
 
-    // Advance time and settle
-    let timeAfterLiquidationLiveness = liquidationTime + 10;
-    await mockOracle.setCurrentTime(timeAfterLiquidationLiveness.toString());
-    await emp.setCurrentTime(timeAfterLiquidationLiveness.toString());
-
     // Push a price such that the dispute fails and ensure the resolution reports correctly. Sponsor1 has 50 units of
     // debt and 150 units of collateral. price of 2.5: 150 / (50 * 2.5) = 120% => undercollateralized
     let disputePrice = toWei("2.5");
     await mockOracle.pushPrice(web3.utils.utf8ToHex("ETH/BTC"), liquidationTime, disputePrice);
+    console.log(`TEST: Pushed a price for liquidation timestamp ${liquidationTime}`);
 
     // Withdraw from liquidation to settle the dispute event.
     const txObject1 = await emp.withdrawLiquidation("0", sponsor1, { from: liquidator });
@@ -346,6 +349,10 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "failed")); // the disputed was not successful based on settlement price
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.tx}`));
 
+    // Advance time so that price request is for a different timestamp.
+    const nextLiquidationTimestamp = liquidationTime + 1;
+    await emp.setCurrentTime(nextLiquidationTimestamp.toString());
+
     // Create a second liquidation from a non-monitored address (sponsor1).
     liquidationTime = (await emp.getCurrentTime()).toNumber();
     await emp.createLiquidation(
@@ -362,15 +369,11 @@ contract("ContractMonitor.js", function(accounts) {
       from: sponsor2
     });
 
-    // Advance time and settle
-    timeAfterLiquidationLiveness = liquidationTime + 10;
-    await mockOracle.setCurrentTime(timeAfterLiquidationLiveness.toString());
-    await emp.setCurrentTime(timeAfterLiquidationLiveness.toString());
-
     // Push a price such that the dispute succeeds and ensure the resolution reports correctly. Sponsor2 has 45 units of
     // debt and 175 units of collateral. price of 2.0: 175 / (45 * 2) = 194% => sufficiently collateralized
     disputePrice = toWei("2.0");
     await mockOracle.pushPrice(web3.utils.utf8ToHex("ETH/BTC"), liquidationTime, disputePrice);
+    console.log(`TEST: Pushed a price for liquidation timestamp ${liquidationTime}`);
 
     // Withdraw from liquidation to settle the dispute event.
     const txObject2 = await emp.withdrawLiquidation("0", sponsor2, { from: sponsor2 });

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -330,7 +330,6 @@ contract("ContractMonitor.js", function(accounts) {
     // debt and 150 units of collateral. price of 2.5: 150 / (50 * 2.5) = 120% => undercollateralized
     let disputePrice = toWei("2.5");
     await mockOracle.pushPrice(web3.utils.utf8ToHex("ETH/BTC"), liquidationTime, disputePrice);
-    console.log(`TEST: Pushed a price for liquidation timestamp ${liquidationTime}`);
 
     // Withdraw from liquidation to settle the dispute event.
     const txObject1 = await emp.withdrawLiquidation("0", sponsor1, { from: liquidator });
@@ -373,7 +372,6 @@ contract("ContractMonitor.js", function(accounts) {
     // debt and 175 units of collateral. price of 2.0: 175 / (45 * 2) = 194% => sufficiently collateralized
     disputePrice = toWei("2.0");
     await mockOracle.pushPrice(web3.utils.utf8ToHex("ETH/BTC"), liquidationTime, disputePrice);
-    console.log(`TEST: Pushed a price for liquidation timestamp ${liquidationTime}`);
 
     // Withdraw from liquidation to settle the dispute event.
     const txObject2 = await emp.withdrawLiquidation("0", sponsor2, { from: sponsor2 });


### PR DESCRIPTION
Resolves #1688

Unfortunately I have been unable to add a unit test for these changes on local networks because all of the local contracts use the `Testable` contract with manual timing. My changes to `ContractMonitor` assume that the `liquidationTime` for any liquidation event is the block timestamp, which is only true for public networks. (We can't query the liquidation object's `liquidationTime` property because the liquidation is deleted after all rewards are withdrawn, which could immediately after the dispute settlement if the dispute FAILs.)

I ultimately tested on mainnet and focused retrospectively on a resolved dispute.

- This is what the logs now look like for dispute settlement events where a price is available:
![Screen Shot 2020-07-06 at 16 52 22](https://user-images.githubusercontent.com/9457025/86642353-d446a800-bfa9-11ea-8126-5d03ce7a4ee9.png)

- If the price is not available, then this simplified log is shown:
![Screen Shot 2020-07-06 at 16 52 29](https://user-images.githubusercontent.com/9457025/86642397-dc9ee300-bfa9-11ea-907d-eb563fd97633.png)

While testing out the ContractMonitor with old events (>7 days ago), I ran into issues where the MedianizerPriceFeed could not query `getHistoricalPriceFeed` on some old liquidation events. This caused the Monitor to fail. Therefore, I also patched the ContractMonitor's error handling with historical prices. This is the simplified log message if a historical price is not available in the medianizer price feed.
![Screen Shot 2020-07-06 at 16 54 29](https://user-images.githubusercontent.com/9457025/86642640-0f48db80-bfaa-11ea-8c16-8447051aa39c.png)
