### PR TITLE
Simplify balancer lequidity mining

### DIFF
--- a/core/scripts/liquidity-mining/CalculateBalancerLPProviders.js
+++ b/core/scripts/liquidity-mining/CalculateBalancerLPProviders.js
@@ -155,9 +155,7 @@ function _saveShareHolderPayout(shareHolderPayout, week) {
   console.log("🗄  File successfully written to", savePath);
 }
 
-// Find information about a given balancer pool `shares` returns a list of all historic LP providers. First tries to
-// query the pool directly based off the pool address. If this does not work then gets the addresses of the tokens
-// the pool holds and uses this to query the graph.
+// Find information about a given balancer `poolAddress` `shares` returns a list of all historic LP providers.
 async function _fetchBalancerPoolInfo(poolAddress) {
   const SUBGRAPH_URL = process.env.SUBGRAPH_URL || "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer";
   const query = `


### PR DESCRIPTION
This PR removes redundant logic from the Balancer liquidity mining script. Previously, the script would try and find the balancer pool based on the provided address. If the user did not provide an address then the script would look for the tokens the pool held. It would then use a different query to find the shareholders.

It turns out that the issue all along was the graph does not support addresses with checksum case. This is why for some pool the query would return the correct balances and for others, it would not. By simply converting the `poolAddress` to a lower case string the query always returns correctly and so the additional roundabout logic that this script had before is no longer needed.