### PR TITLE
fix(truffle-config) include required argv import

### DIFF
--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -14,6 +14,7 @@ const { PublicNetworks } = require("./PublicNetworks.js");
 const { MetaMaskTruffleProvider } = require("./MetaMaskTruffleProvider.js");
 const { isPublicNetwork } = require("./MigrationUtils");
 const Web3 = require("web3");
+const argv = require("minimist")(process.argv.slice(), {});
 require("dotenv").config();
 
 // Fallback to a public mnemonic to prevent exceptions.


### PR DESCRIPTION
Small bug in the truffle config where `argv` is not imported resulting in errors in latest docker configs in serverless environment.