### PR TITLE
bug(deploy-emp): Fix EMP ABI to display constructor params

### DIFF
--- a/packages/core/scripts/local/DeployEMP.js
+++ b/packages/core/scripts/local/DeployEMP.js
@@ -37,6 +37,7 @@ const TokenFactory = artifacts.require("TokenFactory");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
 const Store = artifacts.require("Store");
 const argv = require("minimist")(process.argv.slice(), { boolean: ["test"], string: ["identifier", "collateral"] });
+const { getAbi } = require("../../index");
 
 // Contracts we need to interact with.
 let collateralToken;
@@ -123,7 +124,9 @@ const deployEMP = async callback => {
       timerAddress: await expiringMultiPartyCreator.timerAddress()
     };
 
-    const encodedParameters = web3.eth.abi.encodeParameters(ExpiringMultiParty.abi[0].inputs, [empConstructorParams]);
+    const encodedParameters = web3.eth.abi.encodeParameters(getAbi("ExpiringMultiParty", "1.1.0")[0].inputs, [
+      empConstructorParams
+    ]);
     console.log("Encoded EMP Parameters", encodedParameters);
 
     // Done!


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This script allows the user to call a deployed EMPCreator contract to deploy a new EMP. This script actually successful sends a `createExpiringMultiParty()` transaction because the EMPCreator ABI has not changed from the deployed ABI. However, the call to `web3.eth.abi.encodeParameters(ExpiringMultiParty.abi[0].inputs, [empConstructorParams])` fails:

According to the [web3 docs](https://web3js.readthedocs.io/en/v1.2.6/web3-eth-abi.html#encodeparameters), `encodeParameters` encodes function parameters for a specific contract ABI. `.abi[0]` references the constructor function for the EMP and `.inputs` matches the user's desired constructor params with the constructor params. This line fails because the EMP ABI available to scripts in the `core/` package is the one in the package's `artifacts` corresponding to the code on `master`


**Summary**

This fixes the ABI passed to `encodeParameters` to the ABI that the deployed `ExpiringMultiPartyCreator` uses,
