### PR TITLE
fix(liquidator 1inch integration) incorrect use of artifacts broke production implementation

### DIFF
--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -116,6 +116,8 @@ async function run(
         web3,
         gasEstimator,
         logger,
+        oneSplitAbi: getAbi("OneSplit"),
+        erc20TokenAbi: getAbi("ExpandedERC20"),
         oneSplitAddress
       });
     }

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -687,8 +687,10 @@ contract("Liquidator.js", function(accounts) {
     it("amount-to-liquidate > min-sponsor-tokens, swaps reserveToken (ETH) for tokenCurrency on OneSplit", async function() {
       const oneInchClient = new OneInchExchange({
         web3,
-        logger: spyLogger,
         gasEstimator,
+        logger: spyLogger,
+        oneSplitAbi: OneSplitMock.abi,
+        erc20TokenAbi: Token.abi,
         oneSplitAddress: oneSplitMock.address
       });
       liquidator.oneInchClient = oneInchClient;

--- a/packages/liquidator/test/OneInchExchange.js
+++ b/packages/liquidator/test/OneInchExchange.js
@@ -33,7 +33,14 @@ contract("OneInch", function(accounts) {
 
   before(async function() {
     oneSplitMock = await OneSplitMock.new();
-    oneInch = new OneInchExchange({ web3, logger: spyLogger, gasEstimator, oneSplitAddress: oneSplitMock.address });
+    oneInch = new OneInchExchange({
+      web3,
+      gasEstimator,
+      logger: spyLogger,
+      oneSplitAbi: OneSplitMock.abi,
+      erc20TokenAbi: Token.abi,
+      oneSplitAddress: oneSplitMock.address
+    });
 
     token1 = await Token.new("TOKEN1", "TK1", 18, { from: owner });
     await token1.addMember(1, owner, { from: owner });


### PR DESCRIPTION

**Motivation**

issue #1922

**Summary**

The most recent PR [1855](https://github.com/UMAprotocol/protocol/pull/1855) merged in on Friday last week broke production bots due to an incorrect import of truffle artifacts. Artifacts **must** be injected into the models, like everywhere else in the bots. This change meant that bots would **only** work when executing with `truffle test` and would fail if run with `truffle exec ...` or `node ...`.


**Details**

This PR addresses this error. Additionally, there was a subsequent error in how web3 was being imported for utilities that was also addressed.

**Issue(s)**

Close #1922 