### PR TITLE
feat(affiliates): add coingecko synthetic price fallback and calculator

### DIFF
--- a/packages/affiliates/apps/DeployerRewards.js
+++ b/packages/affiliates/apps/DeployerRewards.js
@@ -43,7 +43,7 @@ async function App(config) {
   });
 
   // get emp info
-  const { collateralTokens, collateralTokenDecimals, syntheticTokenDecimals } = await Promise.reduce(
+  const { collateralTokens, collateralTokenDecimals, syntheticTokenDecimals, syntheticTokens } = await Promise.reduce(
     empWhitelist,
     async (result, address) => {
       // switch this to tokenInfo if you want to base prices off tokens
@@ -53,9 +53,10 @@ async function App(config) {
 
       const syntheticInfo = await emp.tokenInfo(address);
       result.syntheticTokenDecimals.push(syntheticInfo.decimals);
+      result.syntheticTokens.push(syntheticInfo.address);
       return result;
     },
-    { collateralTokens: [], collateralTokenDecimals: [], syntheticTokenDecimals: [] }
+    { collateralTokens: [], collateralTokenDecimals: [], syntheticTokenDecimals: [], syntheticTokens:[] }
   );
 
   const result = await rewards.getRewards({
@@ -66,6 +67,7 @@ async function App(config) {
     empCreatorAddress: empCreator,
     collateralTokens,
     collateralTokenDecimals,
+    syntheticTokens,
     syntheticTokenDecimals
   });
 

--- a/packages/affiliates/apps/DeployerRewards.js
+++ b/packages/affiliates/apps/DeployerRewards.js
@@ -56,7 +56,7 @@ async function App(config) {
       result.syntheticTokens.push(syntheticInfo.address);
       return result;
     },
-    { collateralTokens: [], collateralTokenDecimals: [], syntheticTokenDecimals: [], syntheticTokens:[] }
+    { collateralTokens: [], collateralTokenDecimals: [], syntheticTokenDecimals: [], syntheticTokens: [] }
   );
 
   const result = await rewards.getRewards({

--- a/packages/affiliates/test/mocha/affiliates.js
+++ b/packages/affiliates/test/mocha/affiliates.js
@@ -102,12 +102,12 @@ describe("DeployerRewards", function() {
     // these are all stable coins so they should roughly be around 1 dollar
     // epsilon is high because variations could be nearly a dollar in any direction
     const target = 10n ** 18n;
-    const syntheticPrice = 26.358177384415466
+    const syntheticPrice = 26.358177384415466;
     let result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 18, 18).toString();
-    assert.equal(result,toWei(syntheticPrice.toFixed(18)))
+    assert.equal(result, toWei(syntheticPrice.toFixed(18)));
 
     result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 0, 8).toString();
-    assert.equal(result,toWei(syntheticPrice.toFixed(18)))
+    assert.equal(result, toWei(syntheticPrice.toFixed(18)));
   });
   it("calculateRewards", async function() {
     this.timeout(1000000);

--- a/packages/affiliates/test/mocha/affiliates.js
+++ b/packages/affiliates/test/mocha/affiliates.js
@@ -21,6 +21,10 @@ const devRewardsToDistribute = "50000";
 // mocks
 const { Queries, Coingecko, SynthPrices } = mocks;
 
+const { getWeb3 } = require("@uma/common");
+const web3 = getWeb3();
+const { toWei } = web3.utils;
+
 describe("DeployerRewards", function() {
   let affiliates;
   before(function() {
@@ -51,10 +55,10 @@ describe("DeployerRewards", function() {
       assert.ok(history.history.length());
     });
   });
-  it("getCollateralPriceHistory", async function() {
+  it("getCoingeckoPriceHistory", async function() {
     this.timeout(10000);
     const [, address] = collateralTokens;
-    const result = await affiliates.utils.getCollateralPriceHistory(address, "usd", startingTimestamp, endingTimestamp);
+    const result = await affiliates.utils.getCoingeckoPriceHistory(address, "usd", startingTimestamp, endingTimestamp);
     assert.ok(result.prices.length);
   });
   it("getSyntheticPriceHistory", async function() {
@@ -93,6 +97,17 @@ describe("DeployerRewards", function() {
     result = affiliates.utils.calculateValue(target, "0.021647425848012932", "45829514207149404216", 18, 18).toString();
     diff = BigInt(result) - target;
     assert(diff > 0 ? diff : -diff < epsilon);
+  });
+  it("calculateValueFromUsd", async function() {
+    // these are all stable coins so they should roughly be around 1 dollar
+    // epsilon is high because variations could be nearly a dollar in any direction
+    const target = 10n ** 18n;
+    const syntheticPrice = 26.358177384415466
+    let result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 18, 18).toString();
+    assert.equal(result,toWei(syntheticPrice.toFixed(18)))
+
+    result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 0, 8).toString();
+    assert.equal(result,toWei(syntheticPrice.toFixed(18)))
   });
   it("calculateRewards", async function() {
     this.timeout(1000000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4658,7 +4658,7 @@
     "@truffle/contract" "^4.2.20"
     "@uma/common" "^1.0.1"
 
-"@uma/core@npm:@uma/core@1.2.0":
+"@uma/core-1-2-0@npm:@uma/core@1.2.0", "@uma/core@npm:@uma/core@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@uma/core/-/core-1.2.0.tgz#7fce04924d28194090eecdf4087786f7bb56a755"
   integrity sha512-Etg5ZTDknuGnbgx9U3rZWLCW6aR3INwF/rx5qldtll8WBmWFyGiHTexHrP1fDECXRQ6dn4gzeK4FeDgWhiGvsA==


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2254 


**Summary**

This adds a fallback function for getting synthetic prices. Changes the api internally, each synthetic price now gets a "calcValue" function with it, to convert it to usd.  If synthetic price feed fails it will fallback to coingecko feed. Tested with uGas and did a basic sanity check vs renbtc dec contract.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2254 
