### PR TITLE
feat(monitor-bot) Additional override levels on new sponsors created

### DIFF
--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -302,7 +302,7 @@ async function Poll(callback) {
       //       "syntheticThreshold":"error",                 // BalanceMonitor synthetic balance threshold alert.
       //       "collateralThreshold":"error",                // BalanceMonitor collateral balance threshold alert.
       //       "ethThreshold":"error",                       // BalanceMonitor ETH balance threshold alert.
-      //       "newPositionCreated":"debug"                  // Contract monitor new position created.
+      //       "newPositionCreated":"debug"                  // ContractMonitor new position created.
       //   }
       // }
       monitorConfig: process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null,

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -298,10 +298,11 @@ async function Poll(callback) {
       //  "syntheticVolatilityAlertThreshold": 0.1,          // Threshold for synthetic token on uniswap price volatility over `volatilityWindow`.
       //  "logOverrides":{                                   // override specific events log levels.
       //       "deviation":"error",                          // SyntheticPegMonitor deviation alert.
-      //       "syntheticThreshold":"error",                 // BalanceMonitor synthetic balance threshold alert.
       //       "crThreshold":"error",                        // CRMonitor CR threshold alert.
+      //       "syntheticThreshold":"error",                 // BalanceMonitor synthetic balance threshold alert.
       //       "collateralThreshold":"error",                // BalanceMonitor collateral balance threshold alert.
       //       "ethThreshold":"error",                       // BalanceMonitor ETH balance threshold alert.
+      //       "newPositionCreated":"debug"                  // Contract monitor new position created.
       //   }
       // }
       monitorConfig: process.env.MONITOR_CONFIG ? JSON.parse(process.env.MONITOR_CONFIG) : null,

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -81,6 +81,16 @@ class ContractMonitor {
           // For the config to be valid it must be an array of address.
           return Array.isArray(x) && x.every(y => this.web3.utils.isAddress(y));
         }
+      },
+      logOverrides: {
+        // Specify an override object to change default logging behaviour. Defaults to no overrides. If specified, this
+        // object is structured to contain key for the log to override and value for the logging level. EG:
+        // { newPositionCreated:'debug' } would override the default `info` behaviour for newPositionCreated.
+        value: {},
+        isValid: overrides => {
+          // Override must be one of the default logging levels: ['error','warn','info','http','verbose','debug','silly']
+          return Object.values(overrides).every(param => Object.keys(this.logger.levels).includes(param));
+        }
       }
     };
 
@@ -157,7 +167,7 @@ class ContractMonitor {
         ". tx: " +
         createEtherscanLinkMarkdown(event.transactionHash, this.empProps.networkId);
 
-      this.logger.info({
+      this.logger[this.logOverrides.newPositionCreated || "info"]({
         at: "ContractMonitor",
         message: "New Sponsor Alert 🐣!",
         mrkdwn: mrkdwn


### PR DESCRIPTION
**Motivation**

Small PR that fixes [1980](https://github.com/UMAprotocol/protocol/issues/1980) to enable additional log overrides for new sponsor created events.

**Summary**

Adds an additional log override for `newPositionCreated` to quieten this alert.

**Issue(s)**

Fixes #1980
