### PR TITLE
fix(price-feed): fix age pruning, toBN conversions and param check

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
@@ -48,10 +48,9 @@ class BalancerPriceFeed extends PriceFeedInterface {
   }
   async update() {
     this.lastUpdateTime = await this.getTime();
-    // its possible provider throws error getting block history
-    // we are going to just ignore these errors...
     let blocks = [];
-    if (this.lookback <= 0) {
+    // disabled lookback by setting it to 0
+    if (this.lookback == 0) {
       // handle no lookback, we just want latest block
       const block = await this.getLatestBlock();
       this.blockHistory.insert(block);

--- a/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
@@ -7,10 +7,11 @@ class BalancerPriceFeed extends PriceFeedInterface {
   constructor(logger, web3, getTime, abi, address, tokenIn, tokenOut, lookback) {
     assert(tokenIn, "BalancerPriceFeed requires tokenIn");
     assert(tokenOut, "BalancerPriceFeed requires tokenOut");
-    assert(lookback, "BalancerPriceFeed requires lookback");
+    assert(lookback >= 0, "BalancerPriceFeed requires lookback >= 0");
     super();
     this.logger = logger;
     this.web3 = web3;
+    this.toBN = web3.utils.toBN;
     this.getTime = getTime;
 
     this.contract = new web3.eth.Contract(abi, address);
@@ -19,13 +20,14 @@ class BalancerPriceFeed extends PriceFeedInterface {
     this.tokenIn = tokenIn;
     this.tokenOut = tokenOut;
     this.lookback = lookback;
+    this.getLatestBlock = number => web3.eth.getBlock(number >= 0 ? number : "latest");
     // Provide a getblock function which returns the latest value if no number provided.
-    this.blockHistory = BlockHistory(number => web3.eth.getBlock(number >= 0 ? number : "latest"));
+    this.blockHistory = BlockHistory(this.getLatestBlock);
 
     // Add a callback to get price, error can be thrown from web3 disconection or maybe something else
     // which affects the update call.
     this.priceHistory = PriceHistory(async number => {
-      return this.contract.methods.getSpotPriceSansFee(this.tokenIn, this.tokenOut).call(number);
+      return this.toBN(await this.contract.methods.getSpotPriceSansFee(this.tokenIn, this.tokenOut).call(number));
     });
   }
   getHistoricalPrice(time) {
@@ -48,7 +50,17 @@ class BalancerPriceFeed extends PriceFeedInterface {
     this.lastUpdateTime = await this.getTime();
     // its possible provider throws error getting block history
     // we are going to just ignore these errors...
-    const blocks = await this.blockHistory.update(this.lookback, this.lastUpdateTime);
+    let blocks = [];
+    if (this.lookback <= 0) {
+      // handle no lookback, we just want latest block
+      const block = await this.getLatestBlock();
+      this.blockHistory.insert(block);
+      blocks = this.blockHistory.listBlocks();
+    } else {
+      // handle historical lookback. Have to be careful your lookback time gives a big enough
+      // window to find a single block, otherwise you will have errors.
+      blocks = await this.blockHistory.update(this.lookback, this.lastUpdateTime);
+    }
     await Promise.all(blocks.map(this.priceHistory.update));
   }
 }

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -178,7 +178,8 @@ async function createBalancerPriceFeedForEmp(logger, web3, networker, getTime, e
   assert(empAddress, "createBalancerPriceFeedForEmp: Must pass in an `empAddress`");
   const emp = getEmpAtAddress(web3, empAddress);
   const balancerTokenIn = await emp.methods.tokenCurrency().call();
-  const lookback = 7200;
+  // disable lookback by default
+  const lookback = 0;
   return createPriceFeed(logger, web3, networker, getTime, { balancerTokenIn, lookback, ...config });
 }
 

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -65,7 +65,7 @@ exports.BlockHistory = (getBlock, blocks = []) => {
 
   // Removes blocks from cache which are older than age
   function pruneByTimestamp(age) {
-    blocks = blocks.filter(block => block.timestamp > seconds);
+    blocks = blocks.filter(block => block.timestamp > age);
   }
 
   // Return all blocks in cache

--- a/packages/financial-templates-lib/test/price-feed/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/BalancerPriceFeed.js
@@ -68,4 +68,26 @@ contract("BalancerPriceFeed.js", async function(accounts) {
       assert.equal(balancerPriceFeed.getHistoricalPrice(time), price);
     }
   });
+  it("update", async function() {
+    // should not throw
+    await balancerPriceFeed.update();
+  });
+  it("test 0 lookback", async function() {
+    let balancerPriceFeed = new BalancerPriceFeed(
+      dummyLogger,
+      web3,
+      () => endTime,
+      Balancer.abi,
+      balancerMock.address,
+      // These dont matter in the mock, but would represent the tokenIn and tokenOut for calling price feed.
+      accounts[1],
+      accounts[2],
+      0
+    );
+    // should not crash
+    await balancerPriceFeed.update();
+    const result = balancerPriceFeed.getCurrentPrice();
+    // see that a price exists.
+    assert.exists(result);
+  });
 });

--- a/packages/financial-templates-lib/test/price-feed/utils.js
+++ b/packages/financial-templates-lib/test/price-feed/utils.js
@@ -58,15 +58,18 @@ contract("Price Feed Utils", async function(accounts) {
       // this should return the next block higher than the timestamp
       assert.equal(block.timestamp, Math.ceil(time));
     });
-    it("pruneByTimestamp", function() {
-      blockHistory.pruneByTimestamp(1);
+    it("pruneByTimestamp", async function() {
+      const blockHistory = BlockHistory(getBlock);
+      const priceHistory = PriceHistory(getPrice);
+      await blockHistory.update(blockCount, blockCount);
+      blockHistory.pruneByTimestamp(5);
       const result = blockHistory.listBlocks();
-      assert.equal(result.length, 1);
+      assert.equal(result.length, blockCount - 5);
     });
   });
   describe("PriceHistory", function() {
     it("priceHistory.update", async function() {
-      const block = blockHistory.getClosestBefore(0);
+      const block = blockHistory.getClosestBefore(5);
       const result = await priceHistory.update(block);
       assert.equal(result, await getPrice(block.number));
     });

--- a/packages/financial-templates-lib/test/price-feed/utils.js
+++ b/packages/financial-templates-lib/test/price-feed/utils.js
@@ -58,6 +58,11 @@ contract("Price Feed Utils", async function(accounts) {
       // this should return the next block higher than the timestamp
       assert.equal(block.timestamp, Math.ceil(time));
     });
+    it("pruneByTimestamp", function() {
+      blockHistory.pruneByTimestamp(1);
+      const result = blockHistory.listBlocks();
+      assert.equal(result.length, 1);
+    });
   });
   describe("PriceHistory", function() {
     it("priceHistory.update", async function() {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#1955 

**Summary**

Fixes some API issues and bugs with the balancer price feed that came up during wargames testing.
Additionally default balancer lookback to 0 blocks, and update block finder to add a single block even if its before age, so there is at least one. 

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1955
