### PR TITLE
 feat(price-feeds): adds a new price feed for GASETH kovan

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -61,6 +61,13 @@ const defaultConfigs = {
     invertPrice: true,
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [{ type: "cryptowatch", exchange: "binance", pair: "perlusdt" }]
+  },
+  "kGASETH-TWAP-1Mx1M": {
+    // Kovan Gaseth
+    type: "uniswap",
+    uniswapAddress: "0x0f20793bF444E2318d6a39fCb4792a8985C0ab6e",
+    twapLength: 7200,
+    lookback: 7200
   }
 };
 


### PR DESCRIPTION


**Motivation**

This will allow for bot testing on a kovan synthetic gas contract.


**Summary**

Adding the kovan price identifier for GASETH-TWAP-1Mx1M as a price feed configuration option to allow for bot testing.


**Details**

The Uniswap address is the token pair address of uGAS-JAN21 and WETH.


**Issue(s)**
None
