### PR TITLE
fix(voter-dapp) UMA subgraph query for `priceRequestRounds.identifier` fails

### DIFF
--- a/packages/voter-dapp/src/apollo/queries.js
+++ b/packages/voter-dapp/src/apollo/queries.js
@@ -3,9 +3,7 @@ import { gql } from "@apollo/client";
 export const PRICE_REQUEST_VOTING_DATA = gql`
   query priceRequestRounds {
     priceRequestRounds {
-      identifier {
-        id
-      }
+      id
       roundId
       time
       totalSupplyAtSnapshot

--- a/packages/voter-dapp/src/containers/VoteData.js
+++ b/packages/voter-dapp/src/containers/VoteData.js
@@ -32,7 +32,8 @@ function useVoteData() {
 
       // Load data into `newVoteData` synchronously
       data.priceRequestRounds.forEach(dataForRequest => {
-        const newRoundKey = getRequestKey(dataForRequest.time, dataForRequest.identifier.id, dataForRequest.roundId);
+        const identifier = dataForRequest.id.split("-")[0];
+        const newRoundKey = getRequestKey(dataForRequest.time, identifier, dataForRequest.roundId);
 
         // Commit vote data:
         let uniqueVotersCommitted = {};


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Ever since the subgraph incorporated multiple Voting contracts in this [PR](https://github.com/UMAprotocol/uma-subgraph/pull/6), a query for `priceRequestRounds.identifier` has failed and thrown this error:

```
{
  "errors": [
    {
      "locations": [
        {
          "line": 3,
          "column": 17
        }
      ],
      "message": "Null value resolved for non-null field `identifier`"
    },
    ...
```

I believe this is possibly a problem where price requests for an older Voting contract are not found on the newer Voting contract. I'm currently working with a subgraph developer to fix this issue, but in the absence of a fix this PR will change the query to fetch the price request's identifier via a different method.

You can grab identifier from the `priceRequestRounds.id`, which is structured as <IDENTIFIER>-<TIMESTAMP>-<ROUND-ID>.
