### PR TITLE
Fix buidler tests

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "dependencies": {
     "@awaitjs/express": "^0.3.0",
+    "@nomiclabs/buidler": "^1.3.8",
+    "@nomiclabs/buidler-truffle5": "^1.3.4",
+    "@nomiclabs/buidler-web3": "^1.3.4",
     "@openzeppelin/contracts": "3.0.0",
     "@sendgrid/mail": "^6.4.0",
     "@umaprotocol/financial-templates-lib": "^1.0.0",


### PR DESCRIPTION
This fixes the ci breakage caused by a collision between #1735 and #1729 (I think).

To have access to the buidler binary, the dependencies need to be added to the sub-package (core). They could be removed from the base package.json as well, but as a matter of simplicity, we're holding off cleaning out the root dependencies until the lerna refactor is over.