### PR TITLE
feat(scripts): update node deployment script to use geth

### DIFF
--- a/scripts/DeployNode.sh
+++ b/scripts/DeployNode.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 
+# Usage:
+# ./DeployNode.sh [GCP machine type, defaults to n1-highmem-8]
+#
+# Example:
+# ./DeployNode.sh n1-standard-4
+
 # This script has the following preconditions:
 # 1. You have a GCE SSD disk called node-disk with enough space for a geth db.
 # 2. node-disk is writable by most/all users (rw filesystem permissions have been granted).
 # 3. node-disk contains a folder called ethereum (can be empty).
+
+MACHINE_TYPE=$1
+: ${MACHINE_TYPE:=n1-highmem-8}
 
 gcloud compute instances create-with-container geth-node \
     --container-image docker.io/ethereum/client-go \
@@ -13,7 +22,7 @@ gcloud compute instances create-with-container geth-node \
     --scopes cloud-platform \
     --disk=auto-delete=no,name=node-disk \
     --container-mount-disk=mount-path=/node-disk \
-    --machine-type n1-highmem-8 \
+    --machine-type $MACHINE_TYPE \
     --container-privileged \
     --container-arg="--rpc" \
     --container-arg="--rpcaddr" \

--- a/scripts/DeployNode.sh
+++ b/scripts/DeployNode.sh
@@ -1,26 +1,26 @@
-# This script has the following preconditions:
-# 1. You have a GCE SSD disk called node-disk with enough space for a parity db.
-# 2. node-disk is writable by most/all users (rw filesystem permissions have been granted).
-# 3. node-disk contains a folder called io.parity.ethereum (can be empty).
+#!/usr/bin/env bash
 
-gcloud compute instances create-with-container custom-node \
-    --container-image docker.io/openethereum/openethereum:latest \
+# This script has the following preconditions:
+# 1. You have a GCE SSD disk called node-disk with enough space for a geth db.
+# 2. node-disk is writable by most/all users (rw filesystem permissions have been granted).
+# 3. node-disk contains a folder called ethereum (can be empty).
+
+gcloud compute instances create-with-container geth-node \
+    --container-image docker.io/ethereum/client-go \
     --zone northamerica-northeast1-b \
     --container-restart-policy on-failure \
     --container-stdin \
     --scopes cloud-platform \
     --disk=auto-delete=no,name=node-disk \
     --container-mount-disk=mount-path=/node-disk \
-    --machine-type n1-standard-2 \
+    --machine-type n1-highmem-8 \
     --container-privileged \
-    --container-arg="--chain" \
-    --container-arg="mainnet" \
-    --container-arg="--ipc-path" \
-    --container-arg="./ipc" \
-    --container-arg="--warp-barrier" \
-    --container-arg="9700000" \
-    --container-arg="--no-ancient-blocks" \
-    --container-arg="-d" \
-    --container-arg="/node-disk/io.parity.ethereum" \
-    --container-arg="--ws-interface=all" \
-    --container-arg="--jsonrpc-interface=all"
+    --container-arg="--rpc" \
+    --container-arg="--rpcaddr" \
+    --container-arg="0.0.0.0" \
+    --container-arg="--ws" \
+    --container-arg="--wsaddr" \
+    --container-arg="0.0.0.0" \
+    --container-arg="--ipcdisable" \
+    --container-arg="--datadir" \
+    --container-arg="/node-disk/ethereum"


### PR DESCRIPTION
**Motivation**

Geth is the more popular and stable node client, and having an easy way to deploy a node instance to GCP is valuable for users who don't want to use a node provider service.

**Summary**

Minor updates were made to the deployment script to make it deploy a fairly standard geth node.

**Details**

Note: the current script deploys a pretty beefy instance by default (there's an optional parameter to change this). This helps to avoid syncing issues, but might not be necessary once the node is synced.

The instance size is based on the instances used by the geth team to benchmark for this mode of syncing: https://blog.ethereum.org/2019/07/10/geth-v1-9-0/.

**Issue(s)**

Fixes #1841.
