### PR TITLE
docker: lock node version at 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # To `docker run` with your locally built image, replace `umaprotocol/protocol` with <username>/<imagename>.
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:lts
+FROM node:12
 
 # All source code and execution happens from the protocol directory.
 WORKDIR /protocol


### PR DESCRIPTION
**Motivation**

locks node version in docker in accordance with PR https://github.com/UMAprotocol/protocol/pull/2135

**Summary**

Locks docker node version for consistency.