### PR TITLE
fix(voter-dapp): direct user to download metamask if web3 is not detected

### DIFF
--- a/packages/voter-dapp/src/DrizzleLogin.js
+++ b/packages/voter-dapp/src/DrizzleLogin.js
@@ -8,6 +8,11 @@ import DrizzleInit from "./DrizzleInit.js";
 function DrizzleLogin(props) {
   const [isButtonDisabled, setButtonDisabled] = useState(false);
   const [drizzle, setDrizzle] = useState(null);
+  const [hasMetamask, setHasMetamask] = useState(false);
+
+  const getMetamask = () => {
+    window.open("https://metamask.io/", "_blank");
+  };
 
   const loginFn = () => {
     // Disable the button immediately after pressing.
@@ -38,10 +43,18 @@ function DrizzleLogin(props) {
     </Button>
   );
 
+  let getMetamaskButtonJsx = (
+    <Button variant="contained" color="secondary" onClick={getMetamask}>
+      Get Metamask
+    </Button>
+  );
+
   // This useEffect will only run on the first render.
   // It's a hack to detect whether the user has previously connected. If this is true, we should intantly initiate the
   // login flow since metamask will not require them to press the connect button.
   useEffect(() => {
+    if (window.ethereum == null) return;
+    setHasMetamask(true);
     if (window.ethereum.selectedAddress) {
       loginFn();
     }
@@ -61,7 +74,11 @@ function DrizzleLogin(props) {
       </div>
     );
   } else {
-    return <div style={divStyle}>{buttonJsx}</div>;
+    if (hasMetamask) {
+      return <div style={divStyle}>{buttonJsx}</div>;
+    } else {
+      return <div style={divStyle}>{getMetamaskButtonJsx}</div>;
+    }
   }
 }
 


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->

**Motivation**

#1962 

**Summary**
Added some logic to detect if web3 exists by checking the window.ethereum object. If nothing found it will default to a button which tells user to get metamask. If metamask is found, it will show the standard login button. 

**Details**
This is what the user sees if metamask is not installed after this change. 
![image](https://user-images.githubusercontent.com/4429761/92511408-453d5280-f1db-11ea-8779-524ec29effda.png)

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #1962 
