### PR TITLE
Add script to enable proposing and verifying new collateral currencies

### DIFF
--- a/core/scripts/collateral-umip/1_Propose.js
+++ b/core/scripts/collateral-umip/1_Propose.js
@@ -1,0 +1,73 @@
+// This script generates and submits an identifier-add upgrade transaction to the DVM. It can be run on a local ganache
+// fork of the main net or can be run directly on the main net to execute the upgrade transactions.
+// To run this on the localhost first fork main net into Ganache with the proposerWallet unlocked as follows:
+// ganache-cli --fork https://mainnet.infura.io/v3/d70106f59aef456c9e5bfbb0c2cc7164 --unlock 0x2bAaA41d155ad8a4126184950B31F50A1513cE25
+// Then execute the script as: truffle exec ./scripts/collateral-umip/1_Propose.js --network mainnet-fork --collateral 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --fee 0.1 from core
+
+const AddressWhitelist = artifacts.require("AddressWhitelist");
+const Store = artifacts.require("Store");
+const Governor = artifacts.require("Governor");
+
+const argv = require("minimist")(process.argv.slice(), { string: ["collateral", "fee"] });
+
+const proposerWallet = "0x2bAaA41d155ad8a4126184950B31F50A1513cE25";
+
+async function runExport() {
+  console.log("Running Upgrade🔥");
+  console.log("Connected to network id", await web3.eth.net.getId());
+
+  if (!argv.collateral || !argv.fee) {
+    throw "Must provide --fee and --collateral";
+  }
+
+  // The proposal will first add a final fee for the currency.
+  const store = await Store.deployed();
+  const addFinalFeeToStoreTx = store.contract.methods
+    .setFinalFee(argv.collateral, { rawValue: web3.utils.toWei(argv.fee) })
+    .encodeABI();
+  console.log("addFinalFeeToStoreTx", addFinalFeeToStoreTx);
+
+  // The proposal will then add the currency to the whitelist.
+  const whitelist = await AddressWhitelist.deployed();
+  const addCollateralToWhitelistTx = whitelist.contract.methods.addToWhitelist(argv.collateral).encodeABI();
+  console.log("addCollateralToWhitelistTx", addCollateralToWhitelistTx);
+
+  // Send the proposal
+  const governor = await Governor.deployed();
+  await governor.propose(
+    [
+      {
+        to: store.address,
+        value: 0,
+        data: addFinalFeeToStoreTx
+      },
+      {
+        to: whitelist.address,
+        value: 0,
+        data: addCollateralToWhitelistTx
+      }
+    ],
+    { from: proposerWallet, gas: 2000000 }
+  );
+
+  console.log(`
+
+Proposed collateral currency: ${argv.collateral}
+Proposed final fee: ${argv.fee}
+
+`);
+}
+
+run = async function(callback) {
+  try {
+    await runExport();
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+// Attach this function to the exported function in order to allow the script to be executed through both truffle and a test runner.
+run.runExport = runExport;
+module.exports = run;

--- a/core/scripts/collateral-umip/2_VoteSimulate.js
+++ b/core/scripts/collateral-umip/2_VoteSimulate.js
@@ -1,0 +1,1 @@
+../umip-3/2_VoteSimulate.js

--- a/core/scripts/collateral-umip/3_Verify.js
+++ b/core/scripts/collateral-umip/3_Verify.js
@@ -1,0 +1,41 @@
+// This script verify that the upgrade was executed correctly.
+// It can be run on mainnet after the upgrade is completed or on the local Ganache mainnet fork to validate the
+// execution of the previous two scripts. This script does not need any wallets unlocked and does not make any on-chain
+// state changes. It can be run as:
+// truffle exec ./scripts/creator-umip/3_Verify.js --network mainnet-fork --collateral 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --fee 0.1
+
+const assert = require("assert").strict;
+
+const AddressWhitelist = artifacts.require("AddressWhitelist");
+const Store = artifacts.require("Store");
+
+const argv = require("minimist")(process.argv.slice(), { string: ["collateral", "fee"] });
+
+async function runExport() {
+  console.log("Running Upgrade Verifier🔥");
+
+  if (!argv.collateral || !argv.fee) {
+    throw "Must provide --fee and --collateral";
+  }
+
+  const store = await Store.deployed();
+  assert.equal((await store.computeFinalFee(argv.collateral)).rawValue, web3.utils.toWei(argv.fee));
+
+  const whitelist = await AddressWhitelist.deployed();
+  assert(await whitelist.isOnWhitelist(argv.collateral));
+  console.log("Upgrade Verified!");
+}
+
+run = async function(callback) {
+  try {
+    await runExport();
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+// Attach this function to the exported function in order to allow the script to be executed through both truffle and a test runner.
+run.runExport = runExport;
+module.exports = run;

--- a/core/scripts/collateral-umip/3_Verify.js
+++ b/core/scripts/collateral-umip/3_Verify.js
@@ -2,7 +2,7 @@
 // It can be run on mainnet after the upgrade is completed or on the local Ganache mainnet fork to validate the
 // execution of the previous two scripts. This script does not need any wallets unlocked and does not make any on-chain
 // state changes. It can be run as:
-// truffle exec ./scripts/creator-umip/3_Verify.js --network mainnet-fork --collateral 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --fee 0.1
+// truffle exec ./scripts/collateral-umip/3_Verify.js --network mainnet-fork --collateral 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --fee 0.1
 
 const assert = require("assert").strict;
 


### PR DESCRIPTION
This makes a proposal to add a final fee for the collateral currency and approve the collateral currency.

This will be used to propose [UMIP-10](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-10.md).

Note: this script assumes that the AddressWhitelist address stored in truffle artifacts is the collateral currency whitelist.