### PR TITLE
fix(price-feed): fix import issue in PriceFeedMockScaled

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/PriceFeedMockScaled.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedMockScaled.js
@@ -1,4 +1,4 @@
-const { toBN } = web3.utils;
+const { toBN } = require("web3").utils;
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 const { parseFixed } = require("@ethersproject/bignumber");
 


### PR DESCRIPTION
**Motivation**

https://github.com/UMAprotocol/protocol/issues/1941

**Summary**

Uses an imported Web3 (which doesn't contain a provider, but _does_ contain utils) rather than a global one.

**Issue(s)**

Fixes #1941
