### PR TITLE
Voter dApp bug: Only show spam filter switch if there are spam requests on blacklist

### DIFF
--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -90,18 +90,30 @@ function ActiveRequests({ votingAccount, votingGateway }) {
 
   // Only display non-blacklisted price requests (uniquely identifier by identifier name and timestamp)
   const [showSpamRequests, setShowSpamRequests] = useState(false);
+  const [hasSpamRequests, setHasSpamRequests] = useState(false);
   const [pendingRequests, setPendingRequests] = useState([]);
   useEffect(() => {
+    setHasSpamRequests(false);
+
     if (allPendingRequests) {
-      const _pendingRequests = allPendingRequests.filter(req => {
-        if (showSpamRequests || !REQUEST_BLACKLIST[hexToUtf8(req.identifier)]) return true;
+      const _nonBlacklistedRequests = allPendingRequests.filter(req => {
+        if (!REQUEST_BLACKLIST[hexToUtf8(req.identifier)]) return true;
         else {
-          if (!REQUEST_BLACKLIST[hexToUtf8(req.identifier)].includes(req.time)) return true;
-          else return false;
+          if (!REQUEST_BLACKLIST[hexToUtf8(req.identifier)].includes(req.time)) {
+            return true;
+          } else return false;
         }
       });
+      // If there is at least 1 spam request, set this flag which we'll use to determine whether to show the spam filter switch to users.
+      if (_nonBlacklistedRequests.length < allPendingRequests.length) {
+        setHasSpamRequests(true);
+      }
 
-      setPendingRequests(_pendingRequests);
+      if (showSpamRequests) {
+        setPendingRequests(allPendingRequests);
+      } else {
+        setPendingRequests(_nonBlacklistedRequests);
+      }
     }
   }, [allPendingRequests, REQUEST_BLACKLIST, showSpamRequests]);
 
@@ -624,7 +636,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         </DialogContent>
       </Dialog>
       {/* Only render this spam filter switch if some pending spam requests have been filtered out */}
-      {allPendingRequests.length >= pendingRequests.length && (
+      {hasSpamRequests && (
         <FormGroup>
           <FormControlLabel
             control={

--- a/voter-dapp/src/ActiveRequests.js
+++ b/voter-dapp/src/ActiveRequests.js
@@ -96,7 +96,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     setHasSpamRequests(false);
 
     if (allPendingRequests) {
-      const _nonBlacklistedRequests = allPendingRequests.filter(req => {
+      const nonBlacklistedRequests = allPendingRequests.filter(req => {
         if (!REQUEST_BLACKLIST[hexToUtf8(req.identifier)]) return true;
         else {
           if (!REQUEST_BLACKLIST[hexToUtf8(req.identifier)].includes(req.time)) {
@@ -105,14 +105,14 @@ function ActiveRequests({ votingAccount, votingGateway }) {
         }
       });
       // If there is at least 1 spam request, set this flag which we'll use to determine whether to show the spam filter switch to users.
-      if (_nonBlacklistedRequests.length < allPendingRequests.length) {
+      if (nonBlacklistedRequests.length < allPendingRequests.length) {
         setHasSpamRequests(true);
       }
 
       if (showSpamRequests) {
         setPendingRequests(allPendingRequests);
       } else {
-        setPendingRequests(_nonBlacklistedRequests);
+        setPendingRequests(nonBlacklistedRequests);
       }
     }
   }, [allPendingRequests, REQUEST_BLACKLIST, showSpamRequests]);

--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -78,7 +78,7 @@ function ResolvedRequests({ votingAccount }) {
     setHasSpamRequests(false);
 
     if (allResolvedEvents) {
-      const _nonBlacklistedRequests = allResolvedEvents.filter(ev => {
+      const nonBlacklistedRequests = allResolvedEvents.filter(ev => {
         if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)]) return true;
         else {
           if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)].includes(ev.returnValues.time)) {
@@ -87,14 +87,14 @@ function ResolvedRequests({ votingAccount }) {
         }
       });
       // If there is at least 1 spam request, set this flag which we'll use to determine whether to show the spam filter switch to users.
-      if (_nonBlacklistedRequests.length < allResolvedEvents.length) {
-        setHasSpamRequests(true);
+      if (nonBlacklistedRequests.length < allResolvedEvents.length) {
+        nonBlacklistedRequests(true);
       }
 
       if (showSpamRequests) {
         setResolvedEvents(allResolvedEvents);
       } else {
-        setResolvedEvents(_nonBlacklistedRequests);
+        setResolvedEvents(nonBlacklistedRequests);
       }
     }
   }, [allResolvedEvents, REQUEST_BLACKLIST, showSpamRequests]);

--- a/voter-dapp/src/ResolvedRequests.js
+++ b/voter-dapp/src/ResolvedRequests.js
@@ -72,18 +72,30 @@ function ResolvedRequests({ votingAccount }) {
 
   // Only display non-blacklisted price requests (uniquely identifier by identifier name and timestamp)
   const [showSpamRequests, setShowSpamRequests] = useState(false);
+  const [hasSpamRequests, setHasSpamRequests] = useState(false);
   const [resolvedEvents, setResolvedEvents] = useState([]);
   useEffect(() => {
+    setHasSpamRequests(false);
+
     if (allResolvedEvents) {
-      const _resolvedEvents = allResolvedEvents.filter(ev => {
-        if (showSpamRequests || !REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)]) return true;
+      const _nonBlacklistedRequests = allResolvedEvents.filter(ev => {
+        if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)]) return true;
         else {
-          if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)].includes(ev.returnValues.time)) return true;
-          else return false;
+          if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)].includes(ev.returnValues.time)) {
+            return true;
+          } else return false;
         }
       });
+      // If there is at least 1 spam request, set this flag which we'll use to determine whether to show the spam filter switch to users.
+      if (_nonBlacklistedRequests.length < allResolvedEvents.length) {
+        setHasSpamRequests(true);
+      }
 
-      setResolvedEvents(_resolvedEvents);
+      if (showSpamRequests) {
+        setResolvedEvents(allResolvedEvents);
+      } else {
+        setResolvedEvents(_nonBlacklistedRequests);
+      }
     }
   }, [allResolvedEvents, REQUEST_BLACKLIST, showSpamRequests]);
 
@@ -185,7 +197,7 @@ function ResolvedRequests({ votingAccount }) {
         )}
       </Dialog>
       {/* Only render this spam filter switch if some resolved spam requests have been filtered out */}
-      {allResolvedEvents.length >= resolvedEvents.length && (
+      {hasSpamRequests && (
         <FormGroup>
           <FormControlLabel
             control={


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should be prefixed with the area of code that the change affects and they should be in the present simple tense. Examples:
  
  dvm: adds a new function to compute voting rewards offchain
  monitor bot: fixes broken link in liquidation log
  voter dapp: adds countdown timer component to the header
-->


**Motivation**

Incorrectly implemented logic to determine whether to show the spam switch, previously the check was that if `allPendingRequests >= filteredPendingRequests` which was supposed to check if there were any filtered out requests. This returns a false positive: if there are no price requests on the blacklist, then the condition will always evaluate to true, displaying the spam switch needlessly.

**Summary**

I set a `hasSpamRequests` flag after filtering out non-blacklisted requests. After setting this flag, I then check `showSpamRequests` to determine whether display all requests or only non-blacklisted requests.


