### PR TITLE
improve: adds price identifier BTC-USD-FUTURE-INVERSE-QUARTERLY-25DEC20 to whitelist in IdentifierWhitelist

### DIFF
--- a/packages/core/config/identifiers.json
+++ b/packages/core/config/identifiers.json
@@ -1,6 +1,6 @@
 {
   "BTC/USD": {},
-  "BTC-USD-FUTURE-INVERSE-QUARTERLY-25DEC20": {}
+  "BTC-FUTURE-QUARTERLY/USD": {}
   "USD/BTC": {},
   "ETH/USD": {},
   "CMC Total Market Cap": {},

--- a/packages/core/config/identifiers.json
+++ b/packages/core/config/identifiers.json
@@ -1,5 +1,6 @@
 {
   "BTC/USD": {},
+  "BTC-USD-FUTURE-INVERSE-QUARTERLY-25DEC20": {}
   "USD/BTC": {},
   "ETH/USD": {},
   "CMC Total Market Cap": {},


### PR DESCRIPTION

**Motivation**

This PR adds price identifier to get prices for BTC Quarterly Futures from https://cryptowat.ch/charts/BINANCE:BTC-USD-FUTURE-INVERSE-QUARTERLY-25DEC20. 

