### PR TITLE
fix(truffle-config): fix flaky test provider

### DIFF
--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -137,8 +137,13 @@ function addLocalNetwork(networks, name, customOptions) {
     network_id: "*",
     gas: gas,
     provider: function(provider = nodeUrl) {
-      // Don't use the singleton here because it seems to make truffle tests flaky and creating multiple local providers
-      // won't hurt anything.
+      // Don't use the singleton here because there's not reason to for local networks.
+
+      // Note: this is the way that truffle initializes their host + port http provider.
+      // It is required to fix connection issues when testing.
+      if (typeof provider === "string" && !provider.startsWith("ws")) {
+        return new Web3.providers.HttpProvider(provider, { keepAlive: false });
+      }
       const tempWeb3 = new Web3(provider);
       return tempWeb3.eth.currentProvider;
     }

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -137,7 +137,7 @@ function addLocalNetwork(networks, name, customOptions) {
     network_id: "*",
     gas: gas,
     provider: function(provider = nodeUrl) {
-      // Don't use the singleton here because there's not reason to for local networks.
+      // Don't use the singleton here because there's no reason to for local networks.
 
       // Note: this is the way that truffle initializes their host + port http provider.
       // It is required to fix connection issues when testing.


### PR DESCRIPTION
**Motivation**

Truffle config changes caused tests to be flaky.

**Summary**

Mirrored the way truffle initializes their http provider in the config, so our initialization would match theirs.

For reference: https://github.com/trufflesuite/truffle/blob/813664a0c23c2ed8af423c1163a1cddb6d8fad7e/packages/provider/index.js#L30.

**Issue(s)**

N/A
