### PR TITLE
feat(voting): #1763 require snapshot EOA validation before running reveal

### DIFF
--- a/common/Crypto.js
+++ b/common/Crypto.js
@@ -69,9 +69,9 @@ async function deriveKeyPairFromSignatureTruffle(web3, messageToSign, signingAcc
 }
 
 // Signs a message in a way where it can be verified onchain by the openzeppelin ECDSA library.
-async function signMessage(web3, account, message) {
+async function signMessage(web3, message, account) {
   // Must hash the inner message because Solidity requires a fixed length message to verify a signature.
-  const innerMessageHash = web3.utils.soliditySha3(message);
+  const innerMessageHash = await web3.utils.soliditySha3(message);
 
   // Construct a signature that will be accepted by openzeppelin.
   // See https://github.com/OpenZeppelin/openzeppelin-solidity/blob/1e584e495782ebdb5096fe65037d99dae1cbe940/contracts/cryptography/ECDSA.sol#L53
@@ -94,5 +94,6 @@ module.exports = {
   recoverPublicKey,
   deriveKeyPairFromSignatureTruffle,
   deriveKeyPairFromSignatureMetamask,
+  getMessageSignatureTruffle,
   signMessage
 };

--- a/common/TruffleConfig.js
+++ b/common/TruffleConfig.js
@@ -184,7 +184,7 @@ const TruffleConfig = {
   },
   compilers: {
     solc: {
-      version: "0.6.6",
+      version: "0.6.12",
       settings: {
         optimizer: {
           enabled: true,

--- a/core/buidler.config.js
+++ b/core/buidler.config.js
@@ -26,7 +26,7 @@ task("test")
 
 module.exports = {
   solc: {
-    version: "0.6.6",
+    version: "0.6.12",
     optimizer: {
       enabled: true,
       runs: 200

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -396,7 +396,7 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
         );
 
         // To protect against flash loans, we require snapshot be validated as EOA.
-        require(rounds[roundId].snapshotId != 0, "Round must be snapshotted before reveal can happen");
+        require(rounds[roundId].snapshotId != 0, "Round has no snapshot");
 
         // Get the frozen snapshotId
         uint256 snapshotId = rounds[roundId].snapshotId;

--- a/core/contracts/oracle/implementation/Voting.sol
+++ b/core/contracts/oracle/implementation/Voting.sol
@@ -15,6 +15,7 @@ import "./Constants.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 
 
 /**
@@ -123,6 +124,8 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
 
     // Max value of an unsigned integer.
     uint256 private constant UINT_MAX = ~uint256(0);
+
+    bytes32 public snapshotMessage = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked("Sign For Snapshot")));
 
     /***************************************
      *                EVENTS                *
@@ -347,11 +350,13 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
      * @notice Snapshot the current round's token balances and lock in the inflation rate and GAT.
      * @dev This function can be called multiple times, but only the first call per round into this function or `revealVote`
      * will create the round snapshot. Any later calls will be a no-op. Will revert unless called during reveal period.
+     * @param signature  signature required to prove you are EOA to prevent flash loan issue.
      */
-    function snapshotCurrentRound() external override onlyIfNotMigrated() {
+    function snapshotCurrentRound(bytes calldata signature) external override onlyIfNotMigrated() {
         uint256 blockTime = getCurrentTime();
         require(voteTiming.computeCurrentPhase(blockTime) == Phase.Reveal, "Only snapshot in reveal phase");
-
+        // require public snapshot require signature to ensure EOA caller
+        require(ECDSA.recover(snapshotMessage, signature) == msg.sender, "Signature must match sender");
         uint256 roundId = voteTiming.computeCurrentRoundId(blockTime);
         _freezeRoundVariables(roundId);
     }
@@ -388,14 +393,14 @@ contract Voting is Testable, Ownable, OracleInterface, VotingInterface {
             keccak256(abi.encodePacked(price, salt, msg.sender, time, roundId, identifier)) == voteSubmission.commit,
             "Revealed data != commit hash"
         );
-        delete voteSubmission.commit;
 
-        // Lock in round variables including snapshotId and inflation rate. Not that this will only execute a snapshot
-        // if the `snapshotCurrentRound` function was not already called for this round.
-        _freezeRoundVariables(roundId);
+        // to protect against flash loans, we require snapshot be validated as EOA
+        require(rounds[roundId].snapshotId != 0, "Round must be snapshotted before reveal can happen");
 
         // Get the frozen snapshotId
         uint256 snapshotId = rounds[roundId].snapshotId;
+
+        delete voteSubmission.commit;
 
         // Get the voter's snapshotted balance. Since balances are returned pre-scaled by 10**18, we can directly
         // initialize the Unsigned value with the returned uint.

--- a/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -69,7 +69,7 @@ abstract contract VotingInterface {
      * @dev This function can be called multiple times but each round will only every have one snapshot at the
      * time of calling `_freezeRoundVariables`.
      */
-    function snapshotCurrentRound() external virtual;
+    function snapshotCurrentRound(bytes calldata signature) external virtual;
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.

--- a/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -68,6 +68,8 @@ abstract contract VotingInterface {
      * @notice snapshot the current round's token balances and lock in the inflation rate and GAT.
      * @dev This function can be called multiple times but each round will only every have one snapshot at the
      * time of calling `_freezeRoundVariables`.
+     * @param signature  signature required to prove caller is an EOA to prevent flash loans from being included in the
+     * snapshot.
      */
     function snapshotCurrentRound(bytes calldata signature) external virtual;
 

--- a/core/scripts/Voting.js
+++ b/core/scripts/Voting.js
@@ -454,7 +454,7 @@ class SendgridNotifier {
 }
 
 class VotingSystem {
-  constructor(voting, account, notifiers, signature, snapshotMessage = "Sign For Snapshot") {
+  constructor(voting, account, notifiers, snapshotMessage = "Sign For Snapshot") {
     this.voting = voting;
     this.account = account;
     this.notifiers = notifiers;

--- a/core/test/oracle/Governor.js
+++ b/core/test/oracle/Governor.js
@@ -1,4 +1,10 @@
-const { RegistryRolesEnum, didContractThrow, getRandomUnsignedInt, computeVoteHash } = require("@umaprotocol/common");
+const {
+  RegistryRolesEnum,
+  didContractThrow,
+  getRandomUnsignedInt,
+  computeVoteHash,
+  signMessage
+} = require("@umaprotocol/common");
 const { moveToNextRound, moveToNextPhase } = require("../../utils/Voting.js");
 const { interfaceName } = require("../../utils/Constants.js");
 const truffleAssert = require("truffle-assertions");
@@ -16,6 +22,7 @@ const Finder = artifacts.require("Finder");
 
 // Extract web3 functions into primary namespace.
 const { toBN, toWei, hexToUtf8, utf8ToHex } = web3.utils;
+const snapshotMessage = "Sign For Snapshot";
 
 contract("Governor", function(accounts) {
   let voting;
@@ -24,6 +31,7 @@ contract("Governor", function(accounts) {
   let supportedIdentifiers;
   let finder;
   let timer;
+  let signature;
 
   const proposer = accounts[0];
   const account2 = accounts[1];
@@ -59,6 +67,8 @@ contract("Governor", function(accounts) {
     // To work, the governor must be the owner of the IdentifierWhitelist contracts. This is not the default setup in the test
     // environment, so ownership must be transferred.
     await supportedIdentifiers.transferOwnership(governor.address);
+
+    signature = await signMessage(web3, snapshotMessage, proposer);
   });
 
   beforeEach(async function() {
@@ -198,6 +208,7 @@ contract("Governor", function(accounts) {
     await voting.commitVote(request1.identifier, request1.time, hash1);
     await voting.commitVote(request2.identifier, request2.time, hash2);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request1.identifier, request1.time, vote, salt);
     await voting.revealVote(request2.identifier, request2.time, vote, salt);
     await moveToNextRound(voting);
@@ -239,6 +250,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -282,6 +294,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -328,6 +341,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -380,6 +394,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -422,6 +437,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -466,6 +482,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -511,6 +528,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -554,6 +572,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash2, { from: account2 });
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt, { from: account2 });
     await moveToNextRound(voting);
 
@@ -574,6 +593,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash1);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
   });
@@ -609,6 +629,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -658,6 +679,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -703,6 +725,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 
@@ -784,6 +807,7 @@ contract("Governor", function(accounts) {
     });
     await voting.commitVote(request.identifier, request.time, hash);
     await moveToNextPhase(voting);
+    await voting.snapshotCurrentRound(signature);
     await voting.revealVote(request.identifier, request.time, vote, salt);
     await moveToNextRound(voting);
 

--- a/core/test/oracle/Voting.js
+++ b/core/test/oracle/Voting.js
@@ -131,8 +131,8 @@ contract("Voting", function(accounts) {
     // no sig passed should fail
     assert(await didContractThrow(voting.snapshotCurrentRound()));
 
-    // random bytes shoudl fail
-    assert(await didContractThrow(voting.snapshotCurrentRound(web3.utils.randomHex(32))));
+    // random bytes should fail
+    assert(await didContractThrow(voting.snapshotCurrentRound(web3.utils.randomHex(65))));
 
     // wrong signer
     const badsig1 = await signMessage(web3, snapshotMessage, account2);
@@ -142,10 +142,8 @@ contract("Voting", function(accounts) {
     const badsig2 = await signMessage(web3, snapshotMessage.toLowerCase(), account1);
     assert(await didContractThrow(voting.snapshotCurrentRound(badsig2)));
 
-    assert(await didContractThrow(voting.snapshotCurrentRound(web3.utils.randomHex(32))));
-
     // this should not throw
-    voting.snapshotCurrentRound(signature);
+    await voting.snapshotCurrentRound(signature);
   });
 
   it("One voter, one request", async function() {

--- a/core/test/scripts/Voting.js
+++ b/core/test/scripts/Voting.js
@@ -116,6 +116,7 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(result.skipped.length, 0);
     assert.equal(result.failures.length, 0);
     assert.equal(notifier.notificationsSent, 1);
+
     // Running again should send more emails but not execute any batch commits.
     result = await votingSystem.runIteration(USE_PROD_LOGS);
     assert.equal(result.batches, 0);
@@ -126,6 +127,8 @@ contract("scripts/Voting.js", function(accounts) {
 
     // Move to the reveal phase.
     await moveToNextPhase(voting);
+
+    await votingSystem.runSnapshot();
 
     // Replace the voting system object with a new one so the class can't persist the commit.
     votingSystem = new VotingScript.VotingSystem(voting, voter, [notifier]);
@@ -172,6 +175,8 @@ contract("scripts/Voting.js", function(accounts) {
     // Move to the reveal phase.
     await moveToNextPhase(voting);
 
+    await votingSystem.runSnapshot();
+
     // Replace the voting system object with a new one so the class can't persist the commit.
     votingSystem = new VotingScript.VotingSystem(voting, voter, [notifier]);
     result = await votingSystem.runIteration(USE_PROD_LOGS);
@@ -207,6 +212,8 @@ contract("scripts/Voting.js", function(accounts) {
 
     // Move to the reveal phase.
     await moveToNextPhase(voting);
+
+    await votingSystem.runSnapshot();
 
     // Replace the voting system object with a new one so the class can't persist the commits.
     votingSystem = new VotingScript.VotingSystem(voting, voter, [notifier]);
@@ -254,6 +261,7 @@ contract("scripts/Voting.js", function(accounts) {
     votingSystem.voting.batchCommit = temp;
     await votingSystem.runIteration(USE_PROD_LOGS);
     await moveToNextPhase(voting);
+    await votingSystem.runSnapshot();
     await votingSystem.runIteration(USE_PROD_LOGS);
     await moveToNextRound(voting);
   });
@@ -272,7 +280,10 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(result.updates.length, 1);
     assert.equal(result.skipped.length, 0);
     assert.equal(result.failures.length, 0);
+
     await moveToNextPhase(voting);
+    await votingSystem.runSnapshot();
+
     result = await votingSystem.runIteration(USE_PROD_LOGS);
     assert.equal(result.batches, 1);
     assert.equal(result.updates.length, 1);
@@ -311,6 +322,7 @@ contract("scripts/Voting.js", function(accounts) {
     assert.equal(result.skipped.length, 0);
     assert.equal(result.failures.length, 0);
     await moveToNextPhase(voting);
+    await votingSystem.runSnapshot();
     result = await votingSystem.runIteration(USE_PROD_LOGS);
     assert.equal(result.batches, 1);
     assert.equal(result.updates.length, 1);
@@ -355,6 +367,7 @@ contract("scripts/Voting.js", function(accounts) {
 
     // Move to reveal phase.
     await moveToNextPhase(voting);
+    await votingSystem.runSnapshot();
     pendingVotes = await voting.getPendingRequests();
     assert.equal(
       pendingVotes.length,


### PR DESCRIPTION
BREAKING CHANGE: snapshotting no longer is automatic on first reveal and must be run as a seperate call!

This is a first attempt at implementing solution #4 defined in https://docs.google.com/document/d/11ap5q2ga2OaVIV6MLxpRjzbLZTr0xraUIt2DdfcyzWI/edit#

This introduces a breaking API change, requiring you to verify your signature when snapshot is taken before reveal. Snapshotting no longer happens automatically in the reveal. This could technically be included in reveal, but the combination of the signature being optional for most reveals (since snapshot happens once) and adding signature argument to reveal would require a few other functions changing, meant that it was cleaner to isolate snapshotting. I will leave it up to debate as to what the right design is here. 

Tests have been updated to incorporate this new voting flow, and one test has been removed which tested automatic snapshotting on first reveal. 
