### PR TITLE
Voter dApp: round inflation rate should be %

### DIFF
--- a/voter-dapp/src/containers/VoteData.js
+++ b/voter-dapp/src/containers/VoteData.js
@@ -104,7 +104,7 @@ function useVoteData() {
           uniqueRevealsPctOfCommits: uniqueRevealsPctOfCommits.toString(),
           correctVotes: fromWei(correctVotesRevealed.toString()),
           correctlyRevealedVotesPct: fromWei(pctOfCorrectRevealedVotes.mul(toBN("100")).toString()),
-          roundInflationRate: fromWei(roundInflationRate.toString()),
+          roundInflationRate: fromWei(roundInflationRate.mul(toBN("100")).toString()),
           roundInflationRewardsAvailable: fromWei(roundInflationRewardsAvailable.toString()),
           rewardsClaimed: fromWei(rewardsClaimed.toString()),
           rewardsClaimedPct: fromWei(rewardsClaimedPct.mul(toBN("100")).toString()),


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should be prefixed with the area of code that the change affects and they should be in the present simple tense. Examples:
  
  dvm: adds a new function to compute voting rewards offchain
  monitor bot: fixes broken link in liquidation log
  voter dapp: adds countdown timer component to the header
-->


**Motivation**

#1802 


**Summary**

Store `roundInflationRate` as pct like the other pct's


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1802 
