### PR TITLE
feat(voter-dapp&voter-cli): Hardcode list of non-18 decimal precision identifiers

### DIFF
--- a/packages/cli/src/voting/commitVotes.js
+++ b/packages/cli/src/voting/commitVotes.js
@@ -7,7 +7,9 @@ const {
   batchCommitVotes,
   getVotingRoles,
   VotePhasesEnum,
-  PublicNetworks
+  PublicNetworks,
+  IDENTIFIER_NON_18_PRECISION,
+  formatFixed
 } = require("@umaprotocol/common");
 
 /**
@@ -76,8 +78,18 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
 
         // Construct commitment
         try {
+          const identifierNonStandardPrecision =
+            IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(selections[i].identifier)];
           newCommitments.push(
-            await constructCommitment(selections[i], roundId, web3, priceInput["price"], signingAddress, votingAccount)
+            await constructCommitment(
+              selections[i],
+              roundId,
+              web3,
+              priceInput["price"],
+              signingAddress,
+              votingAccount,
+              identifierNonStandardPrecision
+            )
           );
         } catch (err) {
           failures.push({ request: selections[i], err });
@@ -110,9 +122,14 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
         );
         console.group(style.success("Receipts:"));
         successes.forEach(committedVote => {
+          const identifierNonStandardPrecision = IDENTIFIER_NON_18_PRECISION[
+            web3.utils.hexToUtf8(committedVote.identifier)
+          ]
+            ? IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(committedVote.identifier)]
+            : 18;
           console.log(`- transaction: ${style.link(`${url}${committedVote.txnHash}`)}`);
           console.log(`    - salt: ${committedVote.salt}`);
-          console.log(`    - voted price: ${web3.utils.fromWei(committedVote.price)}`);
+          console.log(`    - voted price: ${formatFixed(committedVote.price, identifierNonStandardPrecision)}`);
         });
         console.groupEnd();
       } else {

--- a/packages/cli/src/voting/commitVotes.js
+++ b/packages/cli/src/voting/commitVotes.js
@@ -78,7 +78,7 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
 
         // Construct commitment
         try {
-          const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(selections[i].identifier))
+          const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(selections[i].identifier));
           newCommitments.push(
             await constructCommitment(
               selections[i],
@@ -121,7 +121,7 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
         );
         console.group(style.success("Receipts:"));
         successes.forEach(committedVote => {
-          const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(committedVote.identifier))
+          const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(committedVote.identifier));
           console.log(`- transaction: ${style.link(`${url}${committedVote.txnHash}`)}`);
           console.log(`    - salt: ${committedVote.salt}`);
           console.log(`    - voted price: ${formatFixed(committedVote.price, identifierPrecision)}`);

--- a/packages/cli/src/voting/commitVotes.js
+++ b/packages/cli/src/voting/commitVotes.js
@@ -8,7 +8,7 @@ const {
   getVotingRoles,
   VotePhasesEnum,
   PublicNetworks,
-  IDENTIFIER_NON_18_PRECISION,
+  getPrecisionForIdentifier,
   formatFixed
 } = require("@umaprotocol/common");
 
@@ -78,8 +78,7 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
 
         // Construct commitment
         try {
-          const identifierNonStandardPrecision =
-            IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(selections[i].identifier)];
+          const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(selections[i].identifier))
           newCommitments.push(
             await constructCommitment(
               selections[i],
@@ -88,7 +87,7 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
               priceInput["price"],
               signingAddress,
               votingAccount,
-              identifierNonStandardPrecision
+              identifierPrecision
             )
           );
         } catch (err) {
@@ -122,14 +121,10 @@ const commitVotes = async (web3, oracle, designatedVoting) => {
         );
         console.group(style.success("Receipts:"));
         successes.forEach(committedVote => {
-          const identifierNonStandardPrecision = IDENTIFIER_NON_18_PRECISION[
-            web3.utils.hexToUtf8(committedVote.identifier)
-          ]
-            ? IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(committedVote.identifier)]
-            : 18;
+          const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(committedVote.identifier))
           console.log(`- transaction: ${style.link(`${url}${committedVote.txnHash}`)}`);
           console.log(`    - salt: ${committedVote.salt}`);
-          console.log(`    - voted price: ${formatFixed(committedVote.price, identifierNonStandardPrecision)}`);
+          console.log(`    - voted price: ${formatFixed(committedVote.price, identifierPrecision)}`);
         });
         console.groupEnd();
       } else {

--- a/packages/cli/src/voting/filterRequestsByRound.js
+++ b/packages/cli/src/voting/filterRequestsByRound.js
@@ -1,4 +1,4 @@
-const { VotePhasesEnum, getLatestEvent, REQUEST_BLACKLIST } = require("@umaprotocol/common");
+const { VotePhasesEnum, getLatestEvent, IDENTIFIER_BLACKLIST } = require("@umaprotocol/common");
 
 /**
  * First, sorts all price requests chronologically from earliest to latest.
@@ -19,9 +19,9 @@ const filterRequestsByRound = async (web3, allPendingRequests, account, roundId,
   if (allPendingRequests.length > 0) {
     // Only display non-blacklisted price requests (uniquely identifier by identifier name and timestamp)
     const pendingRequests = allPendingRequests.filter(req => {
-      if (!REQUEST_BLACKLIST[web3.utils.hexToUtf8(req.identifier)]) return true;
+      if (!IDENTIFIER_BLACKLIST[web3.utils.hexToUtf8(req.identifier)]) return true;
       else {
-        if (!REQUEST_BLACKLIST[web3.utils.hexToUtf8(req.identifier)].includes(req.time)) return true;
+        if (!IDENTIFIER_BLACKLIST[web3.utils.hexToUtf8(req.identifier)].includes(req.time)) return true;
         else return false;
       }
     });

--- a/packages/cli/src/voting/getResolvedVotesByRoundId.js
+++ b/packages/cli/src/voting/getResolvedVotesByRoundId.js
@@ -1,6 +1,6 @@
 const style = require("../textStyle");
 const argv = require("minimist")(process.argv.slice());
-const { IDENTIFIER_NON_18_PRECISION, formatFixed } = require("@umaprotocol/common");
+const { getPrecisionForIdentifier, formatFixed } = require("@umaprotocol/common");
 
 /**
  * Return the list of votes (that the voter has participated in) that have successfully resolved a price
@@ -43,9 +43,7 @@ const getResolvedVotesByRound = async (web3, votingContract, account) => {
     });
 
     resolvedPrices.forEach(price => {
-      const identifierPrecision = IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(price.args.identifier)]
-        ? IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(price.args.identifier)]
-        : 18;
+      const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(price.args.identifier))
       const roundId = price.args.roundId;
       const resolvedPrice = {
         roundId: roundId.toString(),

--- a/packages/cli/src/voting/getResolvedVotesByRoundId.js
+++ b/packages/cli/src/voting/getResolvedVotesByRoundId.js
@@ -43,7 +43,7 @@ const getResolvedVotesByRound = async (web3, votingContract, account) => {
     });
 
     resolvedPrices.forEach(price => {
-      const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(price.args.identifier))
+      const identifierPrecision = getPrecisionForIdentifier(web3.utils.hexToUtf8(price.args.identifier));
       const roundId = price.args.roundId;
       const resolvedPrice = {
         roundId: roundId.toString(),

--- a/packages/cli/src/voting/getResolvedVotesByRoundId.js
+++ b/packages/cli/src/voting/getResolvedVotesByRoundId.js
@@ -1,5 +1,6 @@
 const style = require("../textStyle");
 const argv = require("minimist")(process.argv.slice());
+const { IDENTIFIER_NON_18_PRECISION, formatFixed } = require("@umaprotocol/common");
 
 /**
  * Return the list of votes (that the voter has participated in) that have successfully resolved a price
@@ -42,12 +43,15 @@ const getResolvedVotesByRound = async (web3, votingContract, account) => {
     });
 
     resolvedPrices.forEach(price => {
+      const identifierPrecision = IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(price.args.identifier)]
+        ? IDENTIFIER_NON_18_PRECISION[web3.utils.hexToUtf8(price.args.identifier)]
+        : 18;
       const roundId = price.args.roundId;
       const resolvedPrice = {
         roundId: roundId.toString(),
         identifier: web3.utils.hexToUtf8(price.args.identifier),
         time: style.formatSecondsToUtc(price.args.time),
-        price: web3.utils.fromWei(price.args.price)
+        price: formatFixed(price.args.price.toString(), identifierPrecision)
       };
       roundIds[roundId].push(resolvedPrice);
     });

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -15,7 +15,7 @@ const browserSafe = {
   ...require("./src/SolidityTestUtils"),
   ...require("./src/TimeUtils"),
   ...require("./src/VotingUtils"),
-  ...require("./src/BlacklistedPriceRequests")
+  ...require("./src/PriceIdentifierUtils")
 };
 
 // Note: there are some webpack performance downsides to stripping the module this way, but for now it's more readable

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,6 +25,7 @@
     "/src/**/*.js"
   ],
   "dependencies": {
+    "@ethersproject/bignumber": "^5.0.5",
     "@google-cloud/kms": "^0.3.0",
     "@google-cloud/storage": "^2.4.2",
     "@truffle/hdwallet-provider": "^1.0.25",

--- a/packages/common/src/BlacklistedPriceRequests.js
+++ b/packages/common/src/BlacklistedPriceRequests.js
@@ -1,8 +1,0 @@
-// Blacklisted price requests that will display on voter clients.
-const REQUEST_BLACKLIST = {
-  SOME_IDENTIFIER: ["1596666977"]
-};
-
-module.exports = {
-  REQUEST_BLACKLIST
-};

--- a/packages/common/src/FormattingUtils.js
+++ b/packages/common/src/FormattingUtils.js
@@ -2,6 +2,7 @@ const networkUtils = require("./PublicNetworks");
 
 const BigNumber = require("bignumber.js");
 const moment = require("moment");
+const { formatFixed, parseFixed, BigNumber: ethersBN } = require("@ethersproject/bignumber");
 
 // Apply settings to BigNumber.js library.
 // Note: ROUNDING_MODE is set to round ceiling so we send at least enough collateral to create the requested tokens.
@@ -126,5 +127,8 @@ module.exports = {
   createEtherscanLinkFromtx,
   createShortHexString,
   createEtherscanLinkMarkdown,
-  addSign
+  addSign,
+  formatFixed,
+  parseFixed,
+  ethersBN
 };

--- a/packages/common/src/FormattingUtils.js
+++ b/packages/common/src/FormattingUtils.js
@@ -2,7 +2,7 @@ const networkUtils = require("./PublicNetworks");
 
 const BigNumber = require("bignumber.js");
 const moment = require("moment");
-const { formatFixed, parseFixed, BigNumber: ethersBN } = require("@ethersproject/bignumber");
+const { formatFixed, parseFixed } = require("@ethersproject/bignumber");
 
 // Apply settings to BigNumber.js library.
 // Note: ROUNDING_MODE is set to round ceiling so we send at least enough collateral to create the requested tokens.
@@ -129,6 +129,5 @@ module.exports = {
   createEtherscanLinkMarkdown,
   addSign,
   formatFixed,
-  parseFixed,
-  ethersBN
+  parseFixed
 };

--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -9,9 +9,9 @@ const IDENTIFIER_NON_18_PRECISION = {
   USDBTC: 8
 };
 
-const getPrecisionForIdentifier = (identifier) => {
-  return (IDENTIFIER_NON_18_PRECISION[identifier] ? IDENTIFIER_NON_18_PRECISION[identifier] : 18)
-}
+const getPrecisionForIdentifier = identifier => {
+  return IDENTIFIER_NON_18_PRECISION[identifier] ? IDENTIFIER_NON_18_PRECISION[identifier] : 18;
+};
 
 module.exports = {
   IDENTIFIER_BLACKLIST,

--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -1,0 +1,15 @@
+// Blacklisted price identifiers that will not automatically display on voter clients.
+const IDENTIFIER_BLACKLIST = {
+  SOME_IDENTIFIER: ["1596666977"]
+};
+
+// Price identifiers that should resolve prices to non 18 decimal precision. Any identifiers
+// not on this list are assumed to resolve to 18 decimals.
+const IDENTIFIER_NON_18_PRECISION = {
+  USDBTC: 8
+};
+
+module.exports = {
+  IDENTIFIER_BLACKLIST,
+  IDENTIFIER_NON_18_PRECISION
+};

--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -9,7 +9,12 @@ const IDENTIFIER_NON_18_PRECISION = {
   USDBTC: 8
 };
 
+const getPrecisionForIdentifier = (identifier) => {
+  return (IDENTIFIER_NON_18_PRECISION[identifier] ? IDENTIFIER_NON_18_PRECISION[identifier] : 18)
+}
+
 module.exports = {
   IDENTIFIER_BLACKLIST,
-  IDENTIFIER_NON_18_PRECISION
+  IDENTIFIER_NON_18_PRECISION,
+  getPrecisionForIdentifier
 };

--- a/packages/common/src/VotingUtils.js
+++ b/packages/common/src/VotingUtils.js
@@ -7,6 +7,8 @@ const {
 const { getKeyGenMessage, computeVoteHash } = require("./EncryptionHelper");
 const { BATCH_MAX_COMMITS, BATCH_MAX_RETRIEVALS, BATCH_MAX_REVEALS } = require("./Constants");
 const { getRandomUnsignedInt } = require("./Random.js");
+const { IDENTIFIER_NON_18_PRECISION } = require("./PriceIdentifierUtils");
+const { parseFixed } = require("./FormattingUtils");
 
 const argv = require("minimist")(process.argv.slice());
 
@@ -45,9 +47,10 @@ const getVotingRoles = (account, voting, designatedVoting) => {
  * @param {String | Number | BN} price
  * @param {String} signingAccount
  * @param {String} votingAccount
+ * @param {String?} decimals Default 18 decimal precision for price
  */
-const constructCommitment = async (request, roundId, web3, price, signingAccount, votingAccount) => {
-  const priceWei = web3.utils.toWei(price.toString());
+const constructCommitment = async (request, roundId, web3, price, signingAccount, votingAccount, decimals = 18) => {
+  const priceWei = parseFixed(price.toString(), decimals).toString();
   const salt = getRandomUnsignedInt().toString();
   const hash = computeVoteHash({
     price: priceWei,

--- a/packages/common/src/VotingUtils.js
+++ b/packages/common/src/VotingUtils.js
@@ -7,7 +7,6 @@ const {
 const { getKeyGenMessage, computeVoteHash } = require("./EncryptionHelper");
 const { BATCH_MAX_COMMITS, BATCH_MAX_RETRIEVALS, BATCH_MAX_REVEALS } = require("./Constants");
 const { getRandomUnsignedInt } = require("./Random.js");
-const { IDENTIFIER_NON_18_PRECISION } = require("./PriceIdentifierUtils");
 const { parseFixed } = require("./FormattingUtils");
 
 const argv = require("minimist")(process.argv.slice());

--- a/packages/core/scripts/local/SnapshotCurrentRound.js
+++ b/packages/core/scripts/local/SnapshotCurrentRound.js
@@ -1,0 +1,20 @@
+const Voting = artifacts.require("Voting");
+const { signMessage } = require("@umaprotocol/common");
+
+const snapshotRound = async callback => {
+  try {
+    const voting = await Voting.deployed();
+    const accounts = await web3.eth.getAccounts();
+    const snapshotMessage = "Sign For Snapshot";
+    const signature = await signMessage(web3, snapshotMessage, accounts[0]);
+
+    const transaction = await voting.snapshotCurrentRound(signature, { from: accounts[0] });
+    console.log("Snapshotted current round:", transaction);
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+module.exports = snapshotRound;

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -46,7 +46,7 @@ import {
   decodeTransaction,
   translateAdminVote,
   IDENTIFIER_BLACKLIST,
-  IDENTIFIER_NON_18_PRECISION,
+  getPrecisionForIdentifier,
   parseFixed,
   formatFixed
 } from "@umaprotocol/common";
@@ -343,9 +343,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
       if (!checkboxesChecked[index] || !editState[index]) {
         continue;
       }
-      const identifierPrecision = IDENTIFIER_NON_18_PRECISION[hexToUtf8(pendingRequests[index].identifier)]
-        ? IDENTIFIER_NON_18_PRECISION[hexToUtf8(pendingRequests[index].identifier)]
-        : 18;
+      const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(pendingRequests[index].identifier));
       const price = parseFixed(editState[index], identifierPrecision).toString();
       const salt = getRandomUnsignedInt().toString();
       const encryptedVote = await encryptMessage(
@@ -428,9 +426,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
 
     let currentVote = "";
     if (voteStatus.committedValue && decryptedCommits[index].price) {
-      const identifierPrecision = IDENTIFIER_NON_18_PRECISION[hexToUtf8(pendingRequest.identifier)]
-        ? IDENTIFIER_NON_18_PRECISION[hexToUtf8(pendingRequest.identifier)]
-        : 18;
+      const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(pendingRequests[index].identifier))
       currentVote = formatFixed(decryptedCommits[index].price, identifierPrecision);
     }
     if (votePhase.toString() === VotePhasesEnum.COMMIT) {

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -47,7 +47,6 @@ import {
   translateAdminVote,
   IDENTIFIER_BLACKLIST,
   IDENTIFIER_NON_18_PRECISION,
-  ethersBN,
   parseFixed,
   formatFixed
 } from "@umaprotocol/common";
@@ -344,7 +343,6 @@ function ActiveRequests({ votingAccount, votingGateway }) {
       if (!checkboxesChecked[index] || !editState[index]) {
         continue;
       }
-      // console.log(ethersBN.from(editState[index]))
       const identifierPrecision = IDENTIFIER_NON_18_PRECISION[hexToUtf8(pendingRequests[index].identifier)]
         ? IDENTIFIER_NON_18_PRECISION[hexToUtf8(pendingRequests[index].identifier)]
         : 18;

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -426,7 +426,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
 
     let currentVote = "";
     if (voteStatus.committedValue && decryptedCommits[index].price) {
-      const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(pendingRequests[index].identifier))
+      const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(pendingRequests[index].identifier));
       currentVote = formatFixed(decryptedCommits[index].price, identifierPrecision);
     }
     if (votePhase.toString() === VotePhasesEnum.COMMIT) {

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -414,9 +414,10 @@ function ActiveRequests({ votingAccount, votingGateway }) {
 
   const eventsMap = {};
   for (const reveal of revealEvents) {
-    eventsMap[toPriceRequestKey(reveal.returnValues.identifier, reveal.returnValues.time)] = formatWei(
+    const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(reveal.returnValues.identifier));
+    eventsMap[toPriceRequestKey(reveal.returnValues.identifier, reveal.returnValues.time)] = formatFixed(
       reveal.returnValues.price,
-      web3
+      identifierPrecision
     );
   }
 

--- a/packages/voter-dapp/src/ResolvedRequests.js
+++ b/packages/voter-dapp/src/ResolvedRequests.js
@@ -25,7 +25,7 @@ import {
   isAdminRequest,
   MAX_UINT_VAL,
   IDENTIFIER_BLACKLIST,
-  IDENTIFIER_NON_18_PRECISION,
+  getPrecisionForIdentifier,
   formatFixed
 } from "@umaprotocol/common";
 
@@ -236,9 +236,7 @@ function ResolvedRequests({ votingAccount }) {
                 event.returnValues.time === resolutionData.time
             );
 
-            const identifierPrecision = IDENTIFIER_NON_18_PRECISION[hexToUtf8(resolutionData.identifier)]
-              ? IDENTIFIER_NON_18_PRECISION[hexToUtf8(resolutionData.identifier)]
-              : 18;
+            const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(resolutionData.identifier))
 
             const userVote = revealEvent ? formatFixed(revealEvent.returnValues.price, identifierPrecision) : "No Vote";
             const correctVote = formatFixed(resolutionData.price, identifierPrecision);

--- a/packages/voter-dapp/src/ResolvedRequests.js
+++ b/packages/voter-dapp/src/ResolvedRequests.js
@@ -236,7 +236,7 @@ function ResolvedRequests({ votingAccount }) {
                 event.returnValues.time === resolutionData.time
             );
 
-            const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(resolutionData.identifier))
+            const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(resolutionData.identifier));
 
             const userVote = revealEvent ? formatFixed(revealEvent.returnValues.price, identifierPrecision) : "No Vote";
             const correctVote = formatFixed(resolutionData.price, identifierPrecision);

--- a/packages/voter-dapp/src/ResolvedRequests.js
+++ b/packages/voter-dapp/src/ResolvedRequests.js
@@ -19,7 +19,15 @@ import {
 } from "@material-ui/core";
 
 import { useTableStyles } from "./Styles.js";
-import { formatDate, translateAdminVote, isAdminRequest, MAX_UINT_VAL, REQUEST_BLACKLIST } from "@umaprotocol/common";
+import {
+  formatDate,
+  translateAdminVote,
+  isAdminRequest,
+  MAX_UINT_VAL,
+  IDENTIFIER_BLACKLIST,
+  IDENTIFIER_NON_18_PRECISION,
+  formatFixed
+} from "@umaprotocol/common";
 
 import VoteData from "./containers/VoteData";
 
@@ -79,9 +87,9 @@ function ResolvedRequests({ votingAccount }) {
 
     if (allResolvedEvents) {
       const nonBlacklistedRequests = allResolvedEvents.filter(ev => {
-        if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)]) return true;
+        if (!IDENTIFIER_BLACKLIST[hexToUtf8(ev.returnValues.identifier)]) return true;
         else {
-          if (!REQUEST_BLACKLIST[hexToUtf8(ev.returnValues.identifier)].includes(ev.returnValues.time)) {
+          if (!IDENTIFIER_BLACKLIST[hexToUtf8(ev.returnValues.identifier)].includes(ev.returnValues.time)) {
             return true;
           } else return false;
         }
@@ -97,7 +105,7 @@ function ResolvedRequests({ votingAccount }) {
         setResolvedEvents(nonBlacklistedRequests);
       }
     }
-  }, [allResolvedEvents, REQUEST_BLACKLIST, showSpamRequests]);
+  }, [allResolvedEvents, IDENTIFIER_BLACKLIST, showSpamRequests]);
 
   const revealedVoteEvents =
     useCacheEvents(
@@ -228,8 +236,12 @@ function ResolvedRequests({ votingAccount }) {
                 event.returnValues.time === resolutionData.time
             );
 
-            const userVote = revealEvent ? fromWei(revealEvent.returnValues.price) : "No Vote";
-            const correctVote = fromWei(resolutionData.price);
+            const identifierPrecision = IDENTIFIER_NON_18_PRECISION[hexToUtf8(resolutionData.identifier)]
+              ? IDENTIFIER_NON_18_PRECISION[hexToUtf8(resolutionData.identifier)]
+              : 18;
+
+            const userVote = revealEvent ? formatFixed(revealEvent.returnValues.price, identifierPrecision) : "No Vote";
+            const correctVote = formatFixed(resolutionData.price, identifierPrecision);
 
             const isAdminVote = isAdminRequest(hexToUtf8(resolutionData.identifier));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,7 +1460,7 @@
   dependencies:
     "@ethersproject/bytes" "^5.0.0"
 
-"@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.0":
+"@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.0", "@ethersproject/bignumber@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.5.tgz#31bd7e75aad46ace345fae69b1f5bb120906af1b"
   integrity sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#1870 


**Summary**

We assume that price requests for a given identifier always resolve to the same precision, which is default 18 decimals but can be overridden to a different precision. Therefore, we add a list of identifiers that must resolve to non-18 decimals.


**Details**

[web3](https://github.com/ethereum/web3.js/issues/3169) does not support arbitrary wei precision so I import an `ethersproject` package that handles the `toWei/fromWei` conversion easily by passing in number of decimals to support. This is the same package that [ethers.js](https://github.com/ethers-io/ethers.js/blob/master/packages/units/src.ts/index.ts#L64) uses.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1870
