### PR TITLE
improve(perpetual) move proposal time bounds into config store

### DIFF
--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -155,7 +155,9 @@ abstract contract FundingRateApplier is FeePayer {
         uint256 currentTime = getCurrentTime();
         uint256 updateTime = fundingRate.updateTime;
         require(
-            timestamp > updateTime && timestamp >= currentTime.sub(30 minutes) && timestamp <= currentTime.add(90),
+            timestamp > updateTime &&
+                timestamp >= currentTime.sub(_getConfig().proposalTimePastLimit) &&
+                timestamp <= currentTime.add(_getConfig().proposalTimeFutureLimit),
             "Invalid proposal time"
         );
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -40,9 +40,17 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
         uint256 rewardRate,
         uint256 proposerBond,
         uint256 timelockLiveness,
+        uint256 proposalTimeFutureLimit,
+        uint256 proposalTimePastLimit,
         uint256 proposalPassedTimestamp
     );
-    event ChangedConfigSettings(uint256 rewardRate, uint256 proposerBond, uint256 timelockLiveness);
+    event ChangedConfigSettings(
+        uint256 rewardRate,
+        uint256 proposerBond,
+        uint256 timelockLiveness,
+        uint256 proposalTimeFutureLimit,
+        uint256 proposalTimePastLimit
+    );
 
     /****************************************
      *                MODIFIERS             *
@@ -104,6 +112,8 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
             newConfig.rewardRatePerSecond.rawValue,
             newConfig.proposerBondPct.rawValue,
             newConfig.timelockLiveness,
+            newConfig.proposalTimeFutureLimit,
+            newConfig.proposalTimePastLimit,
             pendingPassedTimestamp
         );
     }
@@ -125,7 +135,9 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
             emit ChangedConfigSettings(
                 currentConfig.rewardRatePerSecond.rawValue,
                 currentConfig.proposerBondPct.rawValue,
-                currentConfig.timelockLiveness
+                currentConfig.timelockLiveness,
+                currentConfig.proposalTimeFutureLimit,
+                currentConfig.proposalTimePastLimit
             );
         }
     }
@@ -141,6 +153,9 @@ contract ConfigStore is ConfigStoreInterface, Testable, Lockable, Ownable {
 
     // Use this method to constrain values with which you can set ConfigSettings.
     function _validateConfig(ConfigStoreInterface.ConfigSettings memory config) internal pure {
+        // Its hard to ascertain what are reasonable limits, into the future and the past, for proposal timestamps.
+        // So, we do not set any limits.
+
         // Make sure timelockLiveness is not too long, otherwise contract can might not be able to fix itself
         // before a vulnerability drains its collateral.
         require(config.timelockLiveness <= 7 days && config.timelockLiveness >= 1 days, "Invalid timelockLiveness");

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
@@ -13,6 +13,11 @@ interface ConfigStoreInterface {
         FixedPoint.Unsigned rewardRatePerSecond;
         // Bond % (of given contract's PfC) that must be staked by proposers. Percentage of 1, e.g. 0.0005 is 0.05%.
         FixedPoint.Unsigned proposerBondPct;
+        // Funding rate proposal timestamp cannot be more than this amount of seconds in the future .
+        uint256 proposalTimeFutureLimit;
+        // Funding rate proposal timestamp cannot be more than this amount of seconds in the past from the latest
+        // update time.
+        uint256 proposalTimePastLimit;
     }
 
     function getCurrentConfig() external view returns (ConfigSettings memory);

--- a/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/ConfigStore.js
@@ -28,12 +28,16 @@ contract("ConfigStore", function(accounts) {
   let testConfig = {
     timelockLiveness: 86401, // 1 day + 1 second
     rewardRatePerSecond: { rawValue: toWei("0.000001") },
-    proposerBondPct: { rawValue: toWei("0.0001") }
+    proposerBondPct: { rawValue: toWei("0.0001") },
+    proposalTimeFutureLimit: 90,
+    proposalTimePastLimit: 1800 // 30 mins
   };
   let defaultConfig = {
     timelockLiveness: 86400, // 1 day
     rewardRatePerSecond: { rawValue: "0" },
-    proposerBondPct: { rawValue: "0" }
+    proposerBondPct: { rawValue: "0" },
+    proposalTimeFutureLimit: 0,
+    proposalTimePastLimit: 0
   };
 
   async function currentConfigMatchesInput(_store, _inputConfig) {
@@ -44,6 +48,8 @@ contract("ConfigStore", function(accounts) {
       _inputConfig.rewardRatePerSecond.rawValue.toString()
     );
     assert.equal(currentConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
+    assert.equal(currentConfig.proposalTimeFutureLimit.toString(), _inputConfig.proposalTimeFutureLimit.toString());
+    assert.equal(currentConfig.proposalTimePastLimit.toString(), _inputConfig.proposalTimePastLimit.toString());
   }
 
   async function pendingConfigMatchesInput(_store, _inputConfig) {
@@ -54,6 +60,8 @@ contract("ConfigStore", function(accounts) {
       _inputConfig.rewardRatePerSecond.rawValue.toString()
     );
     assert.equal(pendingConfig.proposerBondPct.rawValue.toString(), _inputConfig.proposerBondPct.rawValue.toString());
+    assert.equal(pendingConfig.proposalTimeFutureLimit.toString(), _inputConfig.proposalTimeFutureLimit.toString());
+    assert.equal(pendingConfig.proposalTimePastLimit.toString(), _inputConfig.proposalTimePastLimit.toString());
   }
 
   async function storeHasNoPendingConfig(_store) {
@@ -71,6 +79,8 @@ contract("ConfigStore", function(accounts) {
       assert.equal(config.timelockLiveness.toString(), testConfig.timelockLiveness.toString());
       assert.equal(config.rewardRatePerSecond.rawValue.toString(), testConfig.rewardRatePerSecond.rawValue);
       assert.equal(config.proposerBondPct.rawValue.toString(), testConfig.proposerBondPct.rawValue);
+      assert.equal(config.proposalTimeFutureLimit.toString(), testConfig.proposalTimeFutureLimit.toString());
+      assert.equal(config.proposalTimePastLimit.toString(), testConfig.proposalTimePastLimit.toString());
       await storeHasNoPendingConfig(configStore);
     });
     it("Invalid default values revert on construction", async function() {
@@ -113,7 +123,9 @@ contract("ConfigStore", function(accounts) {
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
           ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
-          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString()
+          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
+          ev.proposalTimeFutureLimit.toString() === testConfig.proposalTimeFutureLimit.toString() &&
+          ev.proposalTimePastLimit.toString() === testConfig.proposalTimePastLimit.toString()
         );
       });
       await incrementTime(configStore, defaultConfig.timelockLiveness);
@@ -125,7 +137,9 @@ contract("ConfigStore", function(accounts) {
         return (
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
-          ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString()
+          ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
+          ev.proposalTimeFutureLimit.toString() === testConfig.proposalTimeFutureLimit.toString() &&
+          ev.proposalTimePastLimit.toString() === testConfig.proposalTimePastLimit.toString()
         );
       });
 
@@ -144,7 +158,9 @@ contract("ConfigStore", function(accounts) {
           ev.rewardRate.toString() === testConfig.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === testConfig.proposerBondPct.rawValue &&
           ev.timelockLiveness.toString() === testConfig.timelockLiveness.toString() &&
-          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString()
+          ev.proposalPassedTimestamp.toString() === proposeTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
+          ev.proposalTimeFutureLimit.toString() === testConfig.proposalTimeFutureLimit.toString() &&
+          ev.proposalTimePastLimit.toString() === testConfig.proposalTimePastLimit.toString()
         );
       });
 
@@ -182,7 +198,9 @@ contract("ConfigStore", function(accounts) {
           ev.proposerBond.toString() === test2Config.proposerBondPct.rawValue &&
           ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString() &&
           ev.proposalPassedTimestamp.toString() ===
-            overwriteProposalTime.add(toBN(defaultConfig.timelockLiveness)).toString()
+            overwriteProposalTime.add(toBN(defaultConfig.timelockLiveness)).toString() &&
+          ev.proposalTimeFutureLimit.toString() === test2Config.proposalTimeFutureLimit.toString() &&
+          ev.proposalTimePastLimit.toString() === test2Config.proposalTimePastLimit.toString()
         );
       });
       await currentConfigMatchesInput(configStore, defaultConfig);
@@ -212,7 +230,9 @@ contract("ConfigStore", function(accounts) {
         return (
           ev.rewardRate.toString() === test2Config.rewardRatePerSecond.rawValue &&
           ev.proposerBond.toString() === test2Config.proposerBondPct.rawValue &&
-          ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString()
+          ev.timelockLiveness.toString() === test2Config.timelockLiveness.toString() &&
+          ev.proposalTimeFutureLimit.toString() === test2Config.proposalTimeFutureLimit.toString() &&
+          ev.proposalTimePastLimit.toString() === test2Config.proposalTimePastLimit.toString()
         );
       });
       await storeHasNoPendingConfig(configStore);

--- a/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
@@ -25,7 +25,9 @@ contract("Perpetual", function(accounts) {
       {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: "0" },
-        proposerBondPct: { rawValue: "0" }
+        proposerBondPct: { rawValue: "0" },
+        proposalTimeFutureLimit: 0,
+        proposalTimePastLimit: 0
       },
       timer.address
     );

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
@@ -29,7 +29,9 @@ contract("PerpetualCreator", function(accounts) {
   let testConfig = {
     timelockLiveness: 86400, // 1 day
     rewardRatePerSecond: { rawValue: toWei("0.000001") },
-    proposerBondPct: { rawValue: toWei("0.0001") }
+    proposerBondPct: { rawValue: toWei("0.0001") },
+    proposalTimeFutureLimit: 90,
+    proposalTimePastLimit: 1800
   };
 
   beforeEach(async () => {

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualLiquidatable.js
@@ -139,7 +139,9 @@ contract("PerpetualLiquidatable", function(accounts) {
       {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: "0" },
-        proposerBondPct: { rawValue: "0" }
+        proposerBondPct: { rawValue: "0" },
+        proposalTimeFutureLimit: 0,
+        proposalTimePastLimit: 0
       },
       timer.address
     );

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -122,7 +122,9 @@ contract("PerpetualPositionManager", function(accounts) {
       {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: "0" },
-        proposerBondPct: { rawValue: "0" }
+        proposerBondPct: { rawValue: "0" },
+        proposalTimeFutureLimit: 0,
+        proposalTimePastLimit: 0
       },
       timer.address
     );

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualPositionManager.js
@@ -177,7 +177,9 @@ contract("PerpetualPositionManager", function(accounts) {
     await setNewConfig({
       timelockLiveness: 86400, // 1 day
       rewardRatePerSecond: { rawValue: fundingRateRewardRate },
-      proposerBondPct: { rawValue: "0" }
+      proposerBondPct: { rawValue: "0" },
+      proposalTimeFutureLimit: 0,
+      proposalTimePastLimit: 0
     });
 
     // The total time elapsed to publish the proposal is 5 seconds, so let's set the regular fee to 20%/second.
@@ -804,7 +806,9 @@ contract("PerpetualPositionManager", function(accounts) {
     await setNewConfig({
       timelockLiveness: 86400, // 1 day
       rewardRatePerSecond: { rawValue: fundingRateRewardRate },
-      proposerBondPct: { rawValue: "0" }
+      proposerBondPct: { rawValue: "0" },
+      proposalTimeFutureLimit: 0,
+      proposalTimePastLimit: 0
     });
     await setFundingRateAndAdvanceTime("0");
     await positionManager.applyFundingRate();


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2228


**Summary**

TODO: Determine if we should set reasonable limits on these time bounds.

This adds 100 bytes of bytecode to `PerpetualLib`.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2228 
