### PR TITLE
core: add basic entrypoint

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+const path = require("path");
+
+function getArtifact(contract) {
+  const filePath = path.join(__dirname, "build", "contracts", `${contract}.json`);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(filePath));
+}
+
+function getAbi(contract) {
+  const artifact = getArtifact(contract);
+  return artifact && artifact.abi;
+}
+
+function getAddress(contract, networkId) {
+  const artifact = getArtifact(contract);
+  return artifact && artifact.networks[networkId] && artifact.networks[networkId].address;
+}
+
+module.exports = {
+  getArtifact,
+  getAbi,
+  getAddress
+};

--- a/core/package.json
+++ b/core/package.json
@@ -34,6 +34,7 @@
     "type": "git",
     "url": "git+https://github.com/UMAprotocol/protocol.git"
   },
+  "main": "index.js",
   "files": [
     "./contracts/**/*.sol",
     "./build/contracts/*.js",

--- a/core/test/scripts/index.js
+++ b/core/test/scripts/index.js
@@ -1,0 +1,18 @@
+const { getAbi, getAddress, getArtifact } = require("../../");
+
+describe("index.js", function() {
+  it("Read Contract ABI", async function() {
+    assert.isNotNull(getAbi("Voting"));
+    assert.isNull(getAbi("Nonsense"));
+  });
+
+  it("Read Contract Address", function() {
+    assert.isNotNull(getAddress("Voting", 1));
+    assert.isNull(getAddress("Nonsense", 1));
+  });
+
+  it("Read Artifact", function() {
+    assert.isNotNull(getArtifact("Voting"));
+    assert.isNull(getArtifact("Nonsense"));
+  });
+});


### PR DESCRIPTION
**Motivation**

Once core is deployed, this will allow users to import the contract artifacts, the abis, and the addresses by network.

**Summary**

Simple index.js file was added.

Some notably missing features: browser support and truffle/ethers instantiations. These may be added in the future, but they may end up being unnecessary.

**Issue(s)**

Fixes #1816.
