### PR TITLE
feat(serverless-bots) pull configs from github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # To `docker run` with your locally built image, replace `umaprotocol/protocol` with <username>/<imagename>.
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:lts
+FROM node:14
 
 # All source code and execution happens from the protocol directory.
 WORKDIR /protocol

--- a/packages/core/scripts/severless-cloud-run/CloudRunHub.js
+++ b/packages/core/scripts/severless-cloud-run/CloudRunHub.js
@@ -36,7 +36,7 @@ const datastore = new Datastore();
 // Web3 instance to get current block numbers of polling loops.
 const Web3 = require("web3");
 
-const { Logger, waitForLogger } = require("@uma/financial-templates-lib");
+const { Logger } = require("@uma/financial-templates-lib");
 let logger;
 let protocolRunnerUrl;
 let customNodeUrl;
@@ -47,7 +47,8 @@ hub.post("/", async (req, res) => {
     logger.debug({
       at: "CloudRunHub",
       message: "Running CloudRun hub query",
-      reqBody: req.body
+      reqBody: req.body,
+      hubConfig
     });
     // Validate the post request has both the `bucket` and `configFile` params.
     if (!req.body.bucket || !req.body.configFile) {
@@ -98,12 +99,12 @@ hub.post("/", async (req, res) => {
     let errorOutputs = [];
     let validOutputs = [];
     results.forEach((result, index) => {
-      if (result.status == "rejected" || result?.value?.execResponse?.error || result?.value?.execResponse?.stderr) {
+      if (result.status == "rejected" || result?.value?.execResponse?.error || result?.reason?.code == "500") {
         // If the child process in the spoke crashed it will return 500 (rejected). OR If the child process exited
         // correctly but contained an error.
         errorOutputs.push({
           status: result.status,
-          execResponse: result?.value?.execResponse,
+          execResponse: result?.value?.execResponse || result?.reason?.response?.data?.execResponse,
           botIdentifier: Object.keys(configObject)[index]
         });
       } else {
@@ -158,10 +159,29 @@ const _executeCloudRunSpoke = async (url, body) => {
   }
 };
 
-// Fetch configs for cloud run hub. Either read from a gcp bucket or local storage. GCP uses a readStream which is
-// converted into a buffer such that the config file does not need to first be downloaded from the bucket.
-// This will use the local service account.
+// Fetch configs for cloud run hub. Either read from a gcp bucket, local storage or a git repo. Github configs can pull
+// from a private github repo using the provided Authorization token. GCP uses a readStream which is converted into a
+// buffer such that the config file does not need to first be downloaded from the bucket. This will use the local service
+// account. Local configs are read directly from the process's environment variables.
 const _fetchConfig = async (bucket, file) => {
+  if (hubConfig.configRetrieval == "git") {
+    const response = await fetch(
+      `https://api.github.com/repos/${hubConfig.gitSettings.organization}/${hubConfig.gitSettings.repoName}/contents/${bucket}/${file}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `token ${hubConfig.gitSettings.accessToken}`,
+          "Content-type": "application/json",
+          Accept: "application/vnd.github.v3.raw",
+          "Accept-Charset": "utf-8"
+        }
+      }
+    );
+    const config = await response.json(); // extract JSON from the http response
+    // If there is a message in the config response then something went wrong in fetching from github api.
+    if (config.message) throw new Error(`Could not fetch config! :${JSON.stringify(config)}`);
+    return config;
+  }
   if (hubConfig.configRetrieval == "gcp") {
     const requestPromise = new Promise((resolve, reject) => {
       let buf = "";
@@ -274,12 +294,20 @@ async function Poll(_Logger = Logger, port = 8080, _ProtocolRunnerUrl, _CustomNo
 // If called directly by node, start the Poll process. If imported as a module then do nothing.
 if (require.main === module) {
   // add the logger, port, protocol runnerURL and custom node URL as params.
+  hubConfig;
+  try {
+    hubConfig = process.env.HUB_CONFIG ? JSON.parse(process.env.HUB_CONFIG) : null;
+  } catch (error) {
+    console.error("Malformed hub config!", hubConfig);
+    process.exit(1);
+  }
+
   Poll(
     Logger,
     process.env.PORT,
     process.env.PROTOCOL_RUNNER_URL,
     process.env.CUSTOM_NODE_URL,
-    process.env.HUB_CONFIG ? JSON.parse(process.env.HUB_CONFIG) : null
+    hubConfig
   ).then(() => {});
 }
 

--- a/packages/core/scripts/severless-cloud-run/CloudRunHub.js
+++ b/packages/core/scripts/severless-cloud-run/CloudRunHub.js
@@ -99,7 +99,7 @@ hub.post("/", async (req, res) => {
     let errorOutputs = [];
     let validOutputs = [];
     results.forEach((result, index) => {
-      if (result.status == "rejected" || result?.value?.execResponse?.error || result?.reason?.code == "500") {
+      if (result.status == "rejected" || result?.value?.execResponse?.error || result?.reason?.code != "200") {
         // If the child process in the spoke crashed it will return 500 (rejected). OR If the child process exited
         // correctly but contained an error.
         errorOutputs.push({

--- a/packages/core/scripts/severless-cloud-run/CloudRunSpoke.js
+++ b/packages/core/scripts/severless-cloud-run/CloudRunSpoke.js
@@ -93,9 +93,14 @@ function _execShellCommand(cmd, inputEnv) {
 // Format stdout outputs. Turns all logs generated while running the script into an array of Json objects.
 function _stripExecStdout(output) {
   if (!output) return output;
-  const strippedOutput = _regexStrip(output).replace(/\r?\n|\r/g, ","); // Remove escaped new line chars. Replace with comma between each log output.
-  // Parse the outputs into a json object to get an array of logs.
-  return JSON.parse("[" + strippedOutput.substring(0, strippedOutput.length - 1) + "]");
+  // Parse the outputs into a json object to get an array of logs. It is possible that the output is not in a parable form
+  // if the spoke was running a process that did not correctly generate a winston log. In this case simply return the stripped output.
+  try {
+    const strippedOutput = _regexStrip(output).replace(/\r?\n|\r/g, ","); // Remove escaped new line chars. Replace with comma between each log output.
+    return JSON.parse("[" + strippedOutput.substring(0, strippedOutput.length - 1) + "]");
+  } catch (error) {
+    return _regexStrip(output).replace(/\r?\n|\r/g, "");
+  }
 }
 
 // Format stderr outputs.

--- a/packages/core/scripts/severless-cloud-run/CloudRunSpoke.js
+++ b/packages/core/scripts/severless-cloud-run/CloudRunSpoke.js
@@ -99,14 +99,16 @@ function _stripExecStdout(output) {
     const strippedOutput = _regexStrip(output).replace(/\r?\n|\r/g, ","); // Remove escaped new line chars. Replace with comma between each log output.
     return JSON.parse("[" + strippedOutput.substring(0, strippedOutput.length - 1) + "]");
   } catch (error) {
-    return _regexStrip(output).replace(/\r?\n|\r/g, "");
+    return _regexStrip(output).replace(/\r?\n|\r/g, " ");
   }
 }
 
 // Format stderr outputs.
 function _stripExecStdError(output) {
   if (!output) return output;
-  return _regexStrip(output).replace(/\r?\n|\r/g, ""); // Remove escaped new line chars. Replace with no space.
+  return _regexStrip(output)
+    .replace(/\r?\n|\r/g, "")
+    .replace(/\"/g, ""); // Remove escaped new line chars. Replace with no space.
 }
 
 // This Regex removes unnasasary punctuation from the logs and formats the output in a digestible fashion.


### PR DESCRIPTION
**Motivation**

issue: https://github.com/UMAprotocol/protocol/issues/1875

**Summary**

This PR uses the GitHub API to pull config files directly when executing the spokes process from the hub.


**Details**

This PR adds an option setting within the `HUB_CONFIG` used to parameterize the GitHub calls. An example config that pulls settings from github, uses GCP to run the spoke and stores last queried block number on GCP looks as follows:

```
HUB_CONFIG={"configRetrieval":"git","gitSettings":{"organization":"UMAProtocol","repoName":"bot-configs","accessToken":"GIT-ACCESS-TOKEN"},"saveQueriedBlock":"gcp","spokeRunner":"gcp"}
```

This PR also bumps the docker version to use node 14 to enable the `?.` syntax used in a few places.

**Issue(s)**
First PR addressing #1875. Subsequent PRs will update deployment scripts to pull configs for the polling bots.
