### PR TITLE
feat(price-feeds): refactor cryptowatch to throw errors to allow retries

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -133,7 +133,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     // timestamp (because the close of that OHLC may be relevant).
     const earliestHistoricalTimestamp = Math.floor((currentTime - this.lookback) / this.ohlcPeriod) * this.ohlcPeriod;
 
-    // 1. Construct URLS.
+    // 1. Construct URLs.
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
     const priceUrl =
       `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price` +

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -154,14 +154,13 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     ]);
 
     // 3. Check responses.
-    assert(
-      priceResponse && priceResponse.result && priceResponse.result.price,
-      `🚨Could not parse price result from url ${priceUrl}: ${JSON.stringify(priceResponse)}`
-    );
-    assert(
-      ohlcResponse && ohlcResponse.result && ohlcResponse.result[this.ohlcPeriod],
-      `🚨Could not parse ohlc result from url ${ohlcUrl}: ${JSON.stringify(ohlcResponse)}`
-    );
+    if (!priceResponse || !priceResponse.result || !priceResponse.result.price) {
+      throw new Error(`🚨Could not parse price result from url ${priceUrl}: ${JSON.stringify(priceResponse)}`);
+    }
+
+    if (!ohlcResponse || !ohlcResponse.result || !ohlcResponse.result[this.ohlcPeriod]) {
+      throw new Error(`🚨Could not parse ohlc result from url ${ohlcUrl}: ${JSON.stringify(ohlcResponse)}`);
+    }
 
     // 4. Parse results.
     // Return data structure:

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -1,5 +1,3 @@
-const assert = require("assert");
-
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 const { parseFixed } = require("@ethersproject/bignumber");
 

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -212,8 +212,9 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
       }
     ];
 
-    await cryptoWatchPriceFeed.update();
-    await invertedCryptoWatchPriceFeed.update();
+    // Update should throw errors in both cases.
+    assert.isTrue(await cryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
+    assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
     assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
@@ -232,7 +233,7 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
       }
     ];
 
-    await cryptoWatchPriceFeed.update();
+    assert.isTrue(await cryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
     assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
@@ -249,7 +250,7 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
       }
     ];
 
-    await invertedCryptoWatchPriceFeed.update();
+    assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
     assert.equal(invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);


### PR DESCRIPTION
**Motivation**

#1933.


**Summary**

The cryptowatch price feed was slightly reorganized to throw errors when the api breaks.

Note: the two api calls were also parallelized to slightly speed up execution.


**Issue(s)**

Fixes #1933 
