### PR TITLE
Monitor bot and EMP deployment script updates made while kovan-"war games" testing for yUSD

### DIFF
--- a/core/config/identifiers.json
+++ b/core/config/identifiers.json
@@ -14,5 +14,6 @@
   "Custom Index (1)": {},
   "Custom Index (100)": {},
   "ETH/BTC": {},
-  "COMPUSD": {}
+  "COMPUSD": {},
+  "USDETH": {}
 }

--- a/core/scripts/local/ConvertWeth.js
+++ b/core/scripts/local/ConvertWeth.js
@@ -1,0 +1,42 @@
+/**
+ * @notice Wrap or unwrap --collateral amount of WETH. Unwrap by passing in `--unwrap true` flag.
+ *
+ * Example: `$(npm bin)/truffle exec ./scripts/local/ConvertWeth.js --network test --collateral 25 --emp 0x0`
+ */
+const { toWei, fromWei } = web3.utils;
+
+// Deployed contract ABI's and addresses we need to fetch.
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const WETH9 = artifacts.require("WETH9");
+const argv = require("minimist")(process.argv.slice(), { string: ["collateral", "emp"], boolean: ["unwrap"] });
+
+async function convertWeth(callback) {
+  try {
+    if (!argv.emp || !argv.collateral) {
+      throw new Error(`
+      required: --emp must be the emp address.
+      required: --collateral must be the of WETH to wrap or unwrap
+      `);
+    }
+
+    const emp = await ExpiringMultiParty.at(argv.emp);
+    const weth = await WETH9.at(await emp.collateralCurrency());
+
+    if (!argv.unwrap) {
+      await weth.deposit({ value: toWei(argv.collateral) });
+      console.log(`Wrapped ${argv.collateral} ETH ==> WETH`);
+    } else {
+      console.log("TODO: Implement unwrapping.");
+    }
+
+    const caller = (await web3.eth.getAccounts())[0];
+    const newBalance = await weth.balanceOf(caller);
+    console.log(`New WETH balance: ${fromWei(newBalance.toString())}`);
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+}
+
+module.exports = convertWeth;

--- a/core/scripts/local/CreateTokens.js
+++ b/core/scripts/local/CreateTokens.js
@@ -9,6 +9,7 @@ const { MAX_UINT_VAL } = require("../../../common/Constants");
 // Deployed contract ABI's and addresses we need to fetch.
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const ExpandedERC20 = artifacts.require("ExpandedERC20");
+const WETH9 = artifacts.require("WETH9");
 const argv = require("minimist")(process.argv.slice(), { string: ["emp", "tokens", "collateral"] });
 
 async function createPosition(callback) {
@@ -23,6 +24,13 @@ async function createPosition(callback) {
 
     const emp = await ExpiringMultiParty.at(argv.emp);
     const collateralToken = await ExpandedERC20.at(await emp.collateralCurrency());
+
+    if ((await collateralToken.symbol()) === "WETH") {
+      const weth = await WETH9.at(collateralToken.address);
+      await weth.deposit({ value: toWei(argv.collateral) });
+      console.log(`Wrapped ${argv.collateral} ETH ==> WETH`);
+    }
+
     const account = (await web3.eth.getAccounts())[0];
     const collateral = toBN(toWei(argv.collateral));
     const collateralBalance = await collateralToken.balanceOf(account);

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -131,6 +131,16 @@ const deployEMP = async callback => {
       // Mint accounts[0] collateral.
       await collateralToken.allocateTo(accounts[0], toWei("1000000"));
       console.log("Minted accounts[0] 1,000,000 collateral tokens");
+    } else if (argv.test && collateralToken.address === (await WETH9.deployed()).address) {
+      const initialSponsor = accounts[1];
+      await collateralToken.deposit({ value: toWei("1200"), from: initialSponsor });
+      await collateralToken.approve(emp.address, toWei("1200"), { from: initialSponsor });
+      await emp.create({ rawValue: toWei("1200") }, { rawValue: toWei("1000") }, { from: initialSponsor });
+      console.log("Created an initial position with CR = 120 % for the sponsor: ", initialSponsor);
+
+      // Mint accounts[0] collateral.
+      await collateralToken.deposit({ value: toWei("1000000"), from: accounts[0] });
+      console.log("Converted 1,000,000 collateral WETH for accounts[0]");
     }
   } catch (err) {
     console.error(err);

--- a/core/scripts/local/DeployEMP.js
+++ b/core/scripts/local/DeployEMP.js
@@ -46,9 +46,9 @@ let collateralTokenWhitelist;
 let expiringMultiPartyCreator;
 
 const empCollateralTokenMap = {
-  "COMP/USD": TestnetERC20,
+  COMPUSD: TestnetERC20,
   "ETH/BTC": TestnetERC20,
-  "USD/ETH": WETH9
+  USDETH: WETH9
 };
 
 /** ***************************************************

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -211,6 +211,12 @@ class Disputer {
     }
 
     for (const liquidation of disputedLiquidations) {
+      this.logger.debug({
+        at: "Disputer",
+        message: "Detected a disputed liquidation",
+        liquidation: JSON.stringify(liquidation)
+      });
+
       // Construct transaction.
       const withdraw = this.empContract.methods.withdrawLiquidation(liquidation.id, liquidation.sponsor);
 

--- a/disputer/disputer.js
+++ b/disputer/disputer.js
@@ -100,6 +100,12 @@ class Disputer {
           this.empClient.isDisputable(liquidation, price) &&
           this.empClient.getLastUpdateTime() >= Number(liquidation.liquidationTime) + this.disputeDelay
         ) {
+          this.logger.debug({
+            at: "Disputer",
+            message: "Detected a disputable liquidation",
+            price: price.toString(),
+            liquidation: JSON.stringify(liquidation)
+          });
           return true;
         } else {
           return false;
@@ -126,6 +132,7 @@ class Disputer {
         this.logger.error({
           at: "Disputer",
           message: "Cannot dispute liquidation: not enough collateral (or large enough approval) to initiate dispute✋",
+          disputer: this.account,
           sponsor: disputeableLiquidation.sponsor,
           liquidation: disputeableLiquidation,
           error

--- a/disputer/index.js
+++ b/disputer/index.js
@@ -96,7 +96,7 @@ async function run(logger, address, pollingDelay, priceFeedConfig, disputerConfi
       logger.info({
         at: "Disputer#index",
         message: "Approved EMP to transfer unlimited collateral tokens 💰",
-        collateralApprovalTx: collateralApprovalTx.transactionHash
+        collateralApprovalTx: collateralApprovalTx.tx
       });
     }
 

--- a/financial-templates-lib/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/clients/ExpiringMultiPartyClient.js
@@ -121,6 +121,7 @@ class ExpiringMultiPartyClient {
         const liquidationData = {
           sponsor: liquidation.sponsor,
           id: id.toString(),
+          state: liquidation.state,
           numTokens: liquidation.tokensOutstanding.toString(),
           liquidatedCollateral: liquidation.liquidatedCollateral.toString(),
           lockedCollateral: liquidation.lockedCollateral.toString(),

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -207,6 +207,7 @@ const defaultConfigs = {
     ]
   },
   "COMP/USD": {
+    // Kovan uses the "/"
     type: "medianizer",
     lookback: 7200,
     minTimeBetweenUpdates: 60,
@@ -216,7 +217,18 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
     ]
   },
-  "USD/ETH": {
+  COMPUSD: {
+    // Mainnet has no "/"
+    type: "medianizer",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "compusd" },
+      { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
+      { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
+    ]
+  },
+  USDETH: {
     type: "medianizer",
     lookback: 7200,
     invertPrice: true,

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -29,7 +29,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.lookback,
       networker,
       getTime,
-      config.minTimeBetweenUpdates
+      config.minTimeBetweenUpdates,
+      config.invertPrice // Not checked in config because this parameter just defaults to false.
     );
   } else if (config.type === "uniswap") {
     const requiredFields = ["uniswapAddress", "twapLength", "lookback"];
@@ -205,7 +206,7 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "bitstamp" }
     ]
   },
-  COMPUSD: {
+  "COMP/USD": {
     type: "medianizer",
     lookback: 7200,
     minTimeBetweenUpdates: 60,
@@ -215,14 +216,14 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
     ]
   },
-  "COMP/USD": {
+  "USD/ETH": {
     type: "medianizer",
     lookback: 7200,
+    invertPrice: true,
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [
-      { type: "cryptowatch", exchange: "coinbase-pro", pair: "compusd" },
-      { type: "cryptowatch", exchange: "poloniex", pair: "compusdt" },
-      { type: "cryptowatch", exchange: "ftx", pair: "compusd" }
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "ethusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "ethusdt" }
     ]
   }
 };

--- a/financial-templates-lib/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/price-feed/CreatePriceFeed.js
@@ -235,7 +235,8 @@ const defaultConfigs = {
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [
       { type: "cryptowatch", exchange: "coinbase-pro", pair: "ethusd" },
-      { type: "cryptowatch", exchange: "binance", pair: "ethusdt" }
+      { type: "cryptowatch", exchange: "binance", pair: "ethusdt" },
+      { type: "cryptowatch", exchange: "kraken", pair: "ethusd" }
     ]
   }
 };

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -191,11 +191,13 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   }
 
   _invertPriceSafely(priceBN) {
-    return priceBN && priceBN.gt(this.toBN("0"))
-      ? this.toBN(this.toWei("1"))
+    if (priceBN && priceBN.gt(this.toBN("0"))) {
+      return this.toBN(this.toWei("1"))
         .mul(this.toBN(this.toWei("1")))
-          .div(priceBN)
-      : null;
+        .div(priceBN);
+    } else {
+      return null;
+    }
   }
 }
 

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -16,8 +16,9 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
    * @param {Function} getTime Returns the current time.
    * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
    *      this number of seconds has passed, it will be a no-op.
+   * @param {Bool} invertPrice Indicates if prices should be inverted before returned.
    */
-  constructor(logger, web3, apiKey, exchange, pair, lookback, networker, getTime, minTimeBetweenUpdates) {
+  constructor(logger, web3, apiKey, exchange, pair, lookback, networker, getTime, minTimeBetweenUpdates, invertPrice) {
     super();
     this.logger = logger;
     this.web3 = web3;
@@ -29,6 +30,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     this.networker = networker;
     this.getTime = getTime;
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+    this.invertPrice = invertPrice;
 
     // Use CryptoWatch's most granular option, one minute.
     this.ohlcPeriod = 60;
@@ -39,7 +41,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   }
 
   getCurrentPrice() {
-    return this.currentPrice;
+    return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
   }
 
   getHistoricalPrice(time) {
@@ -76,10 +78,10 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     // If there is no match, that means that the time was past the last data point.
     // In this case, the best match for this price is the current price.
     if (match === undefined) {
-      return this.currentPrice;
+      return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
     }
 
-    return match.openPrice;
+    return this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
   }
 
   getLastUpdateTime() {
@@ -186,6 +188,14 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     this.historicalPricePeriods = newHistoricalPricePeriods;
     this.lastUpdateTime = currentTime;
+  }
+
+  _invertPriceSafely(priceBN) {
+    return priceBN && priceBN.gt(this.toBN("0"))
+      ? this.toBN(this.toWei("1"))
+        .mul(this.toBN(this.toWei("1")))
+          .div(priceBN)
+      : null;
   }
 }
 

--- a/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/price-feed/CryptoWatchPriceFeed.js
@@ -195,8 +195,6 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       return this.toBN(this.toWei("1"))
         .mul(this.toBN(this.toWei("1")))
         .div(priceBN);
-    } else {
-      return null;
     }
   }
 }

