### PR TITLE
feat(affiliates): add extra data to deployer reward results

### DIFF
--- a/packages/affiliates/apps/CreateDataSet.js
+++ b/packages/affiliates/apps/CreateDataSet.js
@@ -22,4 +22,5 @@ async function Run(config) {
 const config = Config();
 Run(config)
   .then(console.log)
-  .catch(console.error);
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/packages/affiliates/apps/DeployerRewards.js
+++ b/packages/affiliates/apps/DeployerRewards.js
@@ -71,7 +71,8 @@ async function App(config) {
 
   return {
     config,
-    result
+    // result will contain deployer rewards as well as per emp rewards
+    ...result
   };
 }
 
@@ -79,4 +80,6 @@ const config = Config();
 
 App(config)
   .then(console.log)
-  .catch(console.error);
+  .catch(console.error)
+  // Process hangs if not forcibly closed. Unknown how to disconnect web3 or bigquery client.
+  .finally(() => process.exit());

--- a/packages/affiliates/libs/models.js
+++ b/packages/affiliates/libs/models.js
@@ -124,7 +124,7 @@ function Balances() {
     return create(addr);
   }
   function set(addr, balance) {
-    assert(balance >= 0n, "balance must be >= 0: " + balance);
+    assert(balance >= 0n, "balance must be >= 0: " + balance + " for " + addr);
     balances.set(addr, balance);
     return balance;
   }

--- a/packages/affiliates/test/mocha/affiliates.js
+++ b/packages/affiliates/test/mocha/affiliates.js
@@ -78,6 +78,8 @@ describe("DeployerRewards", function() {
   });
   it("calculateRewards", async function() {
     this.timeout(100000);
+    // small value to give floating math some wiggle room
+    const epsilon = 0.001;
 
     const startingTimestamp = moment("2020-10-01 23:00:00", "YYYY-MM-DD  HH:mm Z").valueOf(); // utc timestamp
     const endingTimestamp = moment("2020-10-08 23:00:00", "YYYY-MM-DD  HH:mm Z").valueOf();
@@ -93,12 +95,25 @@ describe("DeployerRewards", function() {
       syntheticTokenDecimals: syntheticTokenDecimals
     });
 
-    assert.equal(Object.keys(result).length, 2); // There should be 2 deplorers for the 3 EMPs.
-    assert.equal(
-      Object.values(result).reduce((total, value) => {
-        return Number(total) + Number(value);
-      }, 0),
-      Number(devRewardsToDistribute)
+    assert.equal(Object.keys(result.deployerPayouts).length, 2); // There should be 2 deplorers for the 3 EMPs.
+    assert.equal(Object.keys(result.empPayouts).length, 3); // There should be 3 emps
+
+    assert.isBelow(
+      // compare floats with an epsilon
+      Math.abs(
+        Object.values(result.deployerPayouts).reduce((total, value) => {
+          return Number(total) + Number(value);
+        }, 0) - Number(devRewardsToDistribute)
+      ),
+      epsilon
+    ); // the total rewards distributed should equal the number specified
+    assert.isBelow(
+      Math.abs(
+        Object.values(result.empPayouts).reduce((total, value) => {
+          return Number(total) + Number(value);
+        }, 0) - Number(devRewardsToDistribute)
+      ),
+      epsilon
     ); // the total rewards distributed should equal the number specified
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2171

**Summary**

- adds extra data to allow for "siloing" of rewards per emp
- also adds start / end block timestamp and numbers


![image](https://user-images.githubusercontent.com/4429761/98722580-3b60d880-235f-11eb-9a03-272fae775f67.png)


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2171
