### PR TITLE
feat(pmp): integrate signed fixed point into funding rate applier

### DIFF
--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -74,7 +74,7 @@ abstract contract FeePayer is Testable, Lockable {
         address _collateralAddress,
         address _finderAddress,
         address _timerAddress
-    ) public Testable(_timerAddress) nonReentrant() {
+    ) public Testable(_timerAddress) {
         collateralCurrency = IERC20(_collateralAddress);
         finder = FinderInterface(_finderAddress);
         lastPaymentTime = getCurrentTime();

--- a/packages/core/contracts/financial-templates/funding-rate-store/interfaces/FundingRateStoreInterface.sol
+++ b/packages/core/contracts/financial-templates/funding-rate-store/interfaces/FundingRateStoreInterface.sol
@@ -13,8 +13,8 @@ interface FundingRateStoreInterface {
      * @notice Gets the latest funding rate for `identifier`.
      * @dev This method should never revert.
      * @param identifier uniquely identifier that the calling contracts wants to get a funding rate for.
-     * @return FixedPoint representing the funding rate for the given identifier. Rates > 1 represent "positive"
-     * funding rates, and < 1 represent "negative" funding rates.
+     * @return FixedPoint representing the funding rate for the given identifier. 0.01 would represent a funding rate
+     * of 1% per second. -0.01 would represent a negative funding rate of -1% per second.
      */
-    function getFundingRateForIdentifier(bytes32 identifier) external view returns (FixedPoint.Unsigned memory);
+    function getFundingRateForIdentifier(bytes32 identifier) external view returns (FixedPoint.Signed memory);
 }

--- a/packages/core/contracts/financial-templates/funding-rate-store/test/MockFundingRateStore.sol
+++ b/packages/core/contracts/financial-templates/funding-rate-store/test/MockFundingRateStore.sol
@@ -16,9 +16,8 @@ contract MockFundingRateStore is FundingRateStoreInterface, Testable {
 
     struct FundingRate {
         // Represented in wei as a % of token amount charged per second.
-        // e.g. fundingRate = 1.01 means 1% of token amount charged per second.
-        FixedPoint.Unsigned fundingRate;
-        // int256 fundingRate;
+        // e.g. fundingRate = 0.01 means 1% of token amount charged per second.
+        FixedPoint.Signed fundingRate;
         uint256 timestamp; // Time the verified funding rate became available.
     }
 
@@ -30,19 +29,14 @@ contract MockFundingRateStore is FundingRateStoreInterface, Testable {
     function setFundingRate(
         bytes32 identifier,
         uint256 time,
-        FixedPoint.Unsigned memory fundingRate
+        FixedPoint.Signed memory fundingRate
     ) external {
         fundingRates[identifier].push(FundingRate(fundingRate, time));
     }
 
-    function getFundingRateForIdentifier(bytes32 identifier)
-        external
-        override
-        view
-        returns (FixedPoint.Unsigned memory)
-    {
+    function getFundingRateForIdentifier(bytes32 identifier) external override view returns (FixedPoint.Signed memory) {
         if (fundingRates[identifier].length == 0) {
-            return FixedPoint.fromUnscaledUint(1);
+            return FixedPoint.fromUnscaledInt(0);
         }
         return fundingRates[identifier][fundingRates[identifier].length - 1].fundingRate;
     }

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -169,7 +169,6 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
             params.timerAddress,
             params.excessTokenBeneficiary
         )
-        nonReentrant()
     {
         require(params.collateralRequirement.isGreaterThan(1), "CR is more than 100%");
         require(

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -77,7 +77,7 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
     FixedPoint.Unsigned public emergencyShutdownPrice;
 
     // Timestamp used in case of emergency shutdown.
-    uint256 private emergencyShutdownTimestamp;
+    uint256 public emergencyShutdownTimestamp;
 
     // The excessTokenBeneficiary of any excess tokens added to the contract.
     address public excessTokenBeneficiary;

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -663,8 +663,7 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
         FixedPoint.Unsigned memory startingGlobalCollateral = _getFeeAdjustedCollateral(rawTotalPositionCollateral);
 
         // Remove the collateral and outstanding from the overall total position.
-        FixedPoint.Unsigned memory remainingRawCollateral = positionToLiquidate.rawCollateral;
-        rawTotalPositionCollateral = rawTotalPositionCollateral.sub(remainingRawCollateral);
+        rawTotalPositionCollateral = rawTotalPositionCollateral.sub(positionToLiquidate.rawCollateral);
         totalTokensOutstanding = totalTokensOutstanding.sub(positionToLiquidate.tokensOutstanding);
 
         // Reset the sponsors position to have zero outstanding and collateral.
@@ -703,8 +702,7 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
 
     // Requests a price for `priceIdentifier` at `requestedTime` from the Oracle.
     function _requestOraclePrice(uint256 requestedTime) internal {
-        OracleInterface oracle = _getOracle();
-        oracle.requestPrice(priceIdentifier, requestedTime);
+        _getOracle().requestPrice(priceIdentifier, requestedTime);
     }
 
     // Fetches a resolved Oracle price from the Oracle. Reverts if the Oracle hasn't resolved for this request.

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -156,7 +156,6 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
         public
         FeePayer(_collateralAddress, _finderAddress, _timerAddress)
         FundingRateApplier(_finderAddress, _fundingRateIdentifier, _timerAddress)
-        nonReentrant()
     {
         require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier), "Unsupported price identifier");
 
@@ -555,7 +554,7 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
      * @dev This is supposed to be implemented by any contract that inherits `AdministrateeInterface` and callable
      * only by the Governor contract. This method is therefore minimally implemented in this contract and does nothing.
      */
-    function remargin() external override notEmergencyShutdown() updateFundingRate() nonReentrant() {
+    function remargin() external override {
         return;
     }
 
@@ -564,7 +563,7 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
      * @dev This will drain down to the amount of tracked collateral and drain the full balance of any other token.
      * @param token address of the ERC20 token whose excess balance should be drained.
      */
-    function trimExcess(IERC20 token) external fees() nonReentrant() returns (FixedPoint.Unsigned memory amount) {
+    function trimExcess(IERC20 token) external nonReentrant() returns (FixedPoint.Unsigned memory amount) {
         FixedPoint.Unsigned memory balance = FixedPoint.Unsigned(token.balanceOf(address(this)));
 
         if (address(token) == address(collateralCurrency)) {

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -155,7 +155,7 @@ contract PerpetualPositionManager is FeePayer, FundingRateApplier, Administratee
     )
         public
         FeePayer(_collateralAddress, _finderAddress, _timerAddress)
-        FundingRateApplier(_finderAddress, _fundingRateIdentifier, _timerAddress)
+        FundingRateApplier(_finderAddress, _fundingRateIdentifier)
     {
         require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier), "Unsupported price identifier");
 

--- a/packages/core/contracts/financial-templates/test/FundingRateApplierTest.sol
+++ b/packages/core/contracts/financial-templates/test/FundingRateApplierTest.sol
@@ -19,9 +19,14 @@ contract FundingRateApplierTest is FundingRateApplier {
 
     function calculateEffectiveFundingRate(
         uint256 paymentPeriodSeconds,
-        FixedPoint.Unsigned memory fundingRatePerSecond,
-        FixedPoint.Unsigned memory feeMultiplier
-    ) public pure returns (FixedPoint.Unsigned memory, FixedPoint.Unsigned memory) {
-        return _calculateEffectiveFundingRate(paymentPeriodSeconds, fundingRatePerSecond, feeMultiplier);
+        FixedPoint.Signed memory fundingRatePerSecond,
+        FixedPoint.Unsigned memory currentCumulativeFundingRateMultiplier
+    ) public pure returns (FixedPoint.Unsigned memory, FixedPoint.Signed memory) {
+        return
+            _calculateEffectiveFundingRate(
+                paymentPeriodSeconds,
+                fundingRatePerSecond,
+                currentCumulativeFundingRateMultiplier
+            );
     }
 }

--- a/packages/core/contracts/financial-templates/test/FundingRateApplierTest.sol
+++ b/packages/core/contracts/financial-templates/test/FundingRateApplierTest.sol
@@ -11,7 +11,7 @@ contract FundingRateApplierTest is FundingRateApplier {
         address _fpFinderAddress,
         bytes32 _fundingRateIdentifier,
         address _timerAddress
-    ) public FundingRateApplier(_fpFinderAddress, _fundingRateIdentifier, _timerAddress) {}
+    ) public Testable(_timerAddress) FundingRateApplier(_fpFinderAddress, _fundingRateIdentifier) {}
 
     function applyFundingRate() public {
         _applyEffectiveFundingRate();

--- a/packages/core/scripts/local/CalculateContractBytecode.js
+++ b/packages/core/scripts/local/CalculateContractBytecode.js
@@ -15,8 +15,13 @@ module.exports = async function(callback) {
   // Load contracts into script and output info.
   console.log("loading", argv.contract + ".json");
   let obj = require("./../../build/contracts/" + argv.contract + ".json");
-  const byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
-  const remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
+  let byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
+  let remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
+  console.log("Contract is", byteCodeSize, "bytes in size.");
+  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
+  obj = require("./../../artifacts/" + argv.contract + ".json");
+  byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
+  remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
   console.log("Contract is", byteCodeSize, "bytes in size.");
   console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
   callback();

--- a/packages/core/scripts/local/CalculateContractBytecode.js
+++ b/packages/core/scripts/local/CalculateContractBytecode.js
@@ -1,10 +1,19 @@
 // This simple script tells you how big your contract byte code is and how much you have until you exceed
 // the current block limit as defined by EIP170. This script should be run from the /core directory.
 // To run the script navigate to /core and then run:
-// truffle exec -c ./scripts/local/CalculateContractBytecode.js --contract Voting --network test
+// yarn truffle compile && yarn buidler compile && yarn truffle exec --network test ./scripts/local/CalculateContractBytecode.js --contract Voting
 // where voting is the name of the contract you want to check.
 
 const argv = require("minimist")(process.argv.slice(), { string: ["contract"] });
+
+function printBytecodeInfo(path) {
+  // Load contracts into script and output info.
+  const obj = require(path);
+  const byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
+  const remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
+  console.log("Contract is", byteCodeSize, "bytes in size.");
+  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
+}
 
 module.exports = async function(callback) {
   if (!argv.contract) {
@@ -12,17 +21,15 @@ module.exports = async function(callback) {
     callback();
   }
 
-  // Load contracts into script and output info.
-  console.log("loading", argv.contract + ".json");
-  let obj = require("./../../build/contracts/" + argv.contract + ".json");
-  let byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
-  let remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
-  console.log("Contract is", byteCodeSize, "bytes in size.");
-  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
-  obj = require("./../../artifacts/" + argv.contract + ".json");
-  byteCodeSize = (obj.deployedBytecode.length - 2) / 2;
-  remainingSize = 2 ** 14 + 2 ** 13 - byteCodeSize;
-  console.log("Contract is", byteCodeSize, "bytes in size.");
-  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit.");
+  // Truffle
+  console.group("Truffle Compilation Output");
+  printBytecodeInfo("./../../build/contracts/" + argv.contract + ".json");
+  console.groupEnd();
+
+  // Buidler
+  console.group("Buidler Compilation Output");
+  printBytecodeInfo("./../../artifacts/" + argv.contract + ".json");
+  console.groupEnd();
+
   callback();
 };

--- a/packages/core/test/financial-templates/common/FundingRateApplier.js
+++ b/packages/core/test/financial-templates/common/FundingRateApplier.js
@@ -41,7 +41,7 @@ contract("FundingRateApplier", function() {
     // Cumulative Multiplier: 1 * 1.03 = 1.03
     const test1 = await fundingRateApplier.calculateEffectiveFundingRate(
       20,
-      { rawValue: toWei("1.0015") },
+      { rawValue: toWei("0.0015") },
       { rawValue: toWei("1") }
     );
     assert.equal(test1[0].rawValue, toWei("1.03"));
@@ -52,10 +52,10 @@ contract("FundingRateApplier", function() {
     // Cumulative Multiplier: 1.05 * 1.03 = 1.0815
     const test2 = await fundingRateApplier.calculateEffectiveFundingRate(
       20,
-      { rawValue: toWei("1.0015") },
+      { rawValue: toWei("0.0015") },
       { rawValue: toWei("1.05") }
     );
-    assert.equal(test2[0].rawValue, toWei("1.0815"));
+    assert.equal(test2[0].rawValue, toWei("0.0815"));
     assert.equal(test2[1].rawValue, toWei("1.03"));
 
     // Previous test but change the funding rate to -0.15%:
@@ -63,10 +63,10 @@ contract("FundingRateApplier", function() {
     // Cumulative Multiplier: 1.05 * 0.97 = 1.0185
     const test3 = await fundingRateApplier.calculateEffectiveFundingRate(
       20,
-      { rawValue: toWei("0.9985") },
+      { rawValue: toWei("-0.0015") },
       { rawValue: toWei("1.05") }
     );
-    assert.equal(test3[0].rawValue, toWei("1.0185"));
+    assert.equal(test3[0].rawValue, toWei("-0.0185"));
     assert.equal(test3[1].rawValue, toWei("0.97"));
 
     // Previous test but change the funding rate to 0% meaning that the multiplier shouldn't change:
@@ -74,10 +74,10 @@ contract("FundingRateApplier", function() {
     // Cumulative Multiplier: 1.05 * 1 = 1.05
     const test4 = await fundingRateApplier.calculateEffectiveFundingRate(
       20,
-      { rawValue: toWei("1") },
+      { rawValue: toWei("0") },
       { rawValue: toWei("1.05") }
     );
-    assert.equal(test4[0].rawValue, toWei("1.05"));
+    assert.equal(test4[0].rawValue, toWei("0"));
     assert.equal(test4[1].rawValue, toWei("1"));
   });
   it("Applying positive and negative effective funding rates sets state and emits events correctly", async () => {
@@ -87,7 +87,7 @@ contract("FundingRateApplier", function() {
     // Set a positive funding rate of 1.01 in the store and apply it for a period
     // of 5 seconds. New funding rate should be (1 + 0.01 * 5) * 1 = 1.05
     await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-      rawValue: toWei("1.01")
+      rawValue: toWei("0.01")
     });
     await timer.setCurrentTime(startingTime.add(toBN(5)).toString());
     startingTime = await timer.getCurrentTime();
@@ -99,15 +99,15 @@ contract("FundingRateApplier", function() {
         ev.newMultiplier == toWei("1.05") &&
         ev.updateTime == startingTime.toString() &&
         ev.paymentPeriod == "5" &&
-        ev.latestFundingRate == toWei("1.01") &&
-        ev.effectiveFundingRateForPaymentPeriod == toWei("1.05")
+        ev.latestFundingRate == toWei("0.01") &&
+        ev.effectiveFundingRateForPaymentPeriod == toWei("0.05")
       );
     });
 
     // Set a negative funding rate of 0.98 in the store and apply it for a period
     // of 5 seconds. New funding rate should be (1 - 0.02 * 5) * 1.05 = 0.9 * 1.05 = 0.945
     await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-      rawValue: toWei("0.98")
+      rawValue: toWei("-0.02")
     });
     await timer.setCurrentTime(startingTime.add(toBN(5)).toString());
     startingTime = await timer.getCurrentTime();
@@ -119,15 +119,15 @@ contract("FundingRateApplier", function() {
         ev.newMultiplier == toWei("0.945") &&
         ev.updateTime == startingTime.toString() &&
         ev.paymentPeriod == "5" &&
-        ev.latestFundingRate == toWei("0.98") &&
-        ev.effectiveFundingRateForPaymentPeriod == toWei("0.9")
+        ev.latestFundingRate == toWei("-0.02") &&
+        ev.effectiveFundingRateForPaymentPeriod == toWei("-0.1")
       );
     });
 
     // Set a neutral funding rate in the store and verify that the multiplier
     // does not change.
     await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-      rawValue: toWei("1")
+      rawValue: toWei("0")
     });
     await timer.setCurrentTime(startingTime.add(toBN(5)).toString());
     startingTime = await timer.getCurrentTime();
@@ -139,8 +139,8 @@ contract("FundingRateApplier", function() {
         ev.newMultiplier == toWei("0.945") &&
         ev.updateTime == startingTime.toString() &&
         ev.paymentPeriod == "5" &&
-        ev.latestFundingRate == toWei("1") &&
-        ev.effectiveFundingRateForPaymentPeriod == toWei("1")
+        ev.latestFundingRate == toWei("0") &&
+        ev.effectiveFundingRateForPaymentPeriod == toWei("0")
       );
     });
   });

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
@@ -431,10 +431,10 @@ contract("PerpetualLiquidatable", function(accounts) {
     it("Funding rate multiplier is updated", async () => {
       // Initially cumulativeFundingRateMultiplier is set to 1e18
 
-      // Set a positive funding rate of 1.005 in the store and apply it for a period of 10 seconds. New funding rate should
-      // be 1 * (1 + (1.005 - 1) * 10) = 1.05)
+      // Set a positive funding rate of 0.005 in the store and apply it for a period of 10 seconds. New funding rate should
+      // be 1 * (1 + 0.005 * 10) = 1.05)
       await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-        rawValue: toWei("1.005")
+        rawValue: toWei("0.005")
       });
       await timer.setCurrentTime((await timer.getCurrentTime()).add(toBN(10)).toString()); // Advance the time by 10 seconds
 
@@ -860,9 +860,9 @@ contract("PerpetualLiquidatable", function(accounts) {
         // Initially cumulativeFundingRateMultiplier is set to 1e18
 
         // Set a positive funding rate of 1.005 in the store and apply it for a period of 10 seconds. New funding rate should
-        // be 1 * (1 + (1.005 - 1) * 10) = 1.05)
+        // be 1 * (1 + 0.005 * 10) = 1.05)
         await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-          rawValue: toWei("1.005")
+          rawValue: toWei("0.005")
         });
         await timer.setCurrentTime((await timer.getCurrentTime()).add(toBN(10)).toString()); // Advance the time by 10 seconds
 
@@ -996,9 +996,9 @@ contract("PerpetualLiquidatable", function(accounts) {
         // the price must be <= 150 / 1.2 / 95 = 1.316.
 
         // Set a positive funding rate of 0.995 in the store and apply it for a period of 10 seconds. New funding rate should
-        // be 1 * (1 - (1 - 0.995) * 10) = 0.95)
+        // be 1 * (1 - -0.005 * 10) = 0.95)
         await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-          rawValue: toWei("0.995")
+          rawValue: toWei("-0.005")
         });
         await timer.setCurrentTime((await timer.getCurrentTime()).add(toBN(10)).toString()); // Advance the time by 10 seconds
 
@@ -1066,9 +1066,9 @@ contract("PerpetualLiquidatable", function(accounts) {
         // the price must be <= 150 / 1.2 / 105 = 1.19. Any price above 1.19 will cause the dispute to fail.
 
         // Set a positive funding rate of 1.005 in the store and apply it for a period of 10 seconds. New funding rate should
-        // be 1 * (1 - (1.005 - 1) * 10) = 1.05)
+        // be 1 * (1 - 0.005 * 10) = 1.05)
         await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-          rawValue: toWei("1.005")
+          rawValue: toWei("0.005")
         });
         await timer.setCurrentTime((await timer.getCurrentTime()).add(toBN(10)).toString()); // Advance the time by 10 seconds
 
@@ -1455,9 +1455,9 @@ contract("PerpetualLiquidatable", function(accounts) {
           // We will set the funding rate multiplier to 0.95, which means that both dispute rewards are scaled down by 0.95
 
           // Set a positive funding rate of 0.995 in the store and apply it for a period of 10 seconds. New funding rate should
-          // be 1 * (1 - (1 - 0.995) * 10) = 0.95)
+          // be 1 * (1 - -0.005 * 10) = 0.95)
           await mockFundingRateStore.setFundingRate(fundingRateIdentifier, await timer.getCurrentTime(), {
-            rawValue: toWei("0.995")
+            rawValue: toWei("-0.005")
           });
           await timer.setCurrentTime((await timer.getCurrentTime()).add(toBN(10)).toString()); // Advance the time by 10 seconds
 


### PR DESCRIPTION
**Motivation**

Integrate SignedFixedPoint into the FundingRateApplier and FundingRateStore to make all funding rates centered at 0. Please give feedback here -- let me know if you think this implementation decision doesn't make sense. IMO, it makes the funding rates and the math easier to reason about.

**Summary**

In theory, this should've made the computations simpler. In practice, the inclusion of the new fixed point type and methods increased the bytecode size substantially (600 bytes or so). To make this work, I reworked some areas of the contract to reduce the bytecode.

I also reworked the inheritance structure so that FundingRateApplier inherits from Testable and doesn't store the Timer locally (the current logic was slightly broken as a 0x0 Timer address would've made it fail in prod).

Finally, I also noticed that Buidler's compilation and truffle's compilation gave different bytecode sizes, so I added on to our script to print both.

**Issue(s)**

Fixes #2087.