### PR TITLE
feat(perpetual): Create ConfigStore to house mutable perpetual params (upgradeable after timelock)

### DIFF
--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -147,7 +147,7 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
     function _validateConfig(ConfigSettings memory config) internal pure {
         // Make sure timelockLiveness is not too long, otherwise contract can might not be able to fix itself
         // before a vulnerability drains its collateral. e.g. 604800 = 7 days.
-        require(config.timelockLiveness <= 604800, "Invalid timelockLiveness");
+        require(config.timelockLiveness <= 7 days, "Invalid timelockLiveness");
 
         // Upper limits for the reward and bond rates are estimated based on offline discussions,
         // and it is expected that these hard-coded limits can change in future deployments.

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -101,7 +101,7 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         pendingConfig = newConfig;
 
         // Use current config's liveness period to timelock this proposal.
-        pendingPassedTimestamp = getCurrentTime() + currentConfig.timelockLiveness;
+        pendingPassedTimestamp = getCurrentTime().add(currentConfig.timelockLiveness);
 
         emit ProposedNewConfigSettings(
             msg.sender,

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -154,12 +154,12 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         // For a discussion thread, go [here](https://github.com/UMAprotocol/protocol/pull/2223#discussion_r530692149).
 
         // Proposer bond of 0.04% is based on a maximum expected funding rate error of 200%/year.
-        FixedPoint.Unsigned memory maxProposerBond = FixedPoint.fromUnscaledUint(4).div(10000);
+        FixedPoint.Unsigned memory maxProposerBond = FixedPoint.fromUnscaledUint(4).div(1e4);
         require(config.proposerBondPct.isLessThan(maxProposerBond), "Invalid proposerBondPct");
 
         // Reward rate should be less than 100% a year => 100% / 360 days / 24 hours / 60 mins / 60 secs
         // = 0.0000033
-        FixedPoint.Unsigned memory maxRewardRatePerSecond = FixedPoint.fromUnscaledUint(33).div(10000000);
+        FixedPoint.Unsigned memory maxRewardRatePerSecond = FixedPoint.fromUnscaledUint(33).div(1e7);
         require(config.rewardRatePerSecond.isLessThan(maxRewardRatePerSecond), "Invalid rewardRatePerSecond");
     }
 }

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -52,7 +52,7 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         uint256 timelockLiveness,
         uint256 proposalPassedTimestamp
     );
-    event ChangedNewConfigSettings(uint256 rewardRate, uint256 proposerBond, uint256 timelockLiveness);
+    event ChangedConfigSettings(uint256 rewardRate, uint256 proposerBond, uint256 timelockLiveness);
 
     /****************************************
      *                MODIFIERS             *

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -126,7 +126,7 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
 
             _deletePendingConfig();
 
-            emit ChangedNewConfigSettings(
+            emit ChangedConfigSettings(
                 currentConfig.rewardRatePerSecond.rawValue,
                 currentConfig.proposerBondPct.rawValue,
                 currentConfig.timelockLiveness

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -148,5 +148,10 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         // Make sure updateLiveness is not too long, otherwise contract can might not be able to fix itself
         // before a vulnerability drains its collateral. e.g. 604800 = 7 days.
         require(config.updateLiveness <= 604800, "Invalid paramUpdateLiveness");
+
+        // Make reward rate and proposal bond percentage are less than 100% of PfC. 100% reward rate would
+        // take the entire perpetual's PfC after one successful proposal.
+        require(config.proposerBondPct.isLessThan(1), "Invalid proposerBondPct");
+        require(config.rewardRatePerSecond.isLessThan(1), "Invalid rewardRatePerSecond");
     }
 }

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -146,8 +146,8 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
     // Use this method to constrain values with which you can set ConfigSettings.
     function _validateConfig(ConfigSettings memory config) internal pure {
         // Make sure timelockLiveness is not too long, otherwise contract can might not be able to fix itself
-        // before a vulnerability drains its collateral. e.g. 604800 = 7 days.
-        require(config.timelockLiveness <= 7 days, "Invalid timelockLiveness");
+        // before a vulnerability drains its collateral.
+        require(config.timelockLiveness <= 7 days && config.timelockLiveness >= 1 days, "Invalid timelockLiveness");
 
         // Upper limits for the reward and bond rates are estimated based on offline discussions,
         // and it is expected that these hard-coded limits can change in future deployments.

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -58,12 +58,18 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
      *                MODIFIERS             *
      ****************************************/
 
+    // Update config settings if possible.
     modifier updateConfig() {
-        // Update config settings if possible.
         _updateConfig();
         _;
     }
 
