### PR TITLE
Patch client for updated uniswap subgraph

### DIFF
--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -134,8 +134,8 @@ class GlobalSummaryReporter {
     // If we were using `endBlockNumberForPeriod` to query data for some other pair as well,
     // then we wouldn't be able to set `endBlockNumberForPeriod = latestSwapBlockNumber`
     this.uniswapClient = getUniswapClient();
-    const latestSwap = (await this.uniswapClient.request(queries.LAST_TRADE_FOR_PAIR(this.uniswapPairAddress))).pairs[0]
-      .swaps[0].transaction;
+    const latestSwap = (await this.uniswapClient.request(queries.LAST_TRADE_FOR_PAIR(this.uniswapPairAddress))).swaps[0]
+      .transaction;
     this.latestSwapTimestamp = latestSwap.timestamp;
     this.latestSwapBlockNumber = Number(latestSwap.blockNumber);
     // Note: `endBlockNumberForPeriod` is the highest block number that we will manually query for.

--- a/reporters/uniswapSubgraphClient.js
+++ b/reporters/uniswapSubgraphClient.js
@@ -52,12 +52,10 @@ function PAIR_DATA(pairAddress, block) {
 function LAST_TRADE_FOR_PAIR(pairAddress) {
   return `
     query pairs {
-      pairs(where: {id: "${pairAddress}"}) {
-        swaps(orderBy: timestamp, orderDirection: desc, first: 1) {
-          transaction {
-            blockNumber
-            timestamp
-          }
+      swaps(orderBy: timestamp, orderDirection: desc, first: 1, where: {pair: "${pairAddress}"}) {
+        transaction {
+          blockNumber
+          timestamp
         }
       }
     }


### PR DESCRIPTION
`pairs` query no loner contains `swaps` object.
 
Signed-off-by: Nick Pai <npai.nyc@gmail.com>