### PR TITLE
Fix timer issue in migrations

### DIFF
--- a/core/migrations/14_deploy_expiring_multi_party_creator.js
+++ b/core/migrations/14_deploy_expiring_multi_party_creator.js
@@ -21,7 +21,10 @@ module.exports = async function(deployer, network, accounts) {
   const testnetERC20 = await TestnetERC20.deployed();
   await collateralCurrencyWhitelist.addToWhitelist(testnetERC20.address);
 
-  const timer = await Timer.deployed();
+  // .deployed() will fail if called on a network where the is no Timer (!controllableTiming).
+  const timerAddress = controllableTiming
+    ? (await Timer.deployed()).address
+    : "0x0000000000000000000000000000000000000000";
   const finder = await Finder.deployed();
   const tokenFactory = await TokenFactory.deployed();
   const registry = await Registry.deployed();
@@ -50,7 +53,7 @@ module.exports = async function(deployer, network, accounts) {
     finder.address,
     collateralCurrencyWhitelist.address,
     tokenFactory.address,
-    controllableTiming ? timer.address : "0x0000000000000000000000000000000000000000",
+    timerAddress,
     { from: keys.deployer }
   );
 

--- a/core/migrations/5_deploy_voting.js
+++ b/core/migrations/5_deploy_voting.js
@@ -10,7 +10,10 @@ module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
   const controllableTiming = enableControllableTiming(network);
 
-  const timer = await Timer.deployed();
+  // .deployed() will fail if called on a network where the is no Timer (!controllableTiming).
+  const timerAddress = controllableTiming
+    ? (await Timer.deployed()).address
+    : "0x0000000000000000000000000000000000000000";
 
   // Deploy whitelist of identifiers
   const { contract: identifierWhitelist } = await deploy(deployer, network, IdentifierWhitelist, {
@@ -43,7 +46,7 @@ module.exports = async function(deployer, network, accounts) {
     rewardsExpirationTimeout,
     votingToken.address,
     finder.address,
-    controllableTiming ? timer.address : "0x0000000000000000000000000000000000000000",
+    timerAddress,
     { from: keys.deployer }
   );
 

--- a/core/migrations/8_deploy_store.js
+++ b/core/migrations/8_deploy_store.js
@@ -9,7 +9,10 @@ module.exports = async function(deployer, network, accounts) {
   const keys = getKeysForNetwork(network, accounts);
   const controllableTiming = enableControllableTiming(network);
 
-  const timer = await Timer.deployed();
+  // .deployed() will fail if called on a network where the is no Timer (!controllableTiming).
+  const timerAddress = controllableTiming
+    ? (await Timer.deployed()).address
+    : "0x0000000000000000000000000000000000000000";
 
   // Initialize both fees to 0.
   const initialFixedOracleFeePerSecondPerPfc = { rawValue: "0" };
@@ -21,7 +24,7 @@ module.exports = async function(deployer, network, accounts) {
     Store,
     initialFixedOracleFeePerSecondPerPfc,
     initialWeeklyDelayFeePerSecondPerPfc,
-    controllableTiming ? timer.address : "0x0000000000000000000000000000000000000000",
+    timerAddress,
     { from: keys.deployer }
   );
 

--- a/core/migrations/9_deploy_governor.js
+++ b/core/migrations/9_deploy_governor.js
@@ -10,20 +10,15 @@ module.exports = async function(deployer, network, accounts) {
   const controllableTiming = enableControllableTiming(network);
   const startingId = "0";
 
-  const timer = await Timer.deployed();
+  // .deployed() will fail if called on a network where the is no Timer (!controllableTiming).
+  const timerAddress = controllableTiming
+    ? (await Timer.deployed()).address
+    : "0x0000000000000000000000000000000000000000";
   const finder = await Finder.deployed();
 
-  const { contract: governor } = await deploy(
-    deployer,
-    network,
-    Governor,
-    finder.address,
-    startingId,
-    controllableTiming ? timer.address : "0x0000000000000000000000000000000000000000",
-    {
-      from: keys.deployer
-    }
-  );
+  const { contract: governor } = await deploy(deployer, network, Governor, finder.address, startingId, timerAddress, {
+    from: keys.deployer
+  });
 
   // Add governor to registry so it can send price requests.
   const registry = await Registry.deployed();


### PR DESCRIPTION
Fixes a small issue in #1735 where `Timer.deployed()` is called on networks where there is no deployed timer, causing the migrations to fail. The net effect is that migrations on non-test networks would always fail.

This PR changes these calls to only happen inside the ternary.