### PR TITLE
fix(reporter): Currently overwrites some rows in table

### DIFF
--- a/packages/reporters/src/GlobalSummaryReporter.js
+++ b/packages/reporters/src/GlobalSummaryReporter.js
@@ -594,6 +594,7 @@ class GlobalSummaryReporter {
     };
     if (this.periodTotalCollateralDeposited && this.prevPeriodTotalCollateralDeposited) {
       allSponsorStatsTable["collateral deposited"] = {
+        ...allSponsorStatsTable["collateral deposited"],
         [this.periodLabelInHours]: this.formatDecimalString(this.toWei(this.periodTotalCollateralDeposited)),
         ["Δ from prev. period"]: this.formatDecimalStringWithSign(
           this.toBN(this.toWei(this.periodTotalCollateralDeposited)).sub(
@@ -609,6 +610,7 @@ class GlobalSummaryReporter {
     };
     if (this.periodTotalCollateralWithdrawn && this.prevPeriodTotalCollateralWithdrawn) {
       allSponsorStatsTable["collateral withdrawn"] = {
+        ...allSponsorStatsTable["collateral withdrawn"],
         [this.periodLabelInHours]: this.formatDecimalString(this.toWei(this.periodTotalCollateralWithdrawn)),
         ["Δ from prev. period"]: this.formatDecimalStringWithSign(
           this.toBN(this.toWei(this.periodTotalCollateralWithdrawn)).sub(
@@ -644,6 +646,7 @@ class GlobalSummaryReporter {
         Number(this.prevPeriodTotalCollateralDeposited) - Number(this.prevPeriodTotalCollateralWithdrawn)
       ).toString();
       allSponsorStatsTable["net collateral deposited"] = {
+        ...allSponsorStatsTable["net collateral deposited"],
         [this.periodLabelInHours]: this.formatDecimalString(this.toWei(this.netCollateralWithdrawnPeriod)),
         ["Δ from prev. period"]: this.formatDecimalStringWithSign(
           this.toBN(this.toWei(this.netCollateralWithdrawnPeriod)).sub(
@@ -659,6 +662,7 @@ class GlobalSummaryReporter {
     };
     if (this.periodTotalSyntheticTokensCreated && this.prevPeriodTotalSyntheticTokensCreated) {
       allSponsorStatsTable["tokens minted"] = {
+        ...allSponsorStatsTable["tokens minted"],
         [this.periodLabelInHours]: this.formatDecimalString(this.toWei(this.periodTotalSyntheticTokensCreated)),
         ["Δ from prev. period"]: this.formatDecimalStringWithSign(
           this.toBN(this.toWei(this.periodTotalSyntheticTokensCreated)).sub(
@@ -674,6 +678,7 @@ class GlobalSummaryReporter {
     };
     if (this.periodTotalSyntheticTokensBurned && this.prevPeriodTotalSyntheticTokensBurned) {
       allSponsorStatsTable["tokens burned"] = {
+        ...allSponsorStatsTable["tokens burned"],
         [this.periodLabelInHours]: this.formatDecimalString(this.toWei(this.periodTotalSyntheticTokensBurned)),
         ["Δ from prev. period"]: this.formatDecimalStringWithSign(
           this.toBN(this.toWei(this.periodTotalSyntheticTokensBurned)).sub(
@@ -709,6 +714,7 @@ class GlobalSummaryReporter {
         Number(this.prevPeriodTotalSyntheticTokensCreated) - Number(this.prevPeriodTotalSyntheticTokensBurned)
       ).toString();
       allSponsorStatsTable["net tokens minted"] = {
+        ...allSponsorStatsTable["net tokens minted"],
         [this.periodLabelInHours]: this.formatDecimalString(this.toWei(this.netTokensMintedPeriod)),
         ["Δ from prev. period"]: this.formatDecimalStringWithSign(
           this.toBN(this.toWei(this.netTokensMintedPeriod)).sub(this.toBN(this.toWei(this.netTokensMintedPrevPeriod)))


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Daily reporter is blank when both `cumulative` and `period` data is shown.

```sh
 ┌─────────────────────────────────────────┬────────────┬────────────┬──────────────────────────┬─────────────────────┐
  │                 (index)                 │ cumulative │  current   │ 08/25/2020 to 09/01/2020 │ Δ from prev. period │
  ├─────────────────────────────────────────┼────────────┼────────────┼──────────────────────────┼─────────────────────┤
  │          # of unique sponsors           │    322     │     72     │            14            │         +4          │
  │          collateral deposited           │            │            │         2,937.70         │     -13,377.19      │
  │          collateral withdrawn           │            │            │        30,586.23         │     +25,234.50      │
  │        net collateral deposited         │            │            │        -27,648.52        │     -38,611.70      │
  │              tokens minted              │            │            │        439,299.15        │    -2,247,304.84    │
  │              tokens burned              │            │            │       4,981,490.81       │    +4,102,395.54    │
  │            net tokens minted            │            │            │      -4,542,191.66       │    -6,349,700.39    │
  │ GCR - collateral / # tokens outstanding │            │  0.005595  │                          │                     │
  │         GCR - collateral / TRV          │            │    2.62    │                          │                     │
  │     price from reference pricefeed      │            │  0.002128  │                          │                     │
  └─────────────────────────────────────────┴────────────┴────────────┴──────────────────────────┴─────────────────────┘
 
```

