### PR TITLE
fix(emp-renbtc): add balancerMock and USDBTC reference pricefeed

### DIFF
--- a/packages/core/scripts/local/DeployBalancerMock.js
+++ b/packages/core/scripts/local/DeployBalancerMock.js
@@ -1,0 +1,29 @@
+/**
+ * @notice Deploy a new Balancer market.
+ *
+ *
+ * Example: $(npm bin)/truffle exec ./scripts/local/DeployBalancerMock.js --network kovan_mnemonic
+ */
+
+// Deployed contract ABI's and addresses we need to fetch.
+const BalancerMock = artifacts.require("BalancerMock");
+
+// Contracts we need to interact with.
+let balancer;
+
+/** ***************************************************
+ * Main Script
+ /*****************************************************/
+const deployBalancerMock = async callback => {
+  try {
+    balancer = await BalancerMock.new();
+    console.log(`Deployed new BalancerMock @ ${balancer.address}`);
+  } catch (err) {
+    console.error(err);
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+module.exports = deployBalancerMock;

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -229,7 +229,9 @@ async function createUniswapPriceFeedForEmp(logger, web3, networker, getTime, em
 }
 
 function createTokenPriceFeedForEmp(logger, web3, networker, getTime, empAddress, config = {}) {
-  if (config.type == "balancer") {
+  if (!config.type) {
+    return createReferencePriceFeedForEmp(logger, web3, networker, getTime, empAddress, config);
+  } else if (config.type == "balancer") {
     return createBalancerPriceFeedForEmp(logger, web3, networker, getTime, empAddress, config);
   } else {
     return createUniswapPriceFeedForEmp(logger, web3, networker, getTime, empAddress, config);
@@ -288,7 +290,7 @@ const defaultConfigs = {
     invertPrice: true,
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [
-      { type: "cryptowatch", exchange: "coinbase-pro", pair: "btucsd" },
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "btcusd" },
       { type: "cryptowatch", exchange: "binance", pair: "btcusdt" },
       { type: "cryptowatch", exchange: "bitstamp", pair: "btcusd" }
     ]

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -281,6 +281,17 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "binance", pair: "ethusdt" },
       { type: "cryptowatch", exchange: "kraken", pair: "ethusd" }
     ]
+  },
+  USDBTC: {
+    type: "medianizer",
+    lookback: 7200,
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "btucsd" },
+      { type: "cryptowatch", exchange: "binance", pair: "btcusdt" },
+      { type: "cryptowatch", exchange: "bitstamp", pair: "btcusd" }
+    ]
   }
 };
 

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -229,7 +229,7 @@ async function createUniswapPriceFeedForEmp(logger, web3, networker, getTime, em
 }
 
 function createTokenPriceFeedForEmp(logger, web3, networker, getTime, empAddress, config = {}) {
-  if (!config.type) {
+  if (!config || !config.type) {
     return createReferencePriceFeedForEmp(logger, web3, networker, getTime, empAddress, config);
   } else if (config.type == "balancer") {
     return createBalancerPriceFeedForEmp(logger, web3, networker, getTime, empAddress, config);

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -266,7 +266,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     const balancerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
     assert.equal(balancerFeed, null);
   });
-  it("Create token Price Feed For Balancer", async function() {
+  it("Create token price feed for Balancer", async function() {
     const collateralTokenAddress = "0x0000000000000000000000000000000000000001";
     const config = {
       type: "balancer",
@@ -297,6 +297,67 @@ contract("CreatePriceFeed.js", function(accounts) {
 
     const balancerFeed = await createTokenPriceFeedForEmp(logger, web3, networker, getTime, emp.address, config);
     assert.isTrue(balancerFeed instanceof BalancerPriceFeed);
+  });
+
+  it("Create token price feed for Uniswap", async function() {
+    const collateralTokenAddress = "0x0000000000000000000000000000000000000001";
+    const config = {
+      type: "uniswap",
+      uniswapAddress,
+      twapLength,
+      lookback
+    };
+
+    const constructorParams = {
+      expirationTimestamp: ((await web3.eth.getBlock("latest")).timestamp + 1000).toString(),
+      withdrawalLiveness: "1000",
+      collateralAddress: collateralTokenAddress,
+      finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
+      priceFeedIdentifier: web3.utils.utf8ToHex("ETH/BTC"),
+      syntheticName: "Test UMA Token",
+      syntheticSymbol: "UMATEST",
+      liquidationLiveness: "1000",
+      collateralRequirement: { rawValue: toWei("1.5") },
+      disputeBondPct: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPct: { rawValue: toWei("0.1") },
+      minSponsorTokens: { rawValue: toWei("1") },
+      timerAddress: Timer.address
+    };
+
+    const emp = await ExpiringMultiParty.new(constructorParams);
+
+    const uniswapFeed = await createTokenPriceFeedForEmp(logger, web3, networker, getTime, emp.address, config);
+    assert.isTrue(uniswapFeed instanceof UniswapPriceFeed);
+  });
+
+  it("Create token price feed defaults to Medianizer", async function() {
+    const collateralTokenAddress = "0x0000000000000000000000000000000000000001";
+    const config = undefined;
+
+    const constructorParams = {
+      expirationTimestamp: ((await web3.eth.getBlock("latest")).timestamp + 1000).toString(),
+      withdrawalLiveness: "1000",
+      collateralAddress: collateralTokenAddress,
+      finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
+      priceFeedIdentifier: web3.utils.utf8ToHex("ETH/BTC"),
+      syntheticName: "Test UMA Token",
+      syntheticSymbol: "UMATEST",
+      liquidationLiveness: "1000",
+      collateralRequirement: { rawValue: toWei("1.5") },
+      disputeBondPct: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPct: { rawValue: toWei("0.1") },
+      minSponsorTokens: { rawValue: toWei("1") },
+      timerAddress: Timer.address
+    };
+
+    const emp = await ExpiringMultiParty.new(constructorParams);
+
+    const medianizerFeed = await createTokenPriceFeedForEmp(logger, web3, networker, getTime, emp.address, config);
+    assert.isTrue(medianizerFeed instanceof MedianizerPriceFeed);
   });
 
   it("Valid Medianizer inherited config", async function() {

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -334,8 +334,6 @@ contract("CreatePriceFeed.js", function(accounts) {
 
   it("Create token price feed defaults to Medianizer", async function() {
     const collateralTokenAddress = "0x0000000000000000000000000000000000000001";
-    const config = undefined;
-
     const constructorParams = {
       expirationTimestamp: ((await web3.eth.getBlock("latest")).timestamp + 1000).toString(),
       withdrawalLiveness: "1000",
@@ -356,7 +354,10 @@ contract("CreatePriceFeed.js", function(accounts) {
 
     const emp = await ExpiringMultiParty.new(constructorParams);
 
-    const medianizerFeed = await createTokenPriceFeedForEmp(logger, web3, networker, getTime, emp.address, config);
+    // If `config` is undefined or ommitted (and set to its default value), this should return a Medianizer Price Feed
+    let medianizerFeed = await createTokenPriceFeedForEmp(logger, web3, networker, getTime, emp.address);
+    assert.isTrue(medianizerFeed instanceof MedianizerPriceFeed);
+    medianizerFeed = await createTokenPriceFeedForEmp(logger, web3, networker, getTime, emp.address, undefined);
     assert.isTrue(medianizerFeed instanceof MedianizerPriceFeed);
   });
 


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

BalancerMock used to test SyntheticPegMonitor

`createReferencePriceFeed` config changed so that user doesn't have to specify a MEDIANIZER_PRICE_FEED `.env` var if they are running a bot against an EMP with the USDBTC identifier