+    /**
+     * @notice Propose new configuration settings. New settings go into effect
+     * after a liveness period passes.
+     * @param _initialConfig Configuration settings to initialize `currentConfig` with.
+     * @param _timerAddress Address of testable Timer contract.
+     */
     constructor(ConfigSettings memory _initialConfig, address _timerAddress) public Testable(_timerAddress) {
         _validateConfig(_initialConfig);
         currentConfig = _initialConfig;
@@ -84,13 +90,11 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
     /**
      * @notice Propose new configuration settings. New settings go into effect
      * after a liveness period passes.
+     * @param newConfig Configuration settings to publish after `currentConfig.updateLiveness` passes from now.
      * @dev Callable only by owner. Calling this while there is already a pending proposal
      * will overwrite the pending proposal.
      */
     function proposeNewConfig(ConfigSettings memory newConfig) external onlyOwner() nonReentrant() updateConfig() {
-        // Alternatively, we can revert if there is already a pending proposal.
-        // require(pendingPassedTimestamp == 0, "Pending proposal exists");
-
         _validateConfig(newConfig);
 
         // Warning: This overwrites a pending proposal!

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -146,7 +146,7 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
     // Use this method to constrain values with which you can set ConfigSettings.
     function _validateConfig(ConfigSettings memory config) internal pure {
         // Make sure updateLiveness is not too long, otherwise contract can might not be able to fix itself
-        // before a vulnerability drains its collateral.
+        // before a vulnerability drains its collateral. e.g. 604800 = 7 days.
         require(config.updateLiveness <= 604800, "Invalid paramUpdateLiveness");
     }
 }

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "./ConfigStoreInterface.sol";
+import "../../common/implementation/Testable.sol";
+import "../../common/implementation/Lockable.sol";
+import "../../common/implementation/FixedPoint.sol";
+
+/**
+ * @notice ConfigStore stores configuration settings for a perpetual contract and provides and interface for it
+ * to query settings such as reward rates, proposal bond sizes, etc. The configuration settings can be upgraded
+ * by a privileged account and the upgraded changes are timelocked.
+ */
+contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
+    using SafeMath for uint256;
+    using FixedPoint for FixedPoint.Unsigned;
+
+    /****************************************
+     *        STORE DATA STRUCTURES         *
+     ****************************************/
+
+    // All of the configuration settings available for querying by a perpetual.
+    struct ConfigSettings {
+        // Liveness period (in seconds) for an update to currentConfig to become official.
+        uint256 updateLiveness;
+        // Reward rate paid to successful proposers. Percentage of 1 E.g., .1 is 10%.
+        FixedPoint.Unsigned rewardRatePerSecond;
+        // Bond % (of given contract's PfC) that must be staked by proposers. Percentage of 1, e.g. 0.0005 is 0.05%.
+        FixedPoint.Unsigned proposerBondPct;
+    }
+
+    // Make currentConfig private to force user to call getCurrentConfig, which returns the pendingConfig
+    // if its liveness has expired.
+    ConfigSettings private currentConfig;
+
+    // Beginning on `pendingPassedTimestamp`, the `pendingConfig` can be published as the current config.
+    ConfigSettings public pendingConfig;
+    uint256 public pendingPassedTimestamp;
+
+    /****************************************
+     *                EVENTS                *
+     ****************************************/
+
+    event ProposedNewConfigSettings(
+        address indexed proposer,
+        uint256 rewardRate,
+        uint256 proposerBond,
+        uint256 updateLiveness,
+        uint256 proposalPassedTimestamp
+    );
+    event ChangedNewConfigSettings(uint256 rewardRate, uint256 proposerBond, uint256 updateLiveness);
+
+    /****************************************
+     *                MODIFIERS             *
+     ****************************************/
+
+    modifier updateConfig() {
+        // Update config settings if possible.
+        _updateConfig();
+        _;
+    }
+
+    constructor(ConfigSettings memory _initialConfig, address _timerAddress) public Testable(_timerAddress) {
+        _validateConfig(_initialConfig);
+        currentConfig = _initialConfig;
+    }
+
+    /**
+     * @notice Returns current config or pending config if pending liveness has expired.
+     * @return ConfigSettings config settings that calling financial contract should view as "live".
+     */
+    function getCurrentConfig() external view override nonReentrantView() returns (ConfigSettings memory) {
+        if (_pendingProposalPassed()) {
+            return pendingConfig;
+        } else {
+            return currentConfig;
+        }
+    }
+
+    /**
+     * @notice Propose new configuration settings. New settings go into effect
+     * after a liveness period passes.
+     * @dev Callable only by owner. Calling this while there is already a pending proposal
+     * will overwrite the pending proposal.
+     */
+    function proposeNewConfig(ConfigSettings memory newConfig) external onlyOwner() nonReentrant() updateConfig() {
+        // Alternatively, we can revert if there is already a pending proposal.
+        // require(pendingPassedTimestamp == 0, "Pending proposal exists");
+
+        _validateConfig(newConfig);
+
+        // Warning: This overwrites a pending proposal!
+        pendingConfig = newConfig;
+
+        // Use current config's liveness period to timelock this proposal.
+        pendingPassedTimestamp = getCurrentTime() + currentConfig.updateLiveness;
+
+        emit ProposedNewConfigSettings(
+            msg.sender,
+            newConfig.rewardRatePerSecond.rawValue,
+            newConfig.proposerBondPct.rawValue,
+            newConfig.updateLiveness,
+            pendingPassedTimestamp
+        );
+    }
+
+    function publishPendingConfig() external nonReentrant() updateConfig() {}
+
+    /****************************************
+     *         INTERNAL FUNCTIONS           *
+     ****************************************/
+
+    // Check if pending proposal can overwrite the current config.
+    function _updateConfig() internal {
+        // If liveness has passed, publish new reward rate.
+        if (_pendingProposalPassed()) {
+            currentConfig = pendingConfig;
+
+            _deletePendingConfig();
+
+            emit ChangedNewConfigSettings(
+                currentConfig.rewardRatePerSecond.rawValue,
+                currentConfig.proposerBondPct.rawValue,
+                currentConfig.updateLiveness
+            );
+        }
+    }
+
+    function _deletePendingConfig() internal {
+        delete pendingConfig;
+        pendingPassedTimestamp = 0;
+    }
+
+    function _pendingProposalPassed() internal view returns (bool) {
+        return (pendingPassedTimestamp != 0 && pendingPassedTimestamp <= getCurrentTime());
+    }
+
+    // Use this method to constrain values with which you can set ConfigSettings.
+    function _validateConfig(ConfigSettings memory config) internal pure {
+        // Make sure updateLiveness is not too long, otherwise contract can might not be able to fix itself
+        // before a vulnerability drains its collateral.
+        require(config.updateLiveness <= 604800, "Invalid paramUpdateLiveness");
+    }
+}

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "./ConfigStore.sol";
+
+interface ConfigStoreInterface {
+    function getCurrentConfig() external view returns (ConfigStore.ConfigSettings memory);
+}

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -11,6 +11,7 @@ import "../../common/implementation/Lockable.sol";
 import "../common/TokenFactory.sol";
 import "../common/SyntheticToken.sol";
 import "./PerpetualLib.sol";
