### PR TITLE
feat(EMP contracts) Create callable if new position CR is above GCR

### DIFF
--- a/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -406,9 +406,17 @@ contract PricelessPositionManager is FeePayer, AdministrateeInterface {
         fees()
         nonReentrant()
     {
-        require(_checkCollateralization(collateralAmount, numTokens), "CR below GCR");
-
         PositionData storage positionData = positions[msg.sender];
+
+        // Either the new create ratio or the resultant position CR must be above the current GCR.
+        require(
+            (_checkCollateralization(
+                _getFeeAdjustedCollateral(positionData.rawCollateral).add(collateralAmount),
+                positionData.tokensOutstanding.add(numTokens)
+            ) || _checkCollateralization(collateralAmount, numTokens)),
+            "New CR below GCR"
+        );
+
         require(positionData.withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
         if (positionData.tokensOutstanding.isEqual(0)) {
             require(numTokens.isGreaterThanOrEqual(minSponsorTokens), "Below minimum sponsor position");


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should be prefixed with the area of code that the change affects and they should be in the present simple tense. Examples:
  
  dvm: adds a new function to compute voting rewards offchain
  monitor bot: fixes broken link in liquidation log
  voter dapp: adds countdown timer component to the header
-->


**Motivation**

#1843 


**Summary**

The GCR `require` statement was turned into an OR condition including the current condition (where create CR > GCR) and adding a new one (where resultant position CR > GCR).


**Details**

GCR unit tests updated as well.

I tested a deployment on Kovan of the updated EMPLib and the bytecode deployed fine. The `deployedBytecode` increased by 116 bytes from my local calculation.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1843 
