### PR TITLE
Daily Reporter to query liquidation events from subgraph instead of on-chain past events

### DIFF
--- a/reporters/SponsorReporter.js
+++ b/reporters/SponsorReporter.js
@@ -34,7 +34,7 @@ class SponsorReporter {
     // Define the table rows beforehand to re-use the variables.
     const rowNames = [
       `Synthetic debt(${this.empProps.syntheticCurrencySymbol})`,
-      `Backing collateral${this.empProps.collateralCurrencySymbol})`,
+      `Backing collateral(${this.empProps.collateralCurrencySymbol})`,
       "Position CR %",
       `Synthetic balance(${this.empProps.syntheticCurrencySymbol})`,
       `Collateral balance(${this.empProps.collateralCurrencySymbol})`,
@@ -57,7 +57,7 @@ class SponsorReporter {
         tableInfo[rowNames[2]][wallet.name] = "";
       } else {
         tableInfo[rowNames[0]][wallet.name] = this.formatDecimalString(position[0].numTokens);
-        tableInfo[rowNames[1]][wallet.name] = this.formatDecimalString(position[0].numTokens);
+        tableInfo[rowNames[1]][wallet.name] = this.formatDecimalString(position[0].amountCollateral);
         tableInfo[rowNames[2]][wallet.name] = this.formatDecimalString(
           this._calculatePositionCRPercent(position[0].amountCollateral, position[0].numTokens, currentPrice)
         );

--- a/reporters/graphql/umaSubgraph.js
+++ b/reporters/graphql/umaSubgraph.js
@@ -1,0 +1,50 @@
+const { GraphQLClient } = require("graphql-request");
+
+/**
+ * Return created graphql client or create a new one.
+ * @return `createdClient` singleton graphql client.
+ */
+let subgraphClient;
+function getUmaClient() {
+  if (!subgraphClient) {
+    subgraphClient = new GraphQLClient("https://api.thegraph.com/subgraphs/name/protofire/uma");
+  }
+  return subgraphClient;
+}
+
+/**
+ * Queries all liquidation related events (LiquidationCreated, LiquidationDisputed, LiquidationWithdrawn)
+ * for a particular EMP
+ * @param {String} empAddress
+ */
+function LIQUIDATION_EVENTS_FOR_EMP(empAddress) {
+  return `
+    query liquidations {
+      financialContracts(where: {id: "${empAddress}"}) {
+        liquidations {
+          events{
+            block
+            __typename
+            liquidation {
+              tokensLiquidated
+              lockedCollateral
+              sponsor {
+                id
+              }
+              liquidationId
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+const queries = {
+  LIQUIDATION_EVENTS_FOR_EMP
+};
+
+module.exports = {
+  getUmaClient,
+  queries
+};

--- a/reporters/graphql/uniswapSubgraph.js
+++ b/reporters/graphql/uniswapSubgraph.js
@@ -1,18 +1,15 @@
-// TODO: We should group together graphql related modules but I'm using this location
-// for now because this is the only use case.
-
 const { GraphQLClient } = require("graphql-request");
 
 /**
  * Return created graphql client or create a new one.
  * @return `createdClient` singleton graphql client.
  */
-let uniswapClient;
+let subgraphClient;
 function getUniswapClient() {
-  if (!uniswapClient) {
-    uniswapClient = new GraphQLClient("https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2");
+  if (!subgraphClient) {
+    subgraphClient = new GraphQLClient("https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2");
   }
-  return uniswapClient;
+  return subgraphClient;
 }
 
 /**


### PR DESCRIPTION
This will fix the ABI-incompatibility issue where the reporter cannot query `getPastEvents(LiquidationCreated)` for EMP's with outdated ABI's such as ETHBTC and yCOMP. Moreover, it still works with the yUSD contract. This means that once this PR is merged we can move the ETHBTC and yCOMP reporters to point to `docker/latest` container instead of `docker/abi-patch`.

This is the first PR that will begin the refactoring of the `reporter` to query subgraph data instead of calling `getPastEvents` which is the more efficient approach going forwards.

Additionally, fixes a bug in `SponsorReporter` where collateral in the position was not being reported correctly.

Finally, fixes one other bug in setting the latest block # to query the uniswap subgraph for.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>