### PR TITLE
feat(liquidator/disputer) change decimal logging level

### DIFF
--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -93,7 +93,7 @@ async function run({
     if (!priceFeed) {
       throw new Error("Price feed config is invalid");
     }
-    logger.info({
+    logger.debug({
       at: "Disputer#index",
       message: `Using an ${customPricefeedConfig.decimals} decimal price feed`
     });

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -133,7 +133,7 @@ async function run({
     if (!priceFeed) {
       throw new Error("Price feed config is invalid");
     }
-    logger.info({
+    logger.debug({
       at: "Liquidator#index",
       message: `Using an ${customPricefeedConfig.decimals} decimal price feed`
     });


### PR DESCRIPTION
**Motivation**

Liquidator and Disputer log their decimals every time they boot. This is noisy in the serverless bots where they spam on every loop:
![image](https://user-images.githubusercontent.com/12886084/93341479-7565a080-f82e-11ea-972f-9268291d3e35.png)


**Summary**

Simply change the logging level on creating loggers.
