### PR TITLE
Patched Voter dApp to work w/ updated subgraph

### DIFF
--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -141,6 +141,7 @@ function ResolvedRequests({ votingAccount }) {
             <ListItem>
               <ListItemText
                 primary={"Rewards Available: " + prettyFormatNumber(voteStatsDialogData.roundInflationRewardsAvailable)}
+                // I don't use `prettyFormatNumber` here because for some reason it rounds 0.0005 to 0.001
                 secondary={`Round inflation rate: ${voteStatsDialogData.roundInflationRate}% of Total Supply Snapshot`}
               />
             </ListItem>

--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -96,7 +96,7 @@ function ResolvedRequests({ votingAccount }) {
   });
 
   const prettyFormatNumber = x => {
-    return Number(x).toLocaleString({ minimumFractionDigits: 2 });
+    return Number(x).toLocaleString({ minimumFractionDigits: 4 });
   };
 
   return (
@@ -136,6 +136,12 @@ function ResolvedRequests({ votingAccount }) {
               <ListItemText
                 primary={"Correct Votes: " + prettyFormatNumber(voteStatsDialogData.correctVotes)}
                 secondary={prettyFormatNumber(voteStatsDialogData.correctlyRevealedVotesPct) + "% of Revealed Votes"}
+              />
+            </ListItem>
+            <ListItem>
+              <ListItemText
+                primary={"Rewards Available: " + prettyFormatNumber(voteStatsDialogData.roundInflationRewardsAvailable)}
+                secondary={`Round inflation rate: ${voteStatsDialogData.roundInflationRate}% of Total Supply Snapshot`}
               />
             </ListItem>
             <ListItem>

--- a/voter-dapp/src/apollo/queries.js
+++ b/voter-dapp/src/apollo/queries.js
@@ -9,7 +9,7 @@ export const PRICE_REQUEST_VOTING_DATA = gql`
       roundId
       time
       totalSupplyAtSnapshot
-      commitedVotes {
+      committedVotes {
         voter {
           address
         }
@@ -21,7 +21,7 @@ export const PRICE_REQUEST_VOTING_DATA = gql`
           address
         }
       }
-      claimedPercentage
+      inflationRate
       rewardsClaimed {
         numTokens
         claimer {


### PR DESCRIPTION
UMA subgraph interface changed:
- `commitedVotes` now `committedVotes`
-  Round`claimedPercentage` no longer a prop but also no longer necessary since `inflationRate` is available.

Big add here is that we can use the round's queried `inflationRate` and avoid making contract calls in the VoteData container.

Resolves #1769 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>