### PR TITLE
feat(scripts) Add script to return non-expiry, non-admin price requests

### DIFF
--- a/packages/core/scripts/local/HistoricalPriceRequests.js
+++ b/packages/core/scripts/local/HistoricalPriceRequests.js
@@ -1,0 +1,73 @@
+// Usage: From protocol/, run `yarn truffle exec ./packages/core/scripts/local/HistoricalPriceRequests.js --network mainnet_mnemonic`
+const Voting = artifacts.require("Voting");
+const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
+const { hexToUtf8 } = web3.utils;
+const { getTransactionReceipt } = web3.eth;
+
+const { isAdminRequest } = require("@uma/common");
+// This script fetches and classifies all historical DVM price requests.
+async function run() {
+  const votingLegacy = await Voting.at("0x9921810C710E7c3f7A7C6831e30929f19537a545");
+  const voting = await Voting.deployed();
+
+  let priceRequests = await voting.contract.getPastEvents("PriceRequestAdded", {
+    fromBlock: 0,
+    toBlock: "latest"
+  });
+  const legacyPriceRequests = await votingLegacy.contract.getPastEvents("PriceRequestAdded", {
+    fromBlock: 0,
+    toBlock: "latest"
+  });
+  priceRequests = priceRequests.concat(legacyPriceRequests);
+
+  // Get all non admin votes.
+  const nonAdminReqs = priceRequests.filter(req => {
+    return !isAdminRequest(hexToUtf8(req.returnValues.identifier));
+  });
+
+  // To determine if a price request was a non-expiry price request, we can check if a ContractExpired
+  // event was emitted in the same block # as the PriceRequestAdded event.
+  let getEventsPromises = [];
+  for (let i in nonAdminReqs) {
+    const promise = new Promise(resolve => {
+      // To trigger a price request, some accounts called a financial contract that triggered a price request. So
+      // we'll grab the contract that was called.
+      getTransactionReceipt(nonAdminReqs[i].transactionHash).then(txn => {
+        const empAddress = txn.to;
+        ExpiringMultiParty.at(empAddress).then(emp => {
+          emp.contract
+            .getPastEvents("ContractExpired", {
+              fromBlock: txn.blockNumber,
+              toBlock: txn.blockNumber,
+              to: empAddress
+            })
+            .then(events => {
+              resolve(events);
+            });
+        });
+      });
+    });
+    getEventsPromises.push(promise);
+  }
+
+  // If no ContractExpired events were emitted, then we can assume it was a dispute that triggered the price request.
+  const nonExpiryReqs = (await Promise.all(getEventsPromises)).filter(req => {
+    return req.length === 0;
+  });
+
+  console.log(`There have been ${nonExpiryReqs.length} non-expiry price requests.`);
+}
+
+async function wrapper(callback) {
+  try {
+    await run();
+  } catch (e) {
+    // Forces the script to return a nonzero error code so failure can be detected in bash.
+    callback(e);
+    return;
+  }
+
+  callback();
+}
+
+module.exports = wrapper;


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We might want to display this data on an UMA client.


**Summary**

Queries all `PriceRequestAdded` events and successively filters out non-Admin and non-Expiry requests.


**Details**

Example run:

```sh
yarn truffle exec ./packages/core/scripts/local/HistoricalPriceRequests.js --network mainnet_mnemonic
yarn run v1.22.10
$ /Users/nicholaspai/UMA/protocol/node_modules/.bin/truffle exec ./packages/core/scripts/local/HistoricalPriceRequests.js --network mainnet_mnemonic
Using network 'mainnet_mnemonic'.

There are currently 0 unresolved non-admin price requests.
There have been 3 non-expiry price requests.
✨  Done in 19.04s.
```

