### PR TITLE
improve(slack-transport) remove upper bound on slack message length

### DIFF
--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -15,7 +15,6 @@
     "node-fetch": "^2.6.0",
     "node-pagerduty": "^1.2.0",
     "winston": "^3.2.1",
-    "winston-slack-webhook-transport": "^1.2.1",
     "winston-transport": "^4.3.0"
   },
   "devDependencies": {

--- a/packages/financial-templates-lib/src/logger/SlackTransport.js
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.js
@@ -202,7 +202,7 @@ class SlackHook extends Transport {
           const stringifiedBlock = JSON.stringify(block);
           const redactedBlock =
             stringifiedBlock.substr(0, 1000) +
-            "- MESSAGE REDACTED DUE TO LENGTH -" +
+            "-MESSAGE REDACTED DUE TO LENGTH-" +
             stringifiedBlock.substr(stringifiedBlock.length - 1000, stringifiedBlock.length);
           block = JSON.parse(redactedBlock);
         }

--- a/packages/financial-templates-lib/src/logger/SlackTransport.js
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.js
@@ -201,9 +201,9 @@ class SlackHook extends Transport {
           // If the block (one single part of a message) is larger than 3000 chars then we must redact part of the message.
           const stringifiedBlock = JSON.stringify(block);
           const redactedBlock =
-            stringifiedBlock.substr(0, 1000) +
+            stringifiedBlock.substr(0, 1400) +
             "-MESSAGE REDACTED DUE TO LENGTH-" +
-            stringifiedBlock.substr(stringifiedBlock.length - 1000, stringifiedBlock.length);
+            stringifiedBlock.substr(stringifiedBlock.length - 1400, stringifiedBlock.length);
           block = JSON.parse(redactedBlock);
         }
         if (JSON.stringify([...processedBlocks[messageIndex], block]).length > 3000) {


### PR DESCRIPTION
**Motivation**

https://github.com/UMAprotocol/protocol/issues/2121

Previously the slack transport was limited to sending slack messages no larger than 3500 chars due to a limitation in the slack webhook API. If a message was sent to the API larger than this limit then the transport would fail silently. Normally, this was never an issue as the usage of the Winston logger than would send slack messages is conscious of the size as we are always consistent to not send massive error messages. 

However, this is not always going to be a fair assumption that messages are less than this limit. For example, https://github.com/UMAprotocol/protocol/pull/2118 could produce a slack message that exceeds this limit if the number of bots running is fairly high and they all error out at the same time.


**Summary**

This PR removes the previously used `winston-slack-webhook-transport` and replaces it with our own implementation. This implementation considers the size of the message being sent to slack, provided to the Winston transport, and splits up the log into multiple slack messages accordingly. 


**Details**
There are three main logic branches that this PR introduces:
- If a message is less than 3000 chars in total (considering the header, markdown formatting, and all other associated details) then it is sent to slack in one API call.
- A slack message comprises multiple blocks. In the slack transport, each block would be defined as a key-value pair component in the log sent to Winston. For example, a message generated as `Logger.error({at:"example",message:"some string",some-random-key:"this is an example key"}) would be turned into 3 blocks, for each key within the object. If each block's length exceeds 3000 chars then the new transport will redact the middle part of the block message.
- If the overall set of blocks within a message exceeds 3000 chars then the transport will split the log up into multiple messages to send to the slack API.

**Testing**
This implementation was tested against the three different kinds of messages described above and the output was validated in slack. For example

1) simple case base message:
```
Logger.error({at:"test",message:"testmessage"})
```

2) long message block where redaction occurs:
```
Logger.error({at:"test",message:"testmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessage"})
```

3) multiple block, each has no redaction but collectively gets split over multiple messages:
```
Logger.error({at:"test",message:"testmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagees",message2:"tmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessage"})
``` 

4) multiple blocks where each gets redacted and spread over multiple messages
```
Logger.error({at:"test",message:"testmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagees",message2:"tmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessagetestmessageestmessagetestmessagetestmessagetessage"})
```

**Issue(s)**

close https://github.com/UMAprotocol/protocol/issues/2121