--- a/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
+++ b/financial-templates-lib/test/clients/ExpiringMultiPartyClient.js
@@ -187,6 +187,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         liquidatedCollateral: toWei("100"),
         lockedCollateral: toWei("100"),
         liquidationTime: (await emp.getCurrentTime()).toString(),
+        state: "1",
         liquidator: sponsor1,
         disputer: zeroAddress
       }
@@ -336,6 +337,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         {
           sponsor: sponsor1,
           id: "0",
+          state: "1",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
           liquidatedCollateral: toWei("140"), // This should `lockedCollateral` reduced by requested withdrawal amount
@@ -361,6 +363,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         {
           sponsor: sponsor1,
           id: "0",
+          state: "1",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
           liquidatedCollateral: toWei("140"),
@@ -420,6 +423,7 @@ contract("ExpiringMultiPartyClient.js", function(accounts) {
         {
           sponsor: sponsor1,
           id: "0",
+          state: "2",
           liquidationTime: liquidationTime,
           numTokens: toWei("100"),
           liquidatedCollateral: toWei("150"),

--- a/financial-templates-lib/test/clients/TokenBalanceClient.js
+++ b/financial-templates-lib/test/clients/TokenBalanceClient.js
@@ -7,7 +7,7 @@ const { TokenBalanceClient } = require("../../clients/TokenBalanceClient");
 // Truffle artifacts
 const Token = artifacts.require("ExpandedERC20");
 
-contract("BalanceMonitor.js", function(accounts) {
+contract("TokenBalanceClient.js", function(accounts) {
   const tokenCreator = accounts[0];
   const sponsor1 = accounts[1];
   const sponsor2 = accounts[2];

--- a/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -35,7 +35,6 @@ contract("CreatePriceFeed.js", function(accounts) {
   const minTimeBetweenUpdates = 60;
   const twapLength = 180;
   const uniswapAddress = toChecksumAddress(randomHex(20));
-  const invertPrice = true;
 
   beforeEach(async function() {
     networker = new NetworkerMock();
@@ -74,6 +73,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(validCryptoWatchFeed.pair, pair);
     assert.equal(validCryptoWatchFeed.lookback, lookback);
     assert.equal(validCryptoWatchFeed.getTime(), getTime());
+    assert.equal(validCryptoWatchFeed.invertPrice, undefined);
   });
 
   it("Valid CryptoWatch config without apiKey", async function() {

--- a/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -88,7 +88,14 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
     it("Current price", async function() {
       networker.getJsonReturns = [...validResponses];
       await cryptoWatchPriceFeed.update();
-      assert.isTrue(cryptoWatchPriceFeed.getCurrentPrice().eq(toBN(1).div(toBN(toWei("1.5")))));
+      assert.isTrue(
+        // Should be equal to: toWei(1/1.5)
+        cryptoWatchPriceFeed.getCurrentPrice().eq(
+          toBN(toWei("1"))
+            .mul(toBN(toWei("1")))
+            .div(toBN(toWei("1.5")))
+        )
+      );
     });
 
     it("Historical price", async function() {
@@ -99,16 +106,44 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
       assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376339), null);
 
       // During period 1.
-      assert.isTrue(cryptoWatchPriceFeed.getHistoricalPrice(1588376340).eq(toBN(1).div(toBN(toWei("1.1")))));
+      assert.isTrue(
+        // Should be equal to: toWei(1/1.1)
+        cryptoWatchPriceFeed.getHistoricalPrice(1588376340).eq(
+          toBN(toWei("1"))
+            .mul(toBN(toWei("1")))
+            .div(toBN(toWei("1.1")))
+        )
+      );
 
       // During period 2.
-      assert.isTrue(cryptoWatchPriceFeed.getHistoricalPrice(1588376405).eq(toBN(1).div(toBN(toWei("1.2")))));
+      assert.isTrue(
+        // Should be equal to: toWei(1/1.2)
+        cryptoWatchPriceFeed.getHistoricalPrice(1588376405).eq(
+          toBN(toWei("1"))
+            .mul(toBN(toWei("1")))
+            .div(toBN(toWei("1.2")))
+        )
+      );
 
       // During period 3.
-      assert.isTrue(cryptoWatchPriceFeed.getHistoricalPrice(1588376515).eq(toBN(1).div(toBN(toWei("1.3")))));
+      assert.isTrue(
+        // Should be equal to: toWei(1/1.3)
+        cryptoWatchPriceFeed.getHistoricalPrice(1588376515).eq(
+          toBN(toWei("1"))
+            .mul(toBN(toWei("1")))
+            .div(toBN(toWei("1.3")))
+        )
+      );
 
       // After period 3 should return the most recent price.
-      assert.isTrue(cryptoWatchPriceFeed.getHistoricalPrice(1588376521).eq(toBN(1).div(toBN(toWei("1.5")))));
+      assert.isTrue(
+        // Should be equal to: toWei(1/1.5)
+        cryptoWatchPriceFeed.getHistoricalPrice(1588376521).eq(
+          toBN(toWei("1"))
+            .mul(toBN(toWei("1")))
+            .div(toBN(toWei("1.5")))
+        )
+      );
     });
   });
 

--- a/liquidator/index.js
+++ b/liquidator/index.js
@@ -103,7 +103,7 @@ async function run(logger, address, pollingDelay, priceFeedConfig, liquidatorCon
       logger.info({
         at: "Liquidator#index",
         message: "Approved EMP to transfer unlimited collateral tokens 💰",
-        collateralApprovalTx: collateralApprovalTx.transactionHash
+        collateralApprovalTx: collateralApprovalTx.tx
       });
     }
     if (toBN(currentSyntheticAllowance).lt(toBN(MAX_UINT_VAL).div(toBN("2")))) {
@@ -114,7 +114,7 @@ async function run(logger, address, pollingDelay, priceFeedConfig, liquidatorCon
       logger.info({
         at: "Liquidator#index",
         message: "Approved EMP to transfer unlimited synthetic tokens 💰",
-        collateralApprovalTx: syntheticApprovalTx.transactionHash
+        collateralApprovalTx: syntheticApprovalTx.tx
       });
     }
 

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -133,8 +133,8 @@ class Liquidator {
     // The `price` is a BN that is used to determine if a position is liquidatable. The higher the
     // `price` value, the more collateral that the position is required to have to be correctly collateralized.
     // Therefore, we add a buffer by deriving scaledPrice = price * (1 - crThreshold)
-    const scaledPrice = this.fromWei(
-      price.mul(this.toBN(this.toWei("1")).sub(this.toBN(this.toWei(this.crThreshold.toString()))))
+    const scaledPrice = Math.round(
+      this.fromWei(price.mul(this.toBN(this.toWei("1")).sub(this.toBN(this.toWei(this.crThreshold.toString())))))
     );
 
     // Calculate the maxCollateralPerToken as the scaled price, multiplied by the contracts CRRatio. For a liquidation

--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -133,9 +133,9 @@ class Liquidator {
     // The `price` is a BN that is used to determine if a position is liquidatable. The higher the
     // `price` value, the more collateral that the position is required to have to be correctly collateralized.
     // Therefore, we add a buffer by deriving scaledPrice = price * (1 - crThreshold)
-    const scaledPrice = Math.round(
-      this.fromWei(price.mul(this.toBN(this.toWei("1")).sub(this.toBN(this.toWei(this.crThreshold.toString())))))
-    );
+    const scaledPrice = price
+      .mul(this.toBN(this.toWei("1")).sub(this.toBN(this.toWei(this.crThreshold.toString()))))
+      .div(this.toBN(this.toWei("1")));
 
     // Calculate the maxCollateralPerToken as the scaled price, multiplied by the contracts CRRatio. For a liquidation
     // to be accepted by the contract the position's collateralization ratio must be between [minCollateralPerToken,
@@ -169,6 +169,13 @@ class Liquidator {
     }
 
     for (const position of underCollateralizedPositions) {
+      this.logger.debug({
+        at: "Liquidator",
+        message: "Detected a liquidatable position",
+        scaledPrice: scaledPrice.toString(),
+        position: JSON.stringify(position)
+      });
+
       // Note: query the time again during each iteration to ensure the deadline is set reasonably.
       const currentBlockTime = this.empClient.getLastUpdateTime();
 
@@ -337,6 +344,12 @@ class Liquidator {
     }
 
     for (const liquidation of potentialWithdrawableLiquidations) {
+      this.logger.debug({
+        at: "Liquidator",
+        message: "Detected a pending or expired liquidation",
+        liquidation: JSON.stringify(liquidation)
+      });
+
       // Construct transaction.
       const withdraw = this.empContract.methods.withdrawLiquidation(liquidation.id, liquidation.sponsor);
 

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -60,6 +60,16 @@ class BalanceMonitor {
             })
           );
         }
+      },
+      logOverrides: {
+        // Specify an override object to change default logging behaviour. Defaults to no overrides. If specified, this
+        // object is structured to contain key for the log to override and value for the logging level. EG:
+        // { syntheticThreshold:'error' } would override the default `warn` behaviour for synthetic-balance-threshold events.
+        value: {},
+        isValid: overrides => {
+          // Override must be one of the default logging levels: ['error','warn','info','http','verbose','debug','silly']
+          return Object.values(overrides).every(param => Object.keys(this.logger.levels).includes(param));
+        }
       }
     };
 
@@ -105,7 +115,7 @@ class BalanceMonitor {
         });
       }
       if (this.toBN(this.client.getSyntheticBalance(monitoredAddress)).lt(this.toBN(bot.syntheticThreshold))) {
-        this.logger.warn({
+        this.logger[this.logOverrides.syntheticThreshold ? this.logOverrides.syntheticThreshold : "warn"]({
           at: "BalanceMonitor",
           message: "Low synthetic balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -141,7 +141,7 @@ class CRMonitor {
           ", the position can be liquidated.";
 
         this.logger.warn({
-          at: "ContractMonitor",
+          at: "CRMonitor",
           message: "Collateralization ratio alert 🙅‍♂️!",
           mrkdwn: mrkdwn
         });

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -70,6 +70,16 @@ class SyntheticPegMonitor {
         isValid: x => {
           return typeof x === "number" && x < 1 && x >= 0;
         }
+      },
+      logOverrides: {
+        // Specify an override object to change default logging behaviour. Defaults to no overrides. If specified, this
+        // object is structured to contain key for the log to override and value for the logging level. EG:
+        // { deviation:'error' } would override the default `warn` behaviour for synthetic-peg deviation events.
+        value: {},
+        isValid: overrides => {
+          // Override must be one of the default logging levels: ['error','warn','info','http','verbose','debug','silly']
+          return Object.values(overrides).every(param => Object.keys(this.logger.levels).includes(param));
+        }
       }
     };
     Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
@@ -107,7 +117,7 @@ class SyntheticPegMonitor {
     const deviationError = this._calculateDeviationError(uniswapTokenPrice, cryptoWatchTokenPrice);
     // If the percentage error is greater than (gt) the threshold send a message.
     if (deviationError.abs().gt(this.toBN(this.toWei(this.deviationAlertThreshold.toString())))) {
-      this.logger.warn({
+      this.logger[this.logOverrides.deviation ? this.logOverrides.deviation : "warn"]({
         at: "SyntheticPegMonitor",
         message: "Synthetic off peg alert 😵",
         mrkdwn:

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -240,6 +240,7 @@ async function Poll(callback) {
     //  "volatilityWindow": 600,                           // Length of time (in seconds) to snapshot volatility.
     //  "pegVolatilityAlertThreshold": 0.1,                // Threshold for synthetic peg (identifier) price volatility over `volatilityWindow`.
     //  "syntheticVolatilityAlertThreshold": 0.1,          // Threshold for synthetic token on uniswap price volatility over `volatilityWindow`.
+    //  "logOverrides":{"deviation":"error","syntheticThreshold":"error"}} -> override specific events log levels.
     // }
     const monitorConfig = process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null;
 

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -250,7 +250,7 @@ async function Poll(callback) {
       : null;
 
     // Medianizer price feed averages over a set of different sources to get an average. Config defines the exchanges
-    // to use. EG: {"type":"medianizer","pair":"ethbtc","lookback":7200,"minTimeBetweenUpdates":60,"medianizedFeeds":[
+    // to use. EG: {"type":"medianizer","pair":"ethbtc", "invertPrice":true, "lookback":7200,"minTimeBetweenUpdates":60,"medianizedFeeds":[
     // {"type":"cryptowatch","exchange":"coinbase-pro"},{"type":"cryptowatch","exchange":"binance"}]}
     const medianizerPriceFeedConfig = process.env.MEDIANIZER_PRICE_FEED_CONFIG
       ? JSON.parse(process.env.MEDIANIZER_PRICE_FEED_CONFIG)

--- a/monitors/test/BalanceMonitor.js
+++ b/monitors/test/BalanceMonitor.js
@@ -6,7 +6,12 @@ const sinon = require("sinon");
 const { BalanceMonitor } = require("../BalanceMonitor");
 
 // Helper client script and custom winston transport module to monitor winston log outputs
-const { TokenBalanceClient, SpyTransport, lastSpyLogIncludes } = require("@umaprotocol/financial-templates-lib");
+const {
+  TokenBalanceClient,
+  SpyTransport,
+  lastSpyLogIncludes,
+  lastSpyLogLevel
+} = require("@umaprotocol/financial-templates-lib");
 
 // Truffle artifacts
 const Token = artifacts.require("ExpandedERC20");

--- a/monitors/test/BalanceMonitor.js
+++ b/monitors/test/BalanceMonitor.js
@@ -133,7 +133,12 @@ contract("BalanceMonitor.js", function(accounts) {
     // is set to 100e18, with a balance of 100e18 so moving just 1 wei units of synthetic should trigger an alert.
     // The liquidator bot is still below its threshold we should expect two messages to fire (total calls should be 3 + 2).
     await syntheticToken.transfer(tokenCreator, "1", { from: disputerBot });
-    assert.equal((await syntheticToken.balanceOf(disputerBot)).toString(), toBN(toWei("100")).sub(toBN("1")));
+    assert.equal(
+      (await syntheticToken.balanceOf(disputerBot)).toString(),
+      toBN(toWei("100"))
+        .sub(toBN("1"))
+        .toString()
+    );
 
     await tokenBalanceClient.update();
     await balanceMonitor.checkBotBalances();
@@ -294,7 +299,12 @@ contract("BalanceMonitor.js", function(accounts) {
 
     // Lower the liquidator bot's synthetic balance.
     await syntheticToken.transfer(tokenCreator, "1", { from: liquidatorBot });
-    assert.equal((await syntheticToken.balanceOf(liquidatorBot)).toString(), toBN(toWei("100")).sub(toBN("1")));
+    assert.equal(
+      (await syntheticToken.balanceOf(liquidatorBot)).toString(),
+      toBN(toWei("100"))
+        .sub(toBN("1"))
+        .toString()
+    );
 
     await tokenBalanceClient.update();
     await balanceMonitor.checkBotBalances();


### PR DESCRIPTION
### Many nit fixes, two bigger changes that I put in bold:


EMP deployment and management scripts:
- Add USDETH to identifiers.json list that all get added to IdentifierWhitelist on migration
- Add WETH9 wrapping/unwrapping flow to CreateToken script.
- Add a WETH9 conversion script.
- Update DeployEMP script to use yUSD config details. Updated script so that it adds an identifier to the whitelist if neccessary, and also deals with the WETH9 conversion flow.

Disputer:
- Adds additional details to logs such as disputer's address and data about any "disputable liquidations". Previously, there were no logs detailing disputable liquidations prior to sending out the dispute transaction.
- Collateral approval transaction hash was not parsed correctly from web3.
- Log details about any potential withdrawable disputed liquidations, even before attempting to withdraw rewards.

Liquidator:
- Collateral approval transaction hash was not parsed correctly from web3.
- Add `invertPrice` config option to `CreatePriceFeed.js` which inverts the results of `getCurrentPrice()` and `getHistoricalPrice()` plus unit tests.
- Liquidator's `scaledPrice` calculation sometimes returns a non-integer (i.e. decimal) value. I remove the `fromWei()` wrapping around it to avoid casting it to a decimal prematurely.
- Adds additional details to logs about any "liquidatable positions". Previously, there were no logs detailing these positions prior to sending out a liquidation transaction.
- Log details about any potential withdrawable pending or expired liquidations, even before attempting to withdraw rewards.

Price Feed lib:
- Add USDETH default identifier config
- **Add an `invertPrice` config param to `CryptoWatchPriceFeed` that returns inverted prices for `getCurrentPrice()` and `getHistoricalPrice()`. I had to check that prices are non-zero before attempting to invert them. I also updated the unit tests and documenting comments to reflect this change.**

SyntheticPegMonitor:
- ** Can take in a `logOverride` config option that can change log level for the deviation alert.

BalanceMonitor:
- ** Can take in a `logOverride` config option that can change log level for the synthetic-balance alert.

Misc:
- CRMonitor had a log that had the "ContractMonitor" label
- TokenBalanceClient had a log that had the "BalanceMonitor" label
- Updated comments in monitor/index.js about the new `invertPrice` option for CryptoWatch

Signed-off-by: Nick Pai <npai.nyc@gmail.com>