### PR TITLE
feat(scripts): add script to batch reward retrieval for many voters at once

### DIFF
--- a/packages/core/contracts/common/interfaces/TransactionBatcher.sol
+++ b/packages/core/contracts/common/interfaces/TransactionBatcher.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+
+abstract contract TransactionBatcher {
+    function batchSend(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas
+    ) public virtual payable;
+}

--- a/packages/core/contracts/common/interfaces/TransactionBatcher.sol
+++ b/packages/core/contracts/common/interfaces/TransactionBatcher.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 
+// This is an interface to interact with a deployed implementation by https://github.com/kleros/action-callback-bots for
+// batching on-chain transactions.
 // See deployed implementation here: https://etherscan.io/address/0x82458d1c812d7c930bb3229c9e159cbabd9aa8cb.
 abstract contract TransactionBatcher {
     function batchSend(

--- a/packages/core/contracts/common/interfaces/TransactionBatcher.sol
+++ b/packages/core/contracts/common/interfaces/TransactionBatcher.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 
+// See deployed implementation here: https://etherscan.io/address/0x82458d1c812d7c930bb3229c9e159cbabd9aa8cb.
 abstract contract TransactionBatcher {
     function batchSend(
         address[] memory targets,

--- a/packages/core/scripts/local/ClaimAllRewards.js
+++ b/packages/core/scripts/local/ClaimAllRewards.js
@@ -62,7 +62,7 @@ async function claimRewards() {
   const gasEstimate = await txn.estimateGas({ from: account });
 
   if (gasEstimate > 9000000) {
-    throw "The transaction requires too mucn gas. Will need to be split up.";
+    throw "The transaction requires too much gas. Will need to be split up.";
   }
 
   await transactionBatcher.batchSend(targetArray, valuesArray, dataArray);


### PR DESCRIPTION
**Motivation**

We needed to claim all rewards on behalf of voters in a more efficient way due to the increase in the number of voters since the last Voting.sol upgrade.

**Summary**

To retrieve rewards on behalf of many voters' at once in a gas efficient way, I decided to slightly optimize the ClaimAllRewards script to include use an on-chain transaction batcher contract and parallelize infura calls. Note: once the number of voters ~doubles, this script may need to be set up to split the batch into multiple transactions to avoid hitting the block gas limit.

**Issue(s)**

N/A