### PR TITLE
feat(solidity-licences) Added licenses to all Solidity contracts

### DIFF
--- a/packages/core/contracts/Migrations.sol
+++ b/packages/core/contracts/Migrations.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/implementation/AddressWhitelist.sol
+++ b/packages/core/contracts/common/implementation/AddressWhitelist.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/core/contracts/common/implementation/ExpandedERC20.sol
+++ b/packages/core/contracts/common/implementation/ExpandedERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/core/contracts/common/implementation/FixedPoint.sol
+++ b/packages/core/contracts/common/implementation/FixedPoint.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/packages/core/contracts/common/implementation/Lockable.sol
+++ b/packages/core/contracts/common/implementation/Lockable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/implementation/MultiRole.sol
+++ b/packages/core/contracts/common/implementation/MultiRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/implementation/Testable.sol
+++ b/packages/core/contracts/common/implementation/Testable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "./Timer.sol";

--- a/packages/core/contracts/common/implementation/TestnetERC20.sol
+++ b/packages/core/contracts/common/implementation/TestnetERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/core/contracts/common/implementation/Timer.sol
+++ b/packages/core/contracts/common/implementation/Timer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/implementation/Withdrawable.sol
+++ b/packages/core/contracts/common/implementation/Withdrawable.sol
@@ -2,6 +2,7 @@
  * Withdrawable contract.
  */
 
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/packages/core/contracts/common/interfaces/Balancer.sol
+++ b/packages/core/contracts/common/interfaces/Balancer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/interfaces/ExpandedIERC20.sol
+++ b/packages/core/contracts/common/interfaces/ExpandedIERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/core/contracts/common/interfaces/IERC20Standard.sol
+++ b/packages/core/contracts/common/interfaces/IERC20Standard.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/core/contracts/common/interfaces/OneSplit.sol
+++ b/packages/core/contracts/common/interfaces/OneSplit.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/interfaces/TransactionBatcher.sol
+++ b/packages/core/contracts/common/interfaces/TransactionBatcher.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/common/interfaces/Uniswap.sol
+++ b/packages/core/contracts/common/interfaces/Uniswap.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/test/BalancerMock.sol
+++ b/packages/core/contracts/common/test/BalancerMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../interfaces/Balancer.sol";

--- a/packages/core/contracts/common/test/BasicERC20.sol
+++ b/packages/core/contracts/common/test/BasicERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/core/contracts/common/test/MultiRoleTest.sol
+++ b/packages/core/contracts/common/test/MultiRoleTest.sol
@@ -2,6 +2,7 @@
   MultiRoleTest contract.
 */
 
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../implementation/MultiRole.sol";

--- a/packages/core/contracts/common/test/OneSplitMock.sol
+++ b/packages/core/contracts/common/test/OneSplitMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../interfaces/OneSplit.sol";

--- a/packages/core/contracts/common/test/ReentrancyAttack.sol
+++ b/packages/core/contracts/common/test/ReentrancyAttack.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/test/ReentrancyChecker.sol
+++ b/packages/core/contracts/common/test/ReentrancyChecker.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/common/test/ReentrancyMock.sol
+++ b/packages/core/contracts/common/test/ReentrancyMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../implementation/Lockable.sol";

--- a/packages/core/contracts/common/test/SignedFixedPointTest.sol
+++ b/packages/core/contracts/common/test/SignedFixedPointTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../implementation/FixedPoint.sol";

--- a/packages/core/contracts/common/test/TestableTest.sol
+++ b/packages/core/contracts/common/test/TestableTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../implementation/Testable.sol";

--- a/packages/core/contracts/common/test/UniswapMock.sol
+++ b/packages/core/contracts/common/test/UniswapMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../interfaces/Uniswap.sol";

--- a/packages/core/contracts/common/test/UnsignedFixedPointTest.sol
+++ b/packages/core/contracts/common/test/UnsignedFixedPointTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../implementation/FixedPoint.sol";

--- a/packages/core/contracts/common/test/WithdrawableTest.sol
+++ b/packages/core/contracts/common/test/WithdrawableTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../implementation/Withdrawable.sol";

--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/common/SyntheticToken.sol
+++ b/packages/core/contracts/financial-templates/common/SyntheticToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 import "../../common/implementation/ExpandedERC20.sol";
 import "../../common/implementation/Lockable.sol";

--- a/packages/core/contracts/financial-templates/common/TokenFactory.sol
+++ b/packages/core/contracts/financial-templates/common/TokenFactory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "./SyntheticToken.sol";

