### PR TITLE
Make disputer an independent sub-package

### DIFF
--- a/disputer/package.json
+++ b/disputer/package.json
@@ -4,7 +4,9 @@
   "description": "UMA Disputer",
   "private": true,
   "dependencies": {
-    "dotenv": "^6.2.0"
+    "dotenv": "^6.2.0",
+    "sinon": "^9.0.2",
+    "winston": "^3.2.1"
   },
   "homepage": "http://umaproject.org",
   "license": "AGPL-3.0-or-later",

--- a/disputer/package.json
+++ b/disputer/package.json
@@ -1,10 +1,26 @@
 {
-  "name": "disputer",
-  "version": "0.1.0",
+  "name": "@umaprotocol/disputer",
+  "version": "1.0.0",
   "description": "UMA Disputer",
   "private": true,
   "dependencies": {
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0"
+  },
+  "homepage": "http://umaproject.org",
+  "license": "AGPL-3.0-or-later",
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UMAprotocol/protocol.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/UMAprotocol/protocol/issues"
   }
 }

--- a/disputer/package.json
+++ b/disputer/package.json
@@ -4,8 +4,7 @@
   "description": "UMA Disputer",
   "private": true,
   "dependencies": {
-    "winston": "^3.2.1",
-    "winston-transport": "^4.3.0"
+    "dotenv": "^6.2.0"
   },
   "homepage": "http://umaproject.org",
   "license": "AGPL-3.0-or-later",

--- a/disputer/package.json
+++ b/disputer/package.json
@@ -8,7 +8,7 @@
     "sinon": "^9.0.2",
     "winston": "^3.2.1"
   },
-  "homepage": "http://umaproject.org",
+  "homepage": "https://umaproject.org",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "publishConfig": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "packages": [],
+  "packages": ["disputer"],
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "independent"

--- a/package.json
+++ b/package.json
@@ -96,5 +96,7 @@
   "lint-staged": {
     "*.js": "eslint --cache --fix"
   },
-  "workspaces": []
+  "workspaces": [
+    "disputer"
+  ]
 }


### PR DESCRIPTION
A few notes:
- The disputer will continue to import packages from across the repo since there's no other way to import those js files.
- I've made the dependencies only include packages that the disputer explicitly requires. All other dependencies will come through cross-dependencies elsewhere in the repo. The only exception to this may be truffle, but it's unclear how we'll run truffle once all the dust settles, so I decided to leave it out for now.
- I kept the package private so we'll avoid publishing it until the entire repo is converted.

Related to #1720.