### PR TITLE
improve(median-pricefeed-script) Add helpful logs to medianizer pricefeed output

### DIFF
--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -3,7 +3,8 @@
  * It could be used for example to query a price before committing a vote for a DVM price request.
  * We provide default configurations for querying median prices on specific markets across some exchanges and markets.
  * This script should serve as a template for constructing other historical median queries.
- *  *
+ *
+ * @notice This script will fail if the `--time` is not within a 4 day lookback window and one of the medianized pricefeeds is a cryptowatch price feed.
  * @dev How to run: yarn truffle exec ./packages/core/scripts/local/getMedianHistoricalPrice.js --network mainnet_mnemonic --identifier USDBTC --time 1601503200
  */
 const { fromWei } = web3.utils;

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -56,7 +56,7 @@ async function getMedianHistoricalPrice(callback) {
     }
 
     // Get a price.
-    const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime);
+    const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime, true);
     console.log(`${queryIdentifier} price @ ${queryTime} = ${fromWei(queryPrice.toString())}`);
   } catch (err) {
     callback(err);

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -42,7 +42,7 @@ async function getMedianHistoricalPrice(callback) {
       new Networker(dummyLogger),
       getTime,
       null,
-      { lookback: 345600 }, // Empirically, Cryptowatch API returns data up to ~4 days back.
+      { lookback: 345600 }, // Empirically, Cryptowatch API only returns data up to ~4 days back.
       queryIdentifier
     );
     if (!medianizerPriceFeed) {
@@ -62,8 +62,7 @@ async function getMedianHistoricalPrice(callback) {
     }
     console.log(`⏰ Fetching nearest prices for the timestamp: ${new Date(queryTime * 1000).toUTCString()}`);
 
-    // Get a price. This requests the Cryptowatch API for the specific exchange prices at the timestamp.
-    // The default exchanges to fetch prices for are based on UMIP's and can be found in:
+    // The default exchanges to fetch prices for (and from which the median is derived) are based on UMIP's and can be found in:
     // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
     const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime, true);
     const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
@@ -71,19 +70,6 @@ async function getMedianHistoricalPrice(callback) {
       `\n💹 Median ${queryIdentifier} price @ ${queryTime} = ${Number(fromWei(queryPrice.toString())).toFixed(
         precisionToUse
       )}`
-    );
-
-    console.log(
-      "\n⚠️ If you want to manually verify the specific exchange prices, you can make GET requests to: \n- https://api.cryptowat.ch/markets/<EXCHANGE-NAME>/<PAIR>/ohlc?after=<TIMESTAMP>&before=<TIMESTAMP>&periods=60"
-    );
-    console.log(
-      "- e.g. curl https://api.cryptowat.ch/markets/coinbase-pro/ethusd/ohlc?after=1601503080&before=1601503080&periods=60"
-    );
-    console.log(
-      '\n⚠️ This will return an OHLC data packet as "result", which contains in order: \n- [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].'
-    );
-    console.log(
-      "- We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH."
     );
   } catch (err) {
     callback(err);

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -4,7 +4,7 @@
  * We provide default configurations for querying median prices on specific markets across some exchanges and markets.
  * This script should serve as a template for constructing other historical median queries.
  *  *
- * @dev How to run: $(npm bin)/truffle exec ./scripts/local/GetMedianHistoricalPrice.js --network mainnet --identifier <PRICE-FEED IDENTIFIER> --time <TIMESTAMP IN SECONDS>
+ * @dev How to run: yarn truffle exec ./packages/core/scripts/local/getMedianHistoricalPrice.js --network mainnet_mnemonic --identifier USDBTC --time 1601503200
  */
 const { fromWei } = web3.utils;
 const { createReferencePriceFeedForEmp, Networker } = require("@uma/financial-templates-lib");

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -55,7 +55,9 @@ async function getMedianHistoricalPrice(callback) {
       queryTime = argv.time;
     }
 
-    // Get a price.
+    // Get a price. This requests the Cryptowatch API for the specific exchange prices at the timestamp.
+    // The default exchanges to fetch prices for are based on UMIP's and can be found in:
+    // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
     const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime, true);
     console.log(`${queryIdentifier} price @ ${queryTime} = ${fromWei(queryPrice.toString())}`);
   } catch (err) {

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -72,6 +72,19 @@ async function getMedianHistoricalPrice(callback) {
         precisionToUse
       )}`
     );
+
+    console.log(
+      "\n⚠️ If you want to manually verify the specific exchange prices, you can make GET requests to: \n- https://api.cryptowat.ch/markets/<EXCHANGE-NAME>/<PAIR>/ohlc?after=<TIMESTAMP>&before=<TIMESTAMP>&periods=60"
+    );
+    console.log(
+      "- e.g. curl https://api.cryptowat.ch/markets/coinbase-pro/ethusd/ohlc?after=1601503080&before=1601503080&periods=60"
+    );
+    console.log(
+      '\n⚠️ This will return an OHLC data packet as "result", which contains in order: \n- [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].'
+    );
+    console.log(
+      "- We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH."
+    );
   } catch (err) {
     callback(err);
     return;

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -11,6 +11,12 @@ const { createReferencePriceFeedForEmp, Networker } = require("@uma/financial-te
 const winston = require("winston");
 const argv = require("minimist")(process.argv.slice(), { string: ["identifier", "time"] });
 
+const UMIP_PRECISION = {
+  USDBTC: 8,
+  USDETH: 5
+};
+const DEFAULT_PRECISION = 5;
+
 async function getMedianHistoricalPrice(callback) {
   try {
     // If user did not specify an identifier, provide a default value.
@@ -54,12 +60,18 @@ async function getMedianHistoricalPrice(callback) {
     } else {
       queryTime = argv.time;
     }
+    console.log(`⏰ Fetching nearest prices for the timestamp: ${new Date(queryTime * 1000).toUTCString()}`);
 
     // Get a price. This requests the Cryptowatch API for the specific exchange prices at the timestamp.
     // The default exchanges to fetch prices for are based on UMIP's and can be found in:
     // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
     const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime, true);
-    console.log(`${queryIdentifier} price @ ${queryTime} = ${fromWei(queryPrice.toString())}`);
+    const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
+    console.log(
+      `\n💹 Median ${queryIdentifier} price @ ${queryTime} = ${Number(fromWei(queryPrice.toString())).toFixed(
+        precisionToUse
+      )}`
+    );
   } catch (err) {
     callback(err);
     return;

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -62,7 +62,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
   }
 
-  getHistoricalPrice(time) {
+  getHistoricalPrice(time, debug = false) {
     if (this.lastUpdateTime === undefined) {
       return undefined;
     }
@@ -99,6 +99,10 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
     }
 
+    if (debug) {
+      let priceDebug = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
+      console.log(`Price for exchange: ${this.exchange} => ${this.web3.utils.fromWei(priceDebug.toString())}`);
+    }
     return this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
   }
 

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -62,7 +62,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
   }
 
-  getHistoricalPrice(time, debug = false) {
+  getHistoricalPrice(time) {
     if (this.lastUpdateTime === undefined) {
       return undefined;
     }
@@ -99,10 +99,6 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
     }
 
-    if (debug) {
-      let priceDebug = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
-      console.log(`Price for exchange: ${this.exchange} => ${this.web3.utils.fromWei(priceDebug.toString())}`);
-    }
     return this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
   }
 

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -62,7 +62,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
   }
 
-  getHistoricalPrice(time) {
+  getHistoricalPrice(time, verbose = false) {
     if (this.lastUpdateTime === undefined) {
       return undefined;
     }
@@ -99,7 +99,15 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
     }
 
-    return this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
+    let returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
+    if (verbose) {
+      console.log(
+        `- (${this.exchange}:${this.pair}) Found historical OHLC open price @ ${
+          match.openTime
+        }: ${this.web3.utils.fromWei(returnPrice.toString())}`
+      );
+    }
+    return returnPrice;
   }
 
   getLastUpdateTime() {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -101,11 +101,18 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     let returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
     if (verbose) {
+      console.group(`\n(${this.exchange}:${this.pair}) Historical OHLC @ ${match.closeTime}`);
+      console.log(`- ✅ Open Price:${this.web3.utils.fromWei(returnPrice.toString())}`);
       console.log(
-        `- (${this.exchange}:${this.pair}) Found historical OHLC open price @ ${
-          match.openTime
-        }: ${this.web3.utils.fromWei(returnPrice.toString())}`
+        `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${match.closeTime}&before=${match.closeTime}&periods=60`
       );
+      console.log(
+        '- This will return an OHLC data packet as "result", which contains in order: \n- [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].'
+      );
+      console.log(
+        "- We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH."
+      );
+      console.groupEnd();
     }
     return returnPrice;
   }

--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -28,8 +28,8 @@ class MedianizerPriceFeed extends PriceFeedInterface {
   }
 
   // Takes the median of all of the constituent price feeds' historical prices.
-  getHistoricalPrice(time) {
-    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
+  getHistoricalPrice(time, debug = false) {
+    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time, debug));
 
     if (historicalPrices.some(element => element === undefined || element === null)) {
       return null;

--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -29,12 +29,21 @@ class MedianizerPriceFeed extends PriceFeedInterface {
 
   // Takes the median of all of the constituent price feeds' historical prices.
   getHistoricalPrice(time, debug = false) {
-    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time, debug));
+    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
 
     if (historicalPrices.some(element => element === undefined || element === null)) {
       return null;
     }
 
+    if (debug) {
+      this.priceFeeds.forEach(pricefeed => {
+        console.log(
+          `Price for exchange: ${pricefeed.exchange} => ${pricefeed.web3.utils.fromWei(
+            pricefeed.getHistoricalPrice(time).toString()
+          )}`
+        );
+      });
+    }
     return this._computeMedian(historicalPrices);
   }
 

--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -28,22 +28,13 @@ class MedianizerPriceFeed extends PriceFeedInterface {
   }
 
   // Takes the median of all of the constituent price feeds' historical prices.
-  getHistoricalPrice(time, debug = false) {
-    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
+  getHistoricalPrice(time, verbose = false) {
+    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time, verbose));
 
     if (historicalPrices.some(element => element === undefined || element === null)) {
       return null;
     }
 
-    if (debug) {
-      this.priceFeeds.forEach(pricefeed => {
-        console.log(
-          `Price for exchange: ${pricefeed.exchange} => ${pricefeed.web3.utils.fromWei(
-            pricefeed.getHistoricalPrice(time).toString()
-          )}`
-        );
-      });
-    }
     return this._computeMedian(historicalPrices);
   }
 


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2054


**Summary**

Add optional `debug` parameter to Medianizer `getHistoricalPriceFeed` method to print out the name of the exchanges and the specific prices from which a median is derived from.


**Details**

This should not affect any of the liquidator/disputer bot behaviors.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2054
