### PR TITLE
Add log-level overrides to BalanceMonitor and CRMonitor

### DIFF
--- a/liquidator/liquidator.js
+++ b/liquidator/liquidator.js
@@ -306,7 +306,7 @@ class Liquidator {
       };
 
       // This log level can be overridden by specifying `positionLiquidated` in the `logOverrides`. Otherwise, use info.
-      this.logger[this.logOverrides.positionLiquidated ? this.logOverrides.positionLiquidated : "info"]({
+      this.logger[this.logOverrides.positionLiquidated || "info"]({
         at: "Liquidator",
         message: "Position has been liquidated!🔫",
         position: position,

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -107,7 +107,7 @@ class BalanceMonitor {
       const monitoredAddress = this.web3.utils.toChecksumAddress(bot.address);
 
       if (this.toBN(this.client.getCollateralBalance(monitoredAddress)).lt(this.toBN(bot.collateralThreshold))) {
-        this.logger[this.logOverrides.collateralThreshold ? this.logOverrides.collateralThreshold : "warn"]({
+        this.logger[this.logOverrides.collateralThreshold || "warn"]({
           at: "BalanceMonitor",
           message: "Low collateral balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(
@@ -120,7 +120,7 @@ class BalanceMonitor {
         });
       }
       if (this.toBN(this.client.getSyntheticBalance(monitoredAddress)).lt(this.toBN(bot.syntheticThreshold))) {
-        this.logger[this.logOverrides.syntheticThreshold ? this.logOverrides.syntheticThreshold : "warn"]({
+        this.logger[this.logOverrides.syntheticThreshold || "warn"]({
           at: "BalanceMonitor",
           message: "Low synthetic balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(
@@ -133,7 +133,7 @@ class BalanceMonitor {
         });
       }
       if (this.toBN(this.client.getEtherBalance(monitoredAddress)).lt(this.toBN(bot.etherThreshold))) {
-        this.logger[this.logOverrides.ethThreshold ? this.logOverrides.ethThreshold : "warn"]({
+        this.logger[this.logOverrides.ethThreshold || "warn"]({
           at: "BalanceMonitor",
           message: "Low Ether balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -20,7 +20,9 @@ class BalanceMonitor {
    *         collateralThreshold: x1,
    *         syntheticThreshold: x2,
    *         etherThreshold: x3 },
-   *      ..] }
+   *      ..],
+   *        logOverrides: {syntheticThreshold: "error"}
+   *      }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",

--- a/monitors/BalanceMonitor.js
+++ b/monitors/BalanceMonitor.js
@@ -21,7 +21,7 @@ class BalanceMonitor {
    *         syntheticThreshold: x2,
    *         etherThreshold: x3 },
    *      ..],
-   *        logOverrides: {syntheticThreshold: "error"}
+   *        logOverrides: {syntheticThreshold: "error", collateralThreshold: "error", ethThreshold: "error"}
    *      }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
@@ -107,7 +107,7 @@ class BalanceMonitor {
       const monitoredAddress = this.web3.utils.toChecksumAddress(bot.address);
 
       if (this.toBN(this.client.getCollateralBalance(monitoredAddress)).lt(this.toBN(bot.collateralThreshold))) {
-        this.logger.warn({
+        this.logger[this.logOverrides.collateralThreshold ? this.logOverrides.collateralThreshold : "warn"]({
           at: "BalanceMonitor",
           message: "Low collateral balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(
@@ -133,7 +133,7 @@ class BalanceMonitor {
         });
       }
       if (this.toBN(this.client.getEtherBalance(monitoredAddress)).lt(this.toBN(bot.etherThreshold))) {
-        this.logger.warn({
+        this.logger[this.logOverrides.ethThreshold ? this.logOverrides.ethThreshold : "warn"]({
           at: "BalanceMonitor",
           message: "Low Ether balance warning ⚠️",
           mrkdwn: this._createLowBalanceMrkdwn(

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -155,7 +155,7 @@ class CRMonitor {
           this.formatDecimalString(liquidationPrice) +
           ", the position can be liquidated.";
 
-        this.logger[this.logOverrides.crThreshold ? this.logOverrides.crThreshold : "warn"]({
+        this.logger[this.logOverrides.crThreshold || "warn"]({
           at: "CRMonitor",
           message: "Collateralization ratio alert 🙅‍♂️!",
           mrkdwn: mrkdwn

--- a/monitors/CRMonitor.js
+++ b/monitors/CRMonitor.js
@@ -17,7 +17,9 @@ class CRMonitor {
    *      { walletsToMonitor: [{ name: "Market Making bot", // Friendly bot name
    *            address: "0x12345",                         // Bot address
    *            crAlert: 1.50 },                            // CR alerting threshold to generate an alert message; 1.5=150%
-   *       ...] };
+   *       ...],
+   *        logLevelOverrides: {crThreshold: "error"}       // Log level overrides
+   *      };
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",
             syntheticCurrencySymbol:"ETHBTC",
@@ -58,6 +60,16 @@ class CRMonitor {
               );
             })
           );
+        }
+      },
+      logOverrides: {
+        // Specify an override object to change default logging behaviour. Defaults to no overrides. If specified, this
+        // object is structured to contain key for the log to override and value for the logging level. EG:
+        // { crThreshold:'error' } would override the default `warn` behaviour for CR threshold events.
+        value: {},
+        isValid: overrides => {
+          // Override must be one of the default logging levels: ['error','warn','info','http','verbose','debug','silly']
+          return Object.values(overrides).every(param => Object.keys(this.logger.levels).includes(param));
         }
       }
     };
@@ -143,7 +155,7 @@ class CRMonitor {
           this.formatDecimalString(liquidationPrice) +
           ", the position can be liquidated.";
 
-        this.logger.warn({
+        this.logger[this.logOverrides.crThreshold ? this.logOverrides.crThreshold : "warn"]({
           at: "CRMonitor",
           message: "Collateralization ratio alert 🙅‍♂️!",
           mrkdwn: mrkdwn

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -15,6 +15,7 @@ class SyntheticPegMonitor {
            volatilityWindow: 600,                 // Length of time (in seconds) to snapshot volatility.
            pegVolatilityAlertThreshold: 0.2,      // Threshold for synthetic peg price volatility.
            syntheticVolatilityAlertThreshold: 0.2 // Threshold for synthetic price volatility.
+           logOverrides: {deviation: "error"}     // Log level overrides.
           }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
    *      { collateralCurrencySymbol: "DAI",

--- a/monitors/SyntheticPegMonitor.js
+++ b/monitors/SyntheticPegMonitor.js
@@ -117,7 +117,7 @@ class SyntheticPegMonitor {
     const deviationError = this._calculateDeviationError(uniswapTokenPrice, cryptoWatchTokenPrice);
     // If the percentage error is greater than (gt) the threshold send a message.
     if (deviationError.abs().gt(this.toBN(this.toWei(this.deviationAlertThreshold.toString())))) {
-      this.logger[this.logOverrides.deviation ? this.logOverrides.deviation : "warn"]({
+      this.logger[this.logOverrides.deviation || "warn"]({
         at: "SyntheticPegMonitor",
         message: "Synthetic off peg alert 😵",
         mrkdwn:

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -243,7 +243,9 @@ async function Poll(callback) {
     //  "logOverrides":{                                   // override specific events log levels.
     //       "deviation":"error",                          // SyntheticPegMonitor deviation alert.
     //       "syntheticThreshold":"error",                 // BalanceMonitor synthetic balance threshold alert.
-    //       "crThreshold":"error"}                        // CRMonitor CR threshold alert.
+    //       "crThreshold":"error",                        // CRMonitor CR threshold alert.
+    //       "collateralThreshold":"error",                // BalanceMonitor collateral balance threshold alert.
+    //       "ethThreshold":"error",                       // BalanceMonitor ETH balance threshold alert.
     //   }
     // }
     const monitorConfig = process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null;

--- a/monitors/index.js
+++ b/monitors/index.js
@@ -240,7 +240,11 @@ async function Poll(callback) {
     //  "volatilityWindow": 600,                           // Length of time (in seconds) to snapshot volatility.
     //  "pegVolatilityAlertThreshold": 0.1,                // Threshold for synthetic peg (identifier) price volatility over `volatilityWindow`.
     //  "syntheticVolatilityAlertThreshold": 0.1,          // Threshold for synthetic token on uniswap price volatility over `volatilityWindow`.
-    //  "logOverrides":{"deviation":"error","syntheticThreshold":"error"}} -> override specific events log levels.
+    //  "logOverrides":{                                   // override specific events log levels.
+    //       "deviation":"error",                          // SyntheticPegMonitor deviation alert.
+    //       "syntheticThreshold":"error",                 // BalanceMonitor synthetic balance threshold alert.
+    //       "crThreshold":"error"}                        // CRMonitor CR threshold alert.
+    //   }
     // }
     const monitorConfig = process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null;
 

--- a/monitors/test/BalanceMonitor.js
+++ b/monitors/test/BalanceMonitor.js
@@ -352,17 +352,5 @@ contract("BalanceMonitor.js", function(accounts) {
     assert.isTrue(lastSpyLogIncludes(spy, "Liquidator bot")); // name of bot from bot object
     assert.isTrue(lastSpyLogIncludes(spy, "Ether balance warning"));
     assert.equal(lastSpyLogLevel(spy), "error");
-
-    // await syntheticToken.transfer(tokenCreator, toWei("1001"), { from: liquidatorBot });
-    // assert.equal((await syntheticToken.balanceOf(liquidatorBot)).toString(), toBN(toWei("9999")).toString());
-
-    // // Update monitors.
-    // await tokenBalanceClient.update();
-    // await balanceMonitor.checkBotBalances();
-
-    // assert.equal(spy.callCount, 1);
-    // assert.isTrue(lastSpyLogIncludes(spy, "Liquidator bot")); // name of bot from bot object
-    // assert.isTrue(lastSpyLogIncludes(spy, "synthetic balance warning")); // Tx moved synthetic. should emit accordingly
-    // assert.equal(lastSpyLogLevel(spy), "error");
   });
 });


### PR DESCRIPTION
New log level overrides for the following alerts
- collateralThreshold: when a bot's collateral token balance falls below a threshold
- ethThreshold: when a bot's ETH balance falls below a threshold
- crThreshold: when a monitored wallet's CR falls below a threshold

Updated unit tests as well