### PR TITLE
fix(cli): fix cli startup when installed as a package

### DIFF
--- a/packages/cli/cli_entry.sh
+++ b/packages/cli/cli_entry.sh
@@ -15,4 +15,4 @@ SCRIPT_DIR=$(dirname $SCRIPT_FILE)
 cd $SCRIPT_DIR
 
 echo "Starting CLI..."
-$(npm bin)/truffle exec ./cli.js "$@"
+npx truffle exec ./cli.js "$@"


### PR DESCRIPTION
**Motivation**

CLI fails to startup when installed as a package because npm bin doesn't do dynamic resolution of the truffle dep.

**Summary**

Use `npx` instead. This was tested by modifying the installed package.

**Issue(s)**

N/A issue was never reported.
