### PR TITLE
fix(monitors): bugs related to decimal conversion and one CR monitor requested-withdraw oversight

### DIFF
--- a/packages/core/scripts/local/DeployEMP.js
+++ b/packages/core/scripts/local/DeployEMP.js
@@ -100,8 +100,8 @@ const deployEMP = async callback => {
       sponsorDisputeRewardPct: { rawValue: toWei("0.05") },
       disputerDisputeRewardPct: { rawValue: toWei("0.2") },
       minSponsorTokens: { rawValue: toWei("100") },
-      liquidationLiveness: 300,
-      withdrawalLiveness: 300
+      liquidationLiveness: 7200,
+      withdrawalLiveness: 7200
     };
 
     let _emp = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams, { from: deployer });

--- a/packages/core/scripts/local/DeployEMP.js
+++ b/packages/core/scripts/local/DeployEMP.js
@@ -93,15 +93,15 @@ const deployEMP = async callback => {
       expirationTimestamp: "1601503200", // 09/30/2020 @ 10:00pm (UTC)
       collateralAddress: collateralToken.address,
       priceFeedIdentifier: priceFeedIdentifier,
-      syntheticName: "yUSDBTC Synthetic Token Expiring 1 October 2020",
-      syntheticSymbol: "yUSDBTC-OCT20",
+      syntheticName: "uUSDrBTC Synthetic Token Expiring 1 October 2020",
+      syntheticSymbol: "uUSDrBTC-OCT",
       collateralRequirement: { rawValue: toWei("1.35") },
       disputeBondPct: { rawValue: toWei("0.1") },
       sponsorDisputeRewardPct: { rawValue: toWei("0.05") },
       disputerDisputeRewardPct: { rawValue: toWei("0.2") },
       minSponsorTokens: { rawValue: toWei("100") },
-      liquidationLiveness: 7200,
-      withdrawalLiveness: 7200
+      liquidationLiveness: 300,
+      withdrawalLiveness: 300
     };
 
     let _emp = await expiringMultiPartyCreator.createExpiringMultiParty.call(constructorParams, { from: deployer });

