### PR TITLE
fix(truffle): correct node url resolution in truffle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,6 @@ jobs:
       - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
-      - image: trufflesuite/ganache-cli
-        command: ganache-cli -l 9000000 -f https://mainnet.infura.io/v3/84842078b09946638c03157f83405213 -p 1235
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -114,6 +112,18 @@ jobs:
       - run:
           name: Run tests
           command: yarn run test
+  test_fork:
+    docker:
+      - image: circleci/node:lts
+      - image: trufflesuite/ganache-cli
+        command: ganache-cli -l 9000000 -f https://mainnet.infura.io/v3/84842078b09946638c03157f83405213 -p 9545
+    working_directory: ~/protocol
+    steps:
+      - restore_cache:
+          key: protocol-completed-build-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Run tests
+          command: yarn run test-fork
   coverage:
     docker:
       - image: circleci/node:lts
@@ -194,6 +204,10 @@ workflows:
           requires:
             - checkout_and_install
       - test:
+          context: api_keys
+          requires:
+            - build
+      - test_fork:
           context: api_keys
           requires:
             - build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eslint": "eslint './**/*.js'",
     "prettier": "prettier './**/*.js' './**/*.sol' './**/*.md'",
     "test": "lerna run --stream --concurrency=1 test",
+    "test-fork": "lerna run --stream --concurrency=1 test-fork",
     "load-addresses": "yarn workspace @umaprotocol/core load-addresses",
     "create-release": "lerna version --no-git-tag-version --conventional-commits --no-push",
     "publish-release": "./scripts/run_release.sh",

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -27,8 +27,6 @@ const privateKey = process.env.PRIVATE_KEY
   : "0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709";
 
 // Fallback to a backup non-prod API key.
-const infuraApiKey = process.env.INFURA_API_KEY ? process.env.INFURA_API_KEY : "e34138b2db5b496ab5cc52319d2f0299";
-const customNodeUrl = process.env.CUSTOM_NODE_URL;
 const keyOffset = process.env.KEY_OFFSET ? parseInt(process.env.KEY_OFFSET) : 0; // Start at account 0 by default.
 const numKeys = process.env.NUM_KEYS ? parseInt(process.env.NUM_KEYS) : 2; // Generate two wallets by default.
 let singletonProvider;
@@ -38,7 +36,7 @@ const gasPx = 20000000000; // 20 gwei
 const gas = undefined; // Defining this as undefined (rather than leaving undefined) forces truffle estimate gas usage.
 
 // If a custom node URL is provided, use that. Otherwise use an infura websocket connection.
-function getNodeUrl(networkName) {
+function getNodeUrl(networkName = argv.network) {
   if (isPublicNetwork(networkName) && !networkName.includes("fork")) {
     const infuraApiKey = process.env.INFURA_API_KEY || "e34138b2db5b496ab5cc52319d2f0299";
     return process.env.CUSTOM_NODE_URL || `wss://${name}.infura.io/ws/v3/${infuraApiKey}`;
@@ -204,4 +202,4 @@ function getTruffleConfig(truffleContextDir = "./") {
   };
 }
 
-module.exports = { getTruffleConfig, nodeUrl };
+module.exports = { getTruffleConfig, getNodeUrl };

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -137,11 +137,10 @@ function addLocalNetwork(networks, name, customOptions) {
     network_id: "*",
     gas: gas,
     provider: function(provider = nodeUrl) {
-      if (!singletonProvider) {
-        const tempWeb3 = new Web3(provider);
-        singletonProvider = tempWeb3.eth.currentProvider;
-      }
-      return singletonProvider;
+      // Don't use the singleton here because it seems to make truffle tests flaky and creating multiple local providers
+      // won't hurt anything.
+      const tempWeb3 = new Web3(provider);
+      return tempWeb3.eth.currentProvider;
     }
   };
 

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -43,7 +43,7 @@ function getNodeUrl(networkName = argv.network) {
   }
 
   const port = process.env.CUSTOM_LOCAL_NODE_PORT || "9545";
-  return `ws://127.0.0.1:${port}`;
+  return `http://127.0.0.1:${port}`;
 }
 
 // Adds a public network.

--- a/packages/financial-templates-lib/src/clients/Web3WebsocketClient.js
+++ b/packages/financial-templates-lib/src/clients/Web3WebsocketClient.js
@@ -3,7 +3,7 @@
 // syntax mimics that of the main UMA Truffle implementation to make this backwards compatible.
 
 const Web3 = require("web3");
-const { getTruffleConfig, nodeUrl } = require("@umaprotocol/common");
+const { getTruffleConfig, getNodeUrl } = require("@umaprotocol/common");
 const argv = require("minimist")(process.argv.slice(), { string: ["network"] });
 
 const websocketOptions = {
@@ -21,6 +21,7 @@ const websocketOptions = {
 };
 
 // Create websocket web3 provider. This contains the re-try logic on failed/timeout connections.
+const nodeUrl = getNodeUrl();
 const websocketProvider = new Web3.providers.WebsocketProvider(nodeUrl, websocketOptions);
 
 // Use the websocketProvider to create a provider with an unlocked wallet. This piggybacks off the UMA common TruffleConfig

--- a/packages/liquidator/package.json
+++ b/packages/liquidator/package.json
@@ -29,7 +29,8 @@
     "/src/**/*.js"
   ],
   "scripts": {
-    "test": "truffle test && truffle test test-fork"
+    "test": "truffle test",
+    "test-fork": "truffle test test-fork --network mainnet-fork"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"


### PR DESCRIPTION
**Motivation**

This PR fixes a few issues in the truffle config:
- The nodeUrl does not correctly resolve when not using a custom node.
- Providers are not set up as functions for local networks, so they wouldn't work with scripts that are run as node processes.
- A bunch of local networks are no longer used or required (as far as I can tell).

test-fork was also moved to its own command and ci job since it requires its own ganache instance.

**Summary**

Truffle config was updated to correctly resolve the node url internally and for files that import it.

Providers are now all functions. There are no `host` and `port` fields.

Many local networks were removed.

**Issue(s)**

Fixes #1888 
Fixes #1909.
