### PR TITLE
Daily Reporter: Remove `EMPClient` dependency and event querying done outside of `EMPEventClient`

### DIFF
--- a/reporters/graphql/umaSubgraph.js
+++ b/reporters/graphql/umaSubgraph.js
@@ -13,14 +13,18 @@ function getUmaClient() {
 }
 
 /**
- * Queries all liquidation related events (LiquidationCreated, LiquidationDisputed, LiquidationWithdrawn)
- * for a particular EMP
+ * Queries all data for a particular EMP
  * @param {String} empAddress
  */
-function LIQUIDATION_EVENTS_FOR_EMP(empAddress) {
+function EMP_STATS(empAddress) {
   return `
     query liquidations {
       financialContracts(where: {id: "${empAddress}"}) {
+        positions(first: 1000, where: { collateral_gt: 0 }) {
+          sponsor {
+            id
+          }
+        }
         liquidations {
           events{
             block
@@ -35,13 +39,17 @@ function LIQUIDATION_EVENTS_FOR_EMP(empAddress) {
             }
           }
         }
+        totalCollateralDeposited
+        totalCollateralWithdrawn
+        totalSyntheticTokensCreated
+        totalSyntheticTokensBurned
       }
     }
   `;
 }
 
 const queries = {
-  LIQUIDATION_EVENTS_FOR_EMP
+  EMP_STATS
 };
 
 module.exports = {

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -120,7 +120,6 @@ async function run(
 
   // 7. Global summary reporter reporter to generate EMP wide metrics.
   const globalSummaryReporter = new GlobalSummaryReporter(
-    empClient,
     empEventClient,
     referencePriceFeed,
     uniswapPriceFeed,


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should be prefixed with the area of code that the change affects and they should be in the present simple tense. Examples:
  
  dvm: adds a new function to compute voting rewards offchain
  monitor bot: fixes broken link in liquidation log
  voter dapp: adds countdown timer component to the header
-->


**Motivation**

#1797

**Summary**

I removed all the `EMPClient` dependency as well as any event querying outside of the `EMPEventClient`.

Runtime decreased from >35 seconds to 5 seconds mostly because we no longer need to call `empClient.update()`

IMPORTANTLY: This temporarily will remove all period-specific data for `summary stats` such as Collateral Deposited for a period (and delta vs previous period). This is because the summary cash flows cannot be sub-divided currently by the UMA subgraph. 

**Details**

- To calculate synthetic token holder count, previously was going through all `Transfer` events and constructing a token holder list. I removed the `Transfer`-event fetching as this was running into our web3 node's rate-limiting. Instead, use [ethplorer.io](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) to query tokenholder count. The benefit is speed, while the downside is reliance on a third party and we can no longer query token holder stats "per period". Infura rate-limiting was referenced as potential future technical debt [here](https://github.com/UMAprotocol/protocol/pull/1575#discussion_r435943818). We have hit the limit 😅.

- Instead of using `Transfer` events to compute `totalCollateralDeposited`, `totalCollateralWithdrawn`, and `totalSyntheticBurned`, I query these values directly from the UMA subgraph. The upside here is speed, while the downside is again reliance on a third party and also no longer being able to segment these stats "per period"

- I removed all dependency on the `empClient`, as calling `empClient.update()` took > 30 seconds. I can grab `lastUpdateTimestamp` from the `empEventClient` instead and I can get the # of current active positions via the UMA subgraph. 


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1797
