### PR TITLE
fix(voter-dapp): Parse Admin requests properly

### DIFF
--- a/packages/common/src/AdminUtils.js
+++ b/packages/common/src/AdminUtils.js
@@ -44,11 +44,14 @@ function getAdminRequestId(identifierUtf8) {
 
 // Vote 1 for Yes, 0 for No. Any vote > 0 is technically a Yes, but the 1 is treated as the canonical yes.
 const translateAdminVote = voteValue => {
-  const parsedVoteValue = voteValue ? parseInt(voteValue).toString() : null
-  switch (parsedVoteValue) {
-    case "1":
+  switch (voteValue.toString()) {
+    case("1.0"):
       return "YES";
-    case "0":
+    case ("1"):
+      return "YES";
+    case ("0"):
+      return "NO";
+    case ("0.0"):
       return "NO";
     default:
       return "INVALID ADMIN VOTE";

--- a/packages/common/src/AdminUtils.js
+++ b/packages/common/src/AdminUtils.js
@@ -45,13 +45,13 @@ function getAdminRequestId(identifierUtf8) {
 // Vote 1 for Yes, 0 for No. Any vote > 0 is technically a Yes, but the 1 is treated as the canonical yes.
 const translateAdminVote = voteValue => {
   switch (voteValue.toString()) {
-    case("1.0"):
+    case "1.0":
       return "YES";
-    case ("1"):
+    case "1":
       return "YES";
-    case ("0"):
+    case "0":
       return "NO";
-    case ("0.0"):
+    case "0.0":
       return "NO";
     default:
       return "INVALID ADMIN VOTE";

--- a/packages/common/src/AdminUtils.js
+++ b/packages/common/src/AdminUtils.js
@@ -44,7 +44,8 @@ function getAdminRequestId(identifierUtf8) {
 
 // Vote 1 for Yes, 0 for No. Any vote > 0 is technically a Yes, but the 1 is treated as the canonical yes.
 const translateAdminVote = voteValue => {
-  switch (voteValue) {
+  const parsedVoteValue = voteValue ? parseInt(voteValue).toString() : null
+  switch (parsedVoteValue) {
     case "1":
       return "YES";
     case "0":


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#1899 parsed price requests via `formatFixed` instead of `fromWei`, which always returns a float whereas `fromWei` sometimes returned ints, particularly for Admin requests. Therefore, the voter dApp incorrectly parses admin votes as "1.0" instead of "1".


**Summary**

`translateAdminStatus` should parse "1.0" votes as YES and "0.0" as NO


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1870 
