### PR TITLE
build(release): fix ci release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,6 @@ workflows:
           requires:
             - build
             - test
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,6 @@ workflows:
           requires:
             - build
             - test
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umaprotocol/cli",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "UMA CLI Tool",
   "homepage": "https://umaproject.org",
   "license": "AGPL-3.0-or-later",
@@ -13,9 +13,9 @@
     "url": "git+https://github.com/UMAprotocol/protocol.git"
   },
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.13",
     "bignumber.js": "^8.0.1",
     "chalk-pipe": "^3.0.0",
     "inquirer": "^7.0.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umaprotocol/cli",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "UMA CLI Tool",
   "homepage": "https://umaproject.org",
   "license": "AGPL-3.0-or-later",
@@ -13,9 +13,9 @@
     "url": "git+https://github.com/UMAprotocol/protocol.git"
   },
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
     "bignumber.js": "^8.0.1",
     "chalk-pipe": "^3.0.0",
     "inquirer": "^7.0.4",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umaprotocol/common",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "Common js utilities used by other UMA packages",
   "homepage": "http://umaproject.org",
   "license": "AGPL-3.0-or-later",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umaprotocol/common",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "Common js utilities used by other UMA packages",
   "homepage": "http://umaproject.org",
   "license": "AGPL-3.0-or-later",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umaprotocol/core",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "UMA smart contracts and unit tests",
   "dependencies": {
     "@awaitjs/express": "^0.3.0",
@@ -9,8 +9,8 @@
     "@nomiclabs/buidler-web3": "^1.3.4",
     "@openzeppelin/contracts": "3.0.0",
     "@sendgrid/mail": "^6.4.0",
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
     "express": "^4.17.1",
     "gmail-send": "^1.2.14",
     "minimist": "^1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umaprotocol/core",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "UMA smart contracts and unit tests",
   "dependencies": {
     "@awaitjs/express": "^0.3.0",
@@ -9,8 +9,8 @@
     "@nomiclabs/buidler-web3": "^1.3.4",
     "@openzeppelin/contracts": "3.0.0",
     "@sendgrid/mail": "^6.4.0",
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.13",
     "express": "^4.17.1",
     "gmail-send": "^1.2.14",
     "minimist": "^1.2.0",

--- a/packages/disputer/package.json
+++ b/packages/disputer/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@umaprotocol/disputer",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "UMA Disputer",
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0",
     "truffle": "^5.1.35"

--- a/packages/disputer/package.json
+++ b/packages/disputer/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@umaprotocol/disputer",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "UMA Disputer",
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.13",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0",
     "truffle": "^5.1.35"

--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@umaprotocol/financial-templates-lib",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "Arbitrage automation and libraries for UMA financial templates",
   "dependencies": {
     "@google-cloud/logging-winston": "^3.0.6",
     "@google-cloud/trace-agent": "^4.2.5",
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
     "@uniswap/sdk": "^2.0.5",
     "bluebird": "^3.7.2",
     "dotenv": "^6.2.0",

--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@umaprotocol/financial-templates-lib",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "Arbitrage automation and libraries for UMA financial templates",
   "dependencies": {
     "@google-cloud/logging-winston": "^3.0.6",
     "@google-cloud/trace-agent": "^4.2.5",
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
     "@uniswap/sdk": "^2.0.5",
     "bluebird": "^3.7.2",
     "dotenv": "^6.2.0",

--- a/packages/liquidator/package.json
+++ b/packages/liquidator/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@umaprotocol/liquidator",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "UMA Liquidator",
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.13",
     "@umaprotocol/ynatm": "^0.0.1",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0",

--- a/packages/liquidator/package.json
+++ b/packages/liquidator/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@umaprotocol/liquidator",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "UMA Liquidator",
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
     "@umaprotocol/ynatm": "^0.0.1",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0",

--- a/packages/monitors/package.json
+++ b/packages/monitors/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@umaprotocol/monitors",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "UMA Monitors",
   "homepage": "https://umaproject.org",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.13",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0",
     "truffle": "^5.1.35"

--- a/packages/monitors/package.json
+++ b/packages/monitors/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@umaprotocol/monitors",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "UMA Monitors",
   "homepage": "https://umaproject.org",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "dependencies": {
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0",
     "truffle": "^5.1.35"

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@umaprotocol/reporters",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "Displays Expiring MultiParty on-chain analytics",
   "dependencies": {
     "@google-cloud/datastore": "^6.0.0",
     "@google-cloud/storage": "^2.4.2",
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.13",
     "chalk-pipe": "^3.0.0",
     "dotenv": "^6.2.0",
     "express": "^4.17.1",

--- a/packages/reporters/package.json
+++ b/packages/reporters/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@umaprotocol/reporters",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "Displays Expiring MultiParty on-chain analytics",
   "dependencies": {
     "@google-cloud/datastore": "^6.0.0",
     "@google-cloud/storage": "^2.4.2",
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
-    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/financial-templates-lib": "^1.0.0-alpha.12",
     "chalk-pipe": "^3.0.0",
     "dotenv": "^6.2.0",
     "express": "^4.17.1",

--- a/packages/voter-dapp/package.json
+++ b/packages/voter-dapp/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@umaprotocol/voter-dapp",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.0.2",
     "@material-ui/core": "^4.3.1",
     "@material-ui/icons": "^3.0.2",
     "@material-ui/styles": "^4.3.0",
-    "@umaprotocol/common": "^1.0.0-alpha.11",
-    "@umaprotocol/core": "^1.0.0-alpha.11",
+    "@umaprotocol/common": "^1.0.0-alpha.12",
+    "@umaprotocol/core": "^1.0.0-alpha.12",
     "@umaprotocol/react-plugin": "^1.5.5",
     "@umaprotocol/store": "^1.5.7",
     "bignumber.js": "^8.0.1",

--- a/packages/voter-dapp/package.json
+++ b/packages/voter-dapp/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@umaprotocol/voter-dapp",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.0.2",
     "@material-ui/core": "^4.3.1",
     "@material-ui/icons": "^3.0.2",
     "@material-ui/styles": "^4.3.0",
-    "@umaprotocol/common": "^1.0.0-alpha.12",
-    "@umaprotocol/core": "^1.0.0-alpha.12",
+    "@umaprotocol/common": "^1.0.0-alpha.13",
+    "@umaprotocol/core": "^1.0.0-alpha.13",
     "@umaprotocol/react-plugin": "^1.5.5",
     "@umaprotocol/store": "^1.5.7",
     "bignumber.js": "^8.0.1",

--- a/scripts/run_release.sh
+++ b/scripts/run_release.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Inject the npm token into the npm config.
-npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > ~/.npmrc
 
 # Publish any packages whose versions are not present in the registry.
 yarn lerna publish from-package --yes

--- a/scripts/run_release.sh
+++ b/scripts/run_release.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-# Inject the npm token into the npm config.
-echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > ~/.npmrc
+# Inject the npm token and registry into the npm config.
+cat > ~/.npmrc << EOF
+@umaprotocol:registry=https://registry.npmjs.org/
+@uma:registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${npm_TOKEN}
+EOF
 
 # Publish any packages whose versions are not present in the registry.
 yarn lerna publish from-package --yes


### PR DESCRIPTION
**Motivation**

#1883

**Summary**

The registry URLs needed to be tweaked in the npm config. Not 100% sure why only npmjs.org works, but this is the URL that's recommended in the docs, so it seems sensible to continue using it.

Note: this also bumps the versions because some versions were bumped in the process of testing this fix. I wanted to bump them one last time so when this PR hits master, it will do a publish to ensure it works as expected.

**Issue(s)**

Fixes #1883 
