### PR TITLE
Liquidity mining unit tests

### DIFF
--- a/core/scripts/liquidity-mining/CalculateBalancerLPProviders.js
+++ b/core/scripts/liquidity-mining/CalculateBalancerLPProviders.js
@@ -5,7 +5,9 @@
 // provided by for each liquidity provider to the single whitelisted pool.
 // -> For each snapshot block, calculate the $UMA rewards to be received by each liquidity provider based on the target weekly distribution.
 
-// Example usage from core: node ./scripts/liquidity-mining/CalculateBalancerLPProviders.js --poolAddress="0x0099447ef539718bba3c4d4d4b4491d307eedc53" --fromDate="2020-07-06" --toDate="2020-07-13" --week=1
+// Example usage from core: truffle exec ./scripts/liquidity-mining/calculateBalancerLPProviders.js --network mainnet_mnemonic--poolAddress="0x0099447ef539718bba3c4d4d4b4491d307eedc53" --fromDate="2020-07-06" --toDate="2020-07-13" --week=1
+
+// Set the archival node using: export CUSTOM_NODE_URL=<your node here>
 
 const moment = require("moment");
 const cliProgress = require("cli-progress");
@@ -30,12 +32,12 @@ const UMA_PER_WEEK = toBN(toWei("25000"));
 const BLOCKS_PER_SNAPSHOT = 64;
 let umaPerSnapshot;
 
