### PR TITLE
docs(readme): add lerna and yarn documentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ documentation. If you'd like to view these docs on github instead, check out the
 
 Please see [here](./documentation/developer_reference/bug_bounty.md) for details on our bug bounty.
 
+## Contributing 🙌
+
+Please see our [contributing guidelines](./CONTRIBUTING.md).
+
 ## Developer Information and Tools 👩‍💻
 
 For detailed information on how to initialize and interact with our smart contracts, please see the

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn clean-packages
 yarn
 ```
 
-### Prepare smart contracts 🧐
+### Build the code 🧐
 
 Some code in the repository requires a build step to compile it. To run this build step, use the `qbuild` (quick build) command:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please see [here](./documentation/developer_reference/bug_bounty.md) for details
 
 ## Developer Information and Tools 👩‍💻
 
-For information on how to initialize and interact with our smart contracts, please see the
+For detailed information on how to initialize and interact with our smart contracts, please see the
 [documentation site](https://docs.umaproject.org).
 
 ### Install dependencies 👷‍♂️

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ However, if you'd like to build _everything_, you can use the build command:
 yarn build
 ```
 
+To remove any remnants of previous builds, you can run:
+
+```
+yarn clean
+```
+
 ### Run tests 🦾
 
 To run tests, you'll need to start ganache on port 9545:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You'll need the latest LTS release of nodejs and yarn installed. Assuming that's
 yarn
 ```
 
-If you'd like to completely clear all packages' node_modules and reinstall all deps from scratch, run:
+If you'd like to completely clear all packages' `node_modules` and reinstall all deps from scratch, run:
 
 ```
 yarn clean-packages
@@ -163,7 +163,7 @@ To install this dependency you're using in `@umaprotocol/my-package`, you should
 yarn lerna add @umaprotocol/some-package --scope @umaprotocol/my-package
 ```
 
-By default, this will symlink the package in node_modules rather than attempting to pull the package via npm. This allows
+By default, this will symlink the package in `node_modules` rather than attempting to pull the package via npm. This allows
 the packages to depend on the in-repo versions of one another. If you'd like to reference a particular version from npm,
 you can specify that version exactly in the `package.json` file.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ You'll need the latest LTS release of nodejs and yarn installed. Assuming that's
 yarn
 ```
 
+If you'd like to completely clear all packages' node_modules and reinstall all deps from scratch, run:
+
+```
+yarn clean-packages
+yarn
+```
+
 ### Prepare smart contracts 🧐
 
 Some code in the repository requires a build step to compile it. To run this build step, use the `qbuild` (quick build) command:

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ yarn test
 ```
 
 However, running all of the tests across the repository takes a lot of time. To run the tests for just
-one subpackage, you can run:
+one package, you can run:
 
 ```
-yarn workspace <subpackage_name> test
+yarn workspace <package_name> test
 ```
 
 ### Running the linter 🧽
@@ -104,24 +104,30 @@ To run the linter in the default mode, where it will print all errors and not mo
 yarn lint
 ```
 
+### Packages 📦
+
+Because this repo is a monorepo, it conatains many different npm packages. More will be discussed about these packages in the
+following sections. However, the basic structure is that each pacakge is listed in the `packages/` directory. Each package has
+its own scripts and dependencies and operates (mostly) independently from the others.
+
 ### Adding dependencies 👩‍👦
 
-All runtime/production dependencies should be added to the subpackage that needs them. Development dependencies
-should also generally be installed in subpackages unless they are needed by code that exists outside of any subpackage.
+All runtime/production dependencies should be added to the package that needs them. Development dependencies
+should also generally be installed in packages unless they are needed by code that exists outside of any package.
 
-For more details on subpackages and the monorepo, please see the next section.
+For more details on packages and the monorepo, please see the next section.
 
-To add a dependency to a subpackage:
+To add a dependency to a package:
 
 ```
-yarn workspace <subpackage_name> add <dependency_name>
+yarn workspace <package_name> add <dependency_name>
 ```
 
 Note: development dependencies are those that are not required by the code that's published to the npm registry. If you're not
-sure whether a dependency should be dev or not, just ask! To install a dev dependency in a subpackage:
+sure whether a dependency should be dev or not, just ask! To install a dev dependency in a package:
 
 ```
-yarn workspace <subpackage_name> add <dependency_name> --dev
+yarn workspace <package_name> add <dependency_name> --dev
 ```
 
 To install a dev dependency at root:
@@ -132,6 +138,34 @@ yarn add <dependency_name> --dev
 
 After you've installed a dependency, yarn should automatically update the `yarn.lock` file. If git doesn't notice any changes in that file,
 run `yarn` to update the lockfile.