+import "./ConfigStore.sol";
 
 /**
  * @title Perpetual Contract creator.
@@ -29,6 +30,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
      *     PERP CREATOR DATA STRUCTURES      *
      ****************************************/
 
+    // Immutable params for perpetual contract.
     struct Params {
         address collateralAddress;
         bytes32 priceFeedIdentifier;
@@ -48,6 +50,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
     address public tokenFactoryAddress;
 
     event CreatedPerpetual(address indexed perpetualAddress, address indexed deployerAddress);
+    event CreatedConfigStore(address indexed configStoreAddress, address indexed ownerAddress);
 
     /**
      * @notice Constructs the Perpetual contract.
@@ -68,7 +71,16 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
      * @param params is a `ConstructorParams` object from Perpetual.
      * @return address of the deployed contract.
      */
-    function createPerpetual(Params memory params) public nonReentrant() returns (address) {
+    function createPerpetual(Params memory params, ConfigStore.ConfigSettings memory configSettings)
+        public
+        nonReentrant()
+        returns (address)
+    {
+        // Create new config settings store for this contract and reset ownership to the deployer.
+        ConfigStore configStore = new ConfigStore(configSettings, timerAddress);
+        configStore.transferOwnership(msg.sender);
+        CreatedConfigStore(address(configStore), configStore.owner());
+
         // Create a new synthetic token using the params.
         require(bytes(params.syntheticName).length != 0, "Missing synthetic name");
         require(bytes(params.syntheticSymbol).length != 0, "Missing synthetic symbol");
@@ -78,7 +90,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         // then a default precision of 18 will be applied to the newly created synthetic token.
         uint8 syntheticDecimals = _getSyntheticDecimals(params.collateralAddress);
         ExpandedIERC20 tokenCurrency = tf.createToken(params.syntheticName, params.syntheticSymbol, syntheticDecimals);
-        address derivative = PerpetualLib.deploy(_convertParams(params, tokenCurrency));
+        address derivative = PerpetualLib.deploy(_convertParams(params, tokenCurrency, address(configStore)));
 
         // Give permissions to new derivative contract and then hand over ownership.
         tokenCurrency.addMinter(derivative);
@@ -97,11 +109,11 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
      ****************************************/
 
     // Converts createPerpetual params to Perpetual constructor params.
-    function _convertParams(Params memory params, ExpandedIERC20 newTokenCurrency)
-        private
-        view
-        returns (Perpetual.ConstructorParams memory constructorParams)
-    {
+    function _convertParams(
+        Params memory params,
+        ExpandedIERC20 newTokenCurrency,
+        address configStore
+    ) private view returns (Perpetual.ConstructorParams memory constructorParams) {
         // Known from creator deployment.
         constructorParams.finderAddress = finderAddress;
         constructorParams.timerAddress = timerAddress;
@@ -121,6 +133,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         require(params.liquidationLiveness < 5200 weeks, "Liquidation liveness too large");
 
         // Input from function call.
+        // constructorParams.configStore = configStore;
         constructorParams.tokenAddress = address(newTokenCurrency);
         constructorParams.collateralAddress = params.collateralAddress;
         constructorParams.priceFeedIdentifier = params.priceFeedIdentifier;
@@ -133,6 +146,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         constructorParams.withdrawalLiveness = params.withdrawalLiveness;
         constructorParams.liquidationLiveness = params.liquidationLiveness;
         constructorParams.excessTokenBeneficiary = params.excessTokenBeneficiary;
+        // TODO: Uncomment this line once we add `configStore` to Perpetual constructor params
     }
 
     // IERC20Standard.decimals() will revert if the collateral contract has not implemented the decimals() method,

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -121,7 +121,7 @@ contract("ConfigStore", function(accounts) {
       // Pending config can be published with propose(). In the next test we'll test that publishPendingConfig
       // also updates pending configs.
       proposeTxn = await configStore.proposeNewConfig(testConfig);
-      truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
+      truffleAssert.eventEmitted(proposeTxn, "ChangedConfigSettings", ev => {
         return (
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
@@ -208,7 +208,7 @@ contract("ConfigStore", function(accounts) {
       await incrementTime(configStore, 1);
       await currentConfigMatchesInput(configStore, test2Config);
       proposeTxn = await configStore.publishPendingConfig();
-      truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
+      truffleAssert.eventEmitted(proposeTxn, "ChangedConfigSettings", ev => {
         return (
           ev.rewardRate.toString() === test2Config.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === test2Config.proposerBondPct.rawValue &&

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -76,9 +76,24 @@ contract("ConfigStore", function(accounts) {
     });
 
     it("Invalid default values revert on construction", async function() {
+      // Invalid timelock
       let invalidConfig = {
         ...testConfig,
         updateLiveness: 604800 + 1
+      };
+      assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
+
+      // Invalid reward rate
+      invalidConfig = {
+        ...testConfig,
+        rewardRatePerSecond: { rawValue: toWei("1.01") }
+      };
+      assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
+
+      // Invalid proposal bond
+      invalidConfig = {
+        ...testConfig,
+        proposerBondPct: { rawValue: toWei("1.01") }
       };
       assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
     });

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -1,0 +1,219 @@
+// External libs
+const { toWei, toBN } = web3.utils;
+const truffleAssert = require("truffle-assertions");
+
+// Local libs
+const { didContractThrow } = require("@uma/common");
+const { assert } = require("chai");
+
+// Tested Contract
+const ConfigStore = artifacts.require("ConfigStore");
+
+// Helper Contracts
+const Timer = artifacts.require("Timer");
+
+// Helper functions.
+async function incrementTime(contract, amount) {
+  const currentTime = await contract.getCurrentTime();
+  await contract.setCurrentTime(Number(currentTime) + amount);
+}
+
+contract("ConfigStore", function(accounts) {
+  let timer;
+  let configStore;
+
+  let owner = accounts[0];
+  let rando = accounts[1];
+
+  let testConfig = {
+    updateLiveness: 100,
+    rewardRatePerSecond: { rawValue: toWei("0.0001") },
+    proposerBondPct: { rawValue: toWei("0.04") }
+  };
+  let defaultConfig = {
+    updateLiveness: "0",
+    rewardRatePerSecond: { rawValue: "0" },
+    proposerBondPct: { rawValue: "0" }
+  };
+
+  async function currentConfigMatchesInput(_store, _inputConfig) {
+    let currentConfig = await _store.getCurrentConfig();
+    assert.equal(currentConfig.updateLiveness.toString(), _inputConfig.updateLiveness.toString());
+    assert.equal(
+      currentConfig.rewardRatePerSecond.rawValue.toString(),
+      _inputConfig.rewardRatePerSecond.rawValue.toString()
+    );
+    assert.equal(currentConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
+  }
+
+  async function pendingConfigMatchesInput(_store, _inputConfig) {
+    let pendingConfig = await _store.pendingConfig();
+    assert.equal(pendingConfig.updateLiveness.toString(), _inputConfig.updateLiveness.toString());
+    assert.equal(
+      pendingConfig.rewardRatePerSecond.rawValue.toString(),
+      _inputConfig.rewardRatePerSecond.rawValue.toString()
+    );
+    assert.equal(pendingConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
+  }
+
+  async function storeHasNoPendingConfig(_store) {
+    await pendingConfigMatchesInput(_store, defaultConfig);
+    assert.equal((await _store.pendingPassedTimestamp()).toString(), "0");
+  }
+
+  beforeEach(async () => {
+    timer = await Timer.deployed();
+  });
+
+  describe("Construction", function() {
+    it("Default values get set", async function() {
+      configStore = await ConfigStore.new(testConfig, timer.address);
+      let config = await configStore.getCurrentConfig();
+      assert.equal(config.updateLiveness.toString(), "100");
+      assert.equal(config.rewardRatePerSecond.rawValue.toString(), toWei("0.0001"));
+      assert.equal(config.proposerBondPct.rawValue.toString(), toWei("0.04"));
+      await storeHasNoPendingConfig(configStore);
+    });
+
+    it("Invalid default values revert on construction", async function() {
+      let invalidConfig = {
+        ...testConfig,
+        updateLiveness: 604800 + 1
+      };
+      assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
+    });
+  });
+  describe("Proposing a new configuration", function() {
+    it("Liveness is 0, instant update", async function() {
+      configStore = await ConfigStore.new(defaultConfig, timer.address);
+
+      // Can only propose from owner account
+      assert(await didContractThrow(configStore.proposeNewConfig(testConfig, { from: rando })));
+
+      // Liveness is 0, meaning that `getCurrentConfig()` should return the pending proposal
+      const proposeTime = await configStore.getCurrentTime();
+      let proposeTxn = await configStore.proposeNewConfig(testConfig);
+      truffleAssert.eventEmitted(proposeTxn, "ProposedNewConfigSettings", ev => {
+        return (
+          ev.proposer === owner &&
+          ev.rewardRate.toString() === toWei("0.0001") &&
+          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.updateLiveness.toString() === "100" &&
+          ev.proposalPassedTimestamp.toString() === proposeTime.toString()
+        );
+      });
+      await currentConfigMatchesInput(configStore, testConfig);
+
+      // Pending config is updated, liveness passed timestamp is same as current time.
+      await pendingConfigMatchesInput(configStore, testConfig);
+      assert.equal((await configStore.pendingPassedTimestamp()).toString(), proposeTime.toString());
+
+      // Next propose transaction publishes the new config.
+      let test2Config = {
+        ...testConfig,
+        updateLiveness: 200
+      };
+      proposeTxn = await configStore.proposeNewConfig(test2Config);
+      truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
+        return (
+          ev.rewardRate.toString() === toWei("0.0001") &&
+          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.updateLiveness.toString() === "100"
+        );
+      });
+      truffleAssert.eventEmitted(proposeTxn, "ProposedNewConfigSettings", ev => {
+        // New passed timestamp should take newly updated liveness into account.
+        return (
+          ev.proposer === owner &&
+          ev.rewardRate.toString() === toWei("0.0001") &&
+          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.updateLiveness.toString() === "200" &&
+          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(100)).toString()
+        );
+      });
+      await currentConfigMatchesInput(configStore, testConfig);
+
+      // Pending config and passed timestamp is updated.
+      await pendingConfigMatchesInput(configStore, test2Config);
+      assert.equal((await configStore.pendingPassedTimestamp()).toString(), proposeTime.add(toBN(100)).toString());
+    });
+    it("Liveness is > 0, update occurs after liveness period", async function() {
+      configStore = await ConfigStore.new(testConfig, timer.address);
+
+      // Propose new config.
+      const proposeTime = await configStore.getCurrentTime();
+      let proposeTxn = await configStore.proposeNewConfig(defaultConfig);
+      truffleAssert.eventEmitted(proposeTxn, "ProposedNewConfigSettings", ev => {
+        return (
+          ev.proposer === owner &&
+          ev.rewardRate.toString() === "0" &&
+          ev.proposerBond.toString() === "0" &&
+          ev.updateLiveness.toString() === "0" &&
+          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(100)).toString()
+        );
+      });
+
+      // Current config doesn't change.
+      await currentConfigMatchesInput(configStore, testConfig);
+
+      // Pending config and liveness timestamp is updated.
+      await pendingConfigMatchesInput(configStore, defaultConfig);
+      assert.equal((await configStore.pendingPassedTimestamp()).toString(), proposeTime.add(toBN(100)).toString());
+
+      // Advancing time before the liveness is up doesn't change state.
+      await incrementTime(configStore, 99);
+      await configStore.publishPendingConfig();
+      await currentConfigMatchesInput(configStore, testConfig);
+      await pendingConfigMatchesInput(configStore, defaultConfig);
+      assert.equal((await configStore.pendingPassedTimestamp()).toString(), proposeTime.add(toBN(100)).toString());
+
+      // Proposing a new config overwrites the pending proposal.
+      let test2Config = {
+        ...testConfig,
+        updateLiveness: 200
+      };
+      const overwriteProposalTime = await configStore.getCurrentTime();
+      proposeTxn = await configStore.proposeNewConfig(test2Config);
+      truffleAssert.eventEmitted(proposeTxn, "ProposedNewConfigSettings", ev => {
+        // New passed timestamp should take newly updated liveness into account.
+        return (
+          ev.proposer === owner &&
+          ev.rewardRate.toString() === toWei("0.0001") &&
+          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.updateLiveness.toString() === "200" &&
+          ev.proposalPassedTimestamp.toString() === overwriteProposalTime.add(toBN(100)).toString()
+        );
+      });
+      await currentConfigMatchesInput(configStore, testConfig);
+      await pendingConfigMatchesInput(configStore, test2Config);
+      assert.equal(
+        (await configStore.pendingPassedTimestamp()).toString(),
+        overwriteProposalTime.add(toBN(100)).toString()
+      );
+
+      // Advancing time after the original-proposal's liveness but before the overwrite-proposal's liveness
+      // doesn't change state.
+      await incrementTime(configStore, 99);
+      await configStore.publishPendingConfig();
+      await currentConfigMatchesInput(configStore, testConfig);
+      await pendingConfigMatchesInput(configStore, test2Config);
+      assert.equal(
+        (await configStore.pendingPassedTimestamp()).toString(),
+        overwriteProposalTime.add(toBN(100)).toString()
+      );
+
+      // Finally, advancing past liveness allows pending config to be returned as current config,
+      // and the pending config can be published.
+      await incrementTime(configStore, 1);
+      await currentConfigMatchesInput(configStore, test2Config);
+      proposeTxn = await configStore.publishPendingConfig();
+      truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
+        return (
+          ev.rewardRate.toString() === toWei("0.0001") &&
+          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.updateLiveness.toString() === "200"
+        );
+      });
+    });
+  });
+});

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -26,19 +26,19 @@ contract("ConfigStore", function(accounts) {
   let rando = accounts[1];
 
   let testConfig = {
-    updateLiveness: 100,
+    timelockLiveness: 100,
     rewardRatePerSecond: { rawValue: toWei("0.000001") },
     proposerBondPct: { rawValue: toWei("0.0001") }
   };
   let defaultConfig = {
-    updateLiveness: "0",
+    timelockLiveness: "0",
     rewardRatePerSecond: { rawValue: "0" },
     proposerBondPct: { rawValue: "0" }
   };
 
   async function currentConfigMatchesInput(_store, _inputConfig) {
     let currentConfig = await _store.getCurrentConfig();
-    assert.equal(currentConfig.updateLiveness.toString(), _inputConfig.updateLiveness.toString());
+    assert.equal(currentConfig.timelockLiveness.toString(), _inputConfig.timelockLiveness.toString());
     assert.equal(
       currentConfig.rewardRatePerSecond.rawValue.toString(),
       _inputConfig.rewardRatePerSecond.rawValue.toString()
@@ -48,7 +48,7 @@ contract("ConfigStore", function(accounts) {
 
   async function pendingConfigMatchesInput(_store, _inputConfig) {
     let pendingConfig = await _store.pendingConfig();
-    assert.equal(pendingConfig.updateLiveness.toString(), _inputConfig.updateLiveness.toString());
+    assert.equal(pendingConfig.timelockLiveness.toString(), _inputConfig.timelockLiveness.toString());
     assert.equal(
       pendingConfig.rewardRatePerSecond.rawValue.toString(),
       _inputConfig.rewardRatePerSecond.rawValue.toString()
@@ -69,7 +69,7 @@ contract("ConfigStore", function(accounts) {
     it("Default values get set", async function() {
       configStore = await ConfigStore.new(testConfig, timer.address);
       let config = await configStore.getCurrentConfig();
-      assert.equal(config.updateLiveness.toString(), "100");
+      assert.equal(config.timelockLiveness.toString(), "100");
       assert.equal(config.rewardRatePerSecond.rawValue.toString(), toWei("0.000001"));
       assert.equal(config.proposerBondPct.rawValue.toString(), toWei("0.0001"));
       await storeHasNoPendingConfig(configStore);
@@ -79,7 +79,7 @@ contract("ConfigStore", function(accounts) {
       // Invalid timelock
       let invalidConfig = {
         ...testConfig,
-        updateLiveness: 604800 + 1
+        timelockLiveness: 604800 + 1
       };
       assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
 
@@ -113,7 +113,7 @@ contract("ConfigStore", function(accounts) {
           ev.proposer === owner &&
           ev.rewardRate.toString() === toWei("0.000001") &&
           ev.proposerBond.toString() === toWei("0.0001") &&
-          ev.updateLiveness.toString() === "100" &&
+          ev.timelockLiveness.toString() === "100" &&
           ev.proposalPassedTimestamp.toString() === proposeTime.toString()
         );
       });
@@ -126,14 +126,14 @@ contract("ConfigStore", function(accounts) {
       // Next propose transaction publishes the new config.
       let test2Config = {
         ...testConfig,
-        updateLiveness: 200
+        timelockLiveness: 200
       };
       proposeTxn = await configStore.proposeNewConfig(test2Config);
       truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
         return (
           ev.rewardRate.toString() === toWei("0.000001") &&
           ev.proposerBond.toString() === toWei("0.0001") &&
-          ev.updateLiveness.toString() === "100"
+          ev.timelockLiveness.toString() === "100"
         );
       });
       truffleAssert.eventEmitted(proposeTxn, "ProposedNewConfigSettings", ev => {
@@ -142,7 +142,7 @@ contract("ConfigStore", function(accounts) {
           ev.proposer === owner &&
           ev.rewardRate.toString() === toWei("0.000001") &&
           ev.proposerBond.toString() === toWei("0.0001") &&
-          ev.updateLiveness.toString() === "200" &&
+          ev.timelockLiveness.toString() === "200" &&
           ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(100)).toString()
         );
       });
@@ -163,7 +163,7 @@ contract("ConfigStore", function(accounts) {
           ev.proposer === owner &&
           ev.rewardRate.toString() === "0" &&
           ev.proposerBond.toString() === "0" &&
-          ev.updateLiveness.toString() === "0" &&
+          ev.timelockLiveness.toString() === "0" &&
           ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(100)).toString()
         );
       });
@@ -185,7 +185,7 @@ contract("ConfigStore", function(accounts) {
       // Proposing a new config overwrites the pending proposal.
       let test2Config = {
         ...testConfig,
-        updateLiveness: 200
+        timelockLiveness: 200
       };
       const overwriteProposalTime = await configStore.getCurrentTime();
       proposeTxn = await configStore.proposeNewConfig(test2Config);
@@ -195,7 +195,7 @@ contract("ConfigStore", function(accounts) {
           ev.proposer === owner &&
           ev.rewardRate.toString() === toWei("0.000001") &&
           ev.proposerBond.toString() === toWei("0.0001") &&
-          ev.updateLiveness.toString() === "200" &&
+          ev.timelockLiveness.toString() === "200" &&
           ev.proposalPassedTimestamp.toString() === overwriteProposalTime.add(toBN(100)).toString()
         );
       });
@@ -226,7 +226,7 @@ contract("ConfigStore", function(accounts) {
         return (
           ev.rewardRate.toString() === toWei("0.000001") &&
           ev.proposerBond.toString() === toWei("0.0001") &&
-          ev.updateLiveness.toString() === "200"
+          ev.timelockLiveness.toString() === "200"
         );
       });
     });

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -27,8 +27,8 @@ contract("ConfigStore", function(accounts) {
 
   let testConfig = {
     updateLiveness: 100,
-    rewardRatePerSecond: { rawValue: toWei("0.0001") },
-    proposerBondPct: { rawValue: toWei("0.04") }
+    rewardRatePerSecond: { rawValue: toWei("0.000001") },
+    proposerBondPct: { rawValue: toWei("0.0001") }
   };
   let defaultConfig = {
     updateLiveness: "0",
@@ -70,8 +70,8 @@ contract("ConfigStore", function(accounts) {
       configStore = await ConfigStore.new(testConfig, timer.address);
       let config = await configStore.getCurrentConfig();
       assert.equal(config.updateLiveness.toString(), "100");
-      assert.equal(config.rewardRatePerSecond.rawValue.toString(), toWei("0.0001"));
-      assert.equal(config.proposerBondPct.rawValue.toString(), toWei("0.04"));
+      assert.equal(config.rewardRatePerSecond.rawValue.toString(), toWei("0.000001"));
+      assert.equal(config.proposerBondPct.rawValue.toString(), toWei("0.0001"));
       await storeHasNoPendingConfig(configStore);
     });
 
@@ -86,14 +86,14 @@ contract("ConfigStore", function(accounts) {
       // Invalid reward rate
       invalidConfig = {
         ...testConfig,
-        rewardRatePerSecond: { rawValue: toWei("1.01") }
+        rewardRatePerSecond: { rawValue: toWei("0.00000331") }
       };
       assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
 
       // Invalid proposal bond
       invalidConfig = {
         ...testConfig,
-        proposerBondPct: { rawValue: toWei("1.01") }
+        proposerBondPct: { rawValue: toWei("0.00041") }
       };
       assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
     });
@@ -111,8 +111,8 @@ contract("ConfigStore", function(accounts) {
       truffleAssert.eventEmitted(proposeTxn, "ProposedNewConfigSettings", ev => {
         return (
           ev.proposer === owner &&
-          ev.rewardRate.toString() === toWei("0.0001") &&
-          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.rewardRate.toString() === toWei("0.000001") &&
+          ev.proposerBond.toString() === toWei("0.0001") &&
           ev.updateLiveness.toString() === "100" &&
           ev.proposalPassedTimestamp.toString() === proposeTime.toString()
         );
@@ -131,8 +131,8 @@ contract("ConfigStore", function(accounts) {
       proposeTxn = await configStore.proposeNewConfig(test2Config);
       truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
         return (
-          ev.rewardRate.toString() === toWei("0.0001") &&
-          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.rewardRate.toString() === toWei("0.000001") &&
+          ev.proposerBond.toString() === toWei("0.0001") &&
           ev.updateLiveness.toString() === "100"
         );
       });
@@ -140,8 +140,8 @@ contract("ConfigStore", function(accounts) {
         // New passed timestamp should take newly updated liveness into account.
         return (
           ev.proposer === owner &&
-          ev.rewardRate.toString() === toWei("0.0001") &&
-          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.rewardRate.toString() === toWei("0.000001") &&
+          ev.proposerBond.toString() === toWei("0.0001") &&
           ev.updateLiveness.toString() === "200" &&
           ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(100)).toString()
         );
@@ -193,8 +193,8 @@ contract("ConfigStore", function(accounts) {
         // New passed timestamp should take newly updated liveness into account.
         return (
           ev.proposer === owner &&
-          ev.rewardRate.toString() === toWei("0.0001") &&
-          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.rewardRate.toString() === toWei("0.000001") &&
+          ev.proposerBond.toString() === toWei("0.0001") &&
           ev.updateLiveness.toString() === "200" &&
           ev.proposalPassedTimestamp.toString() === overwriteProposalTime.add(toBN(100)).toString()
         );
@@ -224,8 +224,8 @@ contract("ConfigStore", function(accounts) {
       proposeTxn = await configStore.publishPendingConfig();
       truffleAssert.eventEmitted(proposeTxn, "ChangedNewConfigSettings", ev => {
         return (
-          ev.rewardRate.toString() === toWei("0.0001") &&
-          ev.proposerBond.toString() === toWei("0.04") &&
+          ev.rewardRate.toString() === toWei("0.000001") &&
+          ev.proposerBond.toString() === toWei("0.0001") &&
           ev.updateLiveness.toString() === "200"
         );
       });

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
@@ -30,7 +30,7 @@ contract("PerpetualCreator", function(accounts) {
   // Re-used variables
   let constructorParams;
   let testConfig = {
-    timelockLiveness: 100,
+    timelockLiveness: 86400, // 1 day
     rewardRatePerSecond: { rawValue: toWei("0.000001") },
     proposerBondPct: { rawValue: toWei("0.0001") }
   };

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
@@ -30,9 +30,9 @@ contract("PerpetualCreator", function(accounts) {
   // Re-used variables
   let constructorParams;
   let testConfig = {
-    updateLiveness: 100,
-    rewardRatePerSecond: { rawValue: toWei("0.0001") },
-    proposerBondPct: { rawValue: toWei("0.04") }
+    timelockLiveness: 100,
+    rewardRatePerSecond: { rawValue: toWei("0.000001") },
+    proposerBondPct: { rawValue: toWei("0.0001") }
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2219 


**Summary**

Builds a new `ConfigStore` on each `createPerpetual()` call. `createPerpetual()` now takes an additional `ConfigSettings` param for default config setting values.


**Details**

Follow up PR will add the `ConfigStore` address to the Perpetual's constructor params and read from the `ConfigStoreInterface` settings such as reward rate, proposer bond pct, etc.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2219 
