### PR TITLE
refactor(perp-liquidatable) Withdraw dispute/liquidation rewards in one transaction instead of multiple

### DIFF
--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -240,6 +240,7 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
 
         tokensLiquidated = FixedPoint.min(maxTokensToLiquidate, positionToLiquidate.tokensOutstanding);
+        require(tokensLiquidated.isGreaterThan(0), "Liquidating 0 tokens");
 
         // Starting values for the Position being liquidated. If withdrawal request amount is > position's collateral,
         // then set this to 0, otherwise set it to (startCollateral - withdrawal request amount).
@@ -485,13 +486,6 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
 
             collateralCurrency.safeTransfer(liquidation.liquidator, rewards.paidToLiquidator.rawValue);
         }
-
-        // If the raw amounts of collateral to pay out are 0, which is possible if the liquidation is for 0 collateral,
-        // then revert because there are no rewards to pay.
-        require(
-            (rewards.payToLiquidator.add(rewards.payToSponsor).add(rewards.payToDisputer)).isGreaterThan(0),
-            "Rewards equal to 0"
-        );
 
         emit LiquidationWithdrawn(
             msg.sender,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2149 


**Summary**

Anyone can call `withdrawLiquidation` now, although it will revert if there are no rewards to disperse. It will pay out rewards owed to the liquidator, sponsor, and disputer.

The `LiquidationWithdrawn` event is also changed to include more details about all of the payments. Previously it was only emitted to display data about the caller's withdrawal.

This reduces the contract bytecode by ~400 bytes because it gets rid of an if-else branch, previously determining whether the caller was the sponsor, liquidator, or disputer.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2149 
