### PR TITLE
feat(contracts): add signed fixed point

### DIFF
--- a/packages/core/contracts/common/implementation/FixedPoint.sol
+++ b/packages/core/contracts/common/implementation/FixedPoint.sol
@@ -390,6 +390,7 @@ library FixedPoint {
 
     function fromSigned(Signed memory a) internal pure returns (Unsigned memory) {
         require(a.rawValue >= 0, "Negative value provided");
+        return Unsigned(uint256(a.rawValue));
     }
 
     function fromUnsigned(Unsigned memory a) internal pure returns (Signed memory) {

--- a/packages/core/contracts/common/implementation/FixedPoint.sol
+++ b/packages/core/contracts/common/implementation/FixedPoint.sol
@@ -670,7 +670,7 @@ library FixedPoint {
      * @param b a FixedPoint.Signed.
      * @return the product of `a` and `b`.
      */
-    function mulCeil(Signed memory a, int256 b) internal pure returns (Signed memory) {
+    function mulAwayFromZero(Signed memory a, int256 b) internal pure returns (Signed memory) {
         // Since b is an int, there is no risk of truncation and we can just mul it normally
         return Signed(a.rawValue.mul(b));
     }

--- a/packages/core/contracts/common/implementation/FixedPoint.sol
+++ b/packages/core/contracts/common/implementation/FixedPoint.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 
 
 /**
@@ -8,13 +9,25 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
  */
 library FixedPoint {
     using SafeMath for uint256;
+    using SignedSafeMath for int256;
 
     // Supports 18 decimals. E.g., 1e18 represents "1", 5e17 represents "0.5".
-    // Can represent a value up to (2^256 - 1)/10^18 = ~10^59. 10^59 will be stored internally as uint256 10^77.
+    // For unsigned values:
+    //   This can represent a value up to (2^256 - 1)/10^18 = ~10^59. 10^59 will be stored internally as uint256 10^77.
     uint256 private constant FP_SCALING_FACTOR = 10**18;
 
+    // --------------------------------------- UNSIGNED -----------------------------------------------------------------------------
     struct Unsigned {
         uint256 rawValue;
+    }
+
+    /**
+     * @notice Constructs an `Unsigned` from an unscaled uint, e.g., `b=5` gets stored internally as `5**18`.
+     * @param a uint to convert into a FixedPoint.
+     * @return the converted FixedPoint.
+     */
+    function fromUnscaledUint(uint256 a) internal pure returns (Unsigned memory) {
+        return Unsigned(a.mul(FP_SCALING_FACTOR));
     }
 
     /**
@@ -369,6 +382,382 @@ library FixedPoint {
      */
     function pow(Unsigned memory a, uint256 b) internal pure returns (Unsigned memory output) {
         output = fromUnscaledUint(1);
+        for (uint256 i = 0; i < b; i = i.add(1)) {
+            output = mul(output, a);
+        }
+    }
+
+    // ------------------------------------------------- SIGNED -------------------------------------------------------------
+    // Supports 18 decimals. E.g., 1e18 represents "1", 5e17 represents "0.5".
+    // For signed values:
+    //   This can represent a value up (or down) to +-(2^255 - 1)/10^18 = ~10^58. 10^58 will be stored internally as int256 10^76.
+    int256 private constant SFP_SCALING_FACTOR = 10**18;
+
+    struct Signed {
+        int256 rawValue;
+    }
+
+    function fromSigned(Signed memory a) internal pure returns (Unsigned memory) {
+        require(a.rawValue >= 0, "Negative value provided");
+    }
+
+    function fromUnsigned(Unsigned memory a) internal pure returns (Signed memory) {
+        require(a.rawValue <= uint256(type(int256).max), "Unsigned too large");
+        return Signed(int256(a.rawValue));
+    }
+
+    /**
+     * @notice Constructs a `Signed` from an unscaled int, e.g., `b=5` gets stored internally as `5**18`.
+     * @param an int to convert into a FixedPoint.Signed.
+     * @return the converted FixedPoint.Signed.
+     */
+    function fromUnscaledInt(int256 a) internal pure returns (Signed memory) {
+        return Signed(a.mul(SFP_SCALING_FACTOR));
+    }
+
+    /**
+     * @notice Whether `a` is equal to `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a int256.
+     * @return True if equal, or False.
+     */
+    function isEqual(Signed memory a, int256 b) internal pure returns (bool) {
+        return a.rawValue == fromUnscaledInt(b).rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is equal to `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return True if equal, or False.
+     */
+    function isEqual(Signed memory a, Signed memory b) internal pure returns (bool) {
+        return a.rawValue == b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is greater than `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a > b`, or False.
+     */
+    function isGreaterThan(Signed memory a, Signed memory b) internal pure returns (bool) {
+        return a.rawValue > b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is greater than `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return True if `a > b`, or False.
+     */
+    function isGreaterThan(Signed memory a, int256 b) internal pure returns (bool) {
+        return a.rawValue > fromUnscaledInt(b).rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is greater than `b`.
+     * @param a an int256.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a > b`, or False.
+     */
+    function isGreaterThan(int256 a, Signed memory b) internal pure returns (bool) {
+        return fromUnscaledInt(a).rawValue > b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is greater than or equal to `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a >= b`, or False.
+     */
+    function isGreaterThanOrEqual(Signed memory a, Signed memory b) internal pure returns (bool) {
+        return a.rawValue >= b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is greater than or equal to `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return True if `a >= b`, or False.
+     */
+    function isGreaterThanOrEqual(Signed memory a, int256 b) internal pure returns (bool) {
+        return a.rawValue >= fromUnscaledInt(b).rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is greater than or equal to `b`.
+     * @param a an int256.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a >= b`, or False.
+     */
+    function isGreaterThanOrEqual(int256 a, Signed memory b) internal pure returns (bool) {
+        return fromUnscaledInt(a).rawValue >= b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is less than `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a < b`, or False.
+     */
+    function isLessThan(Signed memory a, Signed memory b) internal pure returns (bool) {
+        return a.rawValue < b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is less than `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return True if `a < b`, or False.
+     */
+    function isLessThan(Signed memory a, int256 b) internal pure returns (bool) {
+        return a.rawValue < fromUnscaledInt(b).rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is less than `b`.
+     * @param a an int256.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a < b`, or False.
+     */
+    function isLessThan(int256 a, Signed memory b) internal pure returns (bool) {
+        return fromUnscaledInt(a).rawValue < b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is less than or equal to `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a <= b`, or False.
+     */
+    function isLessThanOrEqual(Signed memory a, Signed memory b) internal pure returns (bool) {
+        return a.rawValue <= b.rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is less than or equal to `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return True if `a <= b`, or False.
+     */
+    function isLessThanOrEqual(Signed memory a, int256 b) internal pure returns (bool) {
+        return a.rawValue <= fromUnscaledInt(b).rawValue;
+    }
+
+    /**
+     * @notice Whether `a` is less than or equal to `b`.
+     * @param a an int256.
+     * @param b a FixedPoint.Signed.
+     * @return True if `a <= b`, or False.
+     */
+    function isLessThanOrEqual(int256 a, Signed memory b) internal pure returns (bool) {
+        return fromUnscaledInt(a).rawValue <= b.rawValue;
+    }
+
+    /**
+     * @notice The minimum of `a` and `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the minimum of `a` and `b`.
+     */
+    function min(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        return a.rawValue < b.rawValue ? a : b;
+    }
+
+    /**
+     * @notice The maximum of `a` and `b`.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the maximum of `a` and `b`.
+     */
+    function max(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        return a.rawValue > b.rawValue ? a : b;
+    }
+
+    /**
+     * @notice Adds two `Signed`s, reverting on overflow.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the sum of `a` and `b`.
+     */
+    function add(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        return Signed(a.rawValue.add(b.rawValue));
+    }
+
+    /**
+     * @notice Adds an `Signed` to an unscaled int, reverting on overflow.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return the sum of `a` and `b`.
+     */
+    function add(Signed memory a, int256 b) internal pure returns (Signed memory) {
+        return add(a, fromUnscaledInt(b));
+    }
+
+    /**
+     * @notice Subtracts two `Signed`s, reverting on overflow.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the difference of `a` and `b`.
+     */
+    function sub(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        return Signed(a.rawValue.sub(b.rawValue));
+    }
+
+    /**
+     * @notice Subtracts an unscaled int256 from an `Signed`, reverting on overflow.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return the difference of `a` and `b`.
+     */
+    function sub(Signed memory a, int256 b) internal pure returns (Signed memory) {
+        return sub(a, fromUnscaledInt(b));
+    }
+
+    /**
+     * @notice Subtracts an `Signed` from an unscaled int256, reverting on overflow.
+     * @param a an int256.
+     * @param b a FixedPoint.Signed.
+     * @return the difference of `a` and `b`.
+     */
+    function sub(int256 a, Signed memory b) internal pure returns (Signed memory) {
+        return sub(fromUnscaledInt(a), b);
+    }
+
+    /**
+     * @notice Multiplies two `Signed`s, reverting on overflow.
+     * @dev This will "floor" the product.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the product of `a` and `b`.
+     */
+    function mul(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        // There are two caveats with this computation:
+        // 1. Max output for the represented number is ~10^41, otherwise an intermediate value overflows. 10^41 is
+        // stored internally as an int256 ~10^59.
+        // 2. Results that can't be represented exactly are truncated not rounded. E.g., 1.4 * 2e-18 = 2.8e-18, which
+        // would round to 3, but this computation produces the result 2.
+        // No need to use SafeMath because SFP_SCALING_FACTOR != 0.
+        return Signed(a.rawValue.mul(b.rawValue) / SFP_SCALING_FACTOR);
+    }
+
+    /**
+     * @notice Multiplies an `Signed` and an unscaled int256, reverting on overflow.
+     * @dev This will "floor" the product.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return the product of `a` and `b`.
+     */
+    function mul(Signed memory a, int256 b) internal pure returns (Signed memory) {
+        return Signed(a.rawValue.mul(b));
+    }
+
+    /**
+     * @notice Multiplies two `Signed`s and "ceil's" the product, reverting on overflow.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the product of `a` and `b`.
+     */
+    function mulCeil(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        int256 mulRaw = a.rawValue.mul(b.rawValue);
+        int256 mulFloor = mulRaw / SFP_SCALING_FACTOR;
+        int256 mod = mulRaw.mod(SFP_SCALING_FACTOR);
+        if (mod != 0) {
+            return Signed(mulFloor.add(1));
+        } else {
+            return Signed(mulFloor);
+        }
+    }
+
+    /**
+     * @notice Multiplies an `Signed` and an unscaled int256 and "ceil's" the product, reverting on overflow.
+     * @param a a FixedPoint.Signed.
+     * @param b a FixedPoint.Signed.
+     * @return the product of `a` and `b`.
+     */
+    function mulCeil(Signed memory a, int256 b) internal pure returns (Signed memory) {
+        // Since b is an int, there is no risk of truncation and we can just mul it normally
+        return Signed(a.rawValue.mul(b));
+    }
+
+    /**
+     * @notice Divides one `Signed` by an `Signed`, reverting on overflow or division by 0.
+     * @dev This will "floor" the quotient.
+     * @param a a FixedPoint numerator.
+     * @param b a FixedPoint denominator.
+     * @return the quotient of `a` divided by `b`.
+     */
+    function div(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        // There are two caveats with this computation:
+        // 1. Max value for the number dividend `a` represents is ~10^41, otherwise an intermediate value overflows.
+        // 10^41 is stored internally as an int256 10^59.
+        // 2. Results that can't be represented exactly are truncated not rounded. E.g., 2 / 3 = 0.6 repeating, which
+        // would round to 0.666666666666666667, but this computation produces the result 0.666666666666666666.
+        return Signed(a.rawValue.mul(SFP_SCALING_FACTOR).div(b.rawValue));
+    }
+
+    /**
+     * @notice Divides one `Signed` by an unscaled int256, reverting on overflow or division by 0.
+     * @dev This will "floor" the quotient.
+     * @param a a FixedPoint numerator.
+     * @param b an int256 denominator.
+     * @return the quotient of `a` divided by `b`.
+     */
+    function div(Signed memory a, int256 b) internal pure returns (Signed memory) {
+        return Signed(a.rawValue.div(b));
+    }
+
+    /**
+     * @notice Divides one unscaled int256 by an `Signed`, reverting on overflow or division by 0.
+     * @dev This will "floor" the quotient.
+     * @param a an int256 numerator.
+     * @param b a FixedPoint denominator.
+     * @return the quotient of `a` divided by `b`.
+     */
+    function div(int256 a, Signed memory b) internal pure returns (Signed memory) {
+        return div(fromUnscaledInt(a), b);
+    }
+
+    /**
+     * @notice Divides one `Signed` by an `Signed` and "ceil's" the quotient, reverting on overflow or division by 0.
+     * @param a a FixedPoint numerator.
+     * @param b a FixedPoint denominator.
+     * @return the quotient of `a` divided by `b`.
+     */
+    function divAwayFromZero(Signed memory a, Signed memory b) internal pure returns (Signed memory) {
+        int256 aScaled = a.rawValue.mul(SFP_SCALING_FACTOR);
+        int256 divTowardsZero = aScaled.div(b.rawValue);
+        int256 mod = aScaled.mod(b.rawValue);
+        if (mod != 0) {
+            return Signed(divTowardsZero.add(1));
+        } else {
+            return Signed(divTowardsZero);
+        }
+    }
+
+    /**
+     * @notice Divides one `Signed` by an unscaled int256 and "ceil's" the quotient, reverting on overflow or division by 0.
+     * @param a a FixedPoint numerator.
+     * @param b an int256 denominator.
+     * @return the quotient of `a` divided by `b`.
+     */
+    function divAwayFromZero(Signed memory a, int256 b) internal pure returns (Signed memory) {
+        // Because it is possible that a quotient gets truncated, we can't just call "Signed(a.rawValue.div(b))"
+        // similarly to mulCeil with an int256 as the second parameter. Therefore we need to convert b into an Signed.
+        // This creates the possibility of overflow if b is very large.
+        return divAwayFromZero(a, fromUnscaledInt(b));
+    }
+
+    /**
+     * @notice Raises an `Signed` to the power of an unscaled int256, reverting on overflow. E.g., `b=2` squares `a`.
+     * @dev This will "floor" the result.
+     * @param a a FixedPoint.Signed.
+     * @param b an int256.
+     * @return output is `a` to the power of `b`.
+     */
+    function pow(Signed memory a, int256 b) internal pure returns (Signed memory output) {
+        output = fromUnscaledInt(1);
         for (uint256 i = 0; i < b; i = i.add(1)) {
             output = mul(output, a);
         }

--- a/packages/core/contracts/common/test/SignedFixedPointTest.sol
+++ b/packages/core/contracts/common/test/SignedFixedPointTest.sol
@@ -1,0 +1,146 @@
+pragma solidity ^0.6.0;
+
+import "../implementation/FixedPoint.sol";
+
+
+// Wraps the FixedPoint library for testing purposes.
+contract SignedFixedPointTest {
+    using FixedPoint for FixedPoint.Signed;
+    using FixedPoint for int256;
+    using SafeMath for int256;
+
+    function wrapFromUnscaledInt(int256 a) external pure returns (int256) {
+        return FixedPoint.fromUnscaledInt(a).rawValue;
+    }
+
+    function wrapIsEqual(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isEqual(FixedPoint.Signed(b));
+    }
+
+    function wrapMixedIsEqual(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isEqual(b);
+    }
+
+    function wrapIsGreaterThan(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isGreaterThan(FixedPoint.Signed(b));
+    }
+
+    function wrapIsGreaterThanOrEqual(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isGreaterThanOrEqual(FixedPoint.Signed(b));
+    }
+
+    function wrapMixedIsGreaterThan(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isGreaterThan(b);
+    }
+
+    function wrapMixedIsGreaterThanOrEqual(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isGreaterThanOrEqual(b);
+    }
+
+    function wrapMixedIsGreaterThanOpposite(int256 a, int256 b) external pure returns (bool) {
+        return a.isGreaterThan(FixedPoint.Signed(b));
+    }
+
+    function wrapMixedIsGreaterThanOrEqualOpposite(int256 a, int256 b) external pure returns (bool) {
+        return a.isGreaterThanOrEqual(FixedPoint.Signed(b));
+    }
+
+    function wrapIsLessThan(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isLessThan(FixedPoint.Signed(b));
+    }
+
+    function wrapIsLessThanOrEqual(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isLessThanOrEqual(FixedPoint.Signed(b));
+    }
+
+    function wrapMixedIsLessThan(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isLessThan(b);
+    }
+
+    function wrapMixedIsLessThanOrEqual(int256 a, int256 b) external pure returns (bool) {
+        return FixedPoint.Signed(a).isLessThanOrEqual(b);
+    }
+
+    function wrapMixedIsLessThanOpposite(int256 a, int256 b) external pure returns (bool) {
+        return a.isLessThan(FixedPoint.Signed(b));
+    }
+
+    function wrapMixedIsLessThanOrEqualOpposite(int256 a, int256 b) external pure returns (bool) {
+        return a.isLessThanOrEqual(FixedPoint.Signed(b));
+    }
+
+    function wrapMin(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).min(FixedPoint.Signed(b)).rawValue;
+    }
+
+    function wrapMax(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).max(FixedPoint.Signed(b)).rawValue;
+    }
+
+    function wrapAdd(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).add(FixedPoint.Signed(b)).rawValue;
+    }
+
+    // The first int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedAdd(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).add(b).rawValue;
+    }
+
+    function wrapSub(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).sub(FixedPoint.Signed(b)).rawValue;
+    }
+
+    // The first int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedSub(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).sub(b).rawValue;
+    }
+
+    // The second int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedSubOpposite(int256 a, int256 b) external pure returns (int256) {
+        return a.sub(FixedPoint.Signed(b)).rawValue;
+    }
+
+    function wrapMul(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).mul(FixedPoint.Signed(b)).rawValue;
+    }
+
+    function wrapMulAwayFromZero(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).mulAwayFromZero(FixedPoint.Signed(b)).rawValue;
+    }
+
+    // The first int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedMul(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).mul(b).rawValue;
+    }
+
+    function wrapMixedMulAwayFromZero(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).mulAwayFromZero(b).rawValue;
+    }
+
+    function wrapDiv(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).div(FixedPoint.Signed(b)).rawValue;
+    }
+
+    function wrapDivAwayFromZero(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).divAwayFromZero(FixedPoint.Signed(b)).rawValue;
+    }
+
+    // The first int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedDiv(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).div(b).rawValue;
+    }
+
+    function wrapMixedDivAwayFromZero(int256 a, int256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).divAwayFromZero(b).rawValue;
+    }
+
+    // The second int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapMixedDivOpposite(int256 a, int256 b) external pure returns (int256) {
+        return a.div(FixedPoint.Signed(b)).rawValue;
+    }
+
+    // The first int256 is interpreted with a scaling factor and is converted to an `Unsigned` directly.
+    function wrapPow(int256 a, uint256 b) external pure returns (int256) {
+        return FixedPoint.Signed(a).pow(b).rawValue;
+    }
+}

