### PR TITLE
feat(reporter): Global summary reporter to display historical EMP contract stats for period and deltas between periods

### DIFF
--- a/reporters/graphql/umaSubgraph.js
+++ b/reporters/graphql/umaSubgraph.js
@@ -15,11 +15,12 @@ function getUmaClient() {
 /**
  * Queries all data for a particular EMP
  * @param {String} empAddress
+ * @param {Integer?} blockNumber
  */
-function EMP_STATS(empAddress) {
+function EMP_STATS(empAddress, blockNumber) {
   return `
     query liquidations {
-      financialContracts(where: {id: "${empAddress}"}) {
+      financialContracts(where: {id: "${empAddress}"}${blockNumber ? `, block: {number:${blockNumber}}` : ""}) {
         positions(first: 1000, where: { collateral_gt: 0 }) {
           sponsor {
             id


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should be prefixed with the area of code that the change affects and they should be in the present simple tense. Examples:
  
  dvm: adds a new function to compute voting rewards offchain
  monitor bot: fixes broken link in liquidation log
  voter dapp: adds countdown timer component to the header
-->


**Motivation**

Adds the feature originally removed in #1798 when we started calculating total collateral/synthetics deposited/withdrawn for a given EMP using The Graph data. I didn't realize at the time that you could make queries for a specific block height, which I leverage in this PR.

**Summary**

Optionally pass in a `blockNumber` to the UMA subgraph query which modifies the query to fetch data for a specific block height.

**Details**

Example historical data for the two most recent 2-day periods:
![Screen Shot 2020-08-12 at 16 53 25](https://user-images.githubusercontent.com/9457025/90067400-0b9d2880-dcbd-11ea-8085-742f86bc8a85.png)


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1845
