### PR TITLE
ci: fix fork flakiness by adding node mem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
     docker:
       - image: circleci/node:lts
       - image: trufflesuite/ganache-cli
-        command: ganache-cli -l 9000000 -f https://mainnet.infura.io/v3/5f56f0a4c8844c96a430fbd3d7993e39 -p 9545
+        command: NODE_OPTIONS="--max-old-space-size=4096" ganache-cli -l 9000000 -f https://mainnet.infura.io/v3/5f56f0a4c8844c96a430fbd3d7993e39 -p 9545
     working_directory: ~/protocol
     steps:
       - restore_cache:


### PR DESCRIPTION
**Motivation**

`test_fork` ci job seems to be very flaky because the estimate gas calls are eating up large amounts of memory.

**Summary**

Add a node env variable for the ganache instance on that job to increase it's memory to 4 gigs.

**Issue(s)**

N/A -- issue hasn't been reported.