+
+### Depending on another package in the monorepo 🤝
+
+The standard way to pull a JS element from another package is to reference it like this:
+
+```js
+const { importedObject } = require("@umaprotocol/some-package")
+```
+
+Note: the require will resolve to the `main` file specified in the `package.json` file. If you'd like to import a different file, you
+should ensure that that file is exported in the `files` directive inside the `package.json` file. Once you're sure of that, you can
+import it using the following syntax:
+
+```js
+const { importedObject } = require("@umaprotocol/some-package/path/to/some/file")
+```
+
+Note: if this file isn't exported by the `files` directive, it will work locally, but fail when run via an npm installation.
+
+To install this dependency you're using in `@umaprotocol/my-package`, you should run the following command:
+
+```
+yarn lerna add @umaprotocol/some-package --scope @umaprotocol/my-package
+```
+
+By default, this will symlink the package in node_modules rather than attempting to pull the package via npm. This allows
+the packages to depend on the in-repo versions of one another. If you'd like to reference a particular version from npm,
+you can specify that version exactly in the `package.json` file.
 
 ### Using yarn and lerna 🧑‍🍳
 
@@ -158,7 +192,7 @@ yarn lerna <command>
 To run a yarn command in a particular sub-package, you can run the following from _anywhere in the repo_:
 
 ```
-yarn workspace <subpackage_name> <script>
+yarn workspace <package_name> <script>
 ```
 
 For instance, this could be used to run the build command in the `@umaprotocol/core` package:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ yarn lerna run <script> --stream
 
 Note: the stream argument is just to force lerna to stream the output so you get realtime logs.
 
