### PR TITLE
fix(voter-dapp): Salt + price cache incorrectly formats saved vote

### DIFF
--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -632,7 +632,11 @@ function ActiveRequests({ votingAccount, votingGateway }) {
                         <FileCopyIcon />
                       </IconButton>
                       <br />
-                      {"-     Price: " + formatFixed(getCommittedData(commitBackupIndex)[timestamp].price, getCommittedData(commitBackupIndex)[timestamp].identifierPrecision)}
+                      {"-     Price: " +
+                        formatFixed(
+                          getCommittedData(commitBackupIndex)[timestamp].price,
+                          getCommittedData(commitBackupIndex)[timestamp].identifierPrecision
+                        )}
                       <br />
                       <br />
                     </span>

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -32,7 +32,6 @@ import VoteData from "./containers/VoteData";
 import {
   VotePhasesEnum,
   formatDate,
-  formatWei,
   decryptMessage,
   deriveKeyPairFromSignatureMetamask,
   encryptMessage,
@@ -382,7 +381,8 @@ function ActiveRequests({ votingAccount, votingGateway }) {
           ...cookies[newCommitKey],
           [encryptionTimestamp]: {
             salt,
-            price
+            price,
+            identifierPrecision
           }
         }
       );
@@ -632,7 +632,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
                         <FileCopyIcon />
                       </IconButton>
                       <br />
-                      {"-     Price: " + formatWei(getCommittedData(commitBackupIndex)[timestamp].price, web3)}
+                      {"-     Price: " + formatFixed(getCommittedData(commitBackupIndex)[timestamp].price, getCommittedData(commitBackupIndex)[timestamp].identifierPrecision)}
                       <br />
                       <br />
                     </span>


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Incorrect price stored in cache, this does not affect any on-chain data
<img width="528" alt="Screen Shot 2020-08-25 at 23 38 45" src="https://user-images.githubusercontent.com/9457025/91252789-3dd26f80-e72c-11ea-9a02-5e86f59b8239.png">


**Details**

Need to use `formatFixed` method with `identifierPrecision`

