### PR TITLE
ci: clear dependency cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,16 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v11-dependency-cache-{{ checksum "yarn.lock" }}
-            - v11-dependency-cache-
+            - v53-dependency-cache-{{ checksum "yarn.lock" }}
+            - v53-dependency-cache-
       - run:
           name: Install Prereqs
           command: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev yarn
       - run:
           name: Install Dependencies
-          command: npx lerna bootstrap -- --frozen-lockfile
+          command: yarn --frozen-lockfile
       - save_cache:
-          key: v11-dependency-cache-{{ checksum "yarn.lock" }}
+          key: v53-dependency-cache-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
       - save_cache:


### PR DESCRIPTION
This PR just clears the dep cache which seems to fix the sporadic ci errors.