### PR TITLE
ci: fix double compilation target issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,12 @@ jobs:
           key: protocol-completed-build-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Run tests
-          command: yarn run test
+          command: |
+            cd ..
+            mkdir truffle_workaround
+            mv protocol truffle_workaround/
+            cd truffle_workaround/protocol
+            yarn run test
   coverage:
     docker:
       - image: circleci/node:12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,15 @@ jobs:
           key: protocol-completed-build-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Run tests
+          # Note: this is a workaround for a strnage truffle issue.
+          # The core idea is that truffle sees the absolute paths in old artifacts that are used outside of the core
+          # directory and it tries to add those absolute paths to the list of sources to compile. Normally, this
+          # wouldn't be an issue since those absolute paths wouldn't exist on the machine you're compiling on. However,
+          # because the published core contracts are compiled in the ci env, many of these absolute paths do match in
+          # this environment. This creates a very nasty situation where multiple versions of the same contracts are
+          # compiled and it's non-deterministic which one will be used by truffle. To avoid this, we just change the dir
+          # structure to disrupt the absolute paths. This means that truffle will not know how up-to-date the bytecode
+          # is, however, so testing will require a recompile for every contract.
           command: |
             cd ..
             mkdir truffle_workaround


### PR DESCRIPTION
**Motivation**

ci is failing due to multiple solidity versions being compiled twice.

**Summary**

Truffle is finding absolute paths in our previously published artifacts and looking for them in ci, which causes it to find a second set of contracts that have a different (newer) version. To keep it from doing this, we basically just move the protocol dir in the test job to disrupt these absolute paths.

**Issue(s)**
N/A
