### PR TITLE
feat(pricefeed): add pricefeedmockscaled which can use non 18dec

### DIFF
--- a/packages/financial-templates-lib/index.js
+++ b/packages/financial-templates-lib/index.js
@@ -8,5 +8,6 @@ module.exports = {
   ...require("./src/logger/SpyTransport"),
   ...require("./src/price-feed/CreatePriceFeed"),
   ...require("./src/price-feed/Networker"),
-  ...require("./src/price-feed/PriceFeedMock")
+  ...require("./src/price-feed/PriceFeedMock"),
+  ...require("./src/price-feed/PriceFeedMockScaled")
 };

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedMockScaled.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedMockScaled.js
@@ -1,0 +1,80 @@
+const { toBN } = web3.utils;
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+const { parseFixed } = require("@ethersproject/bignumber");
+
+// An implementation of PriceFeedInterface that medianizes other price feeds.
+class PriceFeedMockScaled extends PriceFeedInterface {
+  // Constructs the MedianizerPriceFeed.
+  // priceFeeds a list of priceFeeds to medianize. All elements must be of type PriceFeedInterface. Must be an array of
+  // at least one element.
+  constructor(currentPrice, historicalPrice, lastUpdateTime, invertPrice, decimals = 18) {
+    super();
+    this.updateCalled = 0;
+    this.currentPrice = currentPrice;
+    this.historicalPrice = historicalPrice;
+    this.lastUpdateTime = lastUpdateTime;
+    this.historicalPrices = [];
+    this.invertPrice = invertPrice;
+
+    this.convertDecimals = number => {
+      // Converts price result to wei
+      // returns price conversion to correct decimals as a big number
+      return toBN(parseFixed(number.toString(), decimals).toString());
+    };
+  }
+
+  // only available in mock
+  // this will convert to correct "wei" representation based on decimals in constructor
+  setCurrentPrice(currentPrice) {
+    // allows this to be set to null without throwing
+    this.currentPrice = currentPrice ? this.convertDecimals(currentPrice) : currentPrice;
+  }
+
+  // only available in mock
+  // Store an array of historical prices [{timestamp, price}] so that getHistoricalPrice can return
+  // a price for a specific timestamp if found in this array.
+  // this will convert to correct "wei" representation based on decimals in constructor
+  setHistoricalPrices(historicalPrices) {
+    historicalPrices.forEach(_price => {
+      if (isNaN(_price.timestamp)) {
+        throw "Invalid historical price => [{timestamp, price}]";
+      }
+
+      this.historicalPrices[_price.timestamp] = this.convertDecimals(_price.price);
+    });
+  }
+
+  // only available in mock
+  setHistoricalPrice(historicalPrice) {
+    this.historicalPrice = this.convertDecimals(historicalPrice);
+  }
+
+  setLastUpdateTime(lastUpdateTime) {
+    this.lastUpdateTime = lastUpdateTime;
+  }
+
+  getCurrentPrice() {
+    return this.currentPrice;
+  }
+
+  getHistoricalPrice(time) {
+    // If a price for `time` was set via `setHistoricalPrices`, then return that price, otherwise return the mocked
+    // historical price.
+    if (time in this.historicalPrices) {
+      return this.historicalPrices[time];
+    }
+    return this.historicalPrice;
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  async update() {
+    this.updateCalled++;
+  }
+}
+
+module.exports = {
+  PriceFeedMockScaled
+};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#1938 

**Summary**

Include priceFeedMockScaled instead of priceFeedMock in your tests and update accordlingly.
For minimal effort you can try in the tests:
```js
  const { PriceFeedMockScaled: PriceFeedMock } =  require("@umaprotocol/financial-templates-lib");
  // sorry for long args
  // decimals by default = 18
  priceFeedMock = new PriceFeedMock(undefined, undefined, undefined, undefined, decimals);

  // when setting price you must not convert toWei but provide in eth. the mock will convert it for you.
  //New mock takes a decimal value, and when setting price provide it as a string in ETH.
  // from  
  priceFeedMock.setHistoricalPrice(toWei("1.75"));
  // to 
  priceFeedMock.setHistoricalPrice("1.75");
```


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1938
