### PR TITLE
Decrease monitor bot config requirment

### DIFF
--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -147,6 +147,10 @@ async function getUniswapPairDetails(web3, syntheticTokenAddress, collateralCurr
 }
 
 async function createUniswapPriceFeedForEmp(logger, web3, networker, getTime, empAddress, config) {
+  if (!empAddress) {
+    throw new Error("createUniswapPriceFeedForEmp: Must pass in an `empAddress`");
+  }
+
   const emp = getEmpAtAddress(web3, empAddress);
 
   const collateralCurrencyAddress = await emp.methods.collateralCurrency().call();
@@ -169,6 +173,14 @@ async function createUniswapPriceFeedForEmp(logger, web3, networker, getTime, em
     invertPrice: inverted,
     uniswapAddress: pairAddress
   };
+
+  logger.debug({
+    at: "createUniswapPriceFeedForEmp",
+    message: "Inferred default config from identifier or EMP address",
+    empAddress,
+    defaultConfig,
+    userConfig
+  });
 
   const userConfig = config || {};
 

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -1,6 +1,7 @@
 // This module is used to monitor a list of addresses and their associated collateral, synthetic and ether balances.
 
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
+const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
 
 class BalanceMonitor {
   /**
@@ -8,29 +9,55 @@ class BalanceMonitor {
    * @param {Object} tokenBalanceClient Client used to query token balances for monitored bots and wallets.
    * @param tokenBalanceClient Instance of the TokenBalanceClient from the `financial-templates lib.
    * which provides synchronous access to address balances for a given expiring multi party contract.
-   * @param {List} botsToMonitor Array of bot objects to monitor. Each bot's `botName` `address`, `CollateralThreshold`
+   * @param {Object} config Object containing configuration for the balance monitor. Only option is a `botsToMonitor` 
+   * which is defines an array of bot objects to monitor. Each bot's `botName` `address`, `CollateralThreshold`
    *      and`syntheticThreshold` must be given. Example:
-   *      [{ name: "Liquidator Bot",
+   *      {botsToMonitor:[{ name: "Liquidator Bot",
    *         address: "0x12345"
    *         collateralThreshold: x1,
    *         syntheticThreshold: x2,
    *         etherThreshold: x3 },
-   *      ..]
+   *      ..]}
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",
             priceIdentifier: "ETH/BTC",
             networkId:1 }
    */
-  constructor(logger, tokenBalanceClient, botsToMonitor, empProps) {
+  constructor(logger, tokenBalanceClient, config, empProps) {
     this.logger = logger;
 
     // Instance of the tokenBalanceClient to read account balances from last change update.
     this.client = tokenBalanceClient;
     this.web3 = this.client.web3;
 
-    // Bot addresses and thresholds to monitor.
-    this.botsToMonitor = botsToMonitor;
+    // Bot addresses and thresholds to monitor. If none provided then defaults to monitoring nothing. Configuration
+    // object must conform to correct structure with the right key valued pairs.
+    const defaultConfig = {
+      botsToMonitor: {
+        value: [],
+        isValid: x => {
+          // For the config to be valid it must be an array of objects with the right keys within the object as being
+          // the `name`, `address`, `collateralThreshold`, `syntheticThreshold` and `etherThreshold`.
+          return (
+            Array.isArray(x) && // the value of `botsToMonitor` must be an array of objects.
+            x.every(y => {
+              // Each object within the array must have the following keys.
+              return (
+                Object.keys(y).includes("name") &&
+                Object.keys(y).includes("address") &&
+                this.web3.utils.isAddress(y.address) && // `address` must be a valid Ethereum address.
+                Object.keys(y).includes("collateralThreshold") &&
+                Object.keys(y).includes("syntheticThreshold") &&
+                Object.keys(y).includes("etherThreshold")
+              );
+            })
+          );
+        }
+      }
+    };
+
+    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
 
     // Loop over all bots in the provided config and register them in the tokenBalanceClient. This will ensure that
     // the addresses are populated on the first fire of the clients `update` function enabling stateless execution.

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -48,8 +48,14 @@ class BalanceMonitor {
                 Object.keys(y).includes("address") &&
                 this.web3.utils.isAddress(y.address) && // `address` must be a valid Ethereum address.
                 Object.keys(y).includes("collateralThreshold") &&
+                // Note this expects a string input as this should be a wei encoded version of the input number. If the
+                // collateralThreshold was 5000 Dai this would be represented as 5000e18 or 5000000000000000000000 which
+                // does not play well with JS as a number. As a result, these inputs should be strings.
+                typeof y.collateralThreshold === "string" &&
                 Object.keys(y).includes("syntheticThreshold") &&
-                Object.keys(y).includes("etherThreshold")
+                typeof y.syntheticThreshold === "string" &&
+                Object.keys(y).includes("etherThreshold") &&
+                typeof y.etherThreshold === "string"
               );
             })
           );

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -12,12 +12,12 @@ class BalanceMonitor {
    * @param {Object} config Object containing configuration for the balance monitor. Only option is a `botsToMonitor` 
    * which is defines an array of bot objects to monitor. Each bot's `botName` `address`, `CollateralThreshold`
    *      and`syntheticThreshold` must be given. Example:
-   *      {botsToMonitor:[{ name: "Liquidator Bot",
+   *      { botsToMonitor:[{ name: "Liquidator Bot",
    *         address: "0x12345"
    *         collateralThreshold: x1,
    *         syntheticThreshold: x2,
    *         etherThreshold: x3 },
-   *      ..]}
+   *      ..] }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -1,30 +1,28 @@
 // This module is used to monitor a list of addresses and their associated Collateralization ratio.
 
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
+const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
 
 class CRMonitor {
   /**
    * @notice Constructs new Collateral Requirement Monitor.
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} expiringMultiPartyClient Client used to query EMP status for monitored wallets position info.
-   * @param {List} walletsToMonitor Array of wallets to Monitor. Each wallet's `walletName`, `address`, `crAlert`
-   *      must be given. Example:
-   *      [{ name: "Market Making bot",
-   *         address: "0x12345",
-   *         crAlert: 1.50 }, // Note 150% is represented as 1.5
-   *       ...];
    * @param {Object} priceFeed Module used to query the current token price.
+   * @param {List} config Object containing an array of wallets to Monitor. Each wallet's `walletName`, `address`,
+   * `crAlert` must be given. Example:
+   *      {walletsToMonitor:[{ name: "Market Making bot", // Friendly bot name
+   *            address: "0x12345",                       // Bot address
+   *            crAlert: 1.50 },                          // CR alerting threshold to generate an alert message; 1.5=150%
+   *       ...]};
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",
             priceIdentifier: "ETH/BTC",
             networkId:1 }
    */
-  constructor(logger, expiringMultiPartyClient, walletsToMonitor, priceFeed, empProps) {
+  constructor(logger, expiringMultiPartyClient, priceFeed, config, empProps) {
     this.logger = logger;
-
-    // Wallet addresses and thresholds to monitor.
-    this.walletsToMonitor = walletsToMonitor;
 
     this.empClient = expiringMultiPartyClient;
     this.web3 = this.empClient.web3;
@@ -32,10 +30,34 @@ class CRMonitor {
     // Offchain price feed to compute the current collateralization ratio for the monitored positions.
     this.priceFeed = priceFeed;
 
-    this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
-
     // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId.
     this.empProps = empProps;
+
+    this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
+
+    // Wallets to monitor collateralization ratio.
+    const defaultConfig = {
+      // By default monitor no wallets for correct collateralization ratio.
+      walletsToMonitor: {
+        value: [],
+        isValid: x => {
+          return (
+            Array.isArray(x) && // the value of `walletsToMonitor` must be an array of objects.
+            x.every(y => {
+              // Each object within the array must have the following keys.
+              return (
+                Object.keys(y).includes("name") &&
+                Object.keys(y).includes("address") &&
+                this.web3.utils.isAddress(y.address) && // `address` must be a valid Ethereum address.
+                Object.keys(y).includes("crAlert")
+              );
+            })
+          );
+        }
+      }
+    };
+
+    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
 
     // Helper functions from web3.
     this.toBN = this.web3.utils.toBN;
@@ -44,6 +66,7 @@ class CRMonitor {
 
   // Queries all monitored wallet ballance for collateralization ratio against a given threshold.
   async checkWalletCrRatio() {
+    if (this.walletsToMonitor.length == 0) return; // If there are no wallets to monitor exit early
     // yield the price feed at the current time.
     const price = this.priceFeed.getCurrentPrice();
 

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -47,9 +47,11 @@ class CRMonitor {
               // Each object within the array must have the following keys.
               return (
                 Object.keys(y).includes("name") &&
+                typeof y.name === "string" &&
                 Object.keys(y).includes("address") &&
                 this.web3.utils.isAddress(y.address) && // `address` must be a valid Ethereum address.
-                Object.keys(y).includes("crAlert")
+                Object.keys(y).includes("crAlert") &&
+                typeof y.crAlert === "number"
               );
             })
           );

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -9,12 +9,12 @@ class CRMonitor {
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} expiringMultiPartyClient Client used to query EMP status for monitored wallets position info.
    * @param {Object} priceFeed Module used to query the current token price.
-   * @param {List} config Object containing an array of wallets to Monitor. Each wallet's `walletName`, `address`,
+   * @param {Object} config Object containing an array of wallets to Monitor. Each wallet's `walletName`, `address`,
    * `crAlert` must be given. Example:
-   *      {walletsToMonitor:[{ name: "Market Making bot", // Friendly bot name
-   *            address: "0x12345",                       // Bot address
-   *            crAlert: 1.50 },                          // CR alerting threshold to generate an alert message; 1.5=150%
-   *       ...]};
+   *      { walletsToMonitor: [{ name: "Market Making bot", // Friendly bot name
+   *            address: "0x12345",                         // Bot address
+   *            crAlert: 1.50 },                            // CR alerting threshold to generate an alert message; 1.5=150%
+   *       ...] };
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -2,7 +2,8 @@
 // 2) liquidations are submitted, 3) liquidations are disputed or 4) disputes are resolved.
 
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
-const { revertWrapper, createObjectFromDefaultProps } = require("../common/ContractUtils");
+const { revertWrapper } = require("../common/ContractUtils");
+const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
 
 class ContractMonitor {
   /**

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -10,7 +10,7 @@ class ContractMonitor {
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} expiringMultiPartyEventClient Client used to query EMP events for contract state updates.
    * @param {Object} priceFeed Module used to query the current token price.
-   * @param {Object} config Object containing two arrays of monitored liquidator and disputer bots to inform logs EG:
+   * @param {Object} config Object containing two arrays of monitored liquidator and disputer bots to inform logs Example:
    *      { "monitoredLiquidators": ["0x1234","0x5678"],
    *        "monitoredDisputers": ["0x1234","0x5678"] }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -2,29 +2,25 @@
 // 2) liquidations are submitted, 3) liquidations are disputed or 4) disputes are resolved.
 
 const { createFormatFunction, createEtherscanLinkMarkdown } = require("../common/FormattingUtils");
+const { createObjectFromDefaultProps } = require("../common/ObjectUtils");
 
 class ContractMonitor {
   /**
   * @notice Constructs new contract monitor module.
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} expiringMultiPartyEventClient Client used to query EMP events for contract state updates.
-   * @param {Object} contractMonitorConfigObject Config object containing two arrays of monitored liquidator and disputer
-   *      bots to inform log messages. Example:
-   *      { "monitoredLiquidators": ["0x1234","0x5678"],
-  *         "monitoredDisputers": ["0x1234","0x5678"] }
    * @param {Object} priceFeed Module used to query the current token price.
+   * @param {Object} config Object containing two arrays of monitored liquidator and disputer bots to inform logs EG:
+   *      { "monitoredLiquidators": ["0x1234","0x5678"],
+   *        "monitoredDisputers": ["0x1234","0x5678"] }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",
             priceIdentifier: "ETH/BTC",
             networkId:1 }
    */
-  constructor(logger, expiringMultiPartyEventClient, contractMonitorConfigObject, priceFeed, empProps) {
+  constructor(logger, expiringMultiPartyEventClient, priceFeed, config, empProps) {
     this.logger = logger;
-
-    // Bot and ecosystem accounts to monitor. Will inform the console logs when events are detected from these accounts.
-    this.monitoredLiquidators = contractMonitorConfigObject.monitoredLiquidators;
-    this.monitoredDisputers = contractMonitorConfigObject.monitoredDisputers;
 
     // Offchain price feed to get the price for liquidations.
     this.priceFeed = priceFeed;
@@ -44,6 +40,27 @@ class ContractMonitor {
     this.empProps = empProps;
 
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
+
+    // Bot and ecosystem accounts to monitor, overridden by config parameter.
+    const defaultConfig = {
+      // By default monitor no liquidator bots (empty array).
+      monitoredLiquidators: {
+        value: [],
+        isValid: x => {
+          // For the config to be valid it must be an array of address.
+          return Array.isArray(x) && x.every(y => this.web3.utils.isAddress(y));
+        }
+      },
+      monitoredDisputers: {
+        value: [],
+        isValid: x => {
+          // For the config to be valid it must be an array of address.
+          return Array.isArray(x) && x.every(y => this.web3.utils.isAddress(y));
+        }
+      }
+    };
+
+    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
 
     // Helper functions from web3.
     this.toWei = this.web3.utils.toWei;

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -11,7 +11,12 @@ class SyntheticPegMonitor {
    * @param {Object} web3 Instance of a web3 client provided by the class that initiates the monitor module.
    * @param {Object} uniswapPriceFeed Module used to query the current uniswap token price.
    * @param {Object} medianizerPriceFeed Module used to query the median price among selected price feeds.
-   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults.
+   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults. This includes:
+  *      { deviationAlertThreshold:0.2,           // Threshold used to compare observed and expected token prices.
+           volatilityWindow: 600,                 // Length of time (in seconds) to snapshot volatility.
+           pegVolatilityAlertThreshold: 0.2,      // Threshold for synthetic peg price volatility.
+           syntheticVolatilityAlertThreshold: 0.2 // Threshold for synthetic price volatility.
+          }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -47,28 +47,28 @@ class SyntheticPegMonitor {
         // If the deviation in token price exceeds this value an alert is fired. If set to zero then fire no logs.
         value: uniswapPriceFeed && medianizerPriceFeed ? 0.2 : 0,
         isValid: x => {
-          return x != null && x < 1 && x >= 0;
+          return typeof x === "number" && x < 1 && x >= 0;
         }
       },
       volatilityWindow: {
         // `volatilityWindow`: Length of time (in seconds) to snapshot volatility.
         value: uniswapPriceFeed || medianizerPriceFeed ? 60 * 10 : 0, // 10 minutes
         isValid: x => {
-          return x != null && x >= 0;
+          return typeof x === "number" && x && x >= 0;
         }
       },
       pegVolatilityAlertThreshold: {
         // `pegVolatilityAlertThreshold`: Error threshold for synthetic peg price volatility over `volatilityWindow`.
         value: uniswapPriceFeed ? 0.1 : 0,
         isValid: x => {
-          return x != null && x < 1 && x >= 0;
+          return typeof x === "number" && x < 1 && x >= 0;
         }
       },
       syntheticVolatilityAlertThreshold: {
         // `syntheticVolatilityAlertThreshold`: Error threshold for synthetic price volatility over `volatilityWindow`.
         value: medianizerPriceFeed ? 0.1 : 0,
         isValid: x => {
-          return x != null && x < 1 && x >= 0;
+          return typeof x === "number" && x < 1 && x >= 0;
         }
       }
     };
@@ -82,7 +82,7 @@ class SyntheticPegMonitor {
   // Compares synthetic price on Uniswap with pegged price on medianizer price feed and fires a message
   // if the synythetic price deviates too far from the peg. If deviationAlertThreshold == 0 then do nothing.
   async checkPriceDeviation() {
-    if (this.deviationAlertThreshold == 0) return; // return early if the threshold is zero.
+    if (this.deviationAlertThreshold === 0) return; // return early if the threshold is zero.
     // Get the latest prices from the two price feeds.
     const uniswapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
     const cryptoWatchTokenPrice = this.medianizerPriceFeed.getCurrentPrice();
@@ -128,7 +128,7 @@ class SyntheticPegMonitor {
   // Fires a message if the difference exceeds the `volatilityAlertThreshold` %. `checkPegVolatility` checks if the
   // reference medianizer price feed has a large % change over the window.
   async checkPegVolatility() {
-    if (this.pegVolatilityAlertThreshold == 0) return; // Exit early if not monitoring peg volatility.
+    if (this.pegVolatilityAlertThreshold === 0) return; // Exit early if not monitoring peg volatility.
     const pricefeed = this.medianizerPriceFeed;
 
     const volData = await this._checkPricefeedVolatility(pricefeed);
@@ -179,7 +179,7 @@ class SyntheticPegMonitor {
 
   // `checkSyntheticVolatility` checks if the synthetic uniswap price feed has a large % change over the window.
   async checkSyntheticVolatility() {
-    if (this.syntheticVolatilityAlertThreshold == 0) return; // Exit early if not monitoring synthetic volatility.
+    if (this.syntheticVolatilityAlertThreshold === 0) return; // Exit early if not monitoring synthetic volatility.
     const pricefeed = this.uniswapPriceFeed;
 
     const volData = await this._checkPricefeedVolatility(pricefeed);

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -11,7 +11,7 @@ class SyntheticPegMonitor {
    * @param {Object} web3 Instance of a web3 client provided by the class that initiates the monitor module.
    * @param {Object} uniswapPriceFeed Module used to query the current uniswap token price.
    * @param {Object} medianizerPriceFeed Module used to query the median price among selected price feeds.
-   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults. This includes:
+   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults. Example:
   *      { deviationAlertThreshold:0.2,           // Threshold used to compare observed and expected token prices.
            volatilityWindow: 600,                 // Length of time (in seconds) to snapshot volatility.
            pegVolatilityAlertThreshold: 0.2,      // Threshold for synthetic peg price volatility.

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -108,7 +108,7 @@ async function run(
       eventsFromBlockNumber,
       endingBlock
     );
-    
+
     const contractMonitor = new ContractMonitor(
       logger,
       empEventClient,
@@ -225,22 +225,22 @@ async function Poll(callback) {
 
     // Monitor config contains all configuration settings for all monitor modules. This includes the following:
     // MONITOR_CONFIG={
-    //  "botsToMonitor": [{ name: "Liquidator Bot",       // friendly bot name
-    //     address: "0x12345"                             // bot address
+    //  "botsToMonitor": [{ name: "Liquidator Bot",       // Friendly bot name
+    //     address: "0x12345"                             // Bot address
     //    "collateralThreshold": "500000000000000000000", // 500e18 collateral token currency.
     //    "syntheticThreshold": "2000000000000000000000", // 200e18 synthetic token currency.
-    //    "etherThreshold": "500000000000000000" },       //0.5e18 Wei alert
+    //    "etherThreshold": "500000000000000000" },       // 0.5e18 Wei alert
     //  ...],
-    //  "walletsToMonitor": [{ name: "Market Making bot",  // friendly bot name
+    //  "walletsToMonitor": [{ name: "Market Making bot", // Friendly bot name
     //    address: "0x12345",                             // bot address
     //    crAlert: 1.50 },                                // CR monitoring threshold. 1.5=150%
     //  ...],
-    //  "monitoredLiquidators": ["0x1234","0x5678"],       // array of liquidator bots of interest.
-    //  "monitoredDisputers": ["0x1234","0x5678"],         // array of disputer bots of interest.
-    //  "deviationAlertThreshold": 0.5,                    // if deviation in token price exceeds this fire alert.
+    //  "monitoredLiquidators": ["0x1234","0x5678"],       // Array of liquidator bots of interest.
+    //  "monitoredDisputers": ["0x1234","0x5678"],         // Array of disputer bots of interest.
+    //  "deviationAlertThreshold": 0.5,                    // If deviation in token price exceeds this fire alert.
     //  "volatilityWindow": 600,                           // Length of time (in seconds) to snapshot volatility.
     //  "pegVolatilityAlertThreshold": 0.1,                // Threshold for synthetic peg (identifier) price volatility over `volatilityWindow`.
-    //  "syntheticVolatilityAlertThreshold": 0.1,           // Threshold for synthetic token on uniswap price volatility over `volatilityWindow`.
+    //  "syntheticVolatilityAlertThreshold": 0.1,          // Threshold for synthetic token on uniswap price volatility over `volatilityWindow`.
     // }
     const monitorConfig = process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null;
 

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -4,7 +4,10 @@ const { hexToUtf8 } = web3.utils;
 // Helpers.
 const { delay } = require("../financial-templates-lib/helpers/delay");
 const { Logger, waitForLogger } = require("../financial-templates-lib/logger/Logger");
-const { createPriceFeed } = require("../financial-templates-lib/price-feed/CreatePriceFeed");
+const {
+  createReferencePriceFeedForEmp,
+  createUniswapPriceFeedForEmp
+} = require("../financial-templates-lib/price-feed/CreatePriceFeed");
 const { Networker } = require("../financial-templates-lib/price-feed/Networker");
 
 // Clients to retrieve on-chain data.
@@ -32,10 +35,7 @@ const ExpandedERC20 = artifacts.require("ExpandedERC20");
  *     from. If 0 will look for all events back to deployment of the EMP. If set to null uses current block number.
  * @param {Number} endingBlock Termination block number to define where the monitor bot should end searching for events.
  *     If `null` then will search up until the latest block number in each loop.
- * @param {Object} botMonitorObject Configuration to construct the balance monitor module.
- * @param {Object} walletMonitorObject Configuration to construct the collateralization ratio monitor module.
- * @param {Object} contractMonitorObject Configuration to construct the contract monitor module.
- * @param {Object} syntheticPegMonitorObject Configuration to construct the synthetic peg monitor module.
+ * @param {Object} monitorConfig Configuration object to parameterize all monitor modules.
  * @param {Object} uniswapPriceFeedConfig Configuration to construct the uniswap price feed object.
  * @param {Object} medianizerPriceFeedConfig Configuration to construct the uniswap price feed object.
  * @return None or throws an Error.
@@ -46,10 +46,7 @@ async function run(
   pollingDelay,
   startingBlock,
   endingBlock,
-  botMonitorObject,
-  walletMonitorObject,
-  contractMonitorObject,
-  syntheticPegMonitorObject,
+  monitorConfig,
   uniswapPriceFeedConfig,
   medianizerPriceFeedConfig
 ) {
@@ -63,10 +60,7 @@ async function run(
       pollingDelay,
       startingBlock,
       endingBlock,
-      botMonitorObject,
-      walletMonitorObject,
-      contractMonitorObject,
-      syntheticPegMonitorObject,
+      monitorConfig,
       uniswapPriceFeedConfig,
       medianizerPriceFeedConfig
     });
@@ -88,11 +82,12 @@ async function run(
 
     // Setup medianizer price feed.
     const getTime = () => Math.round(new Date().getTime() / 1000);
-    const medianizerPriceFeed = await createPriceFeed(
+    const medianizerPriceFeed = await createReferencePriceFeedForEmp(
       logger,
       web3,
       new Networker(logger),
       getTime,
+      address,
       medianizerPriceFeedConfig
     );
 
@@ -111,13 +106,7 @@ async function run(
       eventsFromBlockNumber,
       endingBlock
     );
-    const contractMonitor = new ContractMonitor(
-      logger,
-      empEventClient,
-      contractMonitorObject,
-      medianizerPriceFeed,
-      empProps
-    );
+    const contractMonitor = new ContractMonitor(logger, empEventClient, medianizerPriceFeed, monitorConfig, empProps);
 
     // 2. Balance monitor to inform if monitored addresses drop below critical thresholds.
     const tokenBalanceClient = new TokenBalanceClient(
@@ -128,29 +117,30 @@ async function run(
       syntheticTokenAddress
     );
 
-    const balanceMonitor = new BalanceMonitor(logger, tokenBalanceClient, botMonitorObject, empProps);
+    const balanceMonitor = new BalanceMonitor(logger, tokenBalanceClient, monitorConfig, empProps);
 
     // 3. Collateralization Ratio monitor.
     const empClient = new ExpiringMultiPartyClient(logger, ExpiringMultiParty.abi, web3, emp.address);
 
-    const crMonitor = new CRMonitor(logger, empClient, walletMonitorObject, medianizerPriceFeed, empProps);
+    const crMonitor = new CRMonitor(logger, empClient, medianizerPriceFeed, monitorConfig, empProps);
 
-    // 4. Synthetic Peg Monitor.
-    const uniswapPriceFeed = await createPriceFeed(
-      logger,
-      web3,
-      new Networker(logger),
-      getTime,
-      uniswapPriceFeedConfig
-    );
-    const syntheticPegMonitor = new SyntheticPegMonitor(
-      logger,
-      web3,
-      uniswapPriceFeed,
-      medianizerPriceFeed,
-      syntheticPegMonitorObject,
-      empProps
-    );
+    // // 4. Synthetic Peg Monitor.
+    // const uniswapPriceFeed = await createUniswapPriceFeedForEmp(
+    //   logger,
+    //   web3,
+    //   new Networker(logger),
+    //   getTime,
+    //   address,
+    //   uniswapPriceFeedConfig
+    // );
+    // const syntheticPegMonitor = new SyntheticPegMonitor(
+    //   logger,
+    //   web3,
+    //   uniswapPriceFeed,
+    //   medianizerPriceFeed,
+    //   monitorConfig,
+    //   empProps
+    // );
 
     while (true) {
       // 1.  Contract monitor
@@ -178,15 +168,15 @@ async function run(
       // 3.b Check for positions below their CR
       await crMonitor.checkWalletCrRatio();
 
-      // 4. Synthetic peg monitor
-      // 4.a Update the price feeds
-      await uniswapPriceFeed.update();
-      await medianizerPriceFeed.update();
-      // 4.b Check for synthetic peg deviation
-      await syntheticPegMonitor.checkPriceDeviation();
-      // 4.c Check for price feed volatility
-      await syntheticPegMonitor.checkPegVolatility();
-      await syntheticPegMonitor.checkSyntheticVolatility();
+      // // 4. Synthetic peg monitor
+      // // 4.a Update the price feeds
+      // await uniswapPriceFeed.update();
+      // await medianizerPriceFeed.update();
+      // // 4.b Check for synthetic peg deviation
+      // await syntheticPegMonitor.checkPriceDeviation();
+      // // 4.c Check for price feed volatility
+      // await syntheticPegMonitor.checkPegVolatility();
+      // await syntheticPegMonitor.checkSyntheticVolatility();
 
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (pollingDelay === 0) {
@@ -223,58 +213,39 @@ async function Poll(callback) {
     // until. If not set the default to null which indicates that the bot should search up to 'latest'.
     const endingBlock = process.env.ENDING_BLOCK_NUMBER;
 
-    if (
-      !process.env.BOT_MONITOR_OBJECT ||
-      !process.env.WALLET_MONITOR_OBJECT ||
-      !process.env.CONTRACT_MONITOR_OBJECT ||
-      !process.env.SYNTHETIC_PEG_MONITOR_OBJECT
-    ) {
-      throw new Error(
-        "Bad input arg! Specify a: `BOT_MONITOR_OBJECT`, `WALLET_MONITOR_OBJECT`, `CONTRACT_MONITOR_OBJECT` & `SYNTHETIC_PEG_OBJECT` to track."
-      );
-    }
-
-    // Bots to monitor. Each bot can be have a collateralThreshold, syntheticThreshold and etherThreshold. EG:
-    // [{ name: "Liquidator Bot",
-    //    address: "0x12345"
-    //    collateralThreshold: 500000000000000000000, // 500e18 collateral token currency.
-    //    syntheticThreshold: 200000000000000000000000, // 20000e18 synthetic token currency.
-    //    etherThreshold: 500000000000000000 }, //0.5e18 Wei.
-    // ...]
-    const botMonitorObject = JSON.parse(process.env.BOT_MONITOR_OBJECT);
-
-    // Wallet objects to monitor. Each wallet has a friendly name and a crAlert. EG:
-    // [{ name: "Market Making bot",
-    //    address: "0x12345",
-    //    crAlert: 1.50 }, // Note 150% is represented as 1.5
-    //  ...];
-    const walletMonitorObject = JSON.parse(process.env.WALLET_MONITOR_OBJECT);
-
-    // Contract monitor. The monitor needs the addresses of the liquidator and disute bots to inform logs. EG:
-    // { "monitoredLiquidators": ["0x1234","0x5678"],
-    //   "monitoredDisputers": ["0x1234","0x5678"] }
-    const contractMonitorObject = JSON.parse(process.env.CONTRACT_MONITOR_OBJECT);
-
-    // Synthetic Peg monitor. Specify the deviationAlertThreshold, volatilityWindow and volatilityAlertThreshold. EG:
-    // { "deviationAlertThreshold": 0.5, // if the deviation in token price exceeds this value an alert is fired.
-    //   "volatilityWindow": 600 // Length of time (in seconds) to snapshot volatility.
-    //   "volatilityAlertThreshold": 0.1 } // Error threshold for pricefeed's price volatility over `volatilityWindow`.
-    const syntheticPegMonitorObject = JSON.parse(process.env.SYNTHETIC_PEG_MONITOR_OBJECT);
-
-    if (!process.env.UNISWAP_PRICE_FEED_CONFIG || !process.env.MEDIANIZER_PRICE_FEED_CONFIG) {
-      throw new Error(
-        "Bad input arg! Specify `PRICE_FEED_CONFIG` and `MEDIANIZER_PRICE_FEED_CONFIG` to define the price feed settings."
-      );
-    }
+    // Monitor config contains all configuration settings for all monitor modules. This includes the following:
+    // MONITOR_CONFIG={
+    //  "botsToMonitor": [{ name: "Liquidator Bot",       // friendly bot name
+    //     address: "0x12345"                             // bot address
+    //    "collateralThreshold": "500000000000000000000", // 500e18 collateral token currency.
+    //    "syntheticThreshold": "2000000000000000000000", // 200e18 synthetic token currency.
+    //    "etherThreshold": "500000000000000000" },       //0.5e18 Wei alert
+    //  ...],
+    //  "walletsToMonitor": [{ name: "Market Making bot",  // friendly bot name
+    //    address: "0x12345",                             // bot address
+    //    crAlert: 1.50 },                                // CR monitoring threshold. 1.5=150%
+    //  ...],
+    //  "monitoredLiquidators": ["0x1234","0x5678"],       // array of liquidator bots of interest.
+    //  "monitoredDisputers": ["0x1234","0x5678"],         // array of disputer bots of interest.
+    //  "deviationAlertThreshold": 0.5,                    // if deviation in token price exceeds this fire alert.
+    //  "volatilityWindow": 600,                           // Length of time (in seconds) to snapshot volatility.
+    //  "pegVolatilityAlertThreshold": 0.1,                // Threshold for synthetic peg (identifier) price volatility over `volatilityWindow`.
+    //  "syntheticVolatilityAlertThreshold": 0.1,           // Threshold for synthetic token on uniswap price volatility over `volatilityWindow`.
+    // }
+    const monitorConfig = process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null;
 
     // Read price feed configuration from an environment variable. Uniswap price feed contains information about the
     // uniswap market. EG: {"type":"uniswap","twapLength":2,"lookback":7200,"invertPrice":true "uniswapAddress":"0x1234"}
-    const uniswapPriceFeedConfig = JSON.parse(process.env.UNISWAP_PRICE_FEED_CONFIG);
+    const uniswapPriceFeedConfig = process.env.UNISWAP_PRICE_FEED_CONFIG
+      ? JSON.parse(process.env.UNISWAP_PRICE_FEED_CONFIG)
+      : null;
 
     // Medianizer price feed averages over a set of different sources to get an average. Config defines the exchanges
     // to use. EG: {"type":"medianizer","pair":"ethbtc","lookback":7200,"minTimeBetweenUpdates":60,"medianizedFeeds":[
     // {"type":"cryptowatch","exchange":"coinbase-pro"},{"type":"cryptowatch","exchange":"binance"}]}
-    const medianizerPriceFeedConfig = JSON.parse(process.env.MEDIANIZER_PRICE_FEED_CONFIG);
+    const medianizerPriceFeedConfig = process.env.MEDIANIZER_PRICE_FEED_CONFIG
+      ? JSON.parse(process.env.MEDIANIZER_PRICE_FEED_CONFIG)
+      : null;
 
     await run(
       Logger,
@@ -282,10 +253,7 @@ async function Poll(callback) {
       pollingDelay,
       startingBlock,
       endingBlock,
-      botMonitorObject,
-      walletMonitorObject,
-      contractMonitorObject,
-      syntheticPegMonitorObject,
+      monitorConfig,
       uniswapPriceFeedConfig,
       medianizerPriceFeedConfig
     );

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -124,23 +124,23 @@ async function run(
 
     const crMonitor = new CRMonitor(logger, empClient, medianizerPriceFeed, monitorConfig, empProps);
 
-    // // 4. Synthetic Peg Monitor.
-    // const uniswapPriceFeed = await createUniswapPriceFeedForEmp(
-    //   logger,
-    //   web3,
-    //   new Networker(logger),
-    //   getTime,
-    //   address,
-    //   uniswapPriceFeedConfig
-    // );
-    // const syntheticPegMonitor = new SyntheticPegMonitor(
-    //   logger,
-    //   web3,
-    //   uniswapPriceFeed,
-    //   medianizerPriceFeed,
-    //   monitorConfig,
-    //   empProps
-    // );
+    // 4. Synthetic Peg Monitor.
+    const uniswapPriceFeed = await createUniswapPriceFeedForEmp(
+      logger,
+      web3,
+      new Networker(logger),
+      getTime,
+      address,
+      uniswapPriceFeedConfig
+    );
+    const syntheticPegMonitor = new SyntheticPegMonitor(
+      logger,
+      web3,
+      uniswapPriceFeed,
+      medianizerPriceFeed,
+      monitorConfig,
+      empProps
+    );
 
     while (true) {
       // 1.  Contract monitor
@@ -168,15 +168,15 @@ async function run(
       // 3.b Check for positions below their CR
       await crMonitor.checkWalletCrRatio();
 
-      // // 4. Synthetic peg monitor
-      // // 4.a Update the price feeds
-      // await uniswapPriceFeed.update();
-      // await medianizerPriceFeed.update();
-      // // 4.b Check for synthetic peg deviation
-      // await syntheticPegMonitor.checkPriceDeviation();
-      // // 4.c Check for price feed volatility
-      // await syntheticPegMonitor.checkPegVolatility();
-      // await syntheticPegMonitor.checkSyntheticVolatility();
+      // 4. Synthetic peg monitor
+      // 4.a Update the price feeds
+      await uniswapPriceFeed.update();
+      await medianizerPriceFeed.update();
+      // 4.b Check for synthetic peg deviation
+      await syntheticPegMonitor.checkPriceDeviation();
+      // 4.c Check for price feed volatility
+      await syntheticPegMonitor.checkPegVolatility();
+      await syntheticPegMonitor.checkSyntheticVolatility();
 
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (pollingDelay === 0) {

--- a/monitors/test/BalanceMonitor.js
+++ b/monitors/test/BalanceMonitor.js
@@ -22,7 +22,10 @@ contract("BalanceMonitor.js", function(accounts) {
   // Test object for EMP event client
   let balanceMonitor;
   let tokenBalanceClient;
+  let monitorConfig;
   let spy;
+  let spyLogger;
+  let empProps;
 
   beforeEach(async function() {
     // Create new tokens for every test to reset balances of all accounts
@@ -34,7 +37,7 @@ contract("BalanceMonitor.js", function(accounts) {
     // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston
     // logs the correct text based on interactions with the emp. Note that only `info` level messages are captured.
     spy = sinon.spy(); // new spy per test to reset all counters and emited messages.
-    const spyLogger = winston.createLogger({
+    spyLogger = winston.createLogger({
       level: "info",
       transports: [new SpyTransport({ level: "info" }, { spy: spy })]
     });
@@ -47,31 +50,33 @@ contract("BalanceMonitor.js", function(accounts) {
     );
 
     // Create two bot objects to monitor a liquidator bot with a lot of tokens and Eth and a disputer with less.
-    const botMonitorObject = [
-      {
-        name: "Liquidator bot",
-        address: liquidatorBot,
-        collateralThreshold: toWei("10000"), // 10,000.00 tokens of collateral threshold
-        syntheticThreshold: toWei("10000"), // 10,000.00 tokens of debt threshold
-        etherThreshold: toWei("10")
-      },
-      {
-        name: "Disputer bot",
-        address: disputerBot,
-        collateralThreshold: toWei("500"), // 500.00 tokens of collateral threshold
-        syntheticThreshold: toWei("100"), // 100.00 tokens of debt threshold
-        etherThreshold: toWei("1")
-      }
-    ];
+    const monitorConfig = {
+      botsToMonitor: [
+        {
+          name: "Liquidator bot",
+          address: liquidatorBot,
+          collateralThreshold: toWei("10000"), // 10,000.00 tokens of collateral threshold
+          syntheticThreshold: toWei("10000"), // 10,000.00 tokens of debt threshold
+          etherThreshold: toWei("10")
+        },
+        {
+          name: "Disputer bot",
+          address: disputerBot,
+          collateralThreshold: toWei("500"), // 500.00 tokens of collateral threshold
+          syntheticThreshold: toWei("100"), // 100.00 tokens of debt threshold
+          etherThreshold: toWei("1")
+        }
+      ]
+    };
 
-    const empProps = {
+    empProps = {
       collateralCurrencySymbol: await collateralToken.symbol(),
       syntheticCurrencySymbol: await syntheticToken.symbol(),
       priceIdentifier: "ETH/BTC",
       networkId: await web3.eth.net.getId()
     };
 
-    balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, botMonitorObject, empProps);
+    balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, monitorConfig, empProps);
 
     // setup the positions to the initial happy state.
     // Liquidator threshold is 10000 for both collateral and synthetic so mint a bit more to start above this
@@ -219,5 +224,64 @@ contract("BalanceMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "10,000.00")); // Correctly formatted number of threshold collateral
     assert.isTrue(lastSpyLogIncludes(spy, "9,995.00")); // Correctly formatted number of actual collateral
     assert.isTrue(lastSpyLogIncludes(spy, "DAI")); // Message should include the collateral currency symbol
+  });
+  it("Cannot set invalid config", async function() {
+    let errorThrown1;
+    try {
+      // Create an invalid config. A valid config expects an array of objects with keys in the object of `name` `address`
+      // `syntheticThreshold`, `collateralThreshold`, `etherThreshold`. The value of `address` must be of type address.
+      const invalidMonitorConfig1 = {
+        // Config missing `name` and `syntheticThreshold`.
+        botsToMonitor: [
+          {
+            address: liquidatorBot,
+            collateralThreshold: toWei("10000"), // 10,000.00 tokens of collateral threshold
+            etherThreshold: toWei("10")
+          }
+        ]
+      };
+
+      balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, invalidMonitorConfig1, empProps);
+      errorThrown1 = false;
+    } catch (err) {
+      errorThrown1 = true;
+    }
+    assert.isTrue(errorThrown1);
+
+    let errorThrown2;
+    try {
+      // Create an invalid config. A valid config expects an array of objects with keys in the object of `name` `address`
+      // `collateralThreshold`, `etherThreshold`. The value of `address` must be of type address.
+      const invalidMonitorConfig2 = {
+        // Config has an invalid address for the monitored bot.
+        botsToMonitor: [
+          {
+            name: "Monitored liquidator bot",
+            address: "INVALID_ADDRESS",
+            collateralThreshold: toWei("10000"), // 10,000.00 tokens of collateral threshold
+            syntheticThreshold: toWei("10000"), // 10,000.00 tokens of debt threshold
+            etherThreshold: toWei("10")
+          }
+        ]
+      };
+
+      balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, invalidMonitorConfig2, empProps);
+      errorThrown2 = false;
+    } catch (err) {
+      errorThrown2 = true;
+    }
+    assert.isTrue(errorThrown2);
+  });
+  it("Can correctly create balance monitor and query balances with no config provided", async function() {
+    const emptyConfig = {};
+    let errorThrown;
+    try {
+      balanceMonitor = new BalanceMonitor(spyLogger, tokenBalanceClient, emptyConfig, empProps);
+      await balanceMonitor.checkBotBalances();
+      errorThrown = false;
+    } catch (err) {
+      errorThrown = true;
+    }
+    assert.isFalse(errorThrown);
   });
 });

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -124,14 +124,7 @@ contract("ContractMonitor.js", function(accounts) {
       networkId: await web3.eth.net.getId()
     };
 
-    contractMonitor = new ContractMonitor(
-      spyLogger,
-      eventClient,
-      priceFeedMock,
-      monitorConfig,
-      empProps,
-      mockOracle
-    );
+    contractMonitor = new ContractMonitor(spyLogger, eventClient, priceFeedMock, monitorConfig, empProps, mockOracle);
 
     await collateralToken.addMember(1, tokenSponsor, {
       from: tokenSponsor

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -51,6 +51,8 @@ contract("ContractMonitor.js", function(accounts) {
 
   // Price feed mock
   let priceFeedMock;
+  let spyLogger;
+  let empProps;
 
   // re-used variables
   let expirationTime;
@@ -101,7 +103,7 @@ contract("ContractMonitor.js", function(accounts) {
 
     // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston
     // logs the correct text based on interactions with the emp. Note that only `info` level messages are captured.
-    const spyLogger = winston.createLogger({
+    spyLogger = winston.createLogger({
       level: "info",
       transports: [new SpyTransport({ level: "info" }, { spy: spy })]
     });
@@ -111,18 +113,18 @@ contract("ContractMonitor.js", function(accounts) {
     priceFeedMock = new PriceFeedMock();
 
     // Define a configuration object. In this config only monitor one liquidator and one disputer.
-    const contractMonitorConfig = { monitoredLiquidators: [liquidator], monitoredDisputers: [disputer] };
+    const monitorConfig = { monitoredLiquidators: [liquidator], monitoredDisputers: [disputer] };
 
     syntheticToken = await Token.at(await emp.tokenCurrency());
 
-    const empProps = {
+    empProps = {
       collateralCurrencySymbol: await collateralToken.symbol(),
       syntheticCurrencySymbol: await syntheticToken.symbol(),
       priceIdentifier: hexToUtf8(await emp.priceIdentifier()),
       networkId: await web3.eth.net.getId()
     };
 
-    contractMonitor = new ContractMonitor(spyLogger, eventClient, contractMonitorConfig, priceFeedMock, empProps);
+    contractMonitor = new ContractMonitor(spyLogger, eventClient, priceFeedMock, monitorConfig, empProps);
 
     await collateralToken.addMember(1, tokenSponsor, {
       from: tokenSponsor
@@ -387,5 +389,44 @@ contract("ContractMonitor.js", function(accounts) {
     assert.isFalse(lastSpyLogIncludes(spy, "(Monitored dispute bot)")); // This disputer is not monitored
     assert.isTrue(lastSpyLogIncludes(spy, "success")); // the disputed was successful based on settlement price
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.tx}`));
+  });
+  it("Cannot set invalid config", async function() {
+    let errorThrown1;
+    try {
+      // Create an invalid config. A valid config expects two arrays of addresses.
+      const invalidConfig1 = { monitoredLiquidators: liquidator, monitoredDisputers: [disputer] };
+      contractMonitor = new ContractMonitor(spyLogger, eventClient, priceFeedMock, invalidConfig1, empProps);
+      errorThrown1 = false;
+    } catch (err) {
+      errorThrown1 = true;
+    }
+    assert.isTrue(errorThrown1);
+
+    let errorThrown2;
+    try {
+      // Create an invalid config. A valid config expects two arrays of addresses.
+      const invalidConfig2 = { monitoredLiquidators: "NOT AN ADDRESS" };
+      contractMonitor = new ContractMonitor(spyLogger, eventClient, priceFeedMock, invalidConfig2, empProps);
+      errorThrown2 = false;
+    } catch (err) {
+      errorThrown2 = true;
+    }
+    assert.isTrue(errorThrown2);
+  });
+  it("Can correctly create contract monitor with no config provided", async function() {
+    let errorThrown;
+    try {
+      // Create an invalid config. A valid config expects two arrays of addresses.
+      const emptyConfig = {};
+      contractMonitor = new ContractMonitor(spyLogger, eventClient, priceFeedMock, emptyConfig, empProps);
+      await contractMonitor.checkForNewSponsors();
+      await contractMonitor.checkForNewLiquidations();
+      await contractMonitor.checkForNewDisputeEvents();
+      await contractMonitor.checkForNewDisputeSettlementEvents();
+      errorThrown = false;
+    } catch (err) {
+      errorThrown = true;
+    }
+    assert.isFalse(errorThrown);
   });
 });

--- a/monitors/test/index.js
+++ b/monitors/test/index.js
@@ -73,9 +73,14 @@ contract("index.js", function(accounts) {
 
     uniswap = await UniswapMock.new();
 
-    // Run with empty configs for all input values
+    // Run with empty configs for all input values, except for uniswap mock which is needed as no uniswap market in test env.
     defaultMonitorConfig = {};
-    defaultUniswapPricefeedConfig = {};
+    defaultUniswapPricefeedConfig = {
+      type: "uniswap",
+      uniswapAddress: uniswap.address,
+      twapLength: 1,
+      lookback: 1
+    };
     defaultMedianizerPricefeedConfig = {};
 
     // Set two uniswap prices to give it a little history.

--- a/monitors/test/index.js
+++ b/monitors/test/index.js
@@ -27,20 +27,17 @@ contract("index.js", function(accounts) {
 
   let defaultUniswapPricefeedConfig;
   let defaultMedianizerPricefeedConfig;
-  let defaultBotMonitorConfig;
-  let defaultWalletMonitorConfig;
-  let defaultContractMonitorConfig;
-  let defaultSyntheticPegMonitorConfig;
+  let defaultMonitorConfig;
 
   let spy;
   let spyLogger;
 
   before(async function() {
-    collateralToken = await Token.new("UMA", "UMA", 18, { from: contractCreator });
+    collateralToken = await Token.new("DAI", "DAI", 18, { from: contractCreator });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("UMATEST"));
+    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("ETH/BTC"));
   });
 
   beforeEach(async function() {
@@ -57,9 +54,9 @@ contract("index.js", function(accounts) {
       collateralAddress: collateralToken.address,
       finderAddress: Finder.address,
       tokenFactoryAddress: TokenFactory.address,
-      priceFeedIdentifier: utf8ToHex("UMATEST"),
+      priceFeedIdentifier: utf8ToHex("ETH/BTC"),
       syntheticName: "Test UMA Token",
-      syntheticSymbol: "UMATEST",
+      syntheticSymbol: "ETH/BTC",
       liquidationLiveness: "1000",
       collateralRequirement: { rawValue: toWei("1.2") },
       disputeBondPct: { rawValue: toWei("0.1") },
@@ -76,35 +73,10 @@ contract("index.js", function(accounts) {
 
     uniswap = await UniswapMock.new();
 
-    defaultUniswapPricefeedConfig = {
-      type: "uniswap",
-      uniswapAddress: uniswap.address,
-      twapLength: 1,
-      lookback: 1
-    };
-
-    defaultMedianizerPricefeedConfig = {
-      type: "medianizer",
-      apiKey: "test-apikey",
-      pair: "ethbtc",
-      lookback: 1,
-      minTimeBetweenUpdates: 1,
-      medianizedFeeds: [
-        {
-          type: "cryptowatch",
-          exchange: "binance"
-        }
-      ]
-    };
-
-    defaultBotMonitorConfig = [];
-    defaultWalletMonitorConfig = [];
-    defaultContractMonitorConfig = { monitoredLiquidators: [], monitoredDisputers: [] };
-    defaultSyntheticPegMonitorConfig = {
-      deviationAlertThreshold: 0.5,
-      volatilityWindow: 600,
-      volatilityAlertThreshold: 0.1
-    };
+    // Run with empty configs for all input values
+    defaultMonitorConfig = {};
+    defaultUniswapPricefeedConfig = {};
+    defaultMedianizerPricefeedConfig = {};
 
     // Set two uniswap prices to give it a little history.
     await uniswap.setPrice(toWei("1"), toWei("1"));
@@ -120,10 +92,7 @@ contract("index.js", function(accounts) {
       0,
       0,
       null,
-      defaultBotMonitorConfig,
-      defaultWalletMonitorConfig,
-      defaultContractMonitorConfig,
-      defaultSyntheticPegMonitorConfig,
+      defaultMonitorConfig,
       defaultUniswapPricefeedConfig,
       defaultMedianizerPricefeedConfig
     );


### PR DESCRIPTION
The goal of this PR is to drastically cut down the parameters required to run a monitor bot and to implement aggressive defaulting: **you should be able to run the monitor bot by simply providing the EMP address**. This PR is pretty big as it overhalls all monitor modules config inputs and validations.

**High-level changes are as follows:**
1) Before this PR each monitor module would take in its own config object. These looked like: `CONTRACT_MONITOR_OBJECT`, `SYNTHETIC_PEG_MONITOR_OBJECT`, `WALLET_MONITOR_OBJECT` & `BOT_MONITOR_OBJECT`. This is pretty clunky as there are a lot of custom configs needed. Added to this the structure of each of these configs was not consistent: some are arrays of objects, some are arrays of addresses and some are objects. Lastly, the previous implementation differed from the liquidator and disputer bots that simply take in `LIQUIDATOR_CONFIG` and `DISPUTER_CONFIG` respectively.
After this PR the monitor bot only takes in one config variable that contains all settings for the monitor bot: `MONITOR_CONFIG`. This config is always a JSON object (like with the disputer and liquidator configs) and contains all the same config variables as the bots expected before.
2) Before this PR there was no config validation in any of the monitor modules. The expected structure was documented but never validated by the module nor in tests.
After this PR each module sanitizers the input config object using the same method the liquidator and disputer use: `createObjectFromDefaultProps`. For complex object types this involves checking the exact structure of the config object. See the comments in the PR for implementation.

3) The monitor bot now uses `createUniswapPriceFeedForEmp` and `createReferencePriceFeedForEmp` to enable to bots to automatically detect configs for given price feeds, making the price feed config object optional.

4) `SyntheticPegMonitor`'s config object was slightly changed to accommodate monitoring 
 `pegVolatilityAlertThreshold` and `syntheticVolatilityAlertThreshold`. This enables the user to turn off these monitors if they are not useful for a given context. This will enable us to turn off the monitor for the synthetic price while leaving the peg monitor on (or vice versa). This will solve the current issues we are having with `Unable to get volatility data` as we can simply disable this monitor by setting these configs to 0.


This PR is a follow on of #1617. A subsequent PR will implement the same refactors and clean up of defaults to the daily reporter.

As a follow on for this PR the bot's default parameters documentation should be improved. This is documented in issue #1719

close #1642