### PR TITLE
improve(perpetual): Modify ConfigStore constraints and params

### DIFF
--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -167,7 +167,7 @@ abstract contract FundingRateApplier is FeePayer {
         // Set up optimistic oracle.
         bytes32 identifier = fundingRate.identifier;
         bytes memory ancillaryData = _getAncillaryData();
-        // Note: requestPrice will revert if `timestamp` is less than the current block timestamp
+        // Note: requestPrice will revert if `timestamp` is less than the current block timestamp.
         optimisticOracle.requestPrice(identifier, timestamp, ancillaryData, collateralCurrency, 0);
         totalBond = FixedPoint.Unsigned(
             optimisticOracle.setBond(

--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -149,6 +149,7 @@ abstract contract FundingRateApplier is FeePayer {
         returns (FixedPoint.Unsigned memory totalBond)
     {
         require(fundingRate.proposalTime == 0, "Proposal in progress");
+        _validateFundingRate(rate);
 
         // Timestamp must be after the last funding rate update time, within the last 30 minutes, and it cannot be more
         // than 90 seconds ahead of the block timestamp.
@@ -257,6 +258,26 @@ abstract contract FundingRateApplier is FeePayer {
             }
         }
         return fundingRate.rate;
+    }
+
+    function _validateFundingRate(FixedPoint.Signed memory rate) internal pure {
+        // Constraining range of funding rates limits the PfC for any dishonest proposer and enhances the perpetual's
+        // security. A 600% funding rate range is equal to a 5% PfC for a proposer who can deter honest proposers
+        // for 74 hours: 600%/year / 360 days / 24 hours * 74 hours max attack time = ~ 5%.
+        // Note: 600% range is equivalent to a funding rate bounds of +300%/-300%. Imagine that the market is very
+        // volatile currently and that the "true" funding rate for the next 74 hours is -300%, but a dishonest
+        // proposer successfully proposes a rate of +300% (after a two hour liveness) and disputes honest
+        // proposers for the next 72 hours. This results in a funding rate error of 600% for 74 hours, until the DVM
+        // can set the funding rate back to its correct value.
+        FixedPoint.Signed memory MAX_FUNDING_RATE_PER_SECOND =
+            FixedPoint.fromUnscaledInt(300).div(360).div(24).div(60).div(60);
+        FixedPoint.Signed memory MIN_FUNDING_RATE_PER_SECOND =
+            FixedPoint.fromUnscaledInt(-300).div(360).div(24).div(60).div(60);
+
+        require(
+            rate.isLessThanOrEqual(MAX_FUNDING_RATE_PER_SECOND) &&
+                rate.isGreaterThanOrEqual(MIN_FUNDING_RATE_PER_SECOND)
+        );
     }
 
     // Fetches a funding rate from the Store, determines the period over which to compute an effective fee,

--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -262,17 +262,19 @@ abstract contract FundingRateApplier is FeePayer {
 
     function _validateFundingRate(FixedPoint.Signed memory rate) internal pure {
         // Constraining range of funding rates limits the PfC for any dishonest proposer and enhances the perpetual's
-        // security. A 600% funding rate range is equal to a 5% PfC for a proposer who can deter honest proposers
-        // for 74 hours: 600%/year / 360 days / 24 hours * 74 hours max attack time = ~ 5%.
-        // Note: 600% range is equivalent to a funding rate bounds of +300%/-300%. Imagine that the market is very
-        // volatile currently and that the "true" funding rate for the next 74 hours is -300%, but a dishonest
-        // proposer successfully proposes a rate of +300% (after a two hour liveness) and disputes honest
-        // proposers for the next 72 hours. This results in a funding rate error of 600% for 74 hours, until the DVM
+        // security. A 1000% funding rate range is equal to a 8.6% PfC for a proposer who can deter honest proposers
+        // for 74 hours: 1000%/year / 360 days / 24 hours * 74 hours max attack time = ~ 8.6%.
+        // Note: 1000% range is equivalent to a funding rate bounds of +500%/-500%. Imagine that the market is very
+        // volatile currently and that the "true" funding rate for the next 74 hours is -500%, but a dishonest
+        // proposer successfully proposes a rate of +500% (after a two hour liveness) and disputes honest
+        // proposers for the next 72 hours. This results in a funding rate error of 1000% for 74 hours, until the DVM
         // can set the funding rate back to its correct value.
+
+        // Approximate range is corresponding to +/- 500% is [0.000016, -0.000016].
         FixedPoint.Signed memory MAX_FUNDING_RATE_PER_SECOND =
-            FixedPoint.fromUnscaledInt(300).div(360).div(24).div(60).div(60);
+            FixedPoint.fromUnscaledInt(500).div(360).div(24).div(60).div(60);
         FixedPoint.Signed memory MIN_FUNDING_RATE_PER_SECOND =
-            FixedPoint.fromUnscaledInt(-300).div(360).div(24).div(60).div(60);
+            FixedPoint.fromUnscaledInt(-500).div(360).div(24).div(60).div(60);
 
         require(
             rate.isLessThanOrEqual(MAX_FUNDING_RATE_PER_SECOND) &&

--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -260,17 +260,16 @@ abstract contract FundingRateApplier is FeePayer {
         return fundingRate.rate;
     }
 
+    // Constraining the range of funding rates limits the PfC for any dishonest proposer and enhances the
+    // perpetual's security. For example, let's examine the case where the max and min funding rates
+    // are equivalent to +/- 500%/year. This 1000% funding rate range allows a 8.6% profit from corruption for a
+    // proposer who can deter honest proposers for 74 hours:
+    // 1000%/year / 360 days / 24 hours * 74 hours max attack time = ~ 8.6%.
+    // How would attack work? Imagine that the market is very volatile currently and that the "true" funding
+    // rate for the next 74 hours is -500%, but a dishonest proposer successfully proposes a rate of +500%
+    // (after a two hour liveness) and disputes honest proposers for the next 72 hours. This results in a funding
+    // rate error of 1000% for 74 hours, until the DVM can set the funding rate back to its correct value.
     function _validateFundingRate(FixedPoint.Signed memory rate) internal view {
-        // Constraining the range of funding rates limits the PfC for any dishonest proposer and enhances the
-        // perpetual's security. For example, let's examine the case where the max and min funding rates
-        // are equivalent to +/- 500%/year. This 1000% funding rate range allows a 8.6% profit from corruption for a
-        // proposer who can deter honest proposers for 74 hours:
-        // 1000%/year / 360 days / 24 hours * 74 hours max attack time = ~ 8.6%.
-        // How would attack work? Imagine that the market is very volatile currently and that the "true" funding
-        // rate for the next 74 hours is -500%, but a dishonest proposer successfully proposes a rate of +500%
-        // (after a two hour liveness) and disputes honest proposers for the next 72 hours. This results in a funding
-        // rate error of 1000% for 74 hours, until the DVM can set the funding rate back to its correct value.
-
         require(
             rate.isLessThanOrEqual(_getConfig().maxFundingRate) &&
                 rate.isGreaterThanOrEqual(_getConfig().minFundingRate)

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -161,8 +161,10 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
 
     // Use this method to constrain values with which you can set ConfigSettings.
     function _validateConfig(ConfigStoreInterface.ConfigSettings memory config) internal pure {
-        // Its hard to ascertain what are reasonable limits, into the future and the past, for proposal timestamps.
-        // So, we do not set any limits.
+        // We don't set limits on proposal timestamps because there are already natural limits:
+        // - Future: price requests to the OptimisticOracle must be in the past (plus some buffer allowing for the time
+        //   that blocks take to get mined).
+        // - Past: proposal times must be after the last update time.
 
         // Make sure timelockLiveness is not too long, otherwise contract can might not be able to fix itself
         // before a vulnerability drains its collateral.

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -42,7 +42,6 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         uint256 timelockLiveness,
         int256 maxFundingRate,
         int256 minFundingRate,
-        uint256 proposalTimeFutureLimit,
         uint256 proposalTimePastLimit,
         uint256 proposalPassedTimestamp
     );
@@ -52,7 +51,6 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         uint256 timelockLiveness,
         int256 maxFundingRate,
         int256 minFundingRate,
-        uint256 proposalTimeFutureLimit,
         uint256 proposalTimePastLimit
     );
 
@@ -118,7 +116,6 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
             newConfig.timelockLiveness,
             newConfig.maxFundingRate.rawValue,
             newConfig.minFundingRate.rawValue,
-            newConfig.proposalTimeFutureLimit,
             newConfig.proposalTimePastLimit,
             pendingPassedTimestamp
         );
@@ -144,7 +141,6 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
                 currentConfig.timelockLiveness,
                 currentConfig.maxFundingRate.rawValue,
                 currentConfig.minFundingRate.rawValue,
-                currentConfig.proposalTimeFutureLimit,
                 currentConfig.proposalTimePastLimit
             );
         }
@@ -162,8 +158,7 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
     // Use this method to constrain values with which you can set ConfigSettings.
     function _validateConfig(ConfigStoreInterface.ConfigSettings memory config) internal pure {
         // We don't set limits on proposal timestamps because there are already natural limits:
-        // - Future: price requests to the OptimisticOracle must be in the past (plus some buffer allowing for the time
-        //   that blocks take to get mined).
+        // - Future: price requests to the OptimisticOracle must be in the past---we can't add further constraints.
         // - Past: proposal times must always be after the last update time, and  a reasonable past limit would be 30
         //   mins, meaning that no proposal timestamp can be more than 30 minutes behind the current time.
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -183,7 +183,8 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         // were to successfully propose a very high or low funding rate, then their PfC would be very high. The proposer
         // could theoretically keep their "evil" funding rate alive for 74 hours by continuously disputing honest
         // proposers, so we would want to be able to set the proposal bond (equal to the dispute bond) high enough to
-        // reduce the proposer's length of attack.
+        // reduce the proposer's length of attack. The downside of not limiting this is that the config store owner
+        // can set it arbitrarily high and preclude a new funding rate from ever coming in.
 
         // We also don't set a limit on the funding rate max/min because we might need to allow very high magnitude
         // funding rates in extraordinarily volatile market situations. Note, that even though we do not bound

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -40,9 +40,17 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         uint256 rewardRate,
         uint256 proposerBond,
         uint256 timelockLiveness,
+        int256 maxFundingRate,
+        int256 minFundingRate,
         uint256 proposalPassedTimestamp
     );
-    event ChangedConfigSettings(uint256 rewardRate, uint256 proposerBond, uint256 timelockLiveness);
+    event ChangedConfigSettings(
+        uint256 rewardRate,
+        uint256 proposerBond,
+        uint256 timelockLiveness,
+        int256 maxFundingRate,
+        int256 minFundingRate
+    );
 
     /****************************************
      *                MODIFIERS             *
@@ -104,6 +112,8 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
             newConfig.rewardRatePerSecond.rawValue,
             newConfig.proposerBondPct.rawValue,
             newConfig.timelockLiveness,
+            newConfig.maxFundingRate.rawValue,
+            newConfig.minFundingRate.rawValue,
             pendingPassedTimestamp
         );
     }
@@ -125,7 +135,9 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
             emit ChangedConfigSettings(
                 currentConfig.rewardRatePerSecond.rawValue,
                 currentConfig.proposerBondPct.rawValue,
-                currentConfig.timelockLiveness
+                currentConfig.timelockLiveness,
+                currentConfig.maxFundingRate.rawValue,
+                currentConfig.minFundingRate.rawValue
             );
         }
     }
@@ -159,5 +171,10 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         // could theoretically keep their "evil" funding rate alive for 74 hours by continuously disputing honest
         // proposers, so we would want to be able to set the proposal bond (equal to the dispute bond) high enough to
         // reduce the proposer's length of attack.
+
+        // We also don't set a limit on the funding rate max/min because we might need to allow very high magnitude
+        // funding rates in extraordinarily volatile market situations. Note, that even though we do not bound
+        // the max/min, we still recommend that the deployer of this contract set the funding rate max/min values
+        // to bound the PfC of a dishonest proposer.
     }
 }

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
@@ -17,8 +17,6 @@ interface ConfigStoreInterface {
         FixedPoint.Signed maxFundingRate;
         // Minimum funding rate % per second that can be proposed.
         FixedPoint.Signed minFundingRate;
-        // Funding rate proposal timestamp cannot be more than this amount of seconds in the future .
-        uint256 proposalTimeFutureLimit;
         // Funding rate proposal timestamp cannot be more than this amount of seconds in the past from the latest
         // update time.
         uint256 proposalTimePastLimit;

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
@@ -13,6 +13,10 @@ interface ConfigStoreInterface {
         FixedPoint.Unsigned rewardRatePerSecond;
         // Bond % (of given contract's PfC) that must be staked by proposers. Percentage of 1, e.g. 0.0005 is 0.05%.
         FixedPoint.Unsigned proposerBondPct;
+        // Maximum funding rate % per second that can be proposed.
+        FixedPoint.Signed maxFundingRate;
+        // Minimum funding rate % per second that can be proposed.
+        FixedPoint.Signed minFundingRate;
     }
 
     function getCurrentConfig() external view returns (ConfigSettings memory);

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -241,7 +241,7 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
 
         tokensLiquidated = FixedPoint.min(maxTokensToLiquidate, positionToLiquidate.tokensOutstanding);
-        require(tokensLiquidated.isGreaterThan(0));
+        require(tokensLiquidated.isGreaterThan(0), "Liquidating 0 tokens");
 
         // Starting values for the Position being liquidated. If withdrawal request amount is > position's collateral,
         // then set this to 0, otherwise set it to (startCollateral - withdrawal request amount).

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -241,7 +241,7 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
         PositionData storage positionToLiquidate = _getPositionData(sponsor);
 
         tokensLiquidated = FixedPoint.min(maxTokensToLiquidate, positionToLiquidate.tokensOutstanding);
-        require(tokensLiquidated.isGreaterThan(0), "Liquidating 0 tokens");
+        require(tokensLiquidated.isGreaterThan(0));
 
         // Starting values for the Position being liquidated. If withdrawal request amount is > position's collateral,
         // then set this to 0, otherwise set it to (startCollateral - withdrawal request amount).

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -279,7 +279,8 @@ contract PerpetualPositionManager is FundingRateApplier {
         PositionData storage positionData = _getPositionData(msg.sender);
         require(
             positionData.withdrawalRequestPassTimestamp != 0 &&
-                positionData.withdrawalRequestPassTimestamp <= getCurrentTime()
+                positionData.withdrawalRequestPassTimestamp <= getCurrentTime(),
+            "Invalid withdraw request"
         );
 
         // If withdrawal request amount is > position collateral, then withdraw the full collateral amount.
@@ -342,7 +343,7 @@ contract PerpetualPositionManager is FundingRateApplier {
             "Insufficient collateral"
         );
 
-        require(positionData.withdrawalRequestPassTimestamp == 0);
+        require(positionData.withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
         if (positionData.tokensOutstanding.isEqual(0)) {
             require(numTokens.isGreaterThanOrEqual(minSponsorTokens), "Below minimum sponsor position");
             emit NewSponsor(msg.sender);
@@ -714,7 +715,10 @@ contract PerpetualPositionManager is FundingRateApplier {
     // unnecessarily increase contract bytecode size.
     // source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
     function _onlyCollateralizedPosition(address sponsor) internal view {
-        require(_getFeeAdjustedCollateral(positions[sponsor].rawCollateral).isGreaterThan(0));
+        require(
+            _getFeeAdjustedCollateral(positions[sponsor].rawCollateral).isGreaterThan(0),
+            "Position has no collateral"
+        );
     }
 
     function _notEmergencyShutdown() internal view {
@@ -731,7 +735,7 @@ contract PerpetualPositionManager is FundingRateApplier {
     // `create` method because it is possible that `create` is called on a new position (i.e. one without any collateral
     // or tokens outstanding) which would fail the `onlyCollateralizedPosition` modifier on `_getPositionData`.
     function _positionHasNoPendingWithdrawal(address sponsor) internal view {
-        require(_getPositionData(sponsor).withdrawalRequestPassTimestamp == 0);
+        require(_getPositionData(sponsor).withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
     }
 
     /****************************************

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -184,7 +184,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         fees()
         nonReentrant()
     {
-        require(collateralAmount.isGreaterThan(0));
+        require(collateralAmount.isGreaterThan(0), "Invalid collateral amount");
         PositionData storage positionData = _getPositionData(sponsor);
 
         // Increase the position and global collateral balance by collateral amount.
@@ -223,7 +223,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         returns (FixedPoint.Unsigned memory amountWithdrawn)
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(collateralAmount.isGreaterThan(0));
+        require(collateralAmount.isGreaterThan(0), "Invalid collateral amount");
 
         // Decrement the sponsor's collateral and global collateral amounts. Check the GCR between decrement to ensure
         // position remains above the GCR within the witdrawl. If this is not the case the caller must submit a request.
@@ -252,7 +252,8 @@ contract PerpetualPositionManager is FundingRateApplier {
         PositionData storage positionData = _getPositionData(msg.sender);
         require(
             collateralAmount.isGreaterThan(0) &&
-                collateralAmount.isLessThanOrEqual(_getFeeAdjustedCollateral(positionData.rawCollateral))
+                collateralAmount.isLessThanOrEqual(_getFeeAdjustedCollateral(positionData.rawCollateral)),
+            "Invalid collateral amount"
         );
 
         // Update the position object for the user.
@@ -384,7 +385,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         returns (FixedPoint.Unsigned memory amountWithdrawn)
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(numTokens.isLessThanOrEqual(positionData.tokensOutstanding));
+        require(numTokens.isLessThanOrEqual(positionData.tokensOutstanding), "Invalid token amount");
 
         FixedPoint.Unsigned memory fractionRedeemed = numTokens.div(positionData.tokensOutstanding);
         FixedPoint.Unsigned memory collateralRedeemed =

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -184,7 +184,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         fees()
         nonReentrant()
     {
-        require(collateralAmount.isGreaterThan(0), "Invalid collateral amount");
+        require(collateralAmount.isGreaterThan(0));
         PositionData storage positionData = _getPositionData(sponsor);
 
         // Increase the position and global collateral balance by collateral amount.
@@ -223,7 +223,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         returns (FixedPoint.Unsigned memory amountWithdrawn)
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(collateralAmount.isGreaterThan(0), "Invalid collateral amount");
+        require(collateralAmount.isGreaterThan(0));
 
         // Decrement the sponsor's collateral and global collateral amounts. Check the GCR between decrement to ensure
         // position remains above the GCR within the witdrawl. If this is not the case the caller must submit a request.
@@ -252,8 +252,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         PositionData storage positionData = _getPositionData(msg.sender);
         require(
             collateralAmount.isGreaterThan(0) &&
-                collateralAmount.isLessThanOrEqual(_getFeeAdjustedCollateral(positionData.rawCollateral)),
-            "Invalid collateral amount"
+                collateralAmount.isLessThanOrEqual(_getFeeAdjustedCollateral(positionData.rawCollateral))
         );
 
         // Update the position object for the user.
@@ -280,8 +279,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         PositionData storage positionData = _getPositionData(msg.sender);
         require(
             positionData.withdrawalRequestPassTimestamp != 0 &&
-                positionData.withdrawalRequestPassTimestamp <= getCurrentTime(),
-            "Invalid withdraw request"
+                positionData.withdrawalRequestPassTimestamp <= getCurrentTime()
         );
 
         // If withdrawal request amount is > position collateral, then withdraw the full collateral amount.
@@ -344,7 +342,7 @@ contract PerpetualPositionManager is FundingRateApplier {
             "Insufficient collateral"
         );
 
-        require(positionData.withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
+        require(positionData.withdrawalRequestPassTimestamp == 0);
         if (positionData.tokensOutstanding.isEqual(0)) {
             require(numTokens.isGreaterThanOrEqual(minSponsorTokens), "Below minimum sponsor position");
             emit NewSponsor(msg.sender);
@@ -385,7 +383,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         returns (FixedPoint.Unsigned memory amountWithdrawn)
     {
         PositionData storage positionData = _getPositionData(msg.sender);
-        require(numTokens.isLessThanOrEqual(positionData.tokensOutstanding), "Invalid token amount");
+        require(numTokens.isLessThanOrEqual(positionData.tokensOutstanding));
 
         FixedPoint.Unsigned memory fractionRedeemed = numTokens.div(positionData.tokensOutstanding);
         FixedPoint.Unsigned memory collateralRedeemed =
@@ -716,10 +714,7 @@ contract PerpetualPositionManager is FundingRateApplier {
     // unnecessarily increase contract bytecode size.
     // source: https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6
     function _onlyCollateralizedPosition(address sponsor) internal view {
-        require(
-            _getFeeAdjustedCollateral(positions[sponsor].rawCollateral).isGreaterThan(0),
-            "Position has no collateral"
-        );
+        require(_getFeeAdjustedCollateral(positions[sponsor].rawCollateral).isGreaterThan(0));
     }
 
     function _notEmergencyShutdown() internal view {
@@ -736,7 +731,7 @@ contract PerpetualPositionManager is FundingRateApplier {
     // `create` method because it is possible that `create` is called on a new position (i.e. one without any collateral
     // or tokens outstanding) which would fail the `onlyCollateralizedPosition` modifier on `_getPositionData`.
     function _positionHasNoPendingWithdrawal(address sponsor) internal view {
-        require(_getPositionData(sponsor).withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
+        require(_getPositionData(sponsor).withdrawalRequestPassTimestamp == 0);
     }
 
     /****************************************

--- a/packages/core/test/financial-templates/common/FundingRateApplier.js
+++ b/packages/core/test/financial-templates/common/FundingRateApplier.js
@@ -198,7 +198,7 @@ contract("FundingRateApplier", function(accounts) {
   });
 
   it("Proposal time checks", async () => {
-    const newRate = { rawValue: toWei("-0.0001") };
+    const newRate = { rawValue: toWei("-0.000001") };
 
     // Cannot be at or before the last update time.
     assert(await didContractThrow(fundingRateApplier.proposeNewRate(newRate, startTime)));

--- a/packages/core/test/financial-templates/common/FundingRateApplier.js
+++ b/packages/core/test/financial-templates/common/FundingRateApplier.js
@@ -40,7 +40,6 @@ contract("FundingRateApplier", function(accounts) {
   const maxFundingRate = toWei("0.00001");
   const minFundingRate = toWei("-0.00001");
   const tokenScaling = toWei("1");
-  const proposalTimeFutureLimit = 90;
   const proposalTimePastLimit = 1800; // 30 mins.
   const delay = 10000; // 10_000 seconds.
   let startTime;
@@ -105,7 +104,6 @@ contract("FundingRateApplier", function(accounts) {
         proposerBondPct: { rawValue: bondPercentage },
         maxFundingRate: { rawValue: maxFundingRate },
         minFundingRate: { rawValue: minFundingRate },
-        proposalTimeFutureLimit: proposalTimeFutureLimit,
         proposalTimePastLimit: proposalTimePastLimit // 30 mins
       },
       timer.address
@@ -225,10 +223,8 @@ contract("FundingRateApplier", function(accounts) {
     // Time must be within the past and future bounds around the current time.
     assert(await didContractThrow(fundingRateApplier.proposeNewRate(newRate, currentTime - proposalTimePastLimit - 1)));
     await fundingRateApplier.proposeNewRate.call(newRate, currentTime - proposalTimePastLimit);
-    assert(
-      await didContractThrow(fundingRateApplier.proposeNewRate(newRate, currentTime + proposalTimeFutureLimit + 1))
-    );
-    await fundingRateApplier.proposeNewRate(newRate, currentTime + proposalTimeFutureLimit);
+    assert(await didContractThrow(fundingRateApplier.proposeNewRate(newRate, currentTime + 1)));
+    await fundingRateApplier.proposeNewRate(newRate, currentTime);
   });
 
   describe("Undisputed proposal", async () => {

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -31,7 +31,6 @@ contract("ConfigStore", function(accounts) {
     proposerBondPct: { rawValue: toWei("0.0001") },
     maxFundingRate: { rawValue: toWei("0.00001") },
     minFundingRate: { rawValue: toWei("-0.00001") },
-    proposalTimeFutureLimit: 90,
     proposalTimePastLimit: 1800 // 30 mins
   };
   let defaultConfig = {
@@ -40,7 +39,6 @@ contract("ConfigStore", function(accounts) {
     proposerBondPct: { rawValue: "0" },
     maxFundingRate: { rawValue: toWei("0") },
     minFundingRate: { rawValue: toWei("0") },
-    proposalTimeFutureLimit: 0,
     proposalTimePastLimit: 0
   };
 
@@ -54,7 +52,6 @@ contract("ConfigStore", function(accounts) {
     assert.equal(currentConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
     assert.equal(currentConfig.maxFundingRate.rawValue.toString(), _inputConfig.maxFundingRate.rawValue.toString());
     assert.equal(currentConfig.minFundingRate.rawValue.toString(), _inputConfig.minFundingRate.rawValue.toString());
-    assert.equal(currentConfig.proposalTimeFutureLimit.toString(), _inputConfig.proposalTimeFutureLimit.toString());
     assert.equal(currentConfig.proposalTimePastLimit.toString(), _inputConfig.proposalTimePastLimit.toString());
   }
 
@@ -68,7 +65,6 @@ contract("ConfigStore", function(accounts) {
     assert.equal(pendingConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
     assert.equal(pendingConfig.maxFundingRate.rawValue.toString(), _inputConfig.maxFundingRate.rawValue.toString());
     assert.equal(pendingConfig.minFundingRate.rawValue.toString(), _inputConfig.minFundingRate.rawValue.toString());
-    assert.equal(pendingConfig.proposalTimeFutureLimit.toString(), _inputConfig.proposalTimeFutureLimit.toString());
     assert.equal(pendingConfig.proposalTimePastLimit.toString(), _inputConfig.proposalTimePastLimit.toString());
   }
 
@@ -89,7 +85,6 @@ contract("ConfigStore", function(accounts) {
       assert.equal(config.proposerBondPct.rawValue.toString(), testConfig.proposerBondPct.rawValue);
       assert.equal(config.maxFundingRate.rawValue.toString(), testConfig.maxFundingRate.rawValue.toString());
       assert.equal(config.minFundingRate.rawValue.toString(), testConfig.minFundingRate.rawValue.toString());
-      assert.equal(config.proposalTimeFutureLimit.toString(), testConfig.proposalTimeFutureLimit.toString());
       assert.equal(config.proposalTimePastLimit.toString(), testConfig.proposalTimePastLimit.toString());
       await storeHasNoPendingConfig(configStore);
     });
@@ -129,7 +124,6 @@ contract("ConfigStore", function(accounts) {
           ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
           ev.maxFundingRate.toString() === testConfig.maxFundingRate.rawValue &&
           ev.minFundingRate.toString() === testConfig.minFundingRate.rawValue &&
-          ev.proposalTimeFutureLimit.toString() === testConfig.proposalTimeFutureLimit.toString() &&
           ev.proposalTimePastLimit.toString() === testConfig.proposalTimePastLimit.toString()
         );
       });
@@ -145,7 +139,6 @@ contract("ConfigStore", function(accounts) {
           ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
           ev.maxFundingRate.toString() === testConfig.maxFundingRate.rawValue &&
           ev.minFundingRate.toString() === testConfig.minFundingRate.rawValue &&
-          ev.proposalTimeFutureLimit.toString() === testConfig.proposalTimeFutureLimit.toString() &&
           ev.proposalTimePastLimit.toString() === testConfig.proposalTimePastLimit.toString()
         );
       });
@@ -168,7 +161,6 @@ contract("ConfigStore", function(accounts) {
           ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
           ev.maxFundingRate.toString() === testConfig.maxFundingRate.rawValue &&
           ev.minFundingRate.toString() === testConfig.minFundingRate.rawValue &&
-          ev.proposalTimeFutureLimit.toString() === testConfig.proposalTimeFutureLimit.toString() &&
           ev.proposalTimePastLimit.toString() === testConfig.proposalTimePastLimit.toString()
         );
       });
@@ -210,7 +202,6 @@ contract("ConfigStore", function(accounts) {
             overwriteProposalTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
           ev.maxFundingRate.toString() === test2Config.maxFundingRate.rawValue &&
           ev.minFundingRate.toString() === test2Config.minFundingRate.rawValue &&
-          ev.proposalTimeFutureLimit.toString() === test2Config.proposalTimeFutureLimit.toString() &&
           ev.proposalTimePastLimit.toString() === test2Config.proposalTimePastLimit.toString()
         );
       });
@@ -244,7 +235,6 @@ contract("ConfigStore", function(accounts) {
           ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString() &&
           ev.maxFundingRate.toString() === test2Config.maxFundingRate.rawValue &&
           ev.minFundingRate.toString() === test2Config.minFundingRate.rawValue &&
-          ev.proposalTimeFutureLimit.toString() === test2Config.proposalTimeFutureLimit.toString() &&
           ev.proposalTimePastLimit.toString() === test2Config.proposalTimePastLimit.toString()
         );
       });

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -28,12 +28,16 @@ contract("ConfigStore", function(accounts) {
   let testConfig = {
     timelockLiveness: 86401, // 1 day + 1 second
     rewardRatePerSecond: { rawValue: toWei("0.000001") },
-    proposerBondPct: { rawValue: toWei("0.0001") }
+    proposerBondPct: { rawValue: toWei("0.0001") },
+    maxFundingRate: { rawValue: toWei("0.00001") },
+    minFundingRate: { rawValue: toWei("-0.00001") }
   };
   let defaultConfig = {
     timelockLiveness: 86400, // 1 day
     rewardRatePerSecond: { rawValue: "0" },
-    proposerBondPct: { rawValue: "0" }
+    proposerBondPct: { rawValue: "0" },
+    maxFundingRate: { rawValue: toWei("0") },
+    minFundingRate: { rawValue: toWei("0") }
   };
 
   async function currentConfigMatchesInput(_store, _inputConfig) {
@@ -44,6 +48,8 @@ contract("ConfigStore", function(accounts) {
       _inputConfig.rewardRatePerSecond.rawValue.toString()
     );
     assert.equal(currentConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
+    assert.equal(currentConfig.maxFundingRate.rawValue.toString(), _inputConfig.maxFundingRate.rawValue.toString());
+    assert.equal(currentConfig.minFundingRate.rawValue.toString(), _inputConfig.minFundingRate.rawValue.toString());
   }
 
   async function pendingConfigMatchesInput(_store, _inputConfig) {
@@ -54,6 +60,8 @@ contract("ConfigStore", function(accounts) {
       _inputConfig.rewardRatePerSecond.rawValue.toString()
     );
     assert.equal(pendingConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
+    assert.equal(pendingConfig.maxFundingRate.rawValue.toString(), _inputConfig.maxFundingRate.rawValue.toString());
+    assert.equal(pendingConfig.minFundingRate.rawValue.toString(), _inputConfig.minFundingRate.rawValue.toString());
   }
 
   async function storeHasNoPendingConfig(_store) {
@@ -71,6 +79,8 @@ contract("ConfigStore", function(accounts) {
       assert.equal(config.timelockLiveness.toString(), testConfig.timelockLiveness.toString());
       assert.equal(config.rewardRatePerSecond.rawValue.toString(), testConfig.rewardRatePerSecond.rawValue);
       assert.equal(config.proposerBondPct.rawValue.toString(), testConfig.proposerBondPct.rawValue);
+      assert.equal(config.maxFundingRate.rawValue.toString(), testConfig.maxFundingRate.rawValue.toString());
+      assert.equal(config.minFundingRate.rawValue.toString(), testConfig.minFundingRate.rawValue.toString());
       await storeHasNoPendingConfig(configStore);
     });
     it("Invalid default values revert on construction", async function() {
@@ -106,7 +116,9 @@ contract("ConfigStore", function(accounts) {
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
           ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
-          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString()
+          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
+          ev.maxFundingRate.toString() === testConfig.maxFundingRate.rawValue &&
+          ev.minFundingRate.toString() === testConfig.minFundingRate.rawValue
         );
       });
       await incrementTime(configStore, defaultConfig.timelockLiveness);
@@ -118,7 +130,9 @@ contract("ConfigStore", function(accounts) {
         return (
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
-          ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString()
+          ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
+          ev.maxFundingRate.toString() === testConfig.maxFundingRate.rawValue &&
+          ev.minFundingRate.toString() === testConfig.minFundingRate.rawValue
         );
       });
 
@@ -137,7 +151,9 @@ contract("ConfigStore", function(accounts) {
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
           ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
-          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString()
+          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
+          ev.maxFundingRate.toString() === testConfig.maxFundingRate.rawValue &&
+          ev.minFundingRate.toString() === testConfig.minFundingRate.rawValue
         );
       });
 
@@ -175,7 +191,9 @@ contract("ConfigStore", function(accounts) {
           ev.proposerBond.toString() === test2Config.proposerBondPct.rawValue &&
           ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString() &&
           ev.proposalPassedTimestamp.toString() ===
-            overwriteProposalTime.add(toBN(defaultConfig.timelockLiveness)).toString()
+            overwriteProposalTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
+          ev.maxFundingRate.toString() === test2Config.maxFundingRate.rawValue &&
+          ev.minFundingRate.toString() === test2Config.minFundingRate.rawValue
         );
       });
       await currentConfigMatchesInput(configStore, defaultConfig);
@@ -205,7 +223,9 @@ contract("ConfigStore", function(accounts) {
         return (
           ev.rewardRate.toString() === test2Config.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === test2Config.proposerBondPct.rawValue &&
-          ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString()
+          ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString() &&
+          ev.maxFundingRate.toString() === test2Config.maxFundingRate.rawValue &&
+          ev.minFundingRate.toString() === test2Config.minFundingRate.rawValue
         );
       });
       await storeHasNoPendingConfig(configStore);

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -87,13 +87,6 @@ contract("ConfigStore", function(accounts) {
         rewardRatePerSecond: { rawValue: toWei("0.00000331") }
       };
       assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
-
-      // Invalid proposal bond
-      invalidConfig = {
-        ...testConfig,
-        proposerBondPct: { rawValue: toWei("0.00041") }
-      };
-      assert(await didContractThrow(ConfigStore.new(invalidConfig, timer.address)));
     });
   });
   describe("Proposing a new configuration", function() {

--- a/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
@@ -25,7 +25,9 @@ contract("Perpetual", function(accounts) {
       {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: "0" },
-        proposerBondPct: { rawValue: "0" }
+        proposerBondPct: { rawValue: "0" },
+        maxFundingRate: { rawValue: "0" },
+        minFundingRate: { rawValue: "0" }
       },
       timer.address
     );

--- a/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
@@ -28,7 +28,6 @@ contract("Perpetual", function(accounts) {
         proposerBondPct: { rawValue: "0" },
         maxFundingRate: { rawValue: "0" },
         minFundingRate: { rawValue: "0" },
-        proposalTimeFutureLimit: 0,
         proposalTimePastLimit: 0
       },
       timer.address

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
@@ -33,7 +33,6 @@ contract("PerpetualCreator", function(accounts) {
     proposerBondPct: { rawValue: toWei("0.0001") },
     maxFundingRate: { rawValue: toWei("0.00001") },
     minFundingRate: { rawValue: toWei("-0.00001") },
-    proposalTimeFutureLimit: 90,
     proposalTimePastLimit: 1800
   };
 

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
@@ -26,10 +26,13 @@ contract("PerpetualCreator", function(accounts) {
   let collateralTokenWhitelist;
   // Re-used variables
   let constructorParams;
+
   let testConfig = {
     timelockLiveness: 86400, // 1 day
     rewardRatePerSecond: { rawValue: toWei("0.000001") },
-    proposerBondPct: { rawValue: toWei("0.0001") }
+    proposerBondPct: { rawValue: toWei("0.0001") },
+    maxFundingRate: { rawValue: toWei("0.00001") },
+    minFundingRate: { rawValue: toWei("-0.00001") }
   };
 
   beforeEach(async () => {
@@ -318,5 +321,24 @@ contract("PerpetualCreator", function(accounts) {
 
     let configStore = await ConfigStore.at(configStoreAddress);
     assert.equal(await configStore.owner(), contractCreator);
+  });
+  it("Funding rate bounds are set correctly", async function() {
+    let createdAddressResult = await perpetualCreator.createPerpetual(constructorParams, testConfig, {
+      from: contractCreator
+    });
+
+    let perpetualAddress;
+    truffleAssert.eventEmitted(createdAddressResult, "CreatedPerpetual", ev => {
+      perpetualAddress = ev.perpetualAddress;
+      return ev.perpetualAddress != 0 && ev.deployerAddress == contractCreator;
+    });
+    let perpetual = await Perpetual.at(perpetualAddress);
+
+    const currentTime = (await perpetual.getCurrentTime()).toNumber();
+    assert(
+      await didContractThrow(
+        perpetual.proposeNewRate({ rawValue: toWei("0.00002") }, currentTime, { from: contractCreator })
+      )
+    );
   });
 });

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
@@ -55,8 +55,8 @@ contract("PerpetualLiquidatable", function(accounts) {
     .muln(3); // In seconds
   const startTime = "15798990420";
   const minSponsorTokens = toBN(toWei("1"));
-  const maxFundingRate = toWei("0.00001");
-  const minFundingRate = toWei("-0.00001");
+  const maxFundingRate = toWei("0");
+  const minFundingRate = toWei("0");
 
   // Synthetic Token Position contract params
   const withdrawalLiveness = toBN(60)

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
@@ -144,7 +144,6 @@ contract("PerpetualLiquidatable", function(accounts) {
         proposerBondPct: { rawValue: "0" },
         maxFundingRate: { rawValue: maxFundingRate },
         minFundingRate: { rawValue: minFundingRate },
-        proposalTimeFutureLimit: 0,
         proposalTimePastLimit: 0
       },
       timer.address

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
@@ -55,8 +55,8 @@ contract("PerpetualLiquidatable", function(accounts) {
     .muln(3); // In seconds
   const startTime = "15798990420";
   const minSponsorTokens = toBN(toWei("1"));
-  const maxFundingRate = toWei("0");
-  const minFundingRate = toWei("0");
+  const maxFundingRate = toWei("0.00001");
+  const minFundingRate = toWei("-0.00001");
 
   // Synthetic Token Position contract params
   const withdrawalLiveness = toBN(60)

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
@@ -55,6 +55,8 @@ contract("PerpetualLiquidatable", function(accounts) {
     .muln(3); // In seconds
   const startTime = "15798990420";
   const minSponsorTokens = toBN(toWei("1"));
+  const maxFundingRate = toWei("0.00001");
+  const minFundingRate = toWei("-0.00001");
 
   // Synthetic Token Position contract params
   const withdrawalLiveness = toBN(60)
@@ -139,7 +141,9 @@ contract("PerpetualLiquidatable", function(accounts) {
       {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: "0" },
-        proposerBondPct: { rawValue: "0" }
+        proposerBondPct: { rawValue: "0" },
+        maxFundingRate: { rawValue: maxFundingRate },
+        minFundingRate: { rawValue: minFundingRate }
       },
       timer.address
     );

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -127,7 +127,6 @@ contract("PerpetualPositionManager", function(accounts) {
         proposerBondPct: { rawValue: "0" },
         maxFundingRate: { rawValue: maxFundingRate },
         minFundingRate: { rawValue: minFundingRate },
-        proposalTimeFutureLimit: 0,
         proposalTimePastLimit: 0
       },
       timer.address
@@ -184,7 +183,6 @@ contract("PerpetualPositionManager", function(accounts) {
       proposerBondPct: { rawValue: "0" },
       maxFundingRate: { rawValue: maxFundingRate },
       minFundingRate: { rawValue: minFundingRate },
-      proposalTimeFutureLimit: 0,
       proposalTimePastLimit: 0
     });
 
@@ -815,7 +813,6 @@ contract("PerpetualPositionManager", function(accounts) {
       proposerBondPct: { rawValue: "0" },
       maxFundingRate: { rawValue: maxFundingRate },
       minFundingRate: { rawValue: minFundingRate },
-      proposalTimeFutureLimit: 0,
       proposalTimePastLimit: 0
     });
     await setFundingRateAndAdvanceTime("0");

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -828,12 +828,12 @@ contract("PerpetualPositionManager", function(accounts) {
     const currentTime = (await positionManager.getCurrentTime()).toNumber();
     assert(
       await didContractThrow(
-        positionManager.proposeNewRate({ rawValue: toWei("0.00001") }, currentTime, { from: proposer })
+        positionManager.proposeNewRate({ rawValue: toWei("0.00002") }, currentTime, { from: proposer })
       )
     );
     assert(
       await didContractThrow(
-        positionManager.proposeNewRate({ rawValue: toWei("-0.00001") }, currentTime, { from: proposer })
+        positionManager.proposeNewRate({ rawValue: toWei("-0.00002") }, currentTime, { from: proposer })
       )
     );
   });

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -50,8 +50,8 @@ contract("PerpetualPositionManager", function(accounts) {
   const priceFeedIdentifier = utf8ToHex("TEST_IDENTIIFER");
   const fundingRateRewardRate = toWei("0.000001");
   const fundingRateFeedIdentifier = utf8ToHex("TEST_FUNDING_IDENTIFIER"); // example identifier for funding rate.
-  const maxFundingRate = toWei("0.00001");
-  const minFundingRate = toWei("-0.00001");
+  const maxFundingRate = toWei("0");
+  const minFundingRate = toWei("0");
   const minSponsorTokens = "5";
 
   // Conveniently asserts expected collateral and token balances, assuming that

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -50,8 +50,8 @@ contract("PerpetualPositionManager", function(accounts) {
   const priceFeedIdentifier = utf8ToHex("TEST_IDENTIIFER");
   const fundingRateRewardRate = toWei("0.000001");
   const fundingRateFeedIdentifier = utf8ToHex("TEST_FUNDING_IDENTIFIER"); // example identifier for funding rate.
-  const maxFundingRate = toWei("0");
-  const minFundingRate = toWei("0");
+  const maxFundingRate = toWei("0.00001");
+  const minFundingRate = toWei("-0.00001");
   const minSponsorTokens = "5";
 
   // Conveniently asserts expected collateral and token balances, assuming that

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -50,6 +50,8 @@ contract("PerpetualPositionManager", function(accounts) {
   const priceFeedIdentifier = utf8ToHex("TEST_IDENTIIFER");
   const fundingRateRewardRate = toWei("0.000001");
   const fundingRateFeedIdentifier = utf8ToHex("TEST_FUNDING_IDENTIFIER"); // example identifier for funding rate.
+  const maxFundingRate = toWei("0.00001");
+  const minFundingRate = toWei("-0.00001");
   const minSponsorTokens = "5";
 
   // Conveniently asserts expected collateral and token balances, assuming that
@@ -122,7 +124,9 @@ contract("PerpetualPositionManager", function(accounts) {
       {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: "0" },
-        proposerBondPct: { rawValue: "0" }
+        proposerBondPct: { rawValue: "0" },
+        maxFundingRate: { rawValue: maxFundingRate },
+        minFundingRate: { rawValue: minFundingRate }
       },
       timer.address
     );
@@ -175,7 +179,9 @@ contract("PerpetualPositionManager", function(accounts) {
     await setNewConfig({
       timelockLiveness: 86400, // 1 day
       rewardRatePerSecond: { rawValue: fundingRateRewardRate },
-      proposerBondPct: { rawValue: "0" }
+      proposerBondPct: { rawValue: "0" },
+      maxFundingRate: { rawValue: maxFundingRate },
+      minFundingRate: { rawValue: minFundingRate }
     });
 
     // The total time elapsed to publish the proposal is 5 seconds, so let's set the regular fee to 20%/second.
@@ -802,7 +808,9 @@ contract("PerpetualPositionManager", function(accounts) {
     await setNewConfig({
       timelockLiveness: 86400, // 1 day
       rewardRatePerSecond: { rawValue: fundingRateRewardRate },
-      proposerBondPct: { rawValue: "0" }
+      proposerBondPct: { rawValue: "0" },
+      maxFundingRate: { rawValue: maxFundingRate },
+      minFundingRate: { rawValue: minFundingRate }
     });
     await setFundingRateAndAdvanceTime("0");
     await positionManager.applyFundingRate();

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -831,21 +831,6 @@ contract("PerpetualPositionManager", function(accounts) {
     assert.equal((await collateral.balanceOf(proposer)).toString(), toWei("0.02"));
   });
 
-  it("Funding rate proposal must be within limits", async function() {
-    // Max/min funding rate per second is [< +1e-5, > -1e-5].
-    const currentTime = (await positionManager.getCurrentTime()).toNumber();
-    assert(
-      await didContractThrow(
-        positionManager.proposeNewRate({ rawValue: toWei("0.00002") }, currentTime, { from: proposer })
-      )
-    );
-    assert(
-      await didContractThrow(
-        positionManager.proposeNewRate({ rawValue: toWei("-0.00002") }, currentTime, { from: proposer })
-      )
-    );
-  });
-
   it("Basic oracle fees", async function() {
     // Set up position.
     await collateral.approve(positionManager.address, toWei("1000"), { from: other });


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2259 This enhances the Perpetual's economic security by allowing the Perpetual contract deployer to set funding rate bounds via timelock.

Changes:
- Adds config params to limit the range of possible funding rates to propose. This bounds a dishonest proposer's PfC
- Remove bounds from proposer bound, which can be changed to limit a proposer's PfC based on the funding rate.
- Remove future time limit from proposer timestamp, OptimisticOracles must be in the past starting with #2267


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2259 
