### PR TITLE
fix(cryptowatch): fix cryptowatch price feed api query param

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -136,14 +136,14 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
     const priceUrl =
       `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price` +
-      (this.apiKey ? `?apiKey=${this.apiKey}` : "");
+      (this.apiKey ? `?apikey=${this.apiKey}` : "");
 
     // See https://docs.cryptowat.ch/rest-api/markets/ohlc for how this url is constructed.
     const ohlcUrl = [
       `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc`,
       `?after=${earliestHistoricalTimestamp}`,
       `&periods=${this.ohlcPeriod}`,
-      this.apiKey ? `&apiKey=${this.apiKey}` : ""
+      this.apiKey ? `&apikey=${this.apiKey}` : ""
     ].join("");
 
     // 2. Send requests.

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -279,8 +279,8 @@ contract("CryptoWatchPriceFeed.js", function(accounts) {
     await cryptoWatchPriceFeed.update();
 
     assert.deepStrictEqual(networker.getJsonInputs, [
-      "https://api.cryptowat.ch/markets/test-exchange/test-pair/price?apiKey=test-api-key",
-      "https://api.cryptowat.ch/markets/test-exchange/test-pair/ohlc?after=1588376460&periods=60&apiKey=test-api-key"
+      "https://api.cryptowat.ch/markets/test-exchange/test-pair/price?apikey=test-api-key",
+      "https://api.cryptowat.ch/markets/test-exchange/test-pair/ohlc?after=1588376460&periods=60&apikey=test-api-key"
     ]);
   });
 


### PR DESCRIPTION
**Motivation**

API Key wasn't being applied because the capitalization of the query param was incorrect.

**Summary**

Fixed the capitalization.


**Issue(s)**

N/A
