### PR TITLE
feat(pricefeed): adds a new price feed for the GASETH-1M identifier

### DIFF
--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -4,6 +4,7 @@
   "description": "Arbitrage automation and libraries for UMA financial templates",
   "dependencies": {
     "@ethersproject/bignumber": "^5.0.5",
+    "@google-cloud/bigquery": "^5.3.0",
     "@google-cloud/logging-winston": "^3.0.6",
     "@google-cloud/trace-agent": "^4.2.5",
     "@uma/common": "^1.0.1",
@@ -11,7 +12,9 @@
     "@uniswap/sdk": "^2.0.5",
     "bluebird": "^3.7.2",
     "dotenv": "^6.2.0",
+    "highland": "^2.13.5",
     "minimist": "^1.2.0",
+    "moment": "^2.29.1",
     "node-fetch": "^2.6.0",
     "node-pagerduty": "^1.2.0",
     "winston": "^3.2.1",

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -19,7 +19,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
    *      this number of seconds has passed, it will be a no-op.
    * @param {Number} decimals Number of decimals to use to convert price to wei.
    */
-  constructor(logger, web3, lookback, getTime, minTimeBetweenUpdates, decimals = 0) {
+  constructor(logger, web3, lookback, getTime, minTimeBetweenUpdates, decimals = 18) {
     super();
     this.logger = logger;
     this.web3 = web3;
@@ -30,7 +30,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
 
     this.convertDecimals = number => {
       // Converts price result to wei and returns price conversion to correct decimals as a big number.
-      return this.toBN(parseFixed(number.toString(), decimals).toString());
+      return this.toBN(parseFixed(number.toString(), decimals - 18).toString());
     };
   }
 

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -57,17 +57,13 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     // Create the query with the needed time interval.
     const query = this.createQuery(t2, formattedCurrentTime);
 
-    // Submit async call to BigQuery.
+    // Submit async call to BigQuery and check the response.
     let priceResponse;
-    await this.runQuery(query)
-      .then(res => {
-        console.log(res[0].gas_price);
-        priceResponse = res[0].gas_price;
-      })
-      .catch(console.log);
-
-    // Check response.
-    if (!priceResponse) {
+    try {
+      priceResponse = await this.runQuery(query);
+      priceResponse = priceResponse[0].gas_price;
+      console.log(priceResponse);
+    } catch (error) {
       throw new Error(`🚨Could not parse price result from bigquery: ${priceResponse}`);
     }
 
@@ -118,17 +114,13 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     // Create the query with the needed time interval.
     const query = this.createQuery(t2, formattedCurrentTime);
 
-    // Submit async call to BigQuery.
+    // Submit async call to BigQuery and check response.
     let priceResponse;
-    await this.runQuery(query)
-      .then(res => {
-        console.log(res[0].gas_price);
-        priceResponse = res[0].gas_price;
-      })
-      .catch(console.log);
-
-    // Check responses.
-    if (!priceResponse) {
+    try {
+      priceResponse = await this.runQuery(query);
+      priceResponse = priceResponse[0].gas_price;
+      console.log(priceResponse);
+    } catch (error) {
       throw new Error(`🚨Could not parse price result from bigquery: ${priceResponse}`);
     }
 

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -5,8 +5,6 @@ const highland = require("highland");
 const { parseFixed } = require("@ethersproject/bignumber");
 const { createQuery } = require("../queries/GasEthQuery");
 
-const client = new BigQuery();
-
 // An implementation of PriceFeedInterface that uses BigQuery to retrieve prices.
 class BigQueryPriceFeed extends PriceFeedInterface {
   /**
@@ -28,11 +26,17 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
     this.toBN = this.web3.utils.toBN;
     this.dateConversionString = "YYYY-MM-DD HH:mm:ss";
+    this.decimals = decimals;
+    this.client = new BigQuery();
 
-    this.convertDecimals = number => {
-      // Converts price result to wei and returns price conversion to correct decimals as a big number.
-      return this.toBN(parseFixed(number.toString(), decimals - 18).toString());
-    };
+    // this.convertDecimals = number => {
+    //   // Converts price result to wei and returns price conversion to correct decimals as a big number.
+    //   return this.toBN(parseFixed(number.toString(), decimals - 18).toString());
+    // };
+  }
+
+  convertDecimals(number) {
+    return this.toBN(parseFixed(number.toString(), this.decimals - 18).toString());
   }
 
   getCurrentPrice() {
@@ -134,7 +138,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
   }
   async runQuery(query) {
     // returns a node read stream
-    const stream = await client.createQueryStream({ query });
+    const stream = await this.client.createQueryStream({ query });
     // highland wraps a stream and adds utilities simlar to lodash
     // https://caolan.github.io/highland/
     return (

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -42,21 +42,22 @@ class BigQueryPriceFeed extends PriceFeedInterface {
       return undefined;
     }
 
-    // Using moment package to changeto UTC and create acceptable format for BQ
+    // Using moment package to changeto UTC and create acceptable format for BQ.
     const formattedCurrentTime = moment(time)
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
     // 2592000000 is a month time interval
-    let t2 = new Date(time - 2592000000);
+    let t2 = new Date(time);
     t2 = moment(t2)
+      .subtract(30, "days")
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
-    // Create the query with the needed time interval
+    // Create the query with the needed time interval.
     const query = this.createQuery(t2, formattedCurrentTime);
 
-    // Submit async call to BigQuery
+    // Submit async call to BigQuery.
     let priceResponse;
     await this.runQuery(query)
       .then(res => {
@@ -80,17 +81,18 @@ class BigQueryPriceFeed extends PriceFeedInterface {
   }
 
   async update() {
-    // Using current time minus 5 minutes as end-bound of query. This is because the BQ dataset lags ~5 minutes
-    // Using moment package to changeto UTC and create acceptable format for BQ
-    let currentTime = new Date();
-    currentTime = currentTime - 300000;
+    // Using current time minus 5 minutes as end-bound of query. This is because the BQ dataset lags ~5 minutes.
+    // Using moment package to change to UTC and create acceptable format for BQ.
+    const currentTime = new Date();
     const formattedCurrentTime = moment(currentTime)
+      .subtract(5, "minutes")
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
-    // 2592000000 is a month time interval
-    let t2 = new Date(currentTime - 2592000000);
+    // Subtracting 30 days from current time to create the earlier time bound.
+    let t2 = new Date();
     t2 = moment(t2)
+      .subtract(30, "days")
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
@@ -113,10 +115,10 @@ class BigQueryPriceFeed extends PriceFeedInterface {
       lastUpdateTimestamp: this.lastUpdateTime
     });
 
-    // Create the query with the needed time interval
+    // Create the query with the needed time interval.
     const query = this.createQuery(t2, formattedCurrentTime);
 
-    // Submit async call to BigQuery
+    // Submit async call to BigQuery.
     let priceResponse;
     await this.runQuery(query)
       .then(res => {
@@ -152,8 +154,8 @@ class BigQueryPriceFeed extends PriceFeedInterface {
         .toPromise(Promise)
     );
   }
+  // This is a helper method to create a GASETH BQ query with time arguments.
   createQuery(t2, formattedCurrentTime) {
-    // method to create GASETH calculation query with time arguments
     const query = `
         DECLARE halfway int64;
         DECLARE block_count int64;

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -43,17 +43,21 @@ class BigQueryPriceFeed extends PriceFeedInterface {
       return undefined;
     }
 
+    // Using moment package to changeto UTC and create acceptable format for BQ
     const formattedCurrentTime = moment(time)
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
+    // 2592000000 is a month time interval
     let t2 = new Date(time - 2592000000);
     t2 = moment(t2)
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
+    // Create the query with the needed time interval
     const query = this.createQuery(t2, formattedCurrentTime);
 
+    // Submit async call to BigQuery
     let priceResponse;
     await this.runQuery(query)
       .then(res => {
@@ -77,12 +81,15 @@ class BigQueryPriceFeed extends PriceFeedInterface {
   }
 
   async update() {
+    // Using current time minus 5 minutes as end-bound of query. This is because the BQ dataset lags ~5 minutes
+    // Using moment package to changeto UTC and create acceptable format for BQ
     let currentTime = new Date();
     currentTime = currentTime - 300000;
     const formattedCurrentTime = moment(currentTime)
       .utc()
       .format("YYYY-MM-DD HH:mm:ss");
 
+    // 2592000000 is a month time interval
     let t2 = new Date(currentTime - 2592000000);
     t2 = moment(t2)
       .utc()
@@ -107,8 +114,10 @@ class BigQueryPriceFeed extends PriceFeedInterface {
       lastUpdateTimestamp: this.lastUpdateTime
     });
 
+    // Create the query with the needed time interval
     const query = this.createQuery(t2, formattedCurrentTime);
 
+    // Submit async call to BigQuery
     let priceResponse;
     await this.runQuery(query)
       .then(res => {
@@ -117,14 +126,14 @@ class BigQueryPriceFeed extends PriceFeedInterface {
       })
       .catch(console.log);
 
-    // 3. Check responses.
+    // Check responses.
     if (!priceResponse) {
       throw new Error(`🚨Could not parse price result from bigquery: ${priceResponse}`);
     }
 
     const newPrice = this.convertDecimals(priceResponse);
 
-    // 5. Store results.
+    // Store results.
     this.currentPrice = newPrice;
     this.lastUpdateTime = currentTime;
   }
@@ -145,6 +154,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     );
   }
   createQuery(t2, formattedCurrentTime) {
+    // method to create GASETH calculation query with time arguments
     const query = `
         DECLARE halfway int64;
         DECLARE block_count int64;

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -1,0 +1,208 @@
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+const { BigQuery } = require("@google-cloud/bigquery");
+const moment = require("moment");
+const highland = require("highland");
+const { parseFixed } = require("@ethersproject/bignumber");
+
+const client = new BigQuery();
+
+// An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
+class BigQueryPriceFeed extends PriceFeedInterface {
+  /**
+   * @notice Constructs the CryptoWatchPriceFeed.
+   * @param {Object} logger Winston module used to send logs.
+   * @param {Object} web3 Provider from truffle instance to connect to Ethereum network.
+   * @param {Integer} lookback How far in the past the historical prices will be available using getHistoricalPrice.
+   * @param {Function} getTime Returns the current time.
+   * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
+   *      this number of seconds has passed, it will be a no-op.
+   * @param {Number} decimals Number of decimals to use to convert price to wei.
+   */
+  constructor(logger, web3, lookback, getTime, minTimeBetweenUpdates, decimals = 0) {
+    super();
+    this.logger = logger;
+    this.web3 = web3;
+    this.lookback = lookback;
+    this.getTime = getTime;
+    this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+    this.toBN = this.web3.utils.toBN;
+
+    this.convertDecimals = number => {
+      // Converts price result to wei
+      // returns price conversion to correct decimals as a big number
+      return this.toBN(parseFixed(number.toString(), decimals).toString());
+    };
+  }
+
+  getCurrentPrice() {
+    return this.currentPrice;
+  }
+
+  async getHistoricalPrice(time) {
+    if (this.lastUpdateTime === undefined) {
+      return undefined;
+    }
+
+    const formattedCurrentTime = moment(time)
+      .utc()
+      .format("YYYY-MM-DD HH:mm:ss");
+
+    let t2 = new Date(time - 2592000000);
+    t2 = moment(t2)
+      .utc()
+      .format("YYYY-MM-DD HH:mm:ss");
+
+    const query = this.createQuery(t2, formattedCurrentTime);
+
+    let priceResponse;
+    await this.runQuery(query)
+      .then(res => {
+        console.log(res[0].gas_price);
+        priceResponse = res[0].gas_price;
+      })
+      .catch(console.log);
+
+    // Check response.
+    if (!priceResponse) {
+      throw new Error(`🚨Could not parse price result from bigquery: ${priceResponse}`);
+    }
+
+    const returnPrice = this.convertDecimals(priceResponse);
+
+    return returnPrice;
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  async update() {
+    let currentTime = new Date();
+    currentTime = currentTime - 300000;
+    const formattedCurrentTime = moment(currentTime)
+      .utc()
+      .format("YYYY-MM-DD HH:mm:ss");
+
+    let t2 = new Date(currentTime - 2592000000);
+    t2 = moment(t2)
+      .utc()
+      .format("YYYY-MM-DD HH:mm:ss");
+
+    // Return early if the last call was too recent.
+    if (this.lastUpdateTime !== undefined && this.lastUpdateTime + this.minTimeBetweenUpdates > currentTime) {
+      this.logger.debug({
+        at: "BigQueryPriceFeed",
+        message: "Update skipped because the last one was too recent",
+        currentTime: currentTime,
+        lastUpdateTimestamp: this.lastUpdateTime,
+        timeRemainingUntilUpdate: this.lastUpdateTimes + this.minTimeBetweenUpdates - currentTime
+      });
+      return;
+    }
+
+    this.logger.debug({
+      at: "BigQueryPriceFeed",
+      message: "Updating",
+      currentTime: currentTime,
+      lastUpdateTimestamp: this.lastUpdateTime
+    });
+
+    const query = this.createQuery(t2, formattedCurrentTime);
+
+    let priceResponse;
+    await this.runQuery(query)
+      .then(res => {
+        console.log(res[0].gas_price);
+        priceResponse = res[0].gas_price;
+      })
+      .catch(console.log);
+
+    // 3. Check responses.
+    if (!priceResponse) {
+      throw new Error(`🚨Could not parse price result from bigquery: ${priceResponse}`);
+    }
+
+    const newPrice = this.convertDecimals(priceResponse);
+
+    // 5. Store results.
+    this.currentPrice = newPrice;
+    this.lastUpdateTime = currentTime;
+  }
+  async runQuery(query) {
+    // returns a node read stream
+    const stream = await client.createQueryStream({ query });
+    // highland wraps a stream and adds utilities simlar to lodash
+    // https://caolan.github.io/highland/
+    return (
+      highland(stream)
+        // from here you can map or reduce or whatever you need for down stream processing
+        // we are just going to "collect" stream into an array for display
+        .collect()
+        // emit the stream as a promise when the stream ends
+        // this is the start of a data pipeline so you can imagine
+        // this could also "pipe" into some other processing pipeline or write to a file
+        .toPromise(Promise)
+    );
+  }
+  createQuery(t2, formattedCurrentTime) {
+    const query = `
+        DECLARE halfway int64;
+        DECLARE block_count int64;
+        DECLARE max_block int64;
+
+        -- Querying for the amount of blocks in the preset time range. This will allow block_count to be compared against a given minimum block amount.
+        SET (block_count, max_block) = (SELECT AS STRUCT (MAX(number) - MIN(number)), MAX(number) FROM \`bigquery-public-data.crypto_ethereum.blocks\` 
+        WHERE timestamp BETWEEN TIMESTAMP('${t2}', 'UTC') AND TIMESTAMP('${formattedCurrentTime}', 'UTC'));
+
+        CREATE TEMP TABLE cum_gas (
+        gas_price int64,
+        cum_sum int64
+        );
+
+        -- If the minimum threshold of blocks is met, query on a time range
+        IF block_count >= 134400 THEN
+        INSERT INTO cum_gas (
+        SELECT
+            gas_price,
+            SUM(gas_used) OVER (ORDER BY gas_price) AS cum_sum
+        FROM (
+            SELECT
+            gas_price,
+            SUM(receipt_gas_used) AS gas_used
+            FROM
+            \`bigquery-public-data.crypto_ethereum.transactions\`
+            WHERE block_timestamp 
+            BETWEEN TIMESTAMP('${t2}', 'UTC')
+            AND TIMESTAMP('${formattedCurrentTime}', 'UTC')  
+            GROUP BY
+            gas_price));
+        ELSE -- If a minimum threshold of blocks is not met, query for the minimum amount of blocks
+        INSERT INTO cum_gas (
+        SELECT
+            gas_price,
+            SUM(gas_used) OVER (ORDER BY gas_price) AS cum_sum
+        FROM (
+            SELECT
+            gas_price,
+            SUM(receipt_gas_used) AS gas_used
+            FROM
+            \`bigquery-public-data.crypto_ethereum.transactions\`
+            WHERE block_number 
+            BETWEEN (max_block - 134400)
+            AND max_block
+            GROUP BY
+            gas_price));
+        END IF;
+
+        SET halfway = (SELECT DIV(MAX(cum_sum),2) FROM cum_gas);
+
+        SELECT cum_sum, gas_price FROM cum_gas WHERE cum_sum > halfway ORDER BY gas_price LIMIT 1;
+    `;
+
+    return query;
+  }
+}
+
+module.exports = {
+  BigQueryPriceFeed
+};

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -49,7 +49,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
       .utc()
       .format(this.dateConversionString);
 
-    // 2592000000 is a month time interval
+    // Subtracting 30 days from the current time to give the earlier time bound.
     let earlierTimeBound = new Date(time);
     earlierTimeBound = moment(earlierTimeBound)
       .subtract(30, "days")

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -27,6 +27,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     this.getTime = getTime;
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
     this.toBN = this.web3.utils.toBN;
+    this.dateConversionString = "YYYY-MM-DD HH:mm:ss";
 
     this.convertDecimals = number => {
       // Converts price result to wei and returns price conversion to correct decimals as a big number.
@@ -44,19 +45,19 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     }
 
     // Using moment package to changeto UTC and create acceptable format for BQ.
-    const formattedCurrentTime = moment(time)
+    const laterHistoricTimeBound = moment(time)
       .utc()
-      .format("YYYY-MM-DD HH:mm:ss");
+      .format(this.dateConversionString);
 
     // 2592000000 is a month time interval
-    let t2 = new Date(time);
-    t2 = moment(t2)
+    let earlierTimeBound = new Date(time);
+    earlierTimeBound = moment(earlierTimeBound)
       .subtract(30, "days")
       .utc()
-      .format("YYYY-MM-DD HH:mm:ss");
+      .format(this.dateConversionString);
 
     // Create the query with the needed time interval.
-    const query = createQuery(t2, formattedCurrentTime);
+    const query = createQuery(earlierTimeBound, laterHistoricTimeBound);
 
     // Submit async call to BigQuery and check the response.
     let priceResponse;
@@ -84,14 +85,14 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     const formattedCurrentTime = moment(currentTime)
       .subtract(5, "minutes")
       .utc()
-      .format("YYYY-MM-DD HH:mm:ss");
+      .format(this.dateConversionString);
 
     // Subtracting 30 days from current time to create the earlier time bound.
-    let t2 = new Date();
-    t2 = moment(t2)
+    let earlierTimeBound = new Date();
+    earlierTimeBound = moment(earlierTimeBound)
       .subtract(30, "days")
       .utc()
-      .format("YYYY-MM-DD HH:mm:ss");
+      .format(this.dateConversionString);
 
     // Return early if the last call was too recent.
     if (this.lastUpdateTime !== undefined && this.lastUpdateTime + this.minTimeBetweenUpdates > currentTime) {
@@ -113,7 +114,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     });
 
     // Create the query with the needed time interval.
-    const query = createQuery(t2, formattedCurrentTime);
+    const query = createQuery(earlierTimeBound, formattedCurrentTime);
 
     // Submit async call to BigQuery and check response.
     let priceResponse;

--- a/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BigQueryPriceFeed.js
@@ -6,10 +6,10 @@ const { parseFixed } = require("@ethersproject/bignumber");
 
 const client = new BigQuery();
 
-// An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
+// An implementation of PriceFeedInterface that uses BigQuery to retrieve prices.
 class BigQueryPriceFeed extends PriceFeedInterface {
   /**
-   * @notice Constructs the CryptoWatchPriceFeed.
+   * @notice Constructs the BigQueryPriceFeed.
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} web3 Provider from truffle instance to connect to Ethereum network.
    * @param {Integer} lookback How far in the past the historical prices will be available using getHistoricalPrice.
@@ -28,8 +28,7 @@ class BigQueryPriceFeed extends PriceFeedInterface {
     this.toBN = this.web3.utils.toBN;
 
     this.convertDecimals = number => {
-      // Converts price result to wei
-      // returns price conversion to correct decimals as a big number
+      // Converts price result to wei and returns price conversion to correct decimals as a big number.
       return this.toBN(parseFixed(number.toString(), decimals).toString());
     };
   }

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -4,6 +4,7 @@ const { MedianizerPriceFeed } = require("./MedianizerPriceFeed");
 const { CryptoWatchPriceFeed } = require("./CryptoWatchPriceFeed");
 const { UniswapPriceFeed } = require("./UniswapPriceFeed");
 const { BalancerPriceFeed } = require("./BalancerPriceFeed");
+const { BigQueryPriceFeed } = require("./BigQueryPriceFeed");
 
 const Uniswap = require("@uma/core/build/contracts/Uniswap.json");
 const ExpiringMultiParty = require("@uma/core/build/contracts/ExpiringMultiParty.json");
@@ -124,6 +125,20 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.balancerTokenOut,
       config.lookback
     );
+  } else if (config.type === "bigquery") {
+    const requiredFields = [];
+
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    logger.debug({
+      at: "bigQueryPriceFeed",
+      message: "Creating bigQueryPriceFeed",
+      config
+    });
+
+    return new BigQueryPriceFeed(logger, web3, getTime);
   }
 
   logger.error({
@@ -295,6 +310,11 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "binance", pair: "btcusdt" },
       { type: "cryptowatch", exchange: "bitstamp", pair: "btcusd" }
     ]
+  },
+  "GASETH-1M": {
+    type: "bigquery",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60
   }
 };
 

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -311,6 +311,7 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "bitstamp", pair: "btcusd" }
     ]
   },
+  // Adding GASETH-1M identifier as price feed option
   "GASETH-1M": {
     type: "bigquery",
     lookback: 7200,

--- a/packages/financial-templates-lib/src/queries/GasEthQuery.js
+++ b/packages/financial-templates-lib/src/queries/GasEthQuery.js
@@ -1,0 +1,62 @@
+// This is a helper method to create a GASETH BQ query with time arguments.
+function createQuery(t2, formattedCurrentTime) {
+  const query = `
+        DECLARE halfway int64;
+        DECLARE block_count int64;
+        DECLARE max_block int64;
+
+        -- Querying for the amount of blocks in the preset time range. This will allow block_count to be compared against a given minimum block amount.
+        SET (block_count, max_block) = (SELECT AS STRUCT (MAX(number) - MIN(number)), MAX(number) FROM \`bigquery-public-data.crypto_ethereum.blocks\` 
+        WHERE timestamp BETWEEN TIMESTAMP('${t2}', 'UTC') AND TIMESTAMP('${formattedCurrentTime}', 'UTC'));
+
+        CREATE TEMP TABLE cum_gas (
+        gas_price int64,
+        cum_sum int64
+        );
+
+        -- If the minimum threshold of blocks is met, query on a time range
+        IF block_count >= 134400 THEN
+        INSERT INTO cum_gas (
+        SELECT
+            gas_price,
+            SUM(gas_used) OVER (ORDER BY gas_price) AS cum_sum
+        FROM (
+            SELECT
+            gas_price,
+            SUM(receipt_gas_used) AS gas_used
+            FROM
+            \`bigquery-public-data.crypto_ethereum.transactions\`
+            WHERE block_timestamp 
+            BETWEEN TIMESTAMP('${t2}', 'UTC')
+            AND TIMESTAMP('${formattedCurrentTime}', 'UTC')  
+            GROUP BY
+            gas_price));
+        ELSE -- If a minimum threshold of blocks is not met, query for the minimum amount of blocks
+        INSERT INTO cum_gas (
+        SELECT
+            gas_price,
+            SUM(gas_used) OVER (ORDER BY gas_price) AS cum_sum
+        FROM (
+            SELECT
+            gas_price,
+            SUM(receipt_gas_used) AS gas_used
+            FROM
+            \`bigquery-public-data.crypto_ethereum.transactions\`
+            WHERE block_number 
+            BETWEEN (max_block - 134400)
+            AND max_block
+            GROUP BY
+            gas_price));
+        END IF;
+
+        SET halfway = (SELECT DIV(MAX(cum_sum),2) FROM cum_gas);
+
+        SELECT cum_sum, gas_price FROM cum_gas WHERE cum_sum > halfway ORDER BY gas_price LIMIT 1;
+    `;
+
+  return query;
+}
+
+module.exports = {
+  createQuery
+};

--- a/packages/financial-templates-lib/src/queries/GasEthQuery.js
+++ b/packages/financial-templates-lib/src/queries/GasEthQuery.js
@@ -1,5 +1,5 @@
 // This is a helper method to create a GASETH BQ query with time arguments.
-function createQuery(t2, formattedCurrentTime) {
+function createQuery(earlierTimeBound, laterTimeBound) {
   const query = `
         DECLARE halfway int64;
         DECLARE block_count int64;
@@ -7,7 +7,7 @@ function createQuery(t2, formattedCurrentTime) {
 
         -- Querying for the amount of blocks in the preset time range. This will allow block_count to be compared against a given minimum block amount.
         SET (block_count, max_block) = (SELECT AS STRUCT (MAX(number) - MIN(number)), MAX(number) FROM \`bigquery-public-data.crypto_ethereum.blocks\` 
-        WHERE timestamp BETWEEN TIMESTAMP('${t2}', 'UTC') AND TIMESTAMP('${formattedCurrentTime}', 'UTC'));
+        WHERE timestamp BETWEEN TIMESTAMP('${earlierTimeBound}', 'UTC') AND TIMESTAMP('${laterTimeBound}', 'UTC'));
 
         CREATE TEMP TABLE cum_gas (
         gas_price int64,
@@ -27,8 +27,8 @@ function createQuery(t2, formattedCurrentTime) {
             FROM
             \`bigquery-public-data.crypto_ethereum.transactions\`
             WHERE block_timestamp 
-            BETWEEN TIMESTAMP('${t2}', 'UTC')
-            AND TIMESTAMP('${formattedCurrentTime}', 'UTC')  
+            BETWEEN TIMESTAMP('${earlierTimeBound}', 'UTC')
+            AND TIMESTAMP('${laterTimeBound}', 'UTC')  
             GROUP BY
             gas_price));
         ELSE -- If a minimum threshold of blocks is not met, query for the minimum amount of blocks


### PR DESCRIPTION
**Motivation**

This PR adds the ability for liquidation and dispute bots to get monthly median gas prices. This is done by querying Google BigQuery and using the query response as a price feed.

**Summary**

To run this price feed locally, you need to set a `GOOGLE_APPLICATIONS_CREDENTIALS` environment variable with GCP admin or BigQuery permissions.

EMP_ADDRESS also needs to be set to the uGAS Kovan contract address: `0xE57DcDf729E851d68a1B8b71E84BA43B1071456b` 

1. `@google-cloud/bigquery` was added to interact with bigquery in node
2. [Moment.js](https://www.npmjs.com/package/moment) package was added to change dates into acceptable UTC BigQuery format.
3. The option to use a BigQuery price feed, when using the GASETH-1M identifier, was added to `CreatePriceFeed.js`.
4. `BigQueryPriceFeed.js` was added to return the current or historical price for GASETH-1M.
5. `update()` uses [(current time - one month), (current time - five minutes)] UTC as the time interval to parameterize the BQ query with. `getHistoricalPrice()` receives a liquidation time and uses the liquidation time to construct its time interval.
6. `update()` and `getHistoricalPrice()` use `runQuery` to create a BQ api call.

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
No associated issue.
