### PR TITLE
Add buidler artifact directories to prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ modules
 public
 ui
 build
+artifacts
+cache


### PR DESCRIPTION
Buidler artifacts were being picked up by prettier and causing errors. This adds two directories that buidler leaves behind to `.prettierignore`.