--- a/packages/core/contracts/common/test/SignedFixedPointTest.sol
+++ b/packages/core/contracts/common/test/SignedFixedPointTest.sol
@@ -9,6 +9,14 @@ contract SignedFixedPointTest {
     using FixedPoint for int256;
     using SafeMath for int256;
 
+    function wrapFromSigned(int256 a) external pure returns (uint256) {
+        return FixedPoint.fromSigned(FixedPoint.Signed(a)).rawValue;
+    }
+
+    function wrapFromUnsigned(uint256 a) external pure returns (int256) {
+        return FixedPoint.fromUnsigned(FixedPoint.Unsigned(a)).rawValue;
+    }
+
     function wrapFromUnscaledInt(int256 a) external pure returns (int256) {
         return FixedPoint.fromUnscaledInt(a).rawValue;
     }

--- a/packages/core/contracts/common/test/UnsignedFixedPointTest.sol
+++ b/packages/core/contracts/common/test/UnsignedFixedPointTest.sol
@@ -4,7 +4,7 @@ import "../implementation/FixedPoint.sol";
 
 
 // Wraps the FixedPoint library for testing purposes.
-contract FixedPointTest {
+contract UnsignedFixedPointTest {
     using FixedPoint for FixedPoint.Unsigned;
     using FixedPoint for uint256;
     using SafeMath for uint256;

--- a/packages/core/test/common/SignedFixedPoint.js
+++ b/packages/core/test/common/SignedFixedPoint.js
@@ -24,6 +24,7 @@ contract("SignedFixedPoint", function() {
     assert.equal(await fixedPoint.wrapFromSigned("0"), "0");
     assert.equal(await fixedPoint.wrapFromSigned(int_max), int_max.toString());
     assert(await didContractThrow(fixedPoint.wrapFromSigned("-1")));
+    assert(await didContractThrow(fixedPoint.wrapFromSigned(int_min)));
 
     // Unsigned -> Signed
     assert.equal(await fixedPoint.wrapFromUnsigned(toWei("100")), toWei("100"));

--- a/packages/core/test/common/SignedFixedPoint.js
+++ b/packages/core/test/common/SignedFixedPoint.js
@@ -1,0 +1,449 @@
+const { didContractThrow } = require("@uma/common");
+const { assert } = require("chai");
+
+const SignedFixedPointTest = artifacts.require("SignedFixedPointTest");
+
+const { toWei, fromWei, toBN } = web3.utils;
+
+contract("SignedFixedPoint", function() {
+  const int_max = toBN("57896044618658097711785492504343953926634992332820282019728792003956564819967");
+  const int_min = toBN("-57896044618658097711785492504343953926634992332820282019728792003956564819968");
+
+  it("Construction", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    assert.equal(await fixedPoint.wrapFromUnscaledInt("-53"), toWei("-53"));
+    assert.equal(await fixedPoint.wrapFromUnscaledInt("495"), toWei("495"));
+
+    // Reverts on overflow.
+    const tenToFiftyEight = toBN("10").pow(toBN("59"));
+    assert(await didContractThrow(fixedPoint.wrapFromUnscaledInt(tenToFiftyEight)));
+  });
+
+  // This function tests all positive and negative variations/combinations of an input pair.
+  // a and b are the input js numbers.
+  // contractFn is the async function that will be called on the contract.
+  // jsFn is the equivalent js function that should generate the same result as the contract function.
+  // convInputs is a function that takes the inputs and converts them to a version that solidity can handle.
+  // convOut is a function that will take the output of the solidity function and convert it to something that is comparable to the output of the js function.
+  const checkMatchingComputation = async (a, b, contractFn, jsFn, convIn, convOut, fname) => {
+    assert.equal(convOut(await contractFn(...convIn(a, b))), jsFn(a, b), `fname: ${fname}, inputs: ${a}, ${b}`);
+    assert.equal(convOut(await contractFn(...convIn(-a, b))), jsFn(-a, b), `fname: ${fname}, inputs: ${-a}, ${b}`);
+    assert.equal(convOut(await contractFn(...convIn(a, -b))), jsFn(a, -b), `fname: ${fname}, inputs: ${a}, ${-b}`);
+    assert.equal(convOut(await contractFn(...convIn(-a, -b))), jsFn(-a, -b), `fname: ${fname}, inputs: ${-a}, ${-b}`);
+    assert.equal(convOut(await contractFn(...convIn(b, a))), jsFn(b, a), `fname: ${fname}, inputs: ${b}, ${a}`);
+    assert.equal(convOut(await contractFn(...convIn(-b, a))), jsFn(-b, a), `fname: ${fname}, inputs: ${-b}, ${a}`);
+    assert.equal(convOut(await contractFn(...convIn(b, -a))), jsFn(b, -a), `fname: ${fname}, inputs: ${b}, ${-a}`);
+    assert.equal(convOut(await contractFn(...convIn(-b, -a))), jsFn(-b, -a), `fname: ${fname}, inputs: ${-b}, ${-a}`);
+  };
+
+  // A convenient list of js comparison functions that can be passed around.
+  const lt = (a, b) => a < b;
+  const lte = (a, b) => a <= b;
+  const gt = (a, b) => a > b;
+  const gte = (a, b) => a >= b;
+  const eq = (a, b) => a === b;
+
+  // toWei wrapper that takes js numbers rather than strings.
+  const numToWei = a => toWei(a.toString());
+
+  it("Comparison", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Pairs of inputs that will be provided to each comparison functions.
+    const inputPairs = [
+      [1, 3],
+      [2, 2],
+      [0, 0]
+    ];
+
+    // A list of equivalent contract and js functions that we'd like to compare the output to.
+    const functionPairs = [
+      [fixedPoint.wrapIsGreaterThan, gt, "isGreaterThan"],
+      [fixedPoint.wrapIsGreaterThanOrEqual, gte, "isGreaterThanOrEqual"],
+      [fixedPoint.wrapIsEqual, eq, "isEqual"],
+      [fixedPoint.wrapIsLessThanOrEqual, lte, "isLessThanOrEqual"],
+      [fixedPoint.wrapIsLessThan, lt, "isLessThan"]
+    ];
+
+    for (const [a, b] of inputPairs) {
+      for (const [contractFn, jsFn, fname] of functionPairs) {
+        // Combine each pair of inputs with each pair of js and contract function to test each combination.
+        // Note: the inputs are converted toWei to make them fairly standard numbers in solidity.
+        // Note: the output doesn't need to be converted since it is just a boolean (like js).
+        await checkMatchingComputation(
+          a,
+          b,
+          contractFn,
+          jsFn,
+          (...args) => args.map(numToWei),
+          out => out,
+          fname
+        );
+      }
+    }
+  });
+
+  it("Mixed Comparison", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Pairs of inputs that will be provided to each comparison functions.
+    const inputPairs = [
+      [1, 3],
+      [2, 2],
+      [0, 0]
+    ];
+
+    const functionPairs = [
+      [fixedPoint.wrapMixedIsGreaterThan, gt, (a, b) => [numToWei(a), b], "mixedIsGreaterThan"],
+      [fixedPoint.wrapMixedIsGreaterThanOrEqual, gte, (a, b) => [numToWei(a), b], "mixedIsGreaterThanOrEqual"],
+      [fixedPoint.wrapMixedIsEqual, eq, (a, b) => [numToWei(a), b], "mixedIsEqual"],
+      [fixedPoint.wrapMixedIsLessThanOrEqual, lte, (a, b) => [numToWei(a), b], "mixedIsLessThanOrEqual"],
+      [fixedPoint.wrapMixedIsLessThan, lt, (a, b) => [numToWei(a), b], "mixedIsLessThan"],
+      [fixedPoint.wrapMixedIsGreaterThanOpposite, gt, (a, b) => [a, numToWei(b)], "mixedIsGreaterThanOpposite"],
+      [
+        fixedPoint.wrapMixedIsGreaterThanOrEqualOpposite,
+        gte,
+        (a, b) => [a, numToWei(b)],
+        "mixedIsGreaterThanOrEqualOpposite"
+      ],
+      [
+        fixedPoint.wrapMixedIsLessThanOrEqualOpposite,
+        lte,
+        (a, b) => [a, numToWei(b)],
+        "mixedIsLessThanOrEqualOpposite"
+      ],
+      [fixedPoint.wrapMixedIsLessThanOpposite, lt, (a, b) => [a, numToWei(b)], "mixedIsLessThanOpposite"]
+    ];
+
+    for (const [a, b] of inputPairs) {
+      for (const [contractFn, jsFn, inConv, fname] of functionPairs) {
+        // Combine each pair of inputs with each pair of js and contract function to test each combination.
+        // Note: this uses a custom input converter to handle the mixed versions.
+        await checkMatchingComputation(a, b, contractFn, jsFn, inConv, out => out, fname);
+      }
+    }
+  });
+
+  it("Minimum and Maximum", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    const inputPairs = [
+      [5, 6],
+      [100, 0],
+      [2390123, 9320492],
+      [0.001, 234]
+    ];
+
+    const functionPairs = [
+      [fixedPoint.wrapMin, Math.min, "min"],
+      [fixedPoint.wrapMax, Math.max, "max"]
+    ];
+
+    for (const [a, b] of inputPairs) {
+      for (const [contractFn, jsFn, fname] of functionPairs) {
+        // Combine each pair of inputs with each pair of js and contract function to test each combination.
+        // toWei all inputs.
+        // fromWei and convert all outputs to numbers.
+        await checkMatchingComputation(
+          a,
+          b,
+          contractFn,
+          jsFn,
+          (...args) => args.map(numToWei),
+          out => Number(fromWei(out)),
+          fname
+        );
+      }
+    }
+  });
+
+  it("Basic addition and subtraction", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+    const add = (a, b) => a + b;
+    const sub = (a, b) => a - b;
+
+    const inputPairs = [
+      [5, 6],
+      [100, 0],
+      [2390123, 9320492],
+      [1, 234]
+    ];
+
+    const functionPairs = [
+      [fixedPoint.wrapAdd, add, (...args) => args.map(numToWei), "add"],
+      [fixedPoint.wrapSub, sub, (...args) => args.map(numToWei), "sub"],
+      [fixedPoint.wrapMixedAdd, add, (a, b) => [numToWei(a), b], "mixedAdd"],
+      [fixedPoint.wrapMixedSub, sub, (a, b) => [numToWei(a), b], "mixedSub"],
+      [fixedPoint.wrapMixedSubOpposite, sub, (a, b) => [a, numToWei(b)], "mixedSubOpposite"]
+    ];
+
+    for (const [a, b] of inputPairs) {
+      for (const [contractFn, jsFn, convIn, fname] of functionPairs) {
+        // Combine each pair of inputs with each pair of js and contract function to test each combination.
+        // fromWei and convert all outputs to numbers.
+        await checkMatchingComputation(a, b, contractFn, jsFn, convIn, out => Number(fromWei(out)), fname);
+      }
+    }
+  });
+
+  it("Basic multipication and division", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+    const mul = (a, b) => a * b;
+    const div = (a, b) => a / b;
+
+    const inputPairs = [
+      [5, 6],
+      [100, 32],
+      [2390123, 9320492]
+    ];
+
+    const functionPairs = [
+      [fixedPoint.wrapMul, mul, (...args) => args.map(numToWei), "mul"],
+      [fixedPoint.wrapMulAwayFromZero, mul, (...args) => args.map(numToWei), "mul"],
+      [fixedPoint.wrapDiv, div, (...args) => args.map(numToWei), "div"],
+      [fixedPoint.wrapDivAwayFromZero, div, (...args) => args.map(numToWei), "div"],
+      [fixedPoint.wrapMixedMul, mul, (a, b) => [numToWei(a), b], "mixedMul"],
+      [fixedPoint.wrapMixedMulAwayFromZero, mul, (a, b) => [numToWei(a), b], "mixedMul"],
+      [fixedPoint.wrapMixedDiv, div, (a, b) => [numToWei(a), b], "mixedDiv"],
+      [fixedPoint.wrapMixedDivAwayFromZero, div, (a, b) => [numToWei(a), b], "mixedDiv"],
+      [fixedPoint.wrapMixedDivOpposite, div, (a, b) => [a, numToWei(b)], "mixedDivOpposite"]
+    ];
+
+    for (const [a, b] of inputPairs) {
+      for (const [contractFn, jsFn, convIn, fname] of functionPairs) {
+        // Combine each pair of inputs with each pair of js and contract function to test each combination.
+        // fromWei and convert all outputs to numbers.
+        await checkMatchingComputation(a, b, contractFn, jsFn, convIn, out => Number(fromWei(out)), fname);
+      }
+    }
+  });
+
+  it("Addition/Subtraction Overflow/Underflow", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Reverts on overflow.
+    // (int_max-10) + 11 will overflow.
+    assert(await didContractThrow(fixedPoint.wrapAdd(int_max.sub(toBN("10")), toBN("11"))));
+
+    // Underflow.
+    assert(await didContractThrow(fixedPoint.wrapAdd(int_min.add(toBN("10")), toBN("-11"))));
+
+    // Reverts if uint (second argument) can't be represented as an Signed.
+    const tenToFiftyNine = toBN("10").pow(toBN("59"));
+    assert(await didContractThrow(fixedPoint.wrapMixedAdd("0", tenToFiftyNine)));
+
+    // Reverts on underflow.
+    assert(await didContractThrow(fixedPoint.wrapSub(int_min, "1")));
+
+    // Reverts if uint (second argument) can't be represented as an Signed.
+    assert(await didContractThrow(fixedPoint.wrapMixedSub(int_max, tenToFiftyNine)));
+
+    // Reverts on underflow (i.e., result goes below int_min).
+    assert(await didContractThrow(fixedPoint.wrapMixedSub(int_min, "2")));
+
+    // Reverts on underflow (i.e., result goes below int_min).
+    assert(await didContractThrow(fixedPoint.wrapMixedSubOpposite("2", int_min.add(toBN(toWei("1"))))));
+  });
+
+  it("Multipication/Division Overflow/Underflow", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Reverts on overflow.
+    // (uint_max - 1) * 2 overflows.
+    assert(await didContractThrow(fixedPoint.wrapMul(int_max.sub(toBN("1")), toWei("2"))));
+    assert(await didContractThrow(fixedPoint.wrapMul(int_min.add(toBN("1")), toWei("2"))));
+    assert(await didContractThrow(fixedPoint.wrapMulAwayFromZero(int_max.sub(toBN("1")), toWei("2"))));
+    assert(await didContractThrow(fixedPoint.wrapMulAwayFromZero(int_min.add(toBN("1")), toWei("2"))));
+
+    // Reverts on overflow.
+    // (uint_max / 2) * 3 overflows.
+    assert(await didContractThrow(fixedPoint.wrapMixedMul(int_max.div(toBN("2")), "3")));
+    assert(await didContractThrow(fixedPoint.wrapMixedMul(int_min.div(toBN("2")), "3")));
+    assert(await didContractThrow(fixedPoint.wrapMixedMulAwayFromZero(int_max.div(toBN("2")), "3")));
+    assert(await didContractThrow(fixedPoint.wrapMixedMulAwayFromZero(int_min.div(toBN("2")), "3")));
+
+    // Reverts on division by zero.
+    assert(await didContractThrow(fixedPoint.wrapDiv("1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapMixedDiv("1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapMixedDivOpposite("1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapDiv("-1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapMixedDiv("-1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapMixedDivOpposite("-1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapDivAwayFromZero("-1", "0")));
+    assert(await didContractThrow(fixedPoint.wrapMixedDivAwayFromZero("-1", "0")));
+
+    // Large denominator works in normal div but fails in divAwayFromZero due to cast to Signed.
+    const bigDenominator = toBN("10").pow(toBN("75"));
+    let quotient = await fixedPoint.wrapMixedDiv(toWei("1"), bigDenominator);
+    assert.equal(quotient.toString(), "0");
+    assert(await didContractThrow(fixedPoint.wrapMixedDivAwayFromZero(toWei("1"), bigDenominator)));
+  });
+
+  it("Multiplication towards zero", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Positives
+    // Fractions, no precision loss.
+    let product = await fixedPoint.wrapMul(toWei("0.0001"), toWei("5"));
+    assert.equal(product.toString(), toWei("0.0005"));
+
+    // Fractions, precision loss, rounding down.
+    // 1.2 * 2e-18 = 2.4e-18, which can't be represented and gets rounded towards zero to 2.
+    product = await fixedPoint.wrapMul(toWei("1.2"), "2");
+    assert.equal(product.toString(), "2");
+    // 1e-18 * 1e-18 = 1e-36, which can't be represented and gets rounded towards zero to 0.
+    product = await fixedPoint.wrapMul("1", "1");
+    assert.equal(product.toString(), "0");
+
+    // Negatives
+    // Fractions, no precision loss.
+    product = await fixedPoint.wrapMul(toWei("0.0001"), toWei("-5"));
+    assert.equal(product.toString(), toWei("-0.0005"));
+
+    // Fractions, precision loss, rounding down.
+    // +-1.2 * +-2e-18 = -2.4e-18, which can't be represented and gets rounded towards zero to -2.
+    product = await fixedPoint.wrapMul(toWei("-1.2"), "2");
+    assert.equal(product.toString(), "-2");
+    product = await fixedPoint.wrapMul(toWei("1.2"), "-2");
+    assert.equal(product.toString(), "-2");
+
+    // +-1e-18 * +-1e-18 = -1e-36, which can't be represented and gets rounded towards zero to 0.
+    product = await fixedPoint.wrapMul("1", "-1");
+    assert.equal(product.toString(), "0");
+    product = await fixedPoint.wrapMul("-1", "1");
+    assert.equal(product.toString(), "0");
+  });
+
+  it("Multiplication, away from zero", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Positives
+    // Whole numbers above 10**18.
+    let product = await fixedPoint.wrapMulAwayFromZero(toWei("5"), toWei("17"));
+    assert.equal(product.toString(), toWei("85"));
+
+    // Fractions, no precision loss.
+    product = await fixedPoint.wrapMulAwayFromZero(toWei("0.0001"), toWei("5"));
+    assert.equal(product.toString(), toWei("0.0005"));
+
+    // Fractions, precision loss, ceiling.
+    // 1.2 * 2e-18 = 2.4e-18, which can't be represented and gets rounded away from zero to 3.
+    product = await fixedPoint.wrapMulAwayFromZero(toWei("1.2"), "2");
+    assert.equal(product.toString(), "3");
+    // 1e-18 * 1e-18 = 1e-36, which can't be represented and gets rounded away from zero to 1e-18.
+    product = await fixedPoint.wrapMulAwayFromZero("1", "1");
+    assert.equal(product.toString(), "1");
+
+    // Negatives
+    product = await fixedPoint.wrapMulAwayFromZero(toWei("5"), toWei("-17"));
+    assert.equal(product.toString(), toWei("-85"));
+
+    // Fractions, no precision loss.
+    product = await fixedPoint.wrapMulAwayFromZero(toWei("-0.0001"), toWei("5"));
+    assert.equal(product.toString(), toWei("-0.0005"));
+
+    // Fractions, precision loss, ceiling.
+    // +-1.2 * +-2e-18 = -2.4e-18, which can't be represented and gets rounded away from zero to -3.
+    product = await fixedPoint.wrapMulAwayFromZero(toWei("-1.2"), "2");
+    assert.equal(product.toString(), "-3");
+    product = await fixedPoint.wrapMulAwayFromZero(toWei("1.2"), "-2");
+    assert.equal(product.toString(), "-3");
+
+    // +-1e-18 * +-1e-18 = -1e-36, which can't be represented and gets rounded away from zero to -1e-18.
+    product = await fixedPoint.wrapMulAwayFromZero("-1", "1");
+    assert.equal(product.toString(), "-1");
+    product = await fixedPoint.wrapMulAwayFromZero("1", "-1");
+    assert.equal(product.toString(), "-1");
+  });
+
+  it("Division", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Positives
+    // Fractions, precision loss, rounding down.
+    // 1 / 3 = 0.3 repeating, which can't be represented and gets rounded down to 0.333333333333333333.
+    let quotient = await fixedPoint.wrapDiv(toWei("1"), toWei("3"));
+    assert.equal(quotient.toString(), "3".repeat(18));
+    // 1e-18 / 1e19 = 1e-37, which can't be represented and gets floor'd to 0.
+    quotient = await fixedPoint.wrapDiv("1", toWei(toWei("10")));
+    assert.equal(quotient.toString(), "0");
+
+    // Negatives
+    // Fractions, precision loss, rounding down.
+    // +-1 / +-3 = -0.3 repeating, which can't be represented and gets rounded down to 0.333333333333333333.
+    quotient = await fixedPoint.wrapDiv(toWei("-1"), toWei("3"));
+    assert.equal(quotient.toString(), "-" + "3".repeat(18));
+    quotient = await fixedPoint.wrapDiv(toWei("1"), toWei("-3"));
+    assert.equal(quotient.toString(), "-" + "3".repeat(18));
+
+    // +-1e-18 / +-1e19 = -1e-37, which can't be represented and gets floor'd to 0.
+    quotient = await fixedPoint.wrapDiv("-1", toWei(toWei("10")));
+    assert.equal(quotient.toString(), "0");
+    quotient = await fixedPoint.wrapDiv("1", toWei(toWei("-10")));
+    assert.equal(quotient.toString(), "0");
+  });
+
+  it("Division, with ceil", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Positives
+    // Fractions, precision loss, rounding away from zero.
+    // 1 / 3 = 0.3 repeating, which can't be represented and gets rounded up to 0.333333333333333334.
+    let quotient = await fixedPoint.wrapDivAwayFromZero(toWei("1"), toWei("3"));
+    assert.equal(quotient.toString(), "3".repeat(17) + "4");
+    // 1e-18 / 1e19 = 1e-37, which can't be represented and gets rounded away from zero to 1.
+    quotient = await fixedPoint.wrapDivAwayFromZero("1", toWei(toWei("10")));
+    assert.equal(quotient.toString(), "1");
+
+    // Negatives
+    // Fractions, precision loss, rounding away from zero..
+    // +-1 / +-3 = -0.3 repeating, which can't be represented and gets rounded away from zero to -0.333333333333333334.
+    quotient = await fixedPoint.wrapDivAwayFromZero(toWei("-1"), toWei("3"));
+    assert.equal(quotient.toString(), "-" + "3".repeat(17) + "4");
+    quotient = await fixedPoint.wrapDivAwayFromZero(toWei("1"), toWei("-3"));
+    assert.equal(quotient.toString(), "-" + "3".repeat(17) + "4");
+
+    // +-1e-18 / +-1e19 = -1e-37, which can't be represented and gets rounded away from zero to -1.
+    quotient = await fixedPoint.wrapDivAwayFromZero("-1", toWei(toWei("10")));
+    assert.equal(quotient.toString(), "-1");
+    quotient = await fixedPoint.wrapDivAwayFromZero("1", toWei(toWei("-10")));
+    assert.equal(quotient.toString(), "-1");
+  });
+
+  it("Power", async function() {
+    const fixedPoint = await SignedFixedPointTest.new();
+
+    // Positives
+    // 1.5^0 = 1
+    assert.equal(await fixedPoint.wrapPow(toWei("1.5"), "0"), toWei("1"));
+
+    // 1.5^1 = 1.5
+    assert.equal(await fixedPoint.wrapPow(toWei("1.5"), "1"), toWei("1.5"));
+
+    // 1.5^2 = 2.25.
+    assert.equal(await fixedPoint.wrapPow(toWei("1.5"), "2"), toWei("2.25"));
+
+    // 1.5^3 = 3.375
+    assert.equal(await fixedPoint.wrapPow(toWei("1.5"), "3"), toWei("3.375"));
+
+    // Reverts on overflow
+    assert(await didContractThrow(fixedPoint.wrapPow(toWei("10"), "59")));
+
+    // Negatives
+    // -1.5^0 = 1
+    assert.equal(await fixedPoint.wrapPow(toWei("-1.5"), "0"), toWei("1"));
+
+    // -1.5^1 = -1.5
+    assert.equal(await fixedPoint.wrapPow(toWei("-1.5"), "1"), toWei("-1.5"));
+
+    // -1.5^2 = 2.25.
+    assert.equal(await fixedPoint.wrapPow(toWei("-1.5"), "2"), toWei("2.25"));
+
+    // -1.5^3 = -3.375
+    assert.equal(await fixedPoint.wrapPow(toWei("-1.5"), "3"), toWei("-3.375"));
+
+    // Reverts on overflow
+    assert(await didContractThrow(fixedPoint.wrapPow(toWei("-10"), "59")));
+  });
+});

