### PR TITLE
fix pathing

### DIFF
--- a/packages/reporters/src/cloud-run-scripts/SendSlackReport.sh
+++ b/packages/reporters/src/cloud-run-scripts/SendSlackReport.sh
@@ -9,7 +9,7 @@ fi
 
 # Run the daily reporter script and built the output string.
 echo "Generating daily report"
-reportOutput=$(npx truffle exec ../reporters/index.js --network mainnet_mnemonic)
+reportOutput=$(npx truffle exec ./packages/reporters/index.js --network mainnet_mnemonic)
 
 # The output from the node process contains single quotes. These need to be stripped out
 reportOutput="${reportOutput//\'/$' '}"


### PR DESCRIPTION
This PR fixes the hardcoded path issue within the `SendSlackReport.sh` script used to generate daily reports.

It has been tested in production on a temp docker container.