### PR TITLE
ci(slither): fix slither ci job

### DIFF
--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -14,7 +14,7 @@ run_slither() {
 
     # print out slither version for debugging
     slither --version
-    slither --exclude=divide-before-multiply,unused-return,timestamp,naming-convention,pragma,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly,uninitialized-local --filter-paths="@openzeppelin|WETH9.sol|ReentrancyAttack.sol|ReentrancyMock.sol|test" $1
+    slither --exclude=divide-before-multiply,unused-return,timestamp,naming-convention,pragma,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly,uninitialized-local --filter-paths="@openzeppelin|WETH9.sol|test" $1
 }
 
 run_slither $PROTOCOL_DIR/packages/core

--- a/ci/run_slither.sh
+++ b/ci/run_slither.sh
@@ -14,7 +14,7 @@ run_slither() {
 
     # print out slither version for debugging
     slither --version
-    slither --exclude=divide-before-multiply,locked-ether,unused-return,timestamp,naming-convention,pragma,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly --filter-paths="@openzeppelin|WETH9.sol|ReentrancyAttack.sol|ReentrancyMock.sol" $1
+    slither --exclude=divide-before-multiply,unused-return,timestamp,naming-convention,pragma,solc-version,external-function,reentrancy-benign,reentrancy-no-eth,arbitrary-send,incorrect-equality,reentrancy-events,assembly,uninitialized-local --filter-paths="@openzeppelin|WETH9.sol|ReentrancyAttack.sol|ReentrancyMock.sol|test" $1
 }
 
 run_slither $PROTOCOL_DIR/packages/core


### PR DESCRIPTION
**Motivation**

Fix the slither ci job, now that the executable is updated in the docker image.

**Summary**

try-catches are not handled correctly by slither -- see https://github.com/crytic/slither/issues/511, so that check needed to be disabled. This also re-enables the locked ether check and set slither to not analyze test files.

**Issue(s)**

N/A