--- a/packages/core/test/common/SignedFixedPoint.js
+++ b/packages/core/test/common/SignedFixedPoint.js
@@ -18,6 +18,18 @@ contract("SignedFixedPoint", function() {
     // Reverts on overflow.
     const tenToFiftyEight = toBN("10").pow(toBN("59"));
     assert(await didContractThrow(fixedPoint.wrapFromUnscaledInt(tenToFiftyEight)));
+
+    // Signed -> Unsigned
+    assert.equal(await fixedPoint.wrapFromSigned(toWei("100")), toWei("100"));
+    assert.equal(await fixedPoint.wrapFromSigned("0"), "0");
+    assert.equal(await fixedPoint.wrapFromSigned(int_max), int_max.toString());
+    assert(await didContractThrow(fixedPoint.wrapFromSigned("-1")));
+
+    // Unsigned -> Signed
+    assert.equal(await fixedPoint.wrapFromUnsigned(toWei("100")), toWei("100"));
+    assert.equal(await fixedPoint.wrapFromSigned("0"), "0");
+    assert.equal(await fixedPoint.wrapFromUnsigned(int_max), int_max.toString());
+    assert(await didContractThrow(fixedPoint.wrapFromUnsigned(int_max.addn(1))));
   });
 
   // This function tests all positive and negative variations/combinations of an input pair.

