### PR TITLE
improve(medianizer-price-feed) make update method parallelized

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -52,9 +52,7 @@ class MedianizerPriceFeed extends PriceFeedInterface {
 
   // Updates all constituent price feeds.
   async update() {
-    for (const priceFeed of this.priceFeeds) {
-      await priceFeed.update();
-    }
+    await Promise.all(this.priceFeeds.map(priceFeed => priceFeed.update()));
   }
 
   // Inputs are expected to be BNs.


### PR DESCRIPTION
**Motivation**

The `MedianizerPriceFeed.js` implementation does not run batches of calls in parallel. This PR replaces the for loop + await syntax with a Promise.all & map.

**Summary**

Small 1 liner change to speed up pricefeed execution.

**Details**
