### PR TITLE
feat(affiliates): add emp and erc20 interfaces for getting informatio…

### DIFF
--- a/packages/affiliates/libs/contracts.js
+++ b/packages/affiliates/libs/contracts.js
@@ -1,7 +1,8 @@
 const ethers = require("ethers");
 const assert = require("assert");
+const { getAbi } = require("@uma/core");
 function DecodeLog(abi, meta = {}) {
-  assert(abi, "requries abi");
+  assert(abi, "requires abi");
   const iface = new ethers.utils.Interface(abi);
   return (log, props = {}) => {
     return {
@@ -12,7 +13,7 @@ function DecodeLog(abi, meta = {}) {
   };
 }
 function DecodeTransaction(abi, meta = {}) {
-  assert(abi, "requries abi");
+  assert(abi, "requires abi");
   const iface = new ethers.utils.Interface(abi);
   return (transaction, props = {}) => {
     return {
@@ -27,11 +28,76 @@ function decodeAttribution(
   data,
   delimiter = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000"
 ) {
+  assert(data, "requires data to decode");
   return data.split(delimiter)[1];
+}
+
+// Just wraps abi to pass through to contract
+// Lookup by erc20 address
+function Erc20({ abi = getAbi("ERC20"), web3 }) {
+  assert(abi, "requires abi for erc20");
+  const contract = new web3.eth.Contract(abi);
+  function decimals(address) {
+    assert(address, "requires address");
+    contract.options.address = address;
+    return contract.methods.decimals().call();
+  }
+  return {
+    decimals
+  };
+}
+
+// Wrapper for some basic emp functionality.
+// Currently we just need token and collateral info
+// Lookup by emp address
+function Emp({ abi = getAbi("ExpiringMultiParty"), web3 } = {}) {
+  assert(abi, "requires abi for expiring multi party");
+  const contract = new web3.eth.Contract(abi);
+  const erc20 = Erc20({ web3 });
+  function tokenCurrency(address) {
+    assert(address, "requires address");
+    contract.options.address = address;
+    return contract.methods.tokenCurrency().call();
+  }
+  function collateralCurrency(address) {
+    assert(address, "requires address");
+    contract.options.address = address;
+    return contract.methods.collateralCurrency().call();
+  }
+  async function tokenInfo(address) {
+    const tokenAddress = await tokenCurrency(address);
+    return {
+      address: tokenAddress,
+      decimals: await erc20.decimals(tokenAddress)
+    };
+  }
+  async function collateralInfo(address) {
+    const tokenAddress = await collateralCurrency(address);
+    return {
+      address: tokenAddress,
+      decimals: await erc20.decimals(tokenAddress)
+    };
+  }
+  async function info(address) {
+    return {
+      address,
+      token: await tokenInfo(address),
+      collateral: await collateralInfo(address)
+    };
+  }
+  return {
+    tokenCurrency,
+    collateralCurrency,
+    collateralInfo,
+    tokenInfo,
+    info
+  };
 }
 
 module.exports = {
   DecodeLog,
   DecodeTransaction,
-  decodeAttribution
+  decodeAttribution,
+  Emp,
+  Erc20
 };

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -16,6 +16,8 @@
     "tape": "^5.0.1"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "yarn test-mocha && yarn test-truffle",
+    "test-mocha": "mocha test/mocha/*.js",
+    "test-truffle": "truffle test test/truffle/*.js --network=test"
   }
 }

--- a/packages/affiliates/test/mocha/affiliates.js
+++ b/packages/affiliates/test/mocha/affiliates.js
@@ -1,10 +1,10 @@
-const { DeployerRewards } = require("../libs/affiliates");
+const { DeployerRewards } = require("../../libs/affiliates");
 const { assert } = require("chai");
-const empAbi = require("../../core/build/contracts/ExpiringMultiParty");
-const empCreatorAbi = require("../../core/build/contracts/ExpiringMultiPartyCreator");
+const empAbi = require("../../../core/build/contracts/ExpiringMultiParty");
+const empCreatorAbi = require("../../../core/build/contracts/ExpiringMultiPartyCreator");
 const highland = require("highland");
 const datasetName = "set1";
-const params = require(`./datasets/${datasetName}`);
+const params = require(`../datasets/${datasetName}`);
 const {
   empCreator,
   empContracts,
@@ -18,23 +18,23 @@ const devRewardsToDistribute = "50000";
 function Queries() {
   return {
     streamLogsByContract(address) {
-      return highland(require(`./datasets/${datasetName}/logs/${address}`));
+      return highland(require(`../datasets/${datasetName}/logs/${address}`));
     },
     getLogsByContract(address) {
-      return require(`./datasets/${datasetName}/logs/${address}`);
+      return require(`../datasets/${datasetName}/logs/${address}`);
     },
     streamBlocks() {
-      return highland(require(`./datasets/${datasetName}/blocks`));
+      return highland(require(`../datasets/${datasetName}/blocks`));
     },
     getBlocks() {
-      return require(`./datasets/${datasetName}/blocks`);
+      return require(`../datasets/${datasetName}/blocks`);
     }
   };
 }
 function Coingecko() {
   return {
     chart(address) {
-      return require(`./datasets/${datasetName}/coingecko/${address}`);
+      return require(`../datasets/${datasetName}/coingecko/${address}`);
     }
   };
 }

--- a/packages/affiliates/test/mocha/models.js
+++ b/packages/affiliates/test/mocha/models.js
@@ -1,6 +1,6 @@
 const { assert } = require("chai");
-const { History, Balances, SharedAttributions, Prices } = require("../libs/models");
-const Coingecko = require("../libs/coingecko");
+const { History, Balances, SharedAttributions, Prices } = require("../../libs/models");
+const Coingecko = require("../../libs/coingecko");
 const moment = require("moment");
 
 describe("SharedAttributions", function() {

--- a/packages/affiliates/test/mocha/processors.js
+++ b/packages/affiliates/test/mocha/processors.js
@@ -2,7 +2,7 @@ const { assert } = require("chai");
 const { AttributionHistory } = require("../libs/processors");
 const transactions = require("./datasets/set1/tagged-transactions/0xaBBee9fC7a882499162323EEB7BF6614193312e3.json");
 const { DecodeTransaction } = require("../libs/contracts");
-const { abi } = require("../../core/build/contracts/ExpiringMultiParty");
+const abi = getAbi("ExpiringMultiParty");
 
 describe("AttributionHistory", function() {
   let processor;

--- a/packages/affiliates/test/truffle/contracts.js
+++ b/packages/affiliates/test/truffle/contracts.js
@@ -1,0 +1,93 @@
+const { getWeb3, interfaceName } = require("@uma/common");
+const { Emp, Erc20 } = require("../../libs/contracts");
+
+// Contracts and helpers
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const Finder = artifacts.require("Finder");
+const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
+const MockOracle = artifacts.require("MockOracle");
+const TokenFactory = artifacts.require("TokenFactory");
+const Token = artifacts.require("ExpandedERC20");
+const Timer = artifacts.require("Timer");
+const Store = artifacts.require("Store");
+
+const { toWei, utf8ToHex } = web3.utils;
+
+contract("contracts", function(accounts) {
+  describe("emp contract", function() {
+    let emp, empContract, web3, collateralToken, timer, collateral, token;
+    const contractCreator = accounts[4];
+    before(async function() {
+      const identifier = "TESTTOKEN";
+      const identifierWhitelist = await IdentifierWhitelist.deployed();
+      await identifierWhitelist.addSupportedIdentifier(utf8ToHex(identifier));
+      collateralToken = await Token.new("WETH", "WETH", 18, { from: contractCreator });
+      const finder = await Finder.deployed();
+      const mockOracle = await MockOracle.new(finder.address, Timer.address, {
+        from: contractCreator
+      });
+      const mockOracleInterfaceName = utf8ToHex(interfaceName.Oracle);
+      await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
+      const store = await Store.deployed();
+      timer = await Timer.deployed();
+      const empConfig = {
+        expirationTimestamp: Date.now() + 1000 * 60 * 60 * 24 * 1000,
+        withdrawalLiveness: "1000",
+        collateralAddress: collateralToken.address,
+        finderAddress: finder.address,
+        tokenFactoryAddress: TokenFactory.address,
+        priceFeedIdentifier: utf8ToHex(identifier),
+        syntheticName: "Test Token",
+        syntheticSymbol: identifier,
+        liquidationLiveness: "1000",
+        collateralRequirement: { rawValue: toWei("1.2") },
+        disputeBondPct: { rawValue: toWei("0.1") },
+        sponsorDisputeRewardPct: { rawValue: toWei("0.1") },
+        disputerDisputeRewardPct: { rawValue: toWei("0.1") },
+        minSponsorTokens: { rawValue: toWei("5") },
+        timerAddress: timer.address,
+        excessTokenBeneficiary: store.address
+      };
+
+      web3 = getWeb3();
+      // Deploy a new expiring multi party
+      empContract = await ExpiringMultiParty.new(empConfig);
+      emp = Emp({ web3 });
+      collateral = Erc20({ web3 });
+      token = Erc20({ web3, address: await empContract.tokenCurrency() });
+    });
+    it("gets collateral address", async function() {
+      const result = await emp.collateralCurrency(empContract.address);
+      assert.equal(result, collateralToken.address);
+    });
+    it("gets token address", async function() {
+      const result = await emp.tokenCurrency(empContract.address);
+      assert.equal(result, await empContract.tokenCurrency());
+    });
+    it("check token decimals", async function() {
+      const result = await token.decimals(await empContract.tokenCurrency());
+      assert.equal(result, 18);
+    });
+    it("check collateral decimals", async function() {
+      const result = await collateral.decimals(collateralToken.address);
+      assert.equal(result, 18);
+    });
+    it("gets collateral info", async function() {
+      const result = await emp.collateralInfo(empContract.address);
+      assert.equal(result.address, collateralToken.address);
+      assert.equal(result.decimals, 18);
+    });
+    it("gets token info", async function() {
+      const result = await emp.tokenInfo(empContract.address);
+      assert.equal(result.address, await empContract.tokenCurrency());
+      assert.equal(result.decimals, 18);
+    });
+    it("gets emp info", async function() {
+      const result = await emp.info(empContract.address);
+      assert.equal(result.token.address, await empContract.tokenCurrency());
+      assert.equal(result.token.decimals, 18);
+      assert.equal(result.collateral.address, collateralToken.address);
+      assert.equal(result.collateral.decimals, 18);
+    });
+  });
+});


### PR DESCRIPTION
…n for calculations from web3

Signed-off-by: David Adams <david@adams.software>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2123 

**Summary**

Adds a small wrapper around web3 to allow grabbing emp state per address. Also adds truffle tests, so seperates test folder into
`/datasets` `/mocha` `/truffle` and adds yarn scripts for testing each.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2123