--- a/packages/core/test/common/UnsignedFixedPoint.js
+++ b/packages/core/test/common/UnsignedFixedPoint.js
@@ -1,8 +1,8 @@
 const { didContractThrow } = require("@uma/common");
 
-const FixedPointTest = artifacts.require("FixedPointTest");
+const FixedPointTest = artifacts.require("UnsignedFixedPointTest");
 
-contract("FixedPoint", function() {
+contract("UnsignedFixedPoint", function() {
   const uint_max = web3.utils.toBN("115792089237316195423570985008687907853269984665640564039457584007913129639935");
 
   it("Construction", async function() {
@@ -15,7 +15,7 @@ contract("FixedPoint", function() {
     assert(await didContractThrow(fixedPoint.wrapFromUnscaledUint(tenToSixty)));
   });
 
-  it("Comparison", async function() {
+  it("Unsigned Comparison", async function() {
     const fixedPoint = await FixedPointTest.new();
 
     assert.isTrue(await fixedPoint.wrapIsGreaterThan(web3.utils.toWei("2"), web3.utils.toWei("1")));
@@ -39,7 +39,7 @@ contract("FixedPoint", function() {
     assert.isTrue(await fixedPoint.wrapIsLessThanOrEqual(web3.utils.toWei("2"), web3.utils.toWei("3")));
   });
 
-  it("Mixed Comparison", async function() {
+  it("Unsigned Mixed Comparison", async function() {
     const fixedPoint = await FixedPointTest.new();
 
     assert.isTrue(await fixedPoint.wrapMixedIsEqual(web3.utils.toWei("2"), "2"));


### PR DESCRIPTION
**Motivation**

To represent negative funding rates, we need to be able to use signed fixed point numbers.

**Summary**

The fixed point library was expanded to have a `Signed` type with similar functions to the Unsigned type.

Note: I changed the architecture of the tests a bit to avoid manually entering obvious checks that can be verified by comparing against standard js comparisons/arithmetic.

**Issue(s)**

Fixes #2101.

