### PR TITLE
feat(affiliates): improve dataset generation and mocking libraries

### DIFF
--- a/packages/affiliates/apps/CreateDataSet.js
+++ b/packages/affiliates/apps/CreateDataSet.js
@@ -1,0 +1,21 @@
+// saves a dataset to a folder. Users a config file, see example in createdataset.example.js
+// outputs a path for you to load the mocks from.
+// node apps/CreateDataSet.js ./createdataset.example.js
+const { Dataset } = require("../libs/datasets");
+const Config = require("../libs/config");
+const { BigQuery } = require("@google-cloud/bigquery");
+const Coingecko = require("../libs/coingecko");
+const Queries = require("../libs/bigquery");
+
+async function Run(config) {
+  const client = new BigQuery();
+  const queries = Queries({ client });
+  const coingecko = Coingecko();
+  const ds = Dataset(config.datasetPath || process.cwd(), { queries, coingecko });
+  return ds.save(config.name, config);
+}
+
+const config = Config();
+Run(config)
+  .then(console.log)
+  .catch(console.error);

--- a/packages/affiliates/createdataset.example.js
+++ b/packages/affiliates/createdataset.example.js
@@ -4,11 +4,9 @@ const moment = require("moment");
 const empCreator = "0x9A077D4fCf7B26a0514Baa4cff0B481e9c35CE87";
 const empContracts = ["0xaBBee9fC7a882499162323EEB7BF6614193312e3", "0x3605Ec11BA7bD208501cbb24cd890bC58D2dbA56"];
 const syntheticTokens = ["0xF06DdacF71e2992E2122A1a0168C6967aFdf63ce", "0xD16c79c8A39D44B2F3eB45D2019cd6A42B03E2A9"];
-const syntheticTokenDecimals = [18, 18];
 
-const startingTimestamp = moment("2020-09-23 23:00:00", "YYYY-MM-DD  HH:mm Z").valueOf(); // utc timestamp
-
-const endingTimestamp = moment("2020-10-05 23:00:00", "YYYY-MM-DD  HH:mm Z").valueOf();
+const start = moment("2020-09-23 23:00:00", "YYYY-MM-DD  HH:mm Z").valueOf(); // utc timestamp
+const end = moment("2020-10-05 23:00:00", "YYYY-MM-DD  HH:mm Z").valueOf();
 
 module.exports = {
   // this is the sub directory name
@@ -17,9 +15,6 @@ module.exports = {
   empCreator,
   empContracts,
   syntheticTokens,
-  syntheticTokenDecimals,
-  startingTimestamp,
-  endingTimestamp,
-  start: startingTimestamp,
-  end: endingTimestamp
+  start,
+  end
 };

--- a/packages/affiliates/libs/bigquery.js
+++ b/packages/affiliates/libs/bigquery.js
@@ -63,16 +63,16 @@ module.exports = ({ client } = {}) => {
     }
   };
 
