### PR TITLE
fix(voter-dapp): admin votes don't show INVALID ADMIN VOTE before committing a vote

### DIFF
--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -516,7 +516,9 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     } else {
       return (
         <span>
-          {isAdminVote && statusDetails[index].currentVote ? translateAdminVote(statusDetails[index].currentVote) : statusDetails[index].currentVote}{" "}
+          {isAdminVote && statusDetails[index].currentVote
+            ? translateAdminVote(statusDetails[index].currentVote)
+            : statusDetails[index].currentVote}{" "}
           {saveButtonShown ? (
             <Button
               variant="contained"

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -516,7 +516,7 @@ function ActiveRequests({ votingAccount, votingGateway }) {
     } else {
       return (
         <span>
-          {isAdminVote ? translateAdminVote(statusDetails[index].currentVote) : statusDetails[index].currentVote}{" "}
+          {isAdminVote && statusDetails[index].currentVote ? translateAdminVote(statusDetails[index].currentVote) : statusDetails[index].currentVote}{" "}
           {saveButtonShown ? (
             <Button
               variant="contained"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Admin vote shows invalid admin vote by default:
<img width="295" alt="Screen Shot 2020-08-30 at 00 29 52" src="https://user-images.githubusercontent.com/9457025/91651213-ed268380-ea57-11ea-8152-263ddd649413.png">



**Summary**

If no vote committed, don't attempt to `translateAdminVote()`


