### PR TITLE
Explain liquidation status better post-withdrawing rewards

### DIFF
--- a/common/Enums.js
+++ b/common/Enums.js
@@ -20,11 +20,14 @@ const LiquidationStatesEnum = {
 };
 
 // Maps the `liquidationStatus` property in the `LiquidationWithdrawn` event to human readable statuses.
+// Note that these are status translations AFTER a withdrawLiquidation method is called
 const PostWithdrawLiquidationRewardsStatusTranslations = {
-  "0": "Dispute failed",
-  "1": "Liquidation expired",
-  "3": "Dispute succeeded"
-  // Post `withdrawLiquidation()`, the status cannot be "PendingDispute/2" or "DisputeFailed/4"
+  "0": "Liquidation deleted; All rewards have been withdrawn",
+  "1": "Liquidation expired; Liquidator can withdraw rewards",
+  "3": "Dispute succeeded; Not all rewards have been withdrawn"
+  // @dev: Post `withdrawLiquidation()`, the status cannot be "2:PendingDispute" or "4:DisputeFailed"
+  // @dev: If a liquidation has expired or a dispute has failed, then the first withdrawLiquidation() call will delete the liquidation
+  // and reset its state to 0.
 };
 
 // States for an EMP's Position to be in.

--- a/common/Enums.js
+++ b/common/Enums.js
@@ -23,10 +23,9 @@ const LiquidationStatesEnum = {
 // Note that these are status translations AFTER a withdrawLiquidation method is called
 const PostWithdrawLiquidationRewardsStatusTranslations = {
   "0": "Liquidation deleted; All rewards have been withdrawn",
-  "1": "Liquidation expired; Liquidator can withdraw rewards",
   "3": "Dispute succeeded; Not all rewards have been withdrawn"
-  // @dev: Post `withdrawLiquidation()`, the status cannot be "2:PendingDispute" or "4:DisputeFailed"
-  // @dev: If a liquidation has expired or a dispute has failed, then the first withdrawLiquidation() call will delete the liquidation
+  // @dev: Post `withdrawLiquidation()`, the status cannot be "2:PendingDispute", "1:PreDispute" or "4:DisputeFailed"
+  // @dev: If a liquidation has expired, is pre-dispute, or a dispute has failed, then the first withdrawLiquidation() call will delete the liquidation
   // and reset its state to 0.
 };
 

--- a/common/Enums.js
+++ b/common/Enums.js
@@ -25,7 +25,7 @@ const PostWithdrawLiquidationRewardsStatusTranslations = {
   "0": "Liquidation deleted; All rewards have been withdrawn",
   "3": "Dispute succeeded; Not all rewards have been withdrawn"
   // @dev: Post `withdrawLiquidation()`, the status cannot be "2:PendingDispute", "1:PreDispute" or "4:DisputeFailed"
-  // @dev: If a liquidation has expired, is pre-dispute, or a dispute has failed, then the first withdrawLiquidation() call will delete the liquidation
+  // @dev: If a liquidation has expired (i.e. is pre-dispute) or a dispute has failed, then the first withdrawLiquidation() call will delete the liquidation
   // and reset its state to 0.
 };
 


### PR DESCRIPTION
Once a liquidation has expired and the liquidator has withdrawn rewards, the liquidation will be deleted because there are no rewards for other parties remaining. However, the liquidator bot incorrectly translates the ensuing state (state gets reset to 0 once a liquidation is deleted) as "Dispute Failed". 

The subtlety here is that after calling `withdrawLiquidation()` on EITHER a failed-disputed-liquidation OR an expired-liquidation, the state will get set to 0:

See this incorrect log message's "liquidation status" value for example:
![Screen Shot 2020-07-17 at 08 50 59](https://user-images.githubusercontent.com/9457025/87788775-eaefc900-c80b-11ea-9078-2db04496298e.png)

Corrected log message here:
![Screen Shot 2020-07-17 at 11 12 25](https://user-images.githubusercontent.com/9457025/87801983-84c07180-c81e-11ea-8372-0fc105690429.png)

Signed-off-by: Nick Pai <npai.nyc@gmail.com>