--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -46,32 +46,10 @@ async function run({
   try {
     const { toBN } = web3.utils;
 
-    // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
-    // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
-    logger[pollingDelay === 0 ? "debug" : "info"]({
-      at: "Disputer#index",
-      message: "Disputer started🔎",
-      empAddress,
-      pollingDelay,
-      errorRetries,
-      errorRetriesTimeout,
-      priceFeedConfig,
-      disputerConfig,
-      disputerOverridePrice
-    });
-
     const getTime = () => Math.round(new Date().getTime() / 1000);
 
-    // Setup web3 accounts, account instance and pricefeed for EMP.
-    const [accounts, networkId, priceFeed] = await Promise.all([
-      web3.eth.getAccounts(),
-      web3.eth.net.getId(),
-      createReferencePriceFeedForEmp(logger, web3, new Networker(logger), getTime, empAddress, priceFeedConfig)
-    ]);
-
-    if (!priceFeed) {
-      throw new Error("Price feed config is invalid");
-    }
+    // Setup web3 accounts and network
+    const [accounts, networkId] = await Promise.all([web3.eth.getAccounts(), web3.eth.net.getId()]);
 
     // Setup contract instances. NOTE that getAddress("Voting", networkId) will resolve to null in tests.
     const voting = new web3.eth.Contract(getAbi("Voting"), getAddress("Voting", networkId));
@@ -97,11 +75,46 @@ async function run({
     }
 
     const collateralToken = new web3.eth.Contract(getAbi("ExpandedERC20"), collateralTokenAddress);
+    const [currentAllowance, collateralCurrencyDecimals] = await Promise.all([
+      collateralToken.methods.allowance(accounts[0], empAddress).call(),
+      collateralToken.methods.decimals().call()
+    ]);
+
+    // Price feed must use same # of decimals as collateral currency.
+    let customPricefeedConfig = {
+      ...priceFeedConfig,
+      decimals: collateralCurrencyDecimals
+    };
+
+    const [priceFeed] = await Promise.all([
+      createReferencePriceFeedForEmp(logger, web3, new Networker(logger), getTime, empAddress, customPricefeedConfig)
+    ]);
+    if (!priceFeed) {
+      throw new Error("Price feed config is invalid");
+    }
+    logger.info({
+      at: "Disputer#index",
+      message: `Using an ${customPricefeedConfig.decimals} decimal price feed`
+    });
 
     // Generate EMP properties to inform bot of important on-chain state values that we only want to query once.
     const empProps = {
       priceIdentifier: priceIdentifier
     };
+
+    // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
+    // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
+    logger[pollingDelay === 0 ? "debug" : "info"]({
+      at: "Disputer#index",
+      message: "Disputer started🔎",
+      empAddress,
+      pollingDelay,
+      errorRetries,
+      errorRetriesTimeout,
+      priceFeedConfig: customPricefeedConfig,
+      disputerConfig,
+      disputerOverridePrice
+    });
 
     // Client and dispute bot.
     const empClient = new ExpiringMultiPartyClient(logger, getAbi("ExpiringMultiParty"), web3, empAddress);
@@ -119,7 +132,6 @@ async function run({
 
     // The EMP requires approval to transfer the disputer's collateral tokens in order to dispute a liquidation.
     // We'll set this once to the max value and top up whenever the bot's allowance drops below MAX_INT / 2.
-    const currentAllowance = await collateralToken.methods.allowance(accounts[0], empAddress).call();
     if (toBN(currentAllowance).lt(toBN(MAX_UINT_VAL).div(toBN("2")))) {
       await gasEstimator.update();
       const collateralApprovalTx = await collateralToken.methods.approve(empAddress, MAX_UINT_VAL).send({

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -264,7 +264,7 @@ class Disputer {
         at: "Liquidator",
         message: "Withdrawing dispute",
         liquidation: liquidation,
-        amount: this.fromWei(withdrawAmount.rawValue),
+        amount: withdrawAmount.rawValue.toString(),
         txnConfig
       });
 
@@ -307,7 +307,7 @@ class Disputer {
         at: "Disputer",
         message: "Dispute withdrawn🤑",
         liquidation: liquidation,
-        amount: this.fromWei(withdrawAmount.rawValue),
+        amount: withdrawAmount.rawValue.toString(),
         txnConfig,
         liquidationResult: logResult
       });

--- a/packages/disputer/test/index.js
+++ b/packages/disputer/test/index.js
@@ -86,6 +86,46 @@ contract("index.js", function(accounts) {
     await uniswap.setPrice(toWei("1"), toWei("1"));
   });
 
+  it("Detects price feed decimals from collateral decimals", async function() {
+    spy = sinon.spy(); // Create a new spy for each test.
+    spyLogger = winston.createLogger({
+      level: "info",
+      transports: [new SpyTransport({ level: "info" }, { spy: spy })]
+    });
+
+    collateralToken = await Token.new("DAI8", "DAI8", 8, { from: contractCreator });
+    constructorParams = {
+      expirationTimestamp: "20345678900",
+      withdrawalLiveness: "1000",
+      collateralAddress: collateralToken.address,
+      finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
+      priceFeedIdentifier: utf8ToHex("ETH/BTC"),
+      syntheticName: "ETH/BTC synthetic token",
+      syntheticSymbol: "ETH/BTC",
+      liquidationLiveness: "1000",
+      collateralRequirement: { rawValue: toWei("1.2") },
+      disputeBondPct: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPct: { rawValue: toWei("0.1") },
+      minSponsorTokens: { rawValue: toWei("1") },
+      timerAddress: Timer.address
+    };
+    emp = await ExpiringMultiParty.new(constructorParams);
+
+    await Poll.run({
+      logger: spyLogger,
+      web3,
+      empAddress: emp.address,
+      pollingDelay,
+      errorRetries,
+      errorRetriesTimeout,
+      priceFeedConfig: defaultPriceFeedConfig
+    });
+
+    // First log should include # of decimals
+    assert.isTrue(spyLogIncludes(spy, 0, "8"));
+  });
   it("EMP is expired, disputer exits early without throwing", async function() {
     spy = sinon.spy(); // Create a new spy for each test.
     spyLogger = winston.createLogger({

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -18,6 +18,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
    * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
    *      this number of seconds has passed, it will be a no-op.
    * @param {Bool} invertPrice Indicates if prices should be inverted before returned.
+   * @param {Number} decimals Number of decimals to use to convert price to wei.
    */
   constructor(
     logger,

--- a/packages/liquidator/test/index.js
+++ b/packages/liquidator/test/index.js
@@ -93,6 +93,48 @@ contract("index.js", function(accounts) {
     await uniswap.setPrice(toWei("1"), toWei("1"));
   });
 
+  it("Detects price feed decimals from collateral decimals", async function() {
+    spy = sinon.spy(); // Create a new spy for each test.
+    spyLogger = winston.createLogger({
+      level: "info",
+      transports: [new SpyTransport({ level: "info" }, { spy: spy })]
+    });
+
+    collateralToken = await Token.new("DAI8", "DAI8", 8, { from: contractCreator });
+    constructorParams = {
+      expirationTimestamp: "20345678900",
+      withdrawalLiveness: "1000",
+      collateralAddress: collateralToken.address,
+      finderAddress: Finder.address,
+      tokenFactoryAddress: TokenFactory.address,
+      priceFeedIdentifier: utf8ToHex("ETH/BTC"),
+      syntheticName: "ETH/BTC synthetic token",
+      syntheticSymbol: "ETH/BTC",
+      liquidationLiveness: "1000",
+      collateralRequirement: { rawValue: toWei("1.2") },
+      disputeBondPct: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPct: { rawValue: toWei("0.1") },
+      minSponsorTokens: { rawValue: toWei("1") },
+      timerAddress: Timer.address
+    };
+    emp = await ExpiringMultiParty.new(constructorParams);
+
+    await Poll.run({
+      logger: spyLogger,
+      web3,
+      empAddress: emp.address,
+      oneSplitAddress: oneSplitMock.address,
+      pollingDelay,
+      errorRetries,
+      errorRetriesTimeout,
+      priceFeedConfig: defaultPriceFeedConfig
+    });
+
+    // First log should include # of decimals
+    assert.isTrue(spyLogIncludes(spy, 0, "8"));
+  });
+
   it("EMP is expired, liquidator exits early without throwing", async function() {
     spy = sinon.spy(); // Create a new spy for each test.
     spyLogger = winston.createLogger({

--- a/packages/monitors/src/BalanceMonitor.js
+++ b/packages/monitors/src/BalanceMonitor.js
@@ -87,6 +87,13 @@ class BalanceMonitor {
     // Contract constants including collateralCurrencySymbol, syntheticCurrencySymbol, priceIdentifier and networkId.
     this.empProps = empProps;
 
+    this.formatDecimalStringCollateral = createFormatFunction(
+      this.web3,
+      2,
+      4,
+      false,
+      this.empProps.collateralCurrencyDecimals
+    );
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
 
     // Helper functions from web3.
@@ -110,12 +117,13 @@ class BalanceMonitor {
         this.logger[this.logOverrides.collateralThreshold || "warn"]({
           at: "BalanceMonitor",
           message: "Low collateral balance warning ⚠️",
-          mrkdwn: this._createLowBalanceMrkdwn(
+          mrkdwn: this._createLowBalanceMrkdwnCollateralCurrency(
             bot,
             bot.collateralThreshold,
             this.client.getCollateralBalance(monitoredAddress),
             this.empProps.collateralCurrencySymbol,
-            "collateral"
+            "collateral",
+            this.empProps.collateralCurrencyDecimals
           )
         });
       }
@@ -128,7 +136,8 @@ class BalanceMonitor {
             bot.syntheticThreshold,
             this.client.getSyntheticBalance(monitoredAddress),
             this.empProps.syntheticCurrencySymbol,
-            "synthetic"
+            "synthetic",
+            this.empProps.syntheticCurrencyDecimals
           )
         });
       }
@@ -141,7 +150,8 @@ class BalanceMonitor {
             bot.etherThreshold,
             this.client.getEtherBalance(monitoredAddress),
             "ETH",
-            "ether"
+            "ether",
+            18
           )
         });
       }
@@ -161,6 +171,24 @@ class BalanceMonitor {
       tokenSymbol +
       ". Current balance is " +
       this.formatDecimalString(tokenBalance) +
+      " " +
+      tokenSymbol
+    );
+  }
+
+  _createLowBalanceMrkdwnCollateralCurrency(bot, threshold, tokenBalance, tokenSymbol, tokenName) {
+    return (
+      bot.name +
+      " (" +
+      createEtherscanLinkMarkdown(bot.address, this.empProps.networkId) +
+      ") " +
+      tokenName +
+      " balance is less than " +
+      this.formatDecimalStringCollateral(threshold) +
+      " " +
+      tokenSymbol +
+      ". Current balance is " +
+      this.formatDecimalStringCollateral(tokenBalance) +
       " " +
       tokenSymbol
     );

--- a/packages/monitors/src/CRMonitor.js
+++ b/packages/monitors/src/CRMonitor.js
@@ -173,9 +173,9 @@ class CRMonitor {
           this.formatDecimalString(price) +
           ". The collateralization requirement is " +
           this.formatDecimalString(this.empClient.collateralRequirement.muln(100)) +
-          "%. If the price increases to " +
+          "%. Liquidation price: " +
           this.formatDecimalString(liquidationPrice) +
-          ", the position can be liquidated.";
+          ".";
 
         this.logger[this.logOverrides.crThreshold || "warn"]({
           at: "CRMonitor",


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

1) BalanceMonitor should report collateral currency alerts with correct decimal conversion
Follow up to #1947 

2) CRMonitor should take requested withdrawal amounts into account when determining CR ratios

3) Liquidator and Disputer should infer decimals for returned prices from pricefeed from collateral currency

