### PR TITLE
feat(liquidatable): #1553 add new event params to liquidatable events

### DIFF
--- a/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
@@ -104,7 +104,8 @@ contract Liquidatable is PricelessPositionManager {
         uint256 indexed liquidationId,
         uint256 tokensOutstanding,
         uint256 lockedCollateral,
-        uint256 liquidatedCollateral
+        uint256 liquidatedCollateral,
+        uint256 liquidationTime
     );
     event LiquidationDisputed(
         address indexed sponsor,
@@ -121,7 +122,12 @@ contract Liquidatable is PricelessPositionManager {
         uint256 liquidationId,
         bool disputeSucceeded
     );
-    event LiquidationWithdrawn(address indexed caller, uint256 withdrawalAmount, Status indexed liquidationStatus);
+    event LiquidationWithdrawn(
+        address indexed caller,
+        uint256 withdrawalAmount,
+        Status indexed liquidationStatus,
+        uint256 settlementPrice
+    );
 
     /****************************************
      *              MODIFIERS               *
@@ -295,7 +301,8 @@ contract Liquidatable is PricelessPositionManager {
             liquidationId,
             tokensLiquidated.rawValue,
             lockedCollateral.rawValue,
-            liquidatedCollateral.rawValue
+            liquidatedCollateral.rawValue,
+            getCurrentTime()
         );
 
         // Destroy tokens
@@ -454,7 +461,12 @@ contract Liquidatable is PricelessPositionManager {
         // Decrease the total collateral held in liquidatable by the amount withdrawn.
         amountWithdrawn = _removeCollateral(rawLiquidationCollateral, withdrawalAmount);
 
-        emit LiquidationWithdrawn(msg.sender, amountWithdrawn.rawValue, liquidation.state);
+        emit LiquidationWithdrawn(
+            msg.sender,
+            amountWithdrawn.rawValue,
+            liquidation.state,
+            liquidation.settlementPrice.rawValue
+        );
 
         // Transfer amount withdrawn from this contract to the caller.
         collateralCurrency.safeTransfer(msg.sender, amountWithdrawn.rawValue);

--- a/core/test/financial-templates/Liquidatable.js
+++ b/core/test/financial-templates/Liquidatable.js
@@ -361,14 +361,16 @@ contract("Liquidatable", function(accounts) {
         unreachableDeadline,
         { from: liquidator }
       );
+      const liquidationTime = await liquidationContract.getCurrentTime();
       truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
         return (
-          ev.sponsor == sponsor,
-          ev.liquidator == liquidator,
-          ev.liquidationId == 0,
-          ev.tokensOutstanding == amountOfSynthetic.toString(),
-          ev.lockedCollateral == amountOfCollateral.toString(),
-          ev.liquidatedCollateral == amountOfCollateral.toString()
+          ev.sponsor == sponsor &&
+          ev.liquidator == liquidator &&
+          ev.liquidationId == 0 &&
+          ev.tokensOutstanding == amountOfSynthetic.toString() &&
+          ev.lockedCollateral == amountOfCollateral.toString() &&
+          ev.liquidatedCollateral == amountOfCollateral.toString() &&
+          ev.liquidationTime == liquidationTime.toString()
         );
       });
       truffleAssert.eventEmitted(createLiquidationResult, "EndedSponsorPosition", ev => {
@@ -816,7 +818,8 @@ contract("Liquidatable", function(accounts) {
           return (
             ev.caller == liquidator &&
             ev.withdrawalAmount.toString() == expectedPayout.toString() &&
-            ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED
+            ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED &&
+            ev.settlementPrice.toString() == "0"
           );
         });
       });
@@ -851,7 +854,8 @@ contract("Liquidatable", function(accounts) {
           return (
             ev.caller == disputer &&
             ev.withdrawalAmount.toString() == expectedPayout.toString() &&
-            ev.liquidationStatus.toString() == LiquidationStatesEnum.DISPUTE_SUCCEEDED
+            ev.liquidationStatus.toString() == LiquidationStatesEnum.DISPUTE_SUCCEEDED &&
+            ev.settlementPrice.toString() == settlementPrice.toString()
           );
         });
       });
@@ -1092,7 +1096,8 @@ contract("Liquidatable", function(accounts) {
             return (
               ev.caller == sponsor &&
               ev.withdrawalAmount.toString() == expectedPayment.toString() &&
-              ev.liquidationStatus.toString() == LiquidationStatesEnum.DISPUTE_SUCCEEDED
+              ev.liquidationStatus.toString() == LiquidationStatesEnum.DISPUTE_SUCCEEDED &&
+              ev.settlementPrice.toString() == settlementPrice.toString()
             );
           });
         });
@@ -1222,7 +1227,8 @@ contract("Liquidatable", function(accounts) {
               ev.withdrawalAmount.toString() == expectedPayment.toString() &&
               // State should be uninitialized as the struct has been deleted as a result of the withdrawal.
               // Once a dispute fails and the liquidator withdraws the struct is removed from state.
-              ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED
+              ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED &&
+              ev.settlementPrice.toString() == "0"
             );
           });
         });
@@ -1268,14 +1274,16 @@ contract("Liquidatable", function(accounts) {
       assert.equal((await collateralToken.balanceOf(liquidator)).toString(), "0");
 
       // Liquidated collateral and tokens both equal 0.
+      const liquidationTime = await liquidationContract.getCurrentTime();
       truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
         return (
-          ev.sponsor == sponsor,
-          ev.liquidator == liquidator,
-          ev.liquidationId == 0,
-          ev.tokensOutstanding == "0",
-          ev.lockedCollateral == "0",
-          ev.liquidatedCollateral == "0"
+          ev.sponsor == sponsor &&
+          ev.liquidator == liquidator &&
+          ev.liquidationId == 0 &&
+          ev.tokensOutstanding == "0" &&
+          ev.lockedCollateral == "0" &&
+          ev.liquidatedCollateral == "0" &&
+          ev.liquidationTime == liquidationTime.toString()
         );
       });
 
@@ -1293,7 +1301,6 @@ contract("Liquidatable", function(accounts) {
       // the dispute will always be successful. This is because the required collateral is (TRV * CR) = 0 because tokensOutstanding = 0.
       // So regardless, the liquidated collateral will always be enough to cover the required collateral (even if the liquidated collateral is
       // also 0 in this case).
-      const liquidationTime = await liquidationContract.getCurrentTime();
       await mockOracle.pushPrice(priceFeedIdentifier, liquidationTime, "0");
 
       // Disputer reward is 0 since TRV = 0, so disputer gets back their final fee bond.
@@ -1410,20 +1417,21 @@ contract("Liquidatable", function(accounts) {
         unreachableDeadline,
         { from: liquidator }
       );
+      const liquidationTime = await liquidationContract.getCurrentTime();
       truffleAssert.eventEmitted(createLiquidationResult, "LiquidationCreated", ev => {
         return (
-          ev.sponsor == sponsor,
-          ev.liquidator == liquidator,
-          ev.liquidationId == 0,
-          ev.tokensOutstanding == amountOfSynthetic.toString(),
-          ev.lockedCollateral == amountOfCollateral.toString(),
-          ev.liquidatedCollateral == "0"
+          ev.sponsor == sponsor &&
+          ev.liquidator == liquidator &&
+          ev.liquidationId == liquidationParams.liquidationId &&
+          ev.tokensOutstanding == amountOfSynthetic.toString() &&
+          ev.lockedCollateral == amountOfCollateral.toString() &&
+          ev.liquidatedCollateral == "0" &&
+          ev.liquidationTime == liquidationTime.toString()
         );
       });
       // Since the liquidated collateral:synthetic ratio is 0, even the lowest price (amount of collateral each synthetic is worth)
       // above 0 should result in a failed dispute because the liquidator was correct: there is not enough collateral backing the tokens.
       await liquidationContract.dispute(liquidationParams.liquidationId, sponsor, { from: disputer });
-      const liquidationTime = await liquidationContract.getCurrentTime();
       const disputePrice = "1";
       await mockOracle.pushPrice(priceFeedIdentifier, liquidationTime, disputePrice);
       const withdrawLiquidationResult = await liquidationContract.withdrawLiquidation(
@@ -1439,7 +1447,8 @@ contract("Liquidatable", function(accounts) {
           ev.withdrawalAmount.toString() == expectedPayment.toString() &&
           // State should be uninitialized as the struct has been deleted as a result of the withdrawal.
           // Once a dispute fails and the liquidator withdraws the struct is removed from state.
-          ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED
+          ev.liquidationStatus.toString() == LiquidationStatesEnum.UNINITIALIZED &&
+          ev.settlementPrice.toString() == "0"
         );
       });
     });


### PR DESCRIPTION
specifically updates `LiquidationCreated` and `LiquidationWithdrawn`

![image](https://user-images.githubusercontent.com/4429761/87819194-d1fe0c80-c839-11ea-99ce-962fd1830d2c.png)

There might be room for one more event param if needed.

this references #1553