--- a/packages/core/contracts/financial-templates/common/WETH9.sol
+++ b/packages/core/contracts/financial-templates/common/WETH9.sol
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/financial-templates/demo/DepositBox.sol
+++ b/packages/core/contracts/financial-templates/demo/DepositBox.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/funding-rate-store/implementation/FundingRateStore.sol
+++ b/packages/core/contracts/financial-templates/funding-rate-store/implementation/FundingRateStore.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/funding-rate-store/interfaces/FundingRateStoreInterface.sol
+++ b/packages/core/contracts/financial-templates/funding-rate-store/interfaces/FundingRateStoreInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/funding-rate-store/test/MockFundingRateStore.sol
+++ b/packages/core/contracts/financial-templates/funding-rate-store/test/MockFundingRateStore.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/Perpetual.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/Perpetual.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/financial-templates/test/FundingRateApplierTest.sol
+++ b/packages/core/contracts/financial-templates/test/FundingRateApplierTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/implementation/Constants.sol
+++ b/packages/core/contracts/oracle/implementation/Constants.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/oracle/implementation/ContractCreator.sol
+++ b/packages/core/contracts/oracle/implementation/ContractCreator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../interfaces/FinderInterface.sol";

--- a/packages/core/contracts/oracle/implementation/DesignatedVoting.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVoting.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/implementation/DesignatedVotingFactory.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingFactory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/implementation/FinancialContractsAdmin.sol
+++ b/packages/core/contracts/oracle/implementation/FinancialContractsAdmin.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../interfaces/AdministrateeInterface.sol";

--- a/packages/core/contracts/oracle/implementation/Finder.sol
+++ b/packages/core/contracts/oracle/implementation/Finder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/core/contracts/oracle/implementation/Governor.sol
+++ b/packages/core/contracts/oracle/implementation/Governor.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/implementation/IdentifierWhitelist.sol
+++ b/packages/core/contracts/oracle/implementation/IdentifierWhitelist.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../interfaces/IdentifierWhitelistInterface.sol";

--- a/packages/core/contracts/oracle/implementation/Registry.sol
+++ b/packages/core/contracts/oracle/implementation/Registry.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/implementation/ResultComputation.sol
+++ b/packages/core/contracts/oracle/implementation/ResultComputation.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../../common/implementation/FixedPoint.sol";

--- a/packages/core/contracts/oracle/implementation/Store.sol
+++ b/packages/core/contracts/oracle/implementation/Store.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/implementation/TokenMigrator.sol
+++ b/packages/core/contracts/oracle/implementation/TokenMigrator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/implementation/VoteTiming.sol
+++ b/packages/core/contracts/oracle/implementation/VoteTiming.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/packages/core/contracts/oracle/implementation/Voting.sol
+++ b/packages/core/contracts/oracle/implementation/Voting.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/implementation/VotingToken.sol
+++ b/packages/core/contracts/oracle/implementation/VotingToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../../common/implementation/ExpandedERC20.sol";

--- a/packages/core/contracts/oracle/implementation/test/GovernorTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/GovernorTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/implementation/test/MockAdministratee.sol
+++ b/packages/core/contracts/oracle/implementation/test/MockAdministratee.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../../interfaces/AdministrateeInterface.sol";

--- a/packages/core/contracts/oracle/implementation/test/ResultComputationTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/ResultComputationTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/implementation/test/VoteTimingTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/VoteTimingTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../../interfaces/VotingInterface.sol";

--- a/packages/core/contracts/oracle/implementation/test/VotingTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/VotingTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/interfaces/AdministrateeInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/AdministrateeInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/oracle/interfaces/FinderInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/FinderInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/oracle/interfaces/IdentifierWhitelistInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/IdentifierWhitelistInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/interfaces/OracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/OracleInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 

--- a/packages/core/contracts/oracle/interfaces/RegistryInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/RegistryInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/interfaces/StoreInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/StoreInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/core/contracts/oracle/interfaces/VotingInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/VotingInterface.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/oracle/test/MockOracle.sol
+++ b/packages/core/contracts/oracle/test/MockOracle.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 pragma experimental ABIEncoderV2;

--- a/packages/core/contracts/umips/Umip15Upgrader.sol
+++ b/packages/core/contracts/umips/Umip15Upgrader.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../oracle/implementation/Finder.sol";

--- a/packages/core/contracts/umips/Umip3Upgrader.sol
+++ b/packages/core/contracts/umips/Umip3Upgrader.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.6.0;
 
 import "../oracle/implementation/Finder.sol";


### PR DESCRIPTION
**Motivation**

https://github.com/UMAprotocol/protocol/issues/2143

**Summary**

To be compliant with the Solidity styling guide, all Solidity files should specify their SPDX license at the top in a comment. This PR adds this. The list of possible licenses can be found [here](https://spdx.org/licenses/). The `AGPL-3.0-only` tag best matches the license of this repo.

**Question**
The other license option would be `AGPL-3.0-or-later`. Would we prefer that one or is the `AGPL-3.0-only` fine?

**Issue(s)**

close #2143