### PR TITLE
Reporter: add support for other exchange stats besides Uniswap, like Balancer

### DIFF
--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -55,6 +55,9 @@ class GlobalSummaryReporter {
     this.accountingVariance = this.toBN(this.toWei("0.0001"));
 
     this.exchangePairOverride = exchangePairOverride;
+
+    // If we have data from one of the swap exchanges to display, then this will be `true`.
+    this.hasExchangeData = false;
   }
 
   async update() {
@@ -149,6 +152,9 @@ class GlobalSummaryReporter {
     }
 
     // TODO: Balancer data:
+
+    // Have we successfully fetched any exchange data from the graph API?
+    this.hasExchangeData = this.latestSwapTimestamp;
   }
 
   async generateSummaryStatsTable() {
@@ -195,7 +201,7 @@ class GlobalSummaryReporter {
     console.groupEnd();
 
     // 2a. Tokens Swaps table
-    if (this.latestSwapTimestamp) {
+    if (this.hasExchangeData) {
       console.group();
       console.log(
         bold(

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -24,7 +24,7 @@ class GlobalSummaryReporter {
     oracle,
     collateralToken,
     syntheticToken,
-    uniswapPairOverride,
+    exchangePairOverride,
     endDateOffsetSeconds,
     periodLengthSeconds
   ) {
@@ -54,14 +54,13 @@ class GlobalSummaryReporter {
     // allow for FixedPoint rounding errors.
     this.accountingVariance = this.toBN(this.toWei("0.0001"));
 
-    this.uniswapPairOverride = uniswapPairOverride;
+    this.exchangePairOverride = exchangePairOverride;
   }
 
   async update() {
     await this.empClient.update();
     await this.empEventClient.update();
     await this.referencePriceFeed.update();
-    await this.uniswapPriceFeed.update();
 
     // Block number stats.
     this.currentBlockNumber = await this.web3.eth.getBlockNumber();
@@ -116,32 +115,40 @@ class GlobalSummaryReporter {
     // Pricefeed stats.
     this.priceEstimate = this.referencePriceFeed.getCurrentPrice();
 
-    // Initialize Uniswap pair address to get trade data for. Default pair token is the collateral token.
-    this.uniswapPairToken = this.uniswapPairOverride[this.toChecksumAddress(this.empContract.options.address)]
-      ? this.uniswapPairOverride[this.toChecksumAddress(this.empContract.options.address)]
+    // Initialize exchange pair address to get trade data for. Default pair token is the collateral token.
+    this.exchangePairToken = this.exchangePairOverride[this.toChecksumAddress(this.empContract.options.address)]
+      ? this.exchangePairOverride[this.toChecksumAddress(this.empContract.options.address)]
       : this.collateralContract;
-    this.uniswapPairDetails = await getUniswapPairDetails(
-      this.web3,
-      this.syntheticContract.address,
-      this.uniswapPairToken.address
-    );
-    this.uniswapPairAddress = this.uniswapPairDetails.pairAddress.toLowerCase();
 
-    // Set up Uniswap subgraph client and query latest update stats.
-    // If the `latestSwapBlockNumber` < `endBlockNumberForPeriod`, then set `endBlockNumberForPeriod = latestSwapBlockNumber`
-    // otherwise the graphQL client will throw an error when trying to access a block that it has not indexed yet.
-    // Its ok to use the latest swap's block number as the end-period block number because we are only querying swap data for this pair.
-    // If we were using `endBlockNumberForPeriod` to query data for some other pair as well,
-    // then we wouldn't be able to set `endBlockNumberForPeriod = latestSwapBlockNumber`
-    this.uniswapClient = getUniswapClient();
-    const latestSwap = (await this.uniswapClient.request(queries.LAST_TRADE_FOR_PAIR(this.uniswapPairAddress))).swaps[0]
-      .transaction;
-    this.latestSwapTimestamp = latestSwap.timestamp;
-    this.latestSwapBlockNumber = Number(latestSwap.blockNumber);
-    // Note: `endBlockNumberForPeriod` is the highest block number that we will manually query for.
-    if (this.endBlockNumberForPeriod > this.latestSwapBlockNumber) {
-      this.endBlockNumberForPeriod = this.latestSwapBlockNumber;
+    // Uniswap data:
+    if (this.uniswapPriceFeed) {
+      await this.uniswapPriceFeed.update();
+
+      this.uniswapPairDetails = await getUniswapPairDetails(
+        this.web3,
+        this.syntheticContract.address,
+        this.exchangePairToken.address
+      );
+      this.uniswapPairAddress = this.uniswapPairDetails.pairAddress.toLowerCase();
+
+      // Set up Uniswap subgraph client and query latest update stats.
+      // If the `latestSwapBlockNumber` < `endBlockNumberForPeriod`, then set `endBlockNumberForPeriod = latestSwapBlockNumber`
+      // otherwise the graphQL client will throw an error when trying to access a block that it has not indexed yet.
+      // Its ok to use the latest swap's block number as the end-period block number because we are only querying swap data for this pair.
+      // If we were using `endBlockNumberForPeriod` to query data for some other pair as well,
+      // then we wouldn't be able to set `endBlockNumberForPeriod = latestSwapBlockNumber`
+      this.uniswapClient = getUniswapClient();
+      const latestSwap = (await this.uniswapClient.request(queries.LAST_TRADE_FOR_PAIR(this.uniswapPairAddress)))
+        .swaps[0].transaction;
+      this.latestSwapTimestamp = latestSwap.timestamp;
+      this.latestSwapBlockNumber = Number(latestSwap.blockNumber);
+      // Note: `endBlockNumberForPeriod` is the highest block number that we will manually query for.
+      if (this.endBlockNumberForPeriod > this.latestSwapBlockNumber) {
+        this.endBlockNumberForPeriod = this.latestSwapBlockNumber;
+      }
     }
+
+    // TODO: Balancer data:
   }
 
   async generateSummaryStatsTable() {
@@ -187,21 +194,33 @@ class GlobalSummaryReporter {
     this._generateSponsorStats(periods);
     console.groupEnd();
 
-    // 2. Tokens stats table
+    // 2a. Tokens Swaps table
+    if (this.latestSwapTimestamp) {
+      console.group();
+      console.log(
+        bold(
+          `Exchange pair (${await this.syntheticContract.symbol()}-${await this.exchangePairToken.symbol()}) summary stats (as of ${formatDate(
+            this.latestSwapTimestamp,
+            this.web3
+          )})`
+        )
+      );
+      console.log(
+        italic("- Token price is sourced from exchange where synthetic token is traded (i.e. Uniswap, Balancer)")
+      );
+      await this._generateExchangeStats();
+      console.groupEnd();
+    }
+
+    // 2b. Tokens Holder table
     console.group();
     console.log(
-      bold(
-        `Synthetic Token Ownership and Uniswap pair (${await this.syntheticContract.symbol()}-${await this.uniswapPairToken.symbol()}) summary stats (as of ${formatDate(
-          this.latestSwapTimestamp,
-          this.web3
-        )})`
-      )
+      bold(`Synthetic Token Ownership stats (as of ${formatDate(this.empClient.lastUpdateTimestamp, this.web3)})`)
     );
-    console.log(italic("- Token price is sourced from exchange where synthetic token is traded (i.e. Uniswap)"));
     console.log(
       italic("- Token holder counts are equal to the # of unique token holders who held any balance during a period")
     );
-    await this._generateTokenStats(periods);
+    await this._generateTokenHolderStats(periods);
     console.groupEnd();
 
     // 3. Liquidation stats table
@@ -611,86 +630,16 @@ class GlobalSummaryReporter {
     console.table(allSponsorStatsTable);
   }
 
-  async _generateTokenStats(periods) {
-    let allTokenStatsTable = {};
+  async _generateTokenHolderStats(periods) {
+    let allTokenHolderStatsTable = {};
 
-    const currentTokenPrice = this.uniswapPriceFeed.getLastBlockPrice();
-    const twapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
-    allTokenStatsTable["Token price"] = {
-      current: this.formatDecimalString(currentTokenPrice),
-      TWAP: this.formatDecimalString(twapTokenPrice)
-    };
-
-    allTokenStatsTable["# tokens outstanding"] = {
+    allTokenHolderStatsTable["# tokens outstanding"] = {
       current: this.formatDecimalString(this.totalTokensOutstanding)
     };
 
-    // Get uniswap trade data via graphql.
-    const volumeTokenLabel = this.uniswapPairDetails.inverted ? "volumeToken1" : "volumeToken0";
-    const allTokenData = (await this.uniswapClient.request(queries.PAIR_DATA(this.uniswapPairAddress))).pairs[0];
-    const tradeCount = parseInt(allTokenData.txCount);
-    const tradeVolumeTokens = parseFloat(allTokenData[volumeTokenLabel]);
-
-    // Calculate Uniswap trade count and volume data.
-    if (!allTokenData) {
-      // If there is no data for this pair, then we cannot get trade count or volume data.
-      allTokenStatsTable["# trades in Uniswap"] = {
-        cumulative: "Graph data unavailable"
-      };
-      allTokenStatsTable["volume of trades in Uniswap in # of tokens"] = {
-        cumulative: "Graph data unavailable"
-      };
-    } else {
-      // Try to get sub period data from graph. This might fail if subgraph latest block is too far behind actual latest block.
-      let periodTradeCount, prevPeriodTradeCount;
-      let periodTradeVolumeTokens, prevPeriodTradeVolumeTokens;
-      try {
-        const startPeriodTokenData = (
-          await this.uniswapClient.request(queries.PAIR_DATA(this.uniswapPairAddress, this.startBlockNumberForPeriod))
-        ).pairs[0];
-        const endPeriodTokenData = (
-          await this.uniswapClient.request(queries.PAIR_DATA(this.uniswapPairAddress, this.endBlockNumberForPeriod))
-        ).pairs[0];
-        const startPrevPeriodTokenData = (
-          await this.uniswapClient.request(
-            queries.PAIR_DATA(this.uniswapPairAddress, this.startBlockNumberForPreviousPeriod)
-          )
-        ).pairs[0];
-
-        periodTradeCount = parseInt(endPeriodTokenData.txCount) - parseInt(startPeriodTokenData.txCount);
-        prevPeriodTradeCount = parseInt(startPeriodTokenData.txCount) - parseInt(startPrevPeriodTokenData.txCount);
-
-        periodTradeVolumeTokens =
-          parseFloat(endPeriodTokenData[volumeTokenLabel]) - parseFloat(startPeriodTokenData[volumeTokenLabel]);
-        prevPeriodTradeVolumeTokens =
-          parseFloat(startPeriodTokenData[volumeTokenLabel]) - parseFloat(startPrevPeriodTokenData[volumeTokenLabel]);
-      } catch (error) {
-        console.error("Could not get data for subperiod:", error.message);
-        // Ignore error, mark data as unavailable.
-      }
-
-      // Display data in table.
-      allTokenStatsTable["# trades in Uniswap"] = {
-        cumulative: tradeCount,
-        [this.periodLabelInHours]: periodTradeCount,
-        ["Δ from prev. period"]: addSign(periodTradeCount - prevPeriodTradeCount)
-      };
-      allTokenStatsTable["volume of trades in Uniswap in # of tokens"] = {
-        cumulative: formatWithMaxDecimals(tradeVolumeTokens, 2, 4, false),
-        [this.periodLabelInHours]: formatWithMaxDecimals(periodTradeVolumeTokens, 2, 4, false),
-        ["Δ from prev. period"]: formatWithMaxDecimals(
-          periodTradeVolumeTokens - prevPeriodTradeVolumeTokens,
-          2,
-          4,
-          false,
-          true
-        )
-      };
-    }
-
     // Get token holder stats.
     const tokenHolderStats = this._constructTokenHolderList(periods);
-    allTokenStatsTable["# of token holders"] = {
+    allTokenHolderStatsTable["# of token holders"] = {
       current: Object.keys(tokenHolderStats.currentTokenHolders).length,
       cumulative: Object.keys(tokenHolderStats.countAllTokenHolders).length,
       [this.periodLabelInHours]: Object.keys(tokenHolderStats.countPeriodTokenHolders["period"]).length,
@@ -699,7 +648,85 @@ class GlobalSummaryReporter {
           Object.keys(tokenHolderStats.countPeriodTokenHolders["prevPeriod"]).length
       )
     };
-    console.table(allTokenStatsTable);
+    console.table(allTokenHolderStatsTable);
+  }
+
+  async _generateExchangeStats() {
+    let allExchangeStatsTable = {};
+
+    if (this.uniswapPriceFeed) {
+      const currentTokenPrice = this.uniswapPriceFeed.getLastBlockPrice();
+      const twapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
+      allExchangeStatsTable["Token price"] = {
+        current: this.formatDecimalString(currentTokenPrice),
+        TWAP: this.formatDecimalString(twapTokenPrice)
+      };
+
+      // Get uniswap trade data via graphql.
+      const volumeTokenLabel = this.uniswapPairDetails.inverted ? "volumeToken1" : "volumeToken0";
+      const allTokenData = (await this.uniswapClient.request(queries.PAIR_DATA(this.uniswapPairAddress))).pairs[0];
+      const tradeCount = parseInt(allTokenData.txCount);
+      const tradeVolumeTokens = parseFloat(allTokenData[volumeTokenLabel]);
+
+      // Calculate Uniswap trade count and volume data.
+      if (!allTokenData) {
+        // If there is no data for this pair, then we cannot get trade count or volume data.
+        allExchangeStatsTable["# trades in Uniswap"] = {
+          cumulative: "Graph data unavailable"
+        };
+        allExchangeStatsTable["volume of trades in Uniswap in # of tokens"] = {
+          cumulative: "Graph data unavailable"
+        };
+      } else {
+        // Try to get sub period data from graph. This might fail if subgraph latest block is too far behind actual latest block.
+        let periodTradeCount, prevPeriodTradeCount;
+        let periodTradeVolumeTokens, prevPeriodTradeVolumeTokens;
+        try {
+          const startPeriodTokenData = (
+            await this.uniswapClient.request(queries.PAIR_DATA(this.uniswapPairAddress, this.startBlockNumberForPeriod))
+          ).pairs[0];
+          const endPeriodTokenData = (
+            await this.uniswapClient.request(queries.PAIR_DATA(this.uniswapPairAddress, this.endBlockNumberForPeriod))
+          ).pairs[0];
+          const startPrevPeriodTokenData = (
+            await this.uniswapClient.request(
+              queries.PAIR_DATA(this.uniswapPairAddress, this.startBlockNumberForPreviousPeriod)
+            )
+          ).pairs[0];
+
+          periodTradeCount = parseInt(endPeriodTokenData.txCount) - parseInt(startPeriodTokenData.txCount);
+          prevPeriodTradeCount = parseInt(startPeriodTokenData.txCount) - parseInt(startPrevPeriodTokenData.txCount);
+
+          periodTradeVolumeTokens =
+            parseFloat(endPeriodTokenData[volumeTokenLabel]) - parseFloat(startPeriodTokenData[volumeTokenLabel]);
+          prevPeriodTradeVolumeTokens =
+            parseFloat(startPeriodTokenData[volumeTokenLabel]) - parseFloat(startPrevPeriodTokenData[volumeTokenLabel]);
+        } catch (error) {
+          console.error("Could not get data for subperiod:", error.message);
+          // Ignore error, mark data as unavailable.
+        }
+
+        // Display data in table.
+        allExchangeStatsTable["# trades in Uniswap"] = {
+          cumulative: tradeCount,
+          [this.periodLabelInHours]: periodTradeCount,
+          ["Δ from prev. period"]: addSign(periodTradeCount - prevPeriodTradeCount)
+        };
+        allExchangeStatsTable["volume of trades in Uniswap in # of tokens"] = {
+          cumulative: formatWithMaxDecimals(tradeVolumeTokens, 2, 4, false),
+          [this.periodLabelInHours]: formatWithMaxDecimals(periodTradeVolumeTokens, 2, 4, false),
+          ["Δ from prev. period"]: formatWithMaxDecimals(
+            periodTradeVolumeTokens - prevPeriodTradeVolumeTokens,
+            2,
+            4,
+            false,
+            true
+          )
+        };
+      }
+    }
+
+    console.table(allExchangeStatsTable);
   }
 
   _generateLiquidationStats(periods) {

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -134,8 +134,8 @@ class GlobalSummaryReporter {
     // If we were using `endBlockNumberForPeriod` to query data for some other pair as well,
     // then we wouldn't be able to set `endBlockNumberForPeriod = latestSwapBlockNumber`
     this.uniswapClient = getUniswapClient();
-    const latestSwap = (await this.uniswapClient.request(queries.LAST_TRADE_FOR_PAIR(this.uniswapPairAddress))).pairs[0]
-      .swaps[0].transaction;
+    const latestSwap = (await this.uniswapClient.request(queries.LAST_TRADE_FOR_PAIR(this.uniswapPairAddress))).swaps[0]
+      .transaction;
     this.latestSwapTimestamp = latestSwap.timestamp;
     this.latestSwapBlockNumber = Number(latestSwap.blockNumber);
     // Note: `endBlockNumberForPeriod` is the highest block number that we will manually query for.

--- a/reporters/GlobalSummaryReporter.js
+++ b/reporters/GlobalSummaryReporter.js
@@ -890,6 +890,11 @@ class GlobalSummaryReporter {
       const sender = event.returnValues.from;
       const receiver = event.returnValues.to;
 
+      // Ignore transfers for 0 tokens like the final transfer in this transaction: https://etherscan.io/tx/0x0ceebc33f9057e37a187895ad0dd07d8905da49c0c228474975018ca5f044948
+      if (event.returnValues.value === "0") {
+        return;
+      }
+
       if (receiver !== ZERO_ADDRESS) {
         // Add to token holder list.
         countAllTokenHolders[receiver] = true;

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -29,7 +29,7 @@ const Finder = artifacts.require("Finder");
 
 async function run(
   address,
-  uniswapPairOverride,
+  exchangePairOverride,
   walletsToMonitor,
   referencePriceFeedConfig,
   uniswapPriceFeedConfig,
@@ -72,13 +72,16 @@ async function run(
   );
 
   // 2b. Uniswap price feed for calculating synthetic token trading stats.
-  const uniswapPriceFeed = await createPriceFeed(
-    dummyLogger,
-    web3,
-    new Networker(dummyLogger),
-    getTime,
-    uniswapPriceFeedConfig
-  );
+  let uniswapPriceFeed;
+  if (uniswapPriceFeedConfig) {
+    uniswapPriceFeed = await createPriceFeed(
+      dummyLogger,
+      web3,
+      new Networker(dummyLogger),
+      getTime,
+      uniswapPriceFeedConfig
+    );
+  }
 
   // 3. EMP event client for reading past events.
   const startBlock = 0;
@@ -124,7 +127,7 @@ async function run(
     oracle,
     collateralToken,
     syntheticToken,
-    uniswapPairOverride,
+    exchangePairOverride,
     endDateOffsetSeconds,
     periodLengthSeconds
   );
@@ -141,12 +144,7 @@ async function run(
 
 async function Poll(callback) {
   try {
-    if (
-      !process.env.EMP_ADDRESS ||
-      !process.env.WALLET_MONITOR_OBJECT ||
-      !process.env.PRICE_FEED_CONFIG ||
-      !process.env.UNISWAP_PRICE_FEED_CONFIG
-    ) {
+    if (!process.env.EMP_ADDRESS || !process.env.WALLET_MONITOR_OBJECT || !process.env.PRICE_FEED_CONFIG) {
       throw "Bad setup! Must specify EMP_ADDRESS, WALLET_MONITOR_OBJECT, PRICE_FEED_CONFIG, and UNISWAP_PRICE_FEED_CONFIG";
     }
 
@@ -160,8 +158,13 @@ async function Poll(callback) {
     // Configuration for price feed objects. Example:
     // PRICE_FEED_CONFIG={"type":"medianizer","pair":"ethbtc","lookback":7200,"minTimeBetweenUpdates":60,"medianizedFeeds":[{"type":"cryptowatch","exchange":"coinbase-pro"}]}
     const referencePriceFeedConfig = JSON.parse(process.env.PRICE_FEED_CONFIG);
-    // UNISWAP_PRICE_FEED_CONFIG={"type":"uniswap","twapLength":86400,"lookback":7200,"invertPrice":true,"uniswapAddress":"0x1e4F65138Bbdb66b9C4140b2b18255A896272338"}
-    const uniswapPriceFeedConfig = JSON.parse(process.env.UNISWAP_PRICE_FEED_CONFIG);
+
+    // Exchange Information:
+    let uniswapPriceFeedConfig;
+    if (process.env.UNISWAP_PRICE_FEED_CONFIG) {
+      // UNISWAP_PRICE_FEED_CONFIG={"type":"uniswap","twapLength":86400,"lookback":7200,"invertPrice":true,"uniswapAddress":"0x1e4F65138Bbdb66b9C4140b2b18255A896272338"}
+      uniswapPriceFeedConfig = JSON.parse(process.env.UNISWAP_PRICE_FEED_CONFIG);
+    }
 
     // The report will always display "cumulative" and "current" data but it will also show data for a shorter period ("period") whose
     // start and end dates we can control:
@@ -174,13 +177,13 @@ async function Poll(callback) {
       ? parseInt(process.env.PERIOD_REPORT_LENGTH)
       : 24 * 60 * 60;
 
-    // Overrides the Uniswap pair that we want to query trade data for. The assumption is that the GlobalSummaryReporter fetches
-    // data for only one Uniswap pair, and the default pair tokens are the emp-synthetic-token and the emp-collateral-token.
+    // Overrides the Exchange pair that we want to query trade data for. The assumption is that the GlobalSummaryReporter fetches
+    // data for only one pair, and the default pair tokens are the emp-synthetic-token and the emp-collateral-token.
     //
     // TODO: This object could take a long time to initialize if each `contract.at()` makes a network call to check if code exists
     // at the address. We could make this more efficient by either parallelizing via `Promise.all()` or convert this into an address-to-address
     // map and initialize lazily once we determine an address.
-    const uniswapPairOverride = {
+    const exchangePairOverride = {
       // yCOMP <--> COMP
       [web3.utils.toChecksumAddress("0x67DD35EaD67FcD184C8Ff6D0251DF4241F309ce1")]: await ExpandedERC20.at(
         web3.utils.toChecksumAddress("0xc00e94cb662c3520282e6f5717214004a7f26888")
@@ -189,7 +192,7 @@ async function Poll(callback) {
 
     await run(
       empAddress,
-      uniswapPairOverride,
+      exchangePairOverride,
       walletsToMonitor,
       referencePriceFeedConfig,
       uniswapPriceFeedConfig,

--- a/reporters/uniswapSubgraphClient.js
+++ b/reporters/uniswapSubgraphClient.js
@@ -52,12 +52,10 @@ function PAIR_DATA(pairAddress, block) {
 function LAST_TRADE_FOR_PAIR(pairAddress) {
   return `
     query pairs {
-      pairs(where: {id: "${pairAddress}"}) {
-        swaps(orderBy: timestamp, orderDirection: desc, first: 1) {
-          transaction {
-            blockNumber
-            timestamp
-          }
+      swaps(orderBy: timestamp, orderDirection: desc, first: 1, where: {pair: "${pairAddress}"}) {
+        transaction {
+          blockNumber
+          timestamp
         }
       }
     }


### PR DESCRIPTION
- Allows caller to not have to pass in UNISWAP_PRICE_FEED_CONFIG so that in future we can allow callers to choose to pass in BALANCER_PRICE_FEED_CONFIG for example
- Separates exchange stats from holder stats. Previously they were loaded in same function so not passing in uniswap pricefeed would block holder stats from showing

Reporter with exchange stats:
![Screen Shot 2020-07-23 at 11 08 03](https://user-images.githubusercontent.com/9457025/88303834-7ae2b680-ccd5-11ea-9e0c-b97c6124b8a6.png)

Reporter without exchange stats:
![Screen Shot 2020-07-23 at 11 09 24](https://user-images.githubusercontent.com/9457025/88303858-8209c480-ccd5-11ea-8a61-b15b7a26cbc1.png)
