### PR TITLE
Update subgraph API endpoint for daily reporter

### DIFF
--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -138,6 +138,7 @@ class GlobalSummaryReporter {
       .swaps[0].transaction;
     this.latestSwapTimestamp = latestSwap.timestamp;
     this.latestSwapBlockNumber = Number(latestSwap.blockNumber);
+    // Note: `endBlockNumberForPeriod` is the highest block number that we will manually query for.
     if (this.endBlockNumberForPeriod > this.latestSwapBlockNumber) {
       this.endBlockNumberForPeriod = this.latestSwapBlockNumber;
     }

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -28,7 +28,7 @@ const Finder = artifacts.require("Finder");
 
 async function run(
   address,
-  empToUniswapTokenMap,
+  uniswapPairOverride,
   walletsToMonitor,
   referencePriceFeedConfig,
   uniswapPriceFeedConfig,
@@ -123,7 +123,7 @@ async function run(
     oracle,
     collateralToken,
     syntheticToken,
-    empToUniswapTokenMap,
+    uniswapPairOverride,
     endDateOffsetSeconds,
     periodLengthSeconds
   );
@@ -173,22 +173,18 @@ async function Poll(callback) {
       ? parseInt(process.env.PERIOD_REPORT_LENGTH)
       : 24 * 60 * 60;
 
-    // Maps mainnet EMP address of synthetic to the token address that it trades against, for the Uniswap pair that we want to track.
-    // This is neccessary because each synthetic can be part of multiple Uniswap pairs.
-    const empToUniswapTokenMap = {
-      "0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1": {
-        name: "COMP",
-        address: web3.utils.toChecksumAddress("0xc00e94cb662c3520282e6f5717214004a7f26888")
-      },
-      "0x3f2D9eDd9702909Cf1F8C4237B7c4c5931F9C944": {
-        name: "DAI",
-        address: web3.utils.toChecksumAddress("0x6b175474e89094c44da98b954eedeac495271d0f")
-      }
+    // Overrides the Uniswap pair that we want to query trade data for. The assumption is that the GlobalSummaryReporter fetches
+    // data for only one Uniswap pair, and the default pair tokens are the emp-synthetic-token and the emp-collateral-token.
+    const uniswapPairOverride = {
+      // yCOMP <--> COMP
+      [web3.utils.toChecksumAddress("0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1")]: await ExpandedERC20.at(
+        web3.utils.toChecksumAddress("0xc00e94cb662c3520282e6f5717214004a7f26888")
+      )
     };
 
     await run(
       empAddress,
-      empToUniswapTokenMap,
+      uniswapPairOverride,
       walletsToMonitor,
       referencePriceFeedConfig,
       uniswapPriceFeedConfig,

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -28,6 +28,7 @@ const Finder = artifacts.require("Finder");
 
 async function run(
   address,
+  empToUniswapTokenMap,
   walletsToMonitor,
   referencePriceFeedConfig,
   uniswapPriceFeedConfig,
@@ -122,6 +123,7 @@ async function run(
     oracle,
     collateralToken,
     syntheticToken,
+    empToUniswapTokenMap,
     endDateOffsetSeconds,
     periodLengthSeconds
   );
@@ -171,8 +173,22 @@ async function Poll(callback) {
       ? parseInt(process.env.PERIOD_REPORT_LENGTH)
       : 24 * 60 * 60;
 
+    // Maps mainnet EMP address of synthetic to the token address that it trades against, for the Uniswap pair that we want to track.
+    // This is neccessary because each synthetic can be part of multiple Uniswap pairs.
+    const empToUniswapTokenMap = {
+      "0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1": {
+        name: "COMP",
+        address: web3.utils.toChecksumAddress("0xc00e94cb662c3520282e6f5717214004a7f26888")
+      },
+      "0x3f2D9eDd9702909Cf1F8C4237B7c4c5931F9C944": {
+        name: "DAI",
+        address: web3.utils.toChecksumAddress("0x6b175474e89094c44da98b954eedeac495271d0f")
+      }
+    };
+
     await run(
       empAddress,
+      empToUniswapTokenMap,
       walletsToMonitor,
       referencePriceFeedConfig,
       uniswapPriceFeedConfig,

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -175,6 +175,10 @@ async function Poll(callback) {
 
     // Overrides the Uniswap pair that we want to query trade data for. The assumption is that the GlobalSummaryReporter fetches
     // data for only one Uniswap pair, and the default pair tokens are the emp-synthetic-token and the emp-collateral-token.
+    //
+    // TODO: This object could take a long time to initialize if each `contract.at()` makes a network call to check if code exists
+    // at the address. We could make this more efficient by either parallelizing via `Promise.all()` or convert this into an address-to-address
+    // map and initialize lazily once we determine an address.
     const uniswapPairOverride = {
       // yCOMP <--> COMP
       [web3.utils.toChecksumAddress("0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1")]: await ExpandedERC20.at(

--- a/reporters/uniswapSubgraphClient.js
+++ b/reporters/uniswapSubgraphClient.js
@@ -16,21 +16,18 @@ function getUniswapClient() {
 }
 
 /**
- * @notice Return query to get pair data for uniswap pair @ `pairAddress` up to `block`-5 height. Default block height
+ * @notice Return query to get pair data for uniswap pair @ `pairAddress` up to `block` height. Default block height
  * is latest block available in subgraph. This should not be assumed to be the latest mined block for the network,
  * which might be higher than the latest block available in the subgraph.
- * @dev We subtract from the `block` height conservatively because we have observed a delay between the latest network block # (i.e. web3.eth.getBlockNumber),
- * and the latest block number available in the Uniswap subgraph.
  * @param {String} pairAddress Address of uniswap pair
  * @param {[Integer]} block Highest block number to query data from.
  * @return query string
  */
 function PAIR_DATA(pairAddress, block) {
-  const blockNumberLag = 5;
   const queryString = block
     ? `
             query pairs {
-                pairs(block: {number: ${block - blockNumberLag}}, where: {id: "${pairAddress}"}) {
+                pairs(block: {number: ${block}}, where: {id: "${pairAddress}"}) {
                     txCount
                     volumeToken1
                     volumeToken0
@@ -49,8 +46,27 @@ function PAIR_DATA(pairAddress, block) {
   return queryString;
 }
 
+/**
+ * @notice Returns query to get timestamp and blocknumber of latest swap for a pair @ `pairAddress`.
+ */
+function LAST_TRADE_FOR_PAIR(pairAddress) {
+  return `
+    query pairs {
+      pairs(where: {id: "${pairAddress}"}) {
+        swaps(orderBy: timestamp, orderDirection: desc, first: 1) {
+          transaction {
+            blockNumber
+            timestamp
+          }
+        }
+      }
+    }
+  `;
+}
+
 const queries = {
-  PAIR_DATA
+  PAIR_DATA,
+  LAST_TRADE_FOR_PAIR
 };
 
 module.exports = {

--- a/reporters/uniswapSubgraphClient.js
+++ b/reporters/uniswapSubgraphClient.js
@@ -10,13 +10,13 @@ const { GraphQLClient } = require("graphql-request");
 let uniswapClient;
 function getUniswapClient() {
   if (!uniswapClient) {
-    uniswapClient = new GraphQLClient("https://api.thegraph.com/subgraphs/name/ianlapham/unsiwap3");
+    uniswapClient = new GraphQLClient("https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2");
   }
   return uniswapClient;
 }
 
 /**
- * @notice Return query to get pair data for uniswap pair @ `pairAddress` up to `block`-3 height. Default block height
+ * @notice Return query to get pair data for uniswap pair @ `pairAddress` up to `block`-5 height. Default block height
  * is latest block available in subgraph. This should not be assumed to be the latest mined block for the network,
  * which might be higher than the latest block available in the subgraph.
  * @dev We subtract from the `block` height conservatively because we have observed a delay between the latest network block # (i.e. web3.eth.getBlockNumber),


### PR DESCRIPTION
Daily reporter was using an older subgraph endpoint

In addition, reporter assumed that Uniswap pair to grab data for was SYNTHETIC_TOKEN - COLLATERAL_TOKEN but this is not the case for yCOMP:
- The yCOMP synthetic uses DAI as the collateral, but the Uniswap pair we care about is yCOMP-COMP
- However, the ETHBTC synthetic uses DAI as the collateral and the Uniswap pair we care about is ETHBTC-DAI

Therefore, I pass a new parameter into GlobalSummaryReporter that allows user to override the Uniswap pair token. We assume that the `GlobalSummaryReporter` prints out data for a pair involving the EMP's synthetic currency (i.e. ETHBTC or yCOMP), but there could be multiple pairs and tokens the synthetic can trade against. By default, we assume that the user wants the pair including the EMP's collateral token (i.e. DAI), but now the `GlobalSummaryReporter` checks if the user wants to override the pair token. Currently, we override the yCOMP pair so that we track the yCOMP-COMP market instead of the default expected yCOMP-DAI.

Additionally, I noticed that the new subgraph we are using (which is the canonical one used by the official graph [explorer](https://thegraph.com/explorer/subgraph/ianlapham/uniswapv2)) isn't always up to date. In fact, it can sometimes lag by > 100 blocks. Therefore, we need to handle graph queries that desire fetching data up to a certain block. 

These are screengrabs showing how we now handle subgraph data that is not available. Notice how the latestblock we want to grab is ~200 blocks ahead of the subgraph's latest block:
![Screen Shot 2020-07-09 at 14 52 56](https://user-images.githubusercontent.com/9457025/87079953-db152b00-c1f4-11ea-93e2-a00d28b067d9.png)

And this is a successful sub period query (albeit with no trades in the last 24H):
![Screen Shot 2020-07-09 at 14 53 25](https://user-images.githubusercontent.com/9457025/87080032-faac5380-c1f4-11ea-8118-d64057fb3355.png)

I added a graphQL query that fetches the latest timestamp + block of the last swap on the relevant Uniswap pair. We can use this latest blocknumber to set a maximum value for the ending block of the sub period that we want to query for. This allows us to remove the hardcoded `blockDelay` variable that I was using to lag all graphQL queries.


Signed-off-by: Nick Pai <npai.nyc@gmail.com>