### PR TITLE
fix(serverless-hub) retry logic bug

### DIFF
--- a/packages/core/scripts/serverless-orchestration/ServerlessHub.js
+++ b/packages/core/scripts/serverless-orchestration/ServerlessHub.js
@@ -61,7 +61,7 @@ hub.post("/", async (req, res) => {
     const lastQueriedBlockNumber = await _getLastQueriedBlockNumber(req.body.configFile);
     if (!configObject || !lastQueriedBlockNumber)
       throw new Error(
-        `Serverless hub requires a config object and a last updated block number! configObject:${configObject} lastQueriedBlockNumber: ${lastQueriedBlockNumber}`
+        `Serverless hub requires a config object and a last updated block number! configObject:${configObject} lastQueriedBlockNumber:${lastQueriedBlockNumber}`
       );
 
     // Get the latest block number. The query will run from the last queried block number to the latest block number.

--- a/packages/core/scripts/serverless-orchestration/ServerlessHub.js
+++ b/packages/core/scripts/serverless-orchestration/ServerlessHub.js
@@ -60,7 +60,9 @@ hub.post("/", async (req, res) => {
     // Fetch the last block number this given config file queried the blockchain at if running in production. Else, pull from env.
     const lastQueriedBlockNumber = await _getLastQueriedBlockNumber(req.body.configFile);
     if (!configObject || !lastQueriedBlockNumber)
-      throw new Error("Serverless hub requires a config object and a last updated block number!");
+      throw new Error(
+        `Serverless hub requires a config object and a last updated block number! configObject:${configObject} lastQueriedBlockNumber: ${lastQueriedBlockNumber}`
+      );
 
     // Get the latest block number. The query will run from the last queried block number to the latest block number.
     const latestBlockNumber = await _getLatestBlockNumber();
@@ -261,7 +263,7 @@ async function _saveQueriedBlockNumber(configIdentifier, blockNumber) {
 // recorded by the bot to inform where searches should start from.
 async function _getLastQueriedBlockNumber(configIdentifier) {
   // sometimes the GCP datastore can be flaky and return errors when saving data. Use re-try logic to re-run on error.
-  await retry(
+  return await retry(
     async () => {
       if (hubConfig.saveQueriedBlock == "gcp") {
         const key = datastore.key(["BlockNumberLog", configIdentifier]);
@@ -360,4 +362,4 @@ if (require.main === module) {
 }
 
 hub.Poll = Poll;
-module.exports = hub;
+module.exports = { hub, _getLastQueriedBlockNumber };

--- a/packages/core/scripts/serverless-orchestration/ServerlessHub.js
+++ b/packages/core/scripts/serverless-orchestration/ServerlessHub.js
@@ -362,4 +362,4 @@ if (require.main === module) {
 }
 
 hub.Poll = Poll;
-module.exports = { hub, _getLastQueriedBlockNumber };
+module.exports = hub;

--- a/packages/core/scripts/serverless-orchestration/ServerlessHub.js
+++ b/packages/core/scripts/serverless-orchestration/ServerlessHub.js
@@ -61,7 +61,9 @@ hub.post("/", async (req, res) => {
     const lastQueriedBlockNumber = await _getLastQueriedBlockNumber(req.body.configFile);
     if (!configObject || !lastQueriedBlockNumber)
       throw new Error(
-        `Serverless hub requires a config object and a last updated block number! configObject:${configObject} lastQueriedBlockNumber:${lastQueriedBlockNumber}`
+        `Serverless hub requires a config object and a last updated block number! configObject:${JSON.stringify(
+          configObject
+        )} lastQueriedBlockNumber:${lastQueriedBlockNumber}`
       );
 
     // Get the latest block number. The query will run from the last queried block number to the latest block number.


### PR DESCRIPTION
**Motivation**

https://github.com/UMAprotocol/protocol/pull/2111 yesterday introduced a small bug in the hub wherein by not returning the nested value within the retry logic. The PR has been tested in production with a hot-fix docker container and has been validated to work as expected.

**Summary**

Adds a `return` to the value retrieved from GCP data store. This PR also expands the error message a bit by showing the underlying `configObject` & `lastQueriedBlockNumber` returned by the function.
