### PR TITLE
ContractMonitor: catch error if LquidationCreated is not found for matching LiquidationWithdrawn event

### DIFF
--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -291,22 +291,23 @@ class ContractMonitor {
     );
 
     for (let event of newDisputeSettlementEvents) {
-      // Query resolved price for dispute price request. Note that this will return nothing if the
-      // disputed liquidation's block timestamp is not equal to the timestamp of the price request. This could be the
-      // the case if the EMP contract is using the Timer contract for example.
-      const liquidationEvent = this.empEventClient
-        .getAllLiquidationEvents()
-        .find(_event => _event.sponsor === event.sponsor && _event.liquidationId === event.liquidationId);
-      const liquidationTimestamp = (await this.web3.eth.getBlock(liquidationEvent.blockNumber)).timestamp;
       let resolvedPrice;
       try {
+        // Query resolved price for dispute price request. Note that this will return nothing if the
+        // disputed liquidation's block timestamp is not equal to the timestamp of the price request. This could be the
+        // the case if the EMP contract is using the Timer contract for example.
+        const liquidationEvent = this.empEventClient
+          .getAllLiquidationEvents()
+          .find(_event => _event.sponsor === event.sponsor && _event.liquidationId === event.liquidationId);
+        const liquidationTimestamp = (await this.web3.eth.getBlock(liquidationEvent.blockNumber)).timestamp;
+
         resolvedPrice = revertWrapper(
           await this.votingContract.getPrice(this.utf8ToHex(this.empProps.priceIdentifier), liquidationTimestamp, {
             from: this.empContract.options.address
           })
         );
       } catch (error) {
-        // No price available.
+        // No price or matching available.
       }
 
       // Sample message:

--- a/monitors/ContractMonitor.js
+++ b/monitors/ContractMonitor.js
@@ -307,7 +307,7 @@ class ContractMonitor {
           })
         );
       } catch (error) {
-        // No price or matching available.
+        // No price or matching liquidation available.
       }
 
       // Sample message:

--- a/monitors/test/ContractMonitor.js
+++ b/monitors/test/ContractMonitor.js
@@ -327,6 +327,12 @@ contract("ContractMonitor.js", function(accounts) {
     const txObject1 = await emp.withdrawLiquidation("0", sponsor1, { from: liquidator });
     await eventClient.clearState();
 
+    // Even though the dispute settlement has occurred on-chain, because we haven't updated the event client yet,
+    // the contract monitor should not report it and should skip it silently.
+    const existingCallsCount = spy.getCalls().length;
+    await contractMonitor.checkForNewDisputeSettlementEvents();
+    assert.equal(existingCallsCount, spy.getCalls().length);
+
     // Update the eventClient and check it has the dispute event stored correctly
     await eventClient.update();
     priceFeedMock.setHistoricalPrice(toBN(toWei("1")));


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should be prefixed with the area of code that the change affects and they should be in the present simple tense. Examples:
  
  dvm: adds a new function to compute voting rewards offchain
  monitor bot: fixes broken link in liquidation log
  voter dapp: adds countdown timer component to the header
-->


**Motivation**

#1827 

**Summary**

Moved the `liquidationEvents.find(...)` block within the same `try-catch` that attempts to query the DVM's resolved price. I also updated the unit tests to capture situation where EMPEvent client is not updated after a LiquidationWithdrawn event is emitted.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1827
