### PR TITLE
fix(tests): fix liquidator fork tests so they run correctly in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
+    "ganache-cli": "^6.10.2",
     "husky": "^4.2.3",
     "lerna": "^3.22.1",
     "lint-staged": "^10.1.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,6 @@
     "cli-progress": "^3.8.2",
     "ethereumjs-wallet": "^1.0.0",
     "express": "^4.17.1",
-    "ganache-cli": "^6.7.0",
     "gmail-send": "^1.2.14",
     "minimist": "^1.2.0",
     "mocha": "^8.1.2",

--- a/packages/liquidator/package.json
+++ b/packages/liquidator/package.json
@@ -31,7 +31,7 @@
   "bin": "index.js",
   "scripts": {
     "test": "truffle test",
-    "test-fork": "truffle test test-fork --network mainnet-fork"
+    "test-fork": "truffle test --network mainnet-fork $(find test-fork -name '*.js')"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"

--- a/packages/liquidator/test-fork/OneInchExchange.js
+++ b/packages/liquidator/test-fork/OneInchExchange.js
@@ -3,7 +3,11 @@ const { toWei } = web3.utils;
 const { GasEstimator, SpyTransport } = require("@umaprotocol/financial-templates-lib");
 const { OneInchExchange } = require("../src/OneInchExchange");
 
-const { oneInchSwapAndCheck, CONSTANTS } = require("../test/common");
+const { oneInchSwapAndCheck } = require("../test/common");
+const { ALTERNATIVE_ETH_ADDRESS, ONE_SPLIT_ADDRESS } = require("../src/constants");
+
+const OneSplit = artifacts.require("OneSplit");
+const Token = artifacts.require("ExpandedERC20");
 
 const sinon = require("sinon");
 const winston = require("winston");
@@ -11,7 +15,6 @@ const winston = require("winston");
 contract("OneInch", function(accounts) {
   const user = accounts[0];
 
-  const { ALTERNATIVE_ETH_ADDRESS } = CONSTANTS;
   const DAI_ADDRESS = "0x6b175474e89094c44da98b954eedeac495271d0f";
   const BAT_ADDRESS = "0x0d8775f648430679a709e98d2b0cb6250d2887ef";
 
@@ -23,7 +26,14 @@ contract("OneInch", function(accounts) {
 
   const gasEstimator = new GasEstimator(spyLogger);
 
-  const oneInch = new OneInchExchange({ web3, logger: spyLogger, gasEstimator });
+  const oneInch = new OneInchExchange({
+    web3,
+    logger: spyLogger,
+    gasEstimator,
+    oneSplitAbi: OneSplit.abi,
+    erc20TokenAbi: Token.abi,
+    oneSplitAddress: ONE_SPLIT_ADDRESS
+  });
   const swapAndCheck = oneInchSwapAndCheck(oneInch);
 
   it("Swap ETH -> DAI", async function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10641,10 +10641,10 @@ ganache-cli@6.9.0:
     source-map-support "0.5.12"
     yargs "13.2.4"
 
-ganache-cli@^6.7.0:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.10.1.tgz#6e083a92dba204d649c43d8823152bb9e2219807"
-  integrity sha512-3lpBxILtJBxkNVo+U8ad2qbkzB6nZ53gXhXH6NiS0Pauqur86rGbhXz6fNASjBosZm9iJ8Nr71fJd331QODFkQ==
+ganache-cli@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.10.2.tgz#3256774a47437052e2b9d7df2efc2b3f2250cffd"
+  integrity sha512-wCuQjy7k040J8hii1KQ/dYHv8qjdHIcP3fw331AWPqQjeqNquf5HVVQNJOYXINTDofMDkCMQv3ru4ze/A+WyPQ==
   dependencies:
     ethereumjs-util "6.1.0"
     source-map-support "0.5.12"


### PR DESCRIPTION
**Motivation**

#1977.

**Summary**

- Updated the ganache version because the existing version was crashing when trying to estimate gas.
- The one inch fork tests were broken, so some fixes were necessary to get them passing again.
- The truffle command needed to be changed to take in a list of files because passing in a directory doesn't work (and fails silently).
- I also moved the ganache dev dependency up to root because it's useful everywhere, not just core.

**Issue(s)**

Fixes #1977 