-  async function streamLogsByContract(...args) {
+  function streamLogsByContract(...args) {
     const query = queries.logsByContract(...args);
     return client.createQueryStream({ query });
   }
-  async function streamTransactionsByContract(...args) {
+  function streamTransactionsByContract(...args) {
     const query = queries.transactionsByContract(...args);
     return client.createQueryStream({ query });
   }
-  async function streamBlocks(...args) {
-    const query = queries.blocsk(...args);
+  function streamBlocks(...args) {
+    const query = queries.blocks(...args);
     return client.createQueryStream({ query });
   }
   async function getLogsByContract(...args) {

--- a/packages/affiliates/libs/datasets.js
+++ b/packages/affiliates/libs/datasets.js
@@ -1,0 +1,241 @@
+const highland = require("highland");
+const lodash = require("lodash");
+const moment = require("moment");
+
+const fs = require("fs");
+const assert = require("assert");
+const Path = require("path");
+const mkdirp = require("mkdirp");
+
+// put this into csv form
+const SerializeObject = (props = []) => obj => {
+  return props.map(prop => lodash.get(obj, prop, "")).join(",");
+};
+// read from csv into object
+const DeserializeRow = (props = []) => row => {
+  return row.split(",").reduce((result, val, i) => {
+    lodash.set(result, props[i], val.trim());
+    return result;
+  }, {});
+};
+
+const SerializeCsvStream = (props = []) => stream => {
+  const dataStream = highland(stream).map(SerializeObject(props));
+  return highland([props.join(","), dataStream])
+    .flatten()
+    .map(x => x + "\n");
+};
+const DeserializeCsvStream = props => stream => {
+  // include header line if props are included, ie drop first line
+  const drop = props ? 1 : 0;
+  const result = highland(stream)
+    // splits newlines by defaults
+    .split()
+    .drop(drop)
+    .map(line => {
+      if (props == null) {
+        props = line.split(",");
+      } else {
+        return line;
+      }
+    })
+    .compact()
+    .map(line => {
+      return DeserializeRow(props)(line);
+    });
+  return result;
+};
+
+// each class may serialize differently
+// Blocks serialized as a csv to keep filesize small and short
+function Blocks() {
+  return {
+    serialize: SerializeCsvStream(["timestamp.value", "number"]),
+    deserialize: DeserializeCsvStream()
+  };
+}
+// These cant be serialized to csvs unfortunatley due to datastructure incompatibility
+function Logs() {
+  return {
+    // this cant be put into csv with nested arrays
+    serialize(stream) {
+      return highland(stream).map(x => JSON.stringify(x) + "\n");
+    },
+    deserialize(stream) {
+      return highland(stream)
+        .split()
+        .compact()
+        .map(JSON.parse);
+    }
+  };
+}
+function Transactions() {
+  return {
+    // this cant be put into csv with nested arrays
+    serialize(stream) {
+      return highland(stream).map(x => JSON.stringify(x) + "\n");
+    },
+    deserialize(stream) {
+      return highland(stream)
+        .split()
+        .compact()
+        .map(JSON.parse);
+    }
+  };
+}
+function Coingecko() {
+  function serialize(charts) {
+    return JSON.stringify(charts);
+  }
+  function deserialize(stream) {
+    return highland(stream)
+      .reduce("", (result, next) => {
+        return result + next;
+      })
+      .map(JSON.parse);
+  }
+  return {
+    serialize,
+    deserialize
+  };
+}
+
+function Dataset(basePath, { queries, coingecko }) {
+  assert(basePath, "requires dataset basePath");
+  assert(queries, "requires queries");
+  assert(coingecko, "requires coingecko");
+
+  function blocks({ start, end, select = ["timestamp", "number"] }, path) {
+    const fileName = Path.join(path, "blocks.csv");
+    const writeStream = fs.createWriteStream(fileName);
+    const dataStream = queries.streamBlocks(start, end, select);
+    return new Promise(res => {
+      Blocks()
+        .serialize(dataStream)
+        .pipe(writeStream)
+        .on("close", res);
+    });
+  }
+  function logs({ start, end, contract, select }, path) {
+    const fileName = Path.join(path, `logs_${contract}.txt`);
+    const writeStream = fs.createWriteStream(fileName);
+    const dataStream = queries.streamLogsByContract(contract, start, end, select);
+    return new Promise(res => {
+      Logs()
+        .serialize(dataStream)
+        .pipe(writeStream)
+        .on("close", res);
+    });
+  }
+  function transactions({ start, end, contract, select }, path) {
+    const fileName = Path.join(path, `transactions_${contract}.txt`);
+    const writeStream = fs.createWriteStream(fileName);
+    const dataStream = queries.streamTransactionsByContract(contract, start, end, select);
+    return new Promise(res => {
+      Transactions()
+        .serialize(dataStream)
+        .pipe(writeStream)
+        .on("close", res);
+    });
+  }
+  async function prices({ start, end, contract, currency = "usd" }, path) {
+    const fileName = Path.join(path, `coingecko_${contract}_${currency}.txt`);
+    const prices = await coingecko.chart(contract, currency, start, end);
+    fs.writeFileSync(fileName, Coingecko().serialize(prices));
+  }
+  async function save(name, config) {
+    const { empCreator, empContracts, syntheticTokens, start, end } = config;
+    assert(empCreator, "requires empCreator address");
+    assert(empContracts, "requires empContracts array");
+    assert(syntheticTokens, "requires syntheticTokens");
+    assert(start, "requires start time");
+    assert(end, "requires end time");
+    const path = Path.join(basePath, name);
+    await mkdirp(path);
+    await Promise.all([
+      ...syntheticTokens.map(contract => prices({ start, end, contract }, path)),
+      ...empContracts.map(contract => logs({ start, end, contract }, path)),
+      logs({ start, end, contract: empCreator }, path),
+      blocks({ start, end }, path)
+    ]);
+    return path;
+  }
+
+  return {
+    save,
+    utils: {
+      blocks,
+      logs,
+      transactions,
+      prices
+    }
+  };
+}
+
+// Mock coingecko
+function MockCoingecko(basePath) {
+  function chart(address) {
+    const path = Path.join(basePath, `coingecko_${address}.txt`);
+    const readStream = fs.createReadStream(path);
+    return Coingecko()
+      .deserialize(readStream)
+      .toPromise(Promise);
+  }
+  return {
+    chart
+  };
+}
+// Mock big query queries
+function MockQueries(basePath) {
+  function streamLogsByContract(address) {
+    const path = Path.join(basePath, `logs_${address}.txt`);
+    const readStream = fs.createReadStream(path);
+    return Logs().deserialize(readStream);
+  }
+  function getLogsByContract(address) {
+    return streamLogsByContract(address)
+      .collect()
+      .toPromise(Promise);
+  }
+  function streamBlocks(start, end) {
+    const path = Path.join(basePath, "blocks.csv");
+    const readStream = fs.createReadStream(path);
+    return Blocks()
+      .deserialize(readStream)
+      .filter(block => {
+        const blockTime = moment(block.timestamp.value).valueOf();
+        return blockTime >= start && blockTime <= end;
+      });
+  }
+  function getBlocks(start, end) {
+    return streamBlocks(start, end)
+      .collect()
+      .toPromise(Promise);
+  }
+  return {
+    streamLogsByContract,
+    getLogsByContract,
+    streamBlocks,
+    getBlocks
+  };
+}
+
+module.exports = {
+  Dataset,
+  mocks: {
+    Queries: MockQueries,
+    Coingecko: MockCoingecko
+  },
+  serializers: {
+    Blocks,
+    Transactions,
+    Logs,
+    Coingecko
+  },
+  utils: {
+    SerializeCsvStream,
+    DeserializeCsvStream,
+    SerializeObject,
+    DeserializeRow
+  }
+};

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "yarn test-mocha && yarn test-truffle",
     "test-mocha": "mocha test/mocha/*.js",
-    "test-truffle": "truffle test test/truffle/*.js --network=test"
+    "test-truffle": "truffle test test/truffle/*.js --network=test",
+    "test-e2e": "mocha test/e2e/*.js"
   }
 }

--- a/packages/affiliates/test/e2e/README.md
+++ b/packages/affiliates/test/e2e/README.md
@@ -1,0 +1,5 @@
+# End To End Tests
+
+These tests run the entire stack and reach out to external services or write to disk. The idea is that you can test
+as if you were in "production" as a last check to make sure everything works. These should be run locally, but maybe
+in the future they can be added to CI in some way.

--- a/packages/affiliates/test/e2e/datasets.js
+++ b/packages/affiliates/test/e2e/datasets.js
@@ -1,0 +1,194 @@
+const { BigQuery } = require("@google-cloud/bigquery");
+// const highland = require("highland");
+const { assert } = require("chai");
+const fs = require("fs");
+const Path = require("path");
+
+const { Dataset, mocks, serializers } = require("../../libs/datasets");
+const { Blocks, Transactions, Logs, Coingecko } = serializers;
+const Queries = require("../../libs/bigquery");
+const params = require("../../test/datasets/set1");
+const CoingeckoApi = require("../../libs/coingecko");
+
+const basePath = Path.join(__dirname, "test-datasets");
+describe("Datasets", function() {
+  let client, queries, coingecko;
+  before(async function() {
+    client = new BigQuery();
+    queries = Queries({ client });
+    coingecko = CoingeckoApi();
+  });
+  describe("Blocks Serializer", function() {
+    it("serializes", async function() {
+      this.timeout(10000);
+      const config = {
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 5,
+        select: ["timestamp", "number"]
+      };
+      const dataStream = queries.streamBlocks(config.start, config.end, config.select);
+      const stream = Blocks().serialize(dataStream);
+      const result = await stream.collect().toPromise(Promise);
+      assert(result.length);
+      assert.deepEqual(result[0].trim().split(","), ["timestamp.value", "number"]);
+    });
+    it("deserializes", async function() {
+      this.timeout(10000);
+      const config = {
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 5,
+        select: ["timestamp", "number"]
+      };
+      const blocks = Blocks();
+      const dataStream = queries.streamBlocks(config.start, config.end, config.select);
+      const serialized = blocks.serialize(dataStream);
+      const result = await blocks
+        .deserialize(serialized)
+        .collect()
+        .toPromise(Promise);
+      assert(result.length);
+      assert(result[0].number);
+      assert(result[0].timestamp.value);
+    });
+  });
+  describe("Logs Serializer", function() {
+    it("serializes", async function() {
+      this.timeout(10000);
+      const config = {
+        contract: params.empCreator,
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10,
+        select: ["block_timestamp", "block_number", "data", "topics"]
+      };
+      const dataStream = queries.streamLogsByContract(config.contract, config.start, config.end, config.select);
+      const stream = Logs().serialize(dataStream);
+      const result = await stream.collect().toPromise(Promise);
+      assert(result.length);
+    });
+    it("deserializes", async function() {
+      this.timeout(10000);
+      const config = {
+        contract: params.empCreator,
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10,
+        select: ["block_timestamp", "block_number", "data", "topics"]
+      };
+      const logs = Logs();
+      const dataStream = queries.streamLogsByContract(config.contract, config.start, config.end, config.select);
+      const serialized = await logs
+        .serialize(dataStream)
+        .collect()
+        .toPromise(Promise);
+      const result = await logs
+        // simulate a file stream
+        .deserialize(serialized.join("").split(""))
+        .collect()
+        .toPromise(Promise);
+      assert(result.length);
+      assert(result[0].block_number);
+      assert(result[0].block_timestamp.value);
+      assert(result[0].data);
+      assert(result[0].topics);
+    });
+  });
+  describe("Transactions Serializer", function() {
+    it("serializes", async function() {
+      this.timeout(10000);
+      const config = {
+        contract: params.empCreator,
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10,
+        select: ["block_timestamp", "block_number", "input"]
+      };
+      const dataStream = queries.streamTransactionsByContract(config.contract, config.start, config.end, config.select);
+      const stream = Transactions().serialize(dataStream);
+      const result = await stream.collect().toPromise(Promise);
+      assert(result.length);
+    });
+    it("deserializes", async function() {
+      this.timeout(10000);
+      const config = {
+        contract: params.empCreator,
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10,
+        select: ["block_timestamp", "block_number", "input"]
+      };
+      const parser = Transactions();
+      const dataStream = queries.streamTransactionsByContract(config.contract, config.start, config.end, config.select);
+      const serialized = await parser
+        .serialize(dataStream)
+        .collect()
+        .toPromise(Promise);
+      const result = await parser
+        // simulate a file stream
+        .deserialize(serialized.join("").split(""))
+        .collect()
+        .toPromise(Promise);
+      assert(result.length);
+      assert(result[0].block_number);
+      assert(result[0].block_timestamp.value);
+      assert(result[0].input);
+    });
+  });
+  describe("Coingecko Serializer", function() {
+    it("serializes", async function() {
+      this.timeout(10000);
+      const config = {
+        contract: params.syntheticTokens[0],
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10,
+        currency: "usd"
+      };
+      const data = await coingecko.chart(config.contract.toLowerCase(), config.currency, config.start, config.end);
+      const result = Coingecko().serialize(data);
+      assert(result);
+    });
+    it("deserializes", async function() {
+      this.timeout(10000);
+      const config = {
+        contract: params.syntheticTokens[0],
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10,
+        currency: "usd"
+      };
+      const data = await coingecko.chart(config.contract.toLowerCase(), config.currency, config.start, config.end);
+      const serialized = Coingecko().serialize(data);
+      const result = await Coingecko()
+        .deserialize(serialized.split())
+        .toPromise(Promise);
+      assert(result.prices.length);
+      assert(result.total_volumes.length);
+      assert(result.market_caps.length);
+    });
+  });
+  describe("Dataset and Mocks", function() {
+    let path;
+    after(function(done) {
+      fs.rmdir(basePath, { recursive: true }, done);
+    });
+    it("saves new set", async function() {
+      this.timeout(10000);
+      const config = {
+        ...params,
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10
+      };
+      const ds = Dataset(basePath, { queries, coingecko });
+      path = await ds.save("test-set", config);
+    });
+    it("loads query mock", async function() {
+      this.timeout(10000);
+      const config = {
+        ...params,
+        start: params.startingTimestamp,
+        end: params.startingTimestamp + 1000 * 60 * 60 * 24 * 10
+      };
+      assert(path, "requires dataset path");
+      const query = mocks.Queries(path);
+      const blocks = await query.getBlocks(config.start, config.end);
+      assert(blocks.length);
+      const logs = await query.getLogsByContract(config.empCreator);
+      assert(logs.length);
+    });
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2140

**Summary**

This adds a library file called `datasets` which is a collection of modules to generate data set files from bigquery/coingecko and save them to disk in an organized way. This can then be read out through the "mocks" which reconstruct the data from the file. 
Some effort has been put into reducing the filesize for the block list as it will be stored as comma separated values.

This adds a new app called "CreateDataSet" which takes in a configuration file found in createdataset.example.js. 
End to end tests have also been added which are ignored by CI to test the dataset functionality. This can be expanded on in the future as we add more apps/scripts.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2140