-async function main() {
+async function calculateBalancerLPProviders(fromDate, toDate, poolAddress, week) {
   // Create two moment objects from the input string. Convert to UTC time zone. As no time is provided in the input
   // will parse to 12:00am UTC.
-  const fromDate = moment.utc(argv.fromDate, "YYYY-MM-DD");
-  const toDate = moment.utc(argv.toDate, "YYYY-MM-DD");
-  if (!web3.utils.isAddress(argv.poolAddress) || !fromDate.isValid() || !toDate.isValid() || !argv.week) {
+  fromDate = moment.utc(fromDate, "YYYY-MM-DD");
+  toDate = moment.utc(toDate, "YYYY-MM-DD");
+  if (!web3.utils.isAddress(poolAddress) || !fromDate.isValid() || !toDate.isValid() || !week) {
     throw "Missing or invalid parameter! Provide poolAddress, fromDate, toDate & week. fromDate and toDate must be strings formatted YYYY-MM-DD";
   }
 
@@ -57,7 +59,10 @@ async function main() {
     }
   });
 
+  // Calculate the total number of snapshots over the interval.
   const snapshotsToTake = Math.ceil((toBlock - fromBlock) / BLOCKS_PER_SNAPSHOT);
+
+  // $UMA per snapshot is the total $UMA for a given week, divided by the number of snapshots to take.
   umaPerSnapshot = UMA_PER_WEEK.div(toBN(snapshotsToTake.toString()));
   console.log(
     `🔎 Capturing ${snapshotsToTake} snapshots and distributing ${fromWei(
@@ -68,18 +73,44 @@ async function main() {
   );
 
   console.log("⚖️  Finding balancer pool info...");
-  const poolInfo = await utils.fetchBalancerPoolInfo(argv.poolAddress);
+  // Get the information on a particular pool. This includes a mapping of all previous token holders (shareholders).
+  const poolInfo = await utils.fetchBalancerPoolInfo(poolAddress);
 
+  // Extract the addresses of all historic shareholders.
   const shareHolders = poolInfo.shares.flatMap(a => a.userAddress.id);
   console.log("🏖  Number of historic liquidity providers:", shareHolders.length);
 
+  let bPool = new web3.eth.Contract(poolAbi.abi, poolAddress);
+
+  const shareHolderPayout = await _calculatePayoutsBetweenBlocks(
+    bPool,
+    shareHolders,
+    fromBlock,
+    toBlock,
+    BLOCKS_PER_SNAPSHOT,
+    umaPerSnapshot,
+    snapshotsToTake
+  );
+
+  console.log("🎉 Finished calculating payouts!");
+  _saveShareHolderPayout(shareHolderPayout, week);
+}
+
+// Calculate the payout to a list of `shareHolders` between `fromBlock` and `toBlock`. Split the block window up into
+// chunks of `blockPerSnapshot` and at each chunk assign `umaPerSnapshot` at a prorata basis.
+async function _calculatePayoutsBetweenBlocks(
+  bPool,
+  shareHolders,
+  fromBlock,
+  toBlock,
+  blockPerSnapshot,
+  umaPerSnapshot
+) {
   // Create a structure to store the payouts for all historic shareholders.
   let shareHolderPayout = {};
   for (shareHolder of shareHolders) {
     shareHolderPayout[shareHolder] = toBN("0");
   }
-
-  let bPool = new web3.eth.Contract(poolAbi.abi, argv.poolAddress);
 
   console.log("🏃‍♂️Iterating over block range and calculating payouts...");
 
@@ -90,22 +121,22 @@ async function main() {
     },
     cliProgress.Presets.shades_classic
   );
-  progressBar.start(snapshotsToTake, 0);
-
-  for (currentBlock = fromBlock; currentBlock < toBlock; currentBlock += BLOCKS_PER_SNAPSHOT) {
-    shareHolderPayout = await _updatePayoutAtBlock(currentBlock, shareHolderPayout, bPool);
-    progressBar.update(Math.ceil((currentBlock - fromBlock) / BLOCKS_PER_SNAPSHOT));
+  progressBar.start(Math.ceil((toBlock - fromBlock) / blockPerSnapshot), 0);
+  for (currentBlock = fromBlock; currentBlock < toBlock; currentBlock += blockPerSnapshot) {
+    shareHolderPayout = await _updatePayoutAtBlock(bPool, currentBlock, shareHolderPayout, umaPerSnapshot);
+    progressBar.update(Math.ceil((currentBlock - fromBlock) / blockPerSnapshot) + 1);
   }
   progressBar.stop();
 
-  console.log("🎉 Finished calculating payouts!");
-  _saveShareHolderPayout(shareHolderPayout);
+  return shareHolderPayout;
 }
 
-// For a given block number, return an updated shareHolderPayout object that has appended payouts for a given bPool.
-async function _updatePayoutAtBlock(blockNumber, shareHolderPayout, bPool) {
+// For a given `blockNumber` (snapshot in time), return an updated `shareHolderPayout` object that has appended
+// payouts for a given `bPool` at a rate of `umaPerSnapshot`.
+async function _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, umaPerSnapshot) {
   // Get the total supply of Balancer Pool tokens at the given snapshot's block number.
   const bptSupplyAtSnapshot = toBN(await bPool.methods.totalSupply().call(undefined, blockNumber));
+
   // Get the given holders balance at the given block. Generate an array of promises to resolve in parallel.
   let promiseArray = [];
   for (shareHolder of Object.keys(shareHolderPayout)) {
@@ -125,7 +156,7 @@ async function _updatePayoutAtBlock(blockNumber, shareHolderPayout, bPool) {
       .div(bptSupplyAtSnapshot);
 
     // The payout at the snapshot for the holder is their pro-rata fraction of per-snapshot rewards.
-    const shareHolderPayoutAtSnapshot = shareHolderFractionAtSnapshot.mul(umaPerSnapshot).div(toBN(toWei("1")));
+    const shareHolderPayoutAtSnapshot = shareHolderFractionAtSnapshot.mul(toBN(umaPerSnapshot)).div(toBN(toWei("1")));
 
     // Lastly, update the payout object for the given shareholder. This is their previous payout value + their new payout.
     const shareHolderAddress = Object.keys(shareHolderPayout)[index];
@@ -135,23 +166,33 @@ async function _updatePayoutAtBlock(blockNumber, shareHolderPayout, bPool) {
 }
 
 // Generate a json file containing the shareholder output address and associated $UMA token payouts.
-function _saveShareHolderPayout(shareHolderPayout) {
+function _saveShareHolderPayout(shareHolderPayout, week) {
   // First, clean the shareHolderPayout of all zero recipients and convert from wei scaled number.
   for (shareHolder of Object.keys(shareHolderPayout)) {
     if (shareHolderPayout[shareHolder] == "0") delete shareHolderPayout[shareHolder];
     else shareHolderPayout[shareHolder] = fromWei(shareHolderPayout[shareHolder]);
   }
 
-  const savePath = `${path.resolve(__dirname)}/weekly-payouts/${argv.week}_week_UMAsToDistribute.json`;
+  const savePath = `${path.resolve(__dirname)}/weekly-payouts/${week}_week_UMAsToDistribute.json`;
   fs.writeFile(savePath, JSON.stringify(shareHolderPayout), err => {
     if (err) return console.error(err);
     console.log("🗄  File successfully written to", savePath);
   });
 }
 
-main()
-  .then(() => {})
-  .catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+// Function with a callback structured like this is required to enable `truffle exec` to run this script.
+async function Main(callback) {
+  try {
+    // Pull the parameters from process arguments. specifying them like this lets tests add its own.
+    await calculateBalancerLPProviders(argv.fromDate, argv.toDate, argv.poolAddress, argv.week);
+  } catch (error) {
+    console.error(error);
+  }
+  callback();
+}
+
+// Each function is then appended onto to the `Main` which is exported. This enables
+Main.calculateBalancerLPProviders = calculateBalancerLPProviders;
+Main._calculatePayoutsBetweenBlocks = _calculatePayoutsBetweenBlocks;
+Main._updatePayoutAtBlock = _updatePayoutAtBlock;
+module.exports = Main;

--- a/core/scripts/liquidity-mining/CalculateBalancerLPProviders.js
+++ b/core/scripts/liquidity-mining/CalculateBalancerLPProviders.js
@@ -5,7 +5,7 @@
 // provided by for each liquidity provider to the single whitelisted pool.
 // -> For each snapshot block, calculate the $UMA rewards to be received by each liquidity provider based on the target weekly distribution.
 
-// Example usage from core: truffle exec ./scripts/liquidity-mining/calculateBalancerLPProviders.js --network mainnet_mnemonic--poolAddress="0x0099447ef539718bba3c4d4d4b4491d307eedc53" --fromDate="2020-07-06" --toDate="2020-07-13" --week=1
+// Example usage from core: truffle exec ./scripts/liquidity-mining/calculateBalancerLPProviders.js --network mainnet_mnemonic --poolAddress="0x0099447ef539718bba3c4d4d4b4491d307eedc53" --fromDate="2020-07-06" --toDate="2020-07-13" --week=1
 
 // Set the archival node using: export CUSTOM_NODE_URL=<your node here>
 

--- a/core/scripts/liquidity-mining/test/CalculateBalancerLPProviders.js
+++ b/core/scripts/liquidity-mining/test/CalculateBalancerLPProviders.js
@@ -41,8 +41,12 @@ contract("CalculateBalancerLPProviders.js", function(accounts) {
       const tokensPerSnapShot = toWei("5");
 
       // Call the `_updatePayoutAtBlock` to get the distribution at a given `blockNumber`.
-      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
-      const payoutAtBlock = await _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, tokensPerSnapShot);
+      const payoutAtBlock = await _updatePayoutAtBlock(
+        bpToken.contract,
+        blockNumber,
+        shareHolderPayout,
+        tokensPerSnapShot
+      );
 
       // Validate that each shareholder got the right number of tokens for the given block. Expecting 1/5 of all rewards
       // per shareholder as equal token distribution.
@@ -68,8 +72,12 @@ contract("CalculateBalancerLPProviders.js", function(accounts) {
       const tokensPerSnapShot = toWei("5");
 
       // Call the `_updatePayoutAtBlock` to get the distribution at a given `blockNumber`.
-      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
-      const payoutAtBlock = await _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, tokensPerSnapShot);
+      const payoutAtBlock = await _updatePayoutAtBlock(
+        bpToken.contract,
+        blockNumber,
+        shareHolderPayout,
+        tokensPerSnapShot
+      );
 
       // Validate that the single shareholder got all rewards and all other shareholders got none at the given block.
       assert.equal(payoutAtBlock[shareHolders[0]].toString(), tokensPerSnapShot);
@@ -99,8 +107,12 @@ contract("CalculateBalancerLPProviders.js", function(accounts) {
       const tokensPerSnapShot = toWei("10");
 
       // Call the `_updatePayoutAtBlock` to get the distribution at a given `blockNumber`.
-      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
-      const payoutAtBlock = await _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, tokensPerSnapShot);
+      const payoutAtBlock = await _updatePayoutAtBlock(
+        bpToken.contract,
+        blockNumber,
+        shareHolderPayout,
+        tokensPerSnapShot
+      );
 
       // Validate the two shareholders got the correct proportion of token rewards.
       // shareHolder0 expected payout is their pool tokens (10e18) divided by the total pool prevision(10e18+100).
@@ -161,10 +173,9 @@ contract("CalculateBalancerLPProviders.js", function(accounts) {
       assert.equal(endingBlockNumber, startingBlockNumber + blocksToAdvance); // Should have advanced 10 blocks.
 
       const rewardsPerSnapshot = toWei("10"); // For each snapshot in time, payout 10e18 tokens
-      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
 
       const intervalPayout = await Main._calculatePayoutsBetweenBlocks(
-        bPool,
+        bpToken.contract,
         shareHolders,
         startingBlockNumber,
         endingBlockNumber,
@@ -213,9 +224,9 @@ contract("CalculateBalancerLPProviders.js", function(accounts) {
       assert.equal(endingBlockNumber, startingBlockNumber + blocksToAdvance);
 
       const rewardsPerSnapshot = toWei("10"); // For each snapshot in time, payout 10e18 tokens
-      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+
       const intervalPayout = await Main._calculatePayoutsBetweenBlocks(
-        bPool,
+        bpToken.contract,
         shareHolders,
         startingBlockNumber,
         endingBlockNumber,
@@ -318,9 +329,8 @@ contract("CalculateBalancerLPProviders.js", function(accounts) {
       // Check that we have traversed the right number of blocks.
       assert.equal(endingBlockNumber, startingBlockNumber + totalBlocksToAdvance);
 
-      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
       const intervalPayout = await Main._calculatePayoutsBetweenBlocks(
-        bPool,
+        bpToken.contract,
         [...shareHolders, newShareHolder],
         startingBlockNumber,
         endingBlockNumber,

--- a/core/scripts/liquidity-mining/test/CalculateBalancerLPProviders.js
+++ b/core/scripts/liquidity-mining/test/CalculateBalancerLPProviders.js
@@ -1,0 +1,343 @@
+// These unit tests validate that the Balancer LP provider script correctly calculates token payouts.
+
+const { toWei, toBN } = web3.utils;
+
+const {
+  mineTransactionsAtTime,
+  advanceBlockAndSetTime,
+  takeSnapshot,
+  revertToSnapshot
+} = require("@umaprotocol/common");
+
+const Main = require("../CalculateBalancerLPProviders"); // Script to test.
+const { _updatePayoutAtBlock } = require("../CalculateBalancerLPProviders");
+
+const Token = artifacts.require("ExpandedERC20"); // Helper contracts to mock balancer pool.
+
+let bpToken; // balancerPoolToken. Used to mock liquidity provision.
+
+contract("CalculateBalancerLPProviders.js", function(accounts) {
+  const contractCreator = accounts[0];
+  const shareHolders = accounts.slice(1, 6); // Array of accounts 1 -> 5 to represent shareholders(liquidity providers).
+
+  describe("Correctly calculates payout at a given block number (_updatePayoutAtBlock)", function() {
+    beforeEach(async function() {
+      bpToken = await Token.new("BPT", "BPT", 18, {
+        from: contractCreator
+      });
+      await bpToken.addMember(1, contractCreator, {
+        from: contractCreator
+      });
+    });
+
+    it("Correctly splits payout over all liquidity providers (balanced case)", async function() {
+      // Create 10e18 tokens to distribute, sending 2e18 to each liquidity provider.
+      for (shareHolder of shareHolders) {
+        await bpToken.mint(shareHolder, toWei("2"), { from: contractCreator });
+      }
+      // Create an object to store the payouts for a given block. This should be an object with key being the
+      // shareholder address and value being their respective payout.
+      let shareHolderPayout = {};
+      for (shareHolder of shareHolders) {
+        shareHolderPayout[shareHolder] = toBN("0");
+      }
+
+      const blockNumber = await web3.eth.getBlockNumber();
+      // Distribute 5 tokens per snapshot. As there are 5 shareholders, each holding 2e18 tokens, we should expect that
+      // each shareholder should be attributed 1/5 of the total rewards, equalling 1e18 each.
+      const tokensPerSnapShot = toWei("5");
+
+      // Call the `_updatePayoutAtBlock` to get the distribution at a given `blockNumber`.
+      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+      const payoutAtBlock = await _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, tokensPerSnapShot);
+
+      // Validate that each shareholder got the right number of tokens for the given block. Expecting 1/5 of all rewards
+      // per shareholder as equal token distribution.
+      const expectedPayoutPerShareholder = toBN(tokensPerSnapShot).divn(shareHolders.length);
+      for (shareholder of shareHolders) {
+        assert.equal(payoutAtBlock[shareHolder].toString(), expectedPayoutPerShareholder.toString());
+      }
+    });
+    it("Correctly splits payout over all liquidity providers (unbalanced case)", async function() {
+      // Create 10e18 tokens to distribute, sending all to one liquidity provider.
+      await bpToken.mint(shareHolders[0], toWei("10"), { from: contractCreator });
+
+      // Create an object to store the payouts for a given block. This should be an object with key being the
+      // shareholder address and value being their respective payout.
+      let shareHolderPayout = {};
+      for (shareHolder of shareHolders) {
+        shareHolderPayout[shareHolder] = toBN("0");
+      }
+
+      const blockNumber = await web3.eth.getBlockNumber();
+      // Distribute 5 tokens per snapshot. There is only one shareholder who holds tokens at the given block number. They
+      // should exclusively receive all token payouts.
+      const tokensPerSnapShot = toWei("5");
+
+      // Call the `_updatePayoutAtBlock` to get the distribution at a given `blockNumber`.
+      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+      const payoutAtBlock = await _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, tokensPerSnapShot);
+
+      // Validate that the single shareholder got all rewards and all other shareholders got none at the given block.
+      assert.equal(payoutAtBlock[shareHolders[0]].toString(), tokensPerSnapShot);
+      const expectedPayoutPerOtherShareholder = toWei("0");
+      for (shareholder of shareHolders.slice(1, 6)) {
+        assert.equal(payoutAtBlock[shareHolder].toString(), expectedPayoutPerOtherShareholder.toString());
+      }
+    });
+    it("Correctly splits payout over all liquidity providers (extreme fractional case)", async function() {
+      // Create 10e18 tokens to distribute, sending all to one LP and send 100 wei of tokens to another provider.
+      await bpToken.mint(shareHolders[0], toWei("10"), {
+        from: contractCreator
+      }); // shareholder0 gets 10e18 tokens
+      await bpToken.mint(shareHolders[1], "100", {
+        from: contractCreator
+      }); // Shareholder1 gets 100 token. (100 wei)
+
+      // Create an object to store the payouts for a given block. This should be an object with key being the
+      // shareholder address and value being their respective payout.
+      let shareHolderPayout = {};
+      for (shareHolder of shareHolders) {
+        shareHolderPayout[shareHolder] = toBN("0");
+      }
+
+      const blockNumber = await web3.eth.getBlockNumber();
+      // Distribute 10e18 $UMA tokens per snapshot.
+      const tokensPerSnapShot = toWei("10");
+
+      // Call the `_updatePayoutAtBlock` to get the distribution at a given `blockNumber`.
+      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+      const payoutAtBlock = await _updatePayoutAtBlock(bPool, blockNumber, shareHolderPayout, tokensPerSnapShot);
+
+      // Validate the two shareholders got the correct proportion of token rewards.
+      // shareHolder0 expected payout is their pool tokens (10e18) divided by the total pool prevision(10e18+100).
+      const shareHolder0Frac = toBN(toWei("10")) // fraction of the pool is their contribution/total pool
+        .mul(toBN(toWei("1")))
+        .div(toBN(toWei("10")).addn(100));
+
+      const expectedShareHolder0Payout = toBN(tokensPerSnapShot) // The total tokens per snapshot * by their pool ratio.
+        .mul(shareHolder0Frac)
+        .div(toBN(toWei("1")));
+
+      assert.equal(payoutAtBlock[shareHolders[0]].toString(), expectedShareHolder0Payout.toString());
+
+      // shareHolder1 expected payout is their pool tokens (100) divided by the total pool prevision(10e18+100).
+      const shareHolder1Frac = toBN("100") // fraction of the pool is their contribution/total pool
+        .mul(toBN(toWei("1")))
+        .div(toBN(toWei("10")).addn(100));
+      const expectedShareHolder1Payout = toBN(tokensPerSnapShot) // The total tokens per snapshot * by their pool ratio.
+        .mul(shareHolder1Frac)
+        .div(toBN(toWei("1")));
+
+      assert.equal(payoutAtBlock[shareHolders[1]].toString(), expectedShareHolder1Payout.toString());
+
+      // Validate the other shareholders got no rewards.
+      const expectedPayoutPerOtherShareholder = toWei("0");
+      for (shareholder of shareHolders.slice(2, 6)) {
+        assert.equal(payoutAtBlock[shareHolder].toString(), expectedPayoutPerOtherShareholder.toString());
+      }
+    });
+  });
+  describe("Correctly calculates payouts over a range of block numbers (_calculatePayoutsBetweenBlocks)", function() {
+    beforeEach(async function() {
+      bpToken = await Token.new("BPT", "BPT", 18, {
+        from: contractCreator
+      });
+      await bpToken.addMember(1, contractCreator, {
+        from: contractCreator
+      });
+    });
+
+    it("Correctly splits rewards over n blocks (simple case)", async function() {
+      // Create 10e18 tokens to distribute, sending 2e18 to each liquidity provider.
+      for (shareHolder of shareHolders) {
+        await bpToken.mint(shareHolder, toWei("2"), { from: contractCreator });
+      }
+      // Capture the starting block number.
+      const startingBlockNumber = await web3.eth.getBlockNumber();
+      const startingBlockTimestamp = await web3.eth.getBlock(startingBlockNumber).timestamp;
+
+      // Advance the chain 10 blocks into the future while setting the average block time to be 15 seconds.
+      const snapshotsToTake = 10;
+      const blocksPerSnapshot = 1; // Set to 1 to capture a snapshot at every block.
+      const blocksToAdvance = snapshotsToTake * blocksPerSnapshot;
+      for (i = 0; i < blocksToAdvance; i++) {
+        await advanceBlockAndSetTime(web3, startingBlockTimestamp + 15 * (1 + i));
+      }
+      const endingBlockNumber = await web3.eth.getBlockNumber();
+      assert.equal(endingBlockNumber, startingBlockNumber + blocksToAdvance); // Should have advanced 10 blocks.
+
+      const rewardsPerSnapshot = toWei("10"); // For each snapshot in time, payout 10e18 tokens
+      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+
+      const intervalPayout = await Main._calculatePayoutsBetweenBlocks(
+        bPool,
+        shareHolders,
+        startingBlockNumber,
+        endingBlockNumber,
+        blocksPerSnapshot,
+        rewardsPerSnapshot
+      );
+
+      // Validate that:
+      // 1) Returned object should contain all shareholder keys.
+      // 2) Total rewards distributed should match expected.
+      // 3) Individual rewards distributed mach expected
+      const expectedTotalRewardsDistributed = toBN(rewardsPerSnapshot).muln(snapshotsToTake);
+      const expectedIndividualRewardsDistributed = expectedTotalRewardsDistributed.divn(shareHolders.length);
+      let totalRewardsDistributed = toBN("0");
+      for (shareHolder of shareHolders) {
+        assert.isTrue(Object.keys(intervalPayout).includes(shareHolder));
+        assert.equal(intervalPayout[shareHolder].toString(), expectedIndividualRewardsDistributed.toString());
+        totalRewardsDistributed = totalRewardsDistributed.add(intervalPayout[shareHolder]);
+      }
+      assert.equal(expectedTotalRewardsDistributed.toString(), totalRewardsDistributed.toString());
+    });
+    it("Correctly splits rewards over n blocks (multiple block per snapshot and non-equal distribution)", async function() {
+      // Create 31e18 tokens to distribute, sending 2^n*110^18 tokens to each liquidity provider. this works out to:
+      //      shareholder0 2 ^ 0=1e18
+      //      shareholder1 2^1=2e18
+      //      shareholder2 2^2=4e18 ... and so on for the 5 shareholders.
+
+      let index = 0;
+      for (shareHolder of shareHolders) {
+        await bpToken.mint(shareHolder, toWei(Math.pow(2, index).toString()), { from: contractCreator });
+        index += 1;
+      }
+
+      // Capture the starting block number.
+      const startingBlockNumber = await web3.eth.getBlockNumber();
+      const startingBlockTimestamp = await web3.eth.getBlock(startingBlockNumber).timestamp;
+
+      // generate 15 snapshots with each covering 8 blocks. This is equivalent to 120 blocks traversed.
+      const snapshotsToTake = 15;
+      const blocksPerSnapshot = 8;
+      const blocksToAdvance = snapshotsToTake * blocksPerSnapshot;
+      for (i = 0; i < blocksToAdvance; i++) {
+        await advanceBlockAndSetTime(web3, startingBlockTimestamp + 15 * (1 + i));
+      }
+      const endingBlockNumber = await web3.eth.getBlockNumber();
+      assert.equal(endingBlockNumber, startingBlockNumber + blocksToAdvance);
+
+      const rewardsPerSnapshot = toWei("10"); // For each snapshot in time, payout 10e18 tokens
+      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+      const intervalPayout = await Main._calculatePayoutsBetweenBlocks(
+        bPool,
+        shareHolders,
+        startingBlockNumber,
+        endingBlockNumber,
+        blocksPerSnapshot,
+        rewardsPerSnapshot
+      );
+
+      // Validate that the individual rewards distributed mach expected for each shareholder.
+      let expectedTotalRewardsDistributed = toBN(rewardsPerSnapshot).muln(snapshotsToTake);
+      index = 0;
+      for (shareHolder of shareHolders) {
+        const shareHolderFrac = toBN(toWei(Math.pow(2, index).toString()))
+          .mul(toBN(toWei("1")))
+          .div(toBN(toWei("31")));
+        const expectedIndividualRewardsDistributed = expectedTotalRewardsDistributed
+          .mul(shareHolderFrac)
+          .div(toBN(toWei("1")));
+
+        assert.equal(intervalPayout[shareHolder].toString(), expectedIndividualRewardsDistributed.toString());
+        index += 1;
+      }
+    });
+    it("Correctly splits rewards over blocks including inter-snapshot transfers", async function() {
+      // Create 10e18 tokens. Start with all LPs owning 1/5 of the supply (2e18 each).
+      for (shareHolder of shareHolders) {
+        await bpToken.mint(shareHolder, toWei("2"), { from: contractCreator });
+      }
+      const rewardsPerSnapshot = toWei("10"); // For each snapshot in time, payout 10e18 tokens
+
+      // Create a data structure to store expected payouts as we move token balances over time.
+      let shareHolderPayout = {};
+      for (shareHolder of shareHolders) {
+        shareHolderPayout[shareHolder] = toBN("0");
+      }
+
+      // Capture the starting block number.
+      const startingBlockNumber = await web3.eth.getBlockNumber();
+      const startingBlockTimestamp = await web3.eth.getBlock(startingBlockNumber).timestamp;
+      // We will generate 10 snapshots with each covering 10 blocks. This is equivalent to 100 blocks traversed.
+      // Each time ganache accepts a transaction it will advance by 1 block. ¸
+      const snapshotsToTake = 10;
+      const blocksPerSnapshot = 10;
+      let transactionsMadeCount = 0; // Keep track of how many blocks have been advanced.
+      const totalBlocksToAdvance = snapshotsToTake * blocksPerSnapshot;
+
+      // Advance over 2.5 snapshot windows.
+      const blocksToAdvance = 2.5 * blocksPerSnapshot;
+      for (i = 0; i < blocksToAdvance; i++) {
+        await advanceBlockAndSetTime(web3, startingBlockTimestamp + 15 * (1 + i));
+        transactionsMadeCount += 1;
+      }
+
+      // At this point each shareholder has earned 1/5 of all rewards for 2 snapshot periods (1 & 2). As the time was
+      // advanced 2.5 blocks, the last 5 blocks are not counted at this point.
+      for (shareHolder of shareHolders) {
+        shareHolderPayout[shareHolder] = toBN(rewardsPerSnapshot)
+          .muln(2) // 2 periods captured,
+          .divn(5); // 1/5 of the rewards.
+      }
+
+      // Next, let's assume that all shareholders transfer all of their tokens to one LP (shareHolder0)
+      for (shareHolder of shareHolders.slice(1, shareHolders.length)) {
+        await bpToken.transfer(shareHolders[0], (await bpToken.balanceOf(shareHolder)).toString(), {
+          from: shareHolder
+        });
+        transactionsMadeCount += 1;
+      }
+
+      // Advance over another 2.5 snapshot windows.
+      let recentBlockTimestamp = await web3.eth.getBlock(await web3.eth.getBlockNumber()).timestamp;
+      for (i = 0; i < blocksToAdvance; i++) {
+        await advanceBlockAndSetTime(web3, recentBlockTimestamp + 15 * (1 + i));
+        transactionsMadeCount += 1;
+      }
+
+      // From the last shareholderPayoutUpdate snapshots 3,4 and 5 have elapsed. Over this duration shareholder[0] held all LP tokens.
+      shareHolderPayout[shareHolders[0]] = toBN(shareHolderPayout[shareHolders[0]]).add(
+        toBN(rewardsPerSnapshot).muln(3)
+      );
+
+      // Then, all token holders transfer their tokens to a new wallet (who is a _new_ shareholder).
+      const newShareHolder = accounts[9];
+      for (shareHolder of shareHolders) {
+        await bpToken.transfer(newShareHolder, (await bpToken.balanceOf(shareHolder)).toString(), {
+          from: shareHolder
+        });
+        transactionsMadeCount += 1;
+      }
+
+      // Finally, advance the timestamp until the end of the period.
+      recentBlockTimestamp = await web3.eth.getBlock(await web3.eth.getBlockNumber()).timestamp;
+      const finalBlocksToAdvance = startingBlockNumber - recentBlockTimestamp;
+      for (i = 0; i < finalBlocksToAdvance; i++) {
+        await advanceBlockAndSetTime(web3, recentBlockTimestamp + 15 * (1 + i));
+      }
+
+      // Update this new newShareHolder's balance in the mapping. He held all tokens from snapshots 6 -> 10
+      shareHolderPayout[newShareHolder] = toBN(rewardsPerSnapshot).muln(5);
+      const endingBlockNumber = await web3.eth.getBlockNumber();
+      assert.equal(endingBlockNumber, startingBlockNumber + blocksToAdvance);
+
+      let bPool = new web3.eth.Contract(bpToken.abi, bpToken.address);
+      const intervalPayout = await Main._calculatePayoutsBetweenBlocks(
+        bPool,
+        shareHolders,
+        startingBlockNumber,
+        endingBlockNumber,
+        blocksPerSnapshot,
+        rewardsPerSnapshot
+      );
+
+      // Validate that the individual rewards distributed mach expected for each shareholder.
+      for (shareHolder of Object.keys(shareHolderPayout)) {
+        assert.equal(shareHolderPayout[shareHolder].toString(), intervalPayout[shareHolder].toString());
+      }
+    });
+  });
+});


### PR DESCRIPTION
This PR refactors the Liquidity mining script to make it testable via truffle and adds a set of unit tests to validate its behavior.

Specifically, the script is refactored to have one main entry point `calculateBalancerLPProviders` which calls two subsequent functions: `_updatePayoutAtBlock` and `_calculatePayoutsBetweenBlocks`. These two functions contain the business logic of defining payouts at a given block number and payouts over a range of blocks. These two functions are then tested extensively in this test suite.

This refactor **does not directly test** the `calculateBalancerLPProviders` as this preforms two pieces of logic that are not simple to test:
1) finding a block number from a given timestamp is hard to mock and can be manually validated when the script runs and 
2) the graph integration that is used to query historic shareholders.

If we want to test the logic on these two steps we will need to fork the main net in CI for these tests. This is acceptable (and properly a good thing to do) but will be left as an extension that can be added to another PR if we choose to do so.