-## Coverage 🔎
+### Coverage 🔎
 
 We use the [solidity-coverage](https://github.com/sc-forks/solidity-coverage) package to generate our coverage reports.
 You can find the coverage report at [coveralls](https://coveralls.io/github/UMAprotocol/protocol). Otherwise, you can generate it locally by running:
@@ -232,7 +232,7 @@ You can find the coverage report at [coveralls](https://coveralls.io/github/UMAp
 
 The full report can be viewed by opening the `packages/core/coverage/index.html` file in a browser.
 
-## Style Guide 🕺
+### Style Guide 🕺
 
 See [STYLE.md](STYLE.md).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Our docs site is [here](https://docs.umaproject.org). It contains tutorials, explainers, and smart contract
 documentation. If you'd like to view these docs on github instead, check out the
-[documentation folder](./documentation).
+[documentation folder in the docs repo](https://github.com/UMAprotocol/docs/tree/master/docs).
 
 ## Security and Bug Bounty 🐛
 
@@ -35,19 +35,144 @@ For information on how to initialize and interact with our smart contracts, plea
 
 ### Install dependencies 👷‍♂️
 
-You'll need the latest LTS release of nodejs and npm installed. Assuming that's done, run:
+You'll need the latest LTS release of nodejs and yarn installed. Assuming that's done, run `yarn` with no args:
 
 ```
-npm install
+yarn
+```
+
+### Prepare smart contracts 🧐
+
+Some code in the repository requires a build step to compile it. To run this build step, use the `qbuild` (quick build) command:
+
+```
+yarn qbuild
+```
+
+The above command does not include dapps because dapps take a long time to build and they have their own scripts to run locally.
+However, if you'd like to build _everything_, you can use the build command:
+
+```
+yarn build
+```
+
+### Run tests 🦾
+
+To run tests, you'll need to start ganache on port 9545:
+
+```
+yarn ganache-cli -e 1000000000 -p 9545 -l 9000000 -d
+```
+
+Note: if you're interested in what these args do:
+
+- `-e` is the amount of ETH to grant the default accounts.
+- `-p` is the port that ganache will listen on.
+- `-d` tells ganache to use a standard set of deterministic accounts on each run.
+
+Then, you can run all of the tests across the repo by running:
+
+```
+yarn test
+```
+
+However, running all of the tests across the repository takes a lot of time. To run the tests for just
+one subpackage, you can run:
+
+```
+yarn workspace <subpackage_name> test
 ```
 
 ### Running the linter 🧽
 
-To run the formatter, run:
+To run the linter in autofix mode (it will attempt to fix any errors it finds), run:
 
 ```
-npm run lint-fix
+yarn lint-fix
 ```
+
+To run the linter in the default mode, where it will print all errors and not modify code, run:
+
+```
+yarn lint
+```
+
+### Adding dependencies 👩‍👦
+
+All runtime/production dependencies should be added to the subpackage that needs them. Development dependencies
+should also generally be installed in subpackages unless they are needed by code that exists outside of any subpackage.
+
+For more details on subpackages and the monorepo, please see the next section.
+
+To add a dependency to a subpackage:
+
+```
+yarn workspace <subpackage_name> add <dependency_name>
+```
+
+Note: development dependencies are those that are not required by the code that's published to the npm registry. If you're not
+sure whether a dependency should be dev or not, just ask! To install a dev dependency in a subpackage:
+
+```
+yarn workspace <subpackage_name> add <dependency_name> --dev
+```
+
+To install a dev dependency at root:
+
+```
+yarn add <dependency_name> --dev
+```
+
+After you've installed a dependency, yarn should automatically update the `yarn.lock` file. If git doesn't notice any changes in that file,
+run `yarn` to update the lockfile.
+
+### Using yarn and lerna 🧑‍🍳
+
+This repository is a monorepo. That means that it contains many different, but related packages.
+It uses [yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) and [lerna](https://github.com/lerna/lerna)
+to manage these packages.
+
+Note: lerna and yarn workspaces have some overlapping functionality. This is because `lerna` predates `yarn` workspaces and
+is compatible with `yarn` alternatives that don't have workspace functions, like `npm`.
+
+`yarn` should be installed globally to use this repo. This means that you can run any yarn command by running:
+
+```
+yarn <command>
+```
+
+Once you run `yarn` during the install section above, lerna should have been installed locally. After that,
+you should be able to run lerna commands using yarn:
+
+```
+yarn lerna <command>
+```
+
+To run a yarn command in a particular sub-package, you can run the following from _anywhere in the repo_:
+
+```
+yarn workspace <subpackage_name> <script>
+```
+
+For instance, this could be used to run the build command in the `@umaprotocol/core` package:
+
+```
+yarn workspace @umaprotocol/core build
+```
+
+or to install the truffle package as a devDependency in the `@umaprotocol/liquidator` package:
+
+```
+yarn workspace @umaprotocol/liquidator add truffle --dev
+```
+
+To run a package script in _every_ package that has a script by that name, you should use `lerna`:
+
+```
+yarn lerna run <script> --stream
+```
+
+Note: the stream argument is just to force lerna to stream the output so you get realtime logs.
 
 ## Coverage 🔎
 
@@ -55,10 +180,10 @@ We use the [solidity-coverage](https://github.com/sc-forks/solidity-coverage) pa
 You can find the coverage report at [coveralls](https://coveralls.io/github/UMAprotocol/protocol). Otherwise, you can generate it locally by running:
 
 ```
-./ci/coverage.sh core
+./ci/coverage.sh packages/core
 ```
 
-The full report can be viewed by opening the `core/coverage/index.html` file in a browser.
+The full report can be viewed by opening the `packages/core/coverage/index.html` file in a browser.
 
 ## Style Guide 🕺
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ sure whether a dependency should be dev or not, just ask! To install a dev depen
 yarn workspace <package_name> add <dependency_name> --dev
 ```
 
+Note: all root dependencies should be dev dependencies because the root package is not published to npm, so there is no "production" code.
 To install a dev dependency at root:
 
 ```
@@ -223,7 +224,7 @@ To run a package script in _every_ package that has a script by that name, you s
 yarn lerna run <script> --stream
 ```
 
-Note: the stream argument is just to force lerna to stream the output so you get realtime logs.
+Note: the stream argument is just to force lerna to stream the output so you get realtime logs, but it's not required.
 
 ### Coverage 🔎
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "lerna run --stream --concurrency=1 test",
     "load-addresses": "yarn workspace @umaprotocol/core load-addresses",
     "create-release": "lerna version --no-git-tag-version --conventional-commits --no-push",
-    "publish-release": "./scripts/run_release.sh"
+    "publish-release": "./scripts/run_release.sh",
+    "qbuild": "yarn lerna run build --stream --ignore '*/*dapp*'",
+    "build": "yarn lerna run build --stream"
   },
   "author": "UMA Team",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "create-release": "lerna version --no-git-tag-version --conventional-commits --no-push",
     "publish-release": "./scripts/run_release.sh",
     "qbuild": "yarn lerna run build --stream --ignore '*/*dapp*'",
-    "build": "yarn lerna run build --stream"
+    "build": "yarn lerna run build --stream",
+    "clean": "yarn lerna run clean --stream",
+    "clean-packages": "yarn lerna clean --yes && rm -rf node_modules"
   },
   "author": "UMA Team",
   "license": "AGPL-3.0",


### PR DESCRIPTION
**Motivation**

To help users understand how to work and run commands inside the monorepo.

**Summary**

A few convenient yarn scripts were added to root and the readme was updated and extended to explain how to use the new tooling.

Note: this README includes a shift in how we install packages. Since `npx lerna bootstrap` and `yarn` do the exact same thing when used in a yarn workspaces repo, I've elected to make the default installation method `yarn` for simplicity.

**Issue(s)**

Fixes #1884 
