### PR TITLE
fix(serverless-hub) winston return values from hub to slack transport

### DIFF
--- a/packages/core/scripts/severless-cloud-run/CloudRunHub.js
+++ b/packages/core/scripts/severless-cloud-run/CloudRunHub.js
@@ -126,14 +126,25 @@ hub.post("/", async (req, res) => {
     });
     res.status(200).send({ message: "All calls returned correctly", output: { errorOutputs, validOutputs } });
   } catch (errorOutput) {
+    logger.debug({
+      at: "CloudRunHub",
+      message: "Some spoke calls returned errors (details)🚨",
+      output: errorOutput instanceof Error ? errorOutput.message : errorOutput
+    });
     logger.error({
       at: "CloudRunHub",
-      message: "Some calls returned errors 🚨",
-      output: errorOutput instanceof Error ? errorOutput.message : errorOutput
+      message: "Some spoke calls returned errors 🚨",
+      output:
+        errorOutput instanceof Error
+          ? errorOutput.message
+          : {
+              errorOutputs: Object.keys(errorOutput.errorOutputs), // eslint-disable-line indent
+              validOutputs: Object.keys(errorOutput.validOutputs) // eslint-disable-line indent
+            } // eslint-disable-line indent
     });
 
     res.status(500).send({
-      message: "Some calls returned errors",
+      message: "Some spoke calls returned errors",
       output: errorOutput instanceof Error ? errorOutput.message : errorOutput
     });
   }


### PR DESCRIPTION
**Motivation**

Previously, the hub would log all information returned from the spokes within one large log. This is great for debugging within GCP. See the screenshot below where you can see the top part of a returned log from the hub, including the start of the output from the spokes:
![image](https://user-images.githubusercontent.com/12886084/93375119-f8e7b780-f857-11ea-83e2-ce9fa1f4c27e.png)


An issue with this is that all messages sent to the Winston transport with `error` or `info` get sent to slack. This log message is way too big to fit within slack and infact exceeds the ~5000 char limit on the slack webhook.

**Summary**

As a result, this PR changes how the logging works at the resolution of a failed hub call to generate two logs: 

1) a detailed log that can be read in from GCP, the `debug` log level. This log contains all returned values.
2) a less detailed log that can be read from slack, the `error` log level. This log only contains the errored spoke names. An example is shown below:
![image](https://user-images.githubusercontent.com/12886084/93375363-58de5e00-f858-11ea-83f8-beb0388eb813.png)
