### PR TITLE
ci: fix fork tests by including a hardcoded gas amount

### DIFF
--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -165,7 +165,8 @@ for (const [id, { name }] of Object.entries(PublicNetworks)) {
 // Add test network.
 addLocalNetwork(networks, "test");
 
-// Mainnet fork is just a local network with id 1.
+// Mainnet fork is just a local network with id 1 and a hardcoded gas limit because ganache has difficulty estimating gas on forks.
+// Note: this gas limit is the default ganache block gas limit.
 addLocalNetwork(networks, "mainnet-fork", { network_id: 1, gas: 6721975 });
 
 // MetaMask truffle provider requires a longer timeout so that user has time to point web browser with metamask to localhost:3333

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -166,7 +166,7 @@ for (const [id, { name }] of Object.entries(PublicNetworks)) {
 addLocalNetwork(networks, "test");
 
 // Mainnet fork is just a local network with id 1.
-addLocalNetwork(networks, "mainnet-fork", { network_id: 1 });
+addLocalNetwork(networks, "mainnet-fork", { network_id: 1, gas: 6721975 });
 
 // MetaMask truffle provider requires a longer timeout so that user has time to point web browser with metamask to localhost:3333
 addLocalNetwork(networks, "metamask", {


### PR DESCRIPTION
**Motivation**

The fork tests are still failing after https://github.com/UMAprotocol/protocol/pull/1993 failed to fix the issue.

**Summary**

This adds a hardcoded gas limit to the mainnet-fork network so no gas estimation is required.

**Issue(s)**

N/A
