### PR TITLE
improve(affiliates): add some basic test cases to validate payout logic

### DIFF
--- a/packages/affiliates/libs/affiliates.js
+++ b/packages/affiliates/libs/affiliates.js
@@ -150,17 +150,17 @@ const DeployerRewards = ({ queries, empCreatorAbi, empAbi, coingecko, synthPrice
     empDeployers = new Map(empDeployers);
     let startBlock, endBlock;
 
-    const rewardsPerBlock = toBN(toWei(totalRewards)).div(toBN(blocks.length));
+    const rewardsPerBlock = toBN(toWei(totalRewards.toString())).div(toBN(blocks.length));
     const payoutPerSnapshot = rewardsPerBlock.mul(toBN(snapshotSteps));
     const valuePerSnapshot = blocks.reduce((result, block, index) => {
       if (index % snapshotSteps !== 0) return result;
       if (startBlock == null) startBlock = block;
       endBlock = block;
-      const { timestamp } = block;
+      const { timestamp, number } = block;
       const valueByEmp = empWhitelist.reduce((result, empAddress, empIndex) => {
         try {
           const [syntheticTokenPrices, syntheticValueCalculation] = syntheticTokenPricesWithValueCalculation[empIndex];
-          const { tokens } = balanceHistories.get(empAddress).history.lookup(block.number);
+          const { tokens } = balanceHistories.get(empAddress).history.lookup(number);
           const [, closestCollateralPrice] = collateralTokenPrices[empIndex].closest(timestamp);
           const [, closestSyntheticPrice] = syntheticTokenPrices.closest(timestamp);
           const totalTokens = Object.values(tokens).reduce((result, value) => {

--- a/packages/affiliates/libs/contracts.js
+++ b/packages/affiliates/libs/contracts.js
@@ -1,6 +1,7 @@
 const ethers = require("ethers");
 const assert = require("assert");
 const { getAbi } = require("@uma/core");
+
 function DecodeLog(abi, meta = {}) {
   assert(abi, "requires abi");
   const iface = new ethers.utils.Interface(abi);

--- a/packages/affiliates/libs/mocks.js
+++ b/packages/affiliates/libs/mocks.js
@@ -1,0 +1,70 @@
+// Mocks that allow you to inject in your datasets as arrays/objects for testing. This is different from
+// dataset mocks which load mocked data from a file. This allows you to pass in custom data.
+// This was going to be used for simple testing but its too difficult to mock transaction data.
+const highland = require("highland");
+const assert = require("assert");
+
+// Mocking the big query library.
+// Pass in blocks as an array of blocks
+// Pass in logs as logs[contractAddress] = [{...log data}]
+function Queries({ blocks = [], logs = {} }) {
+  function streamAllLogsByContract(address) {
+    return highland(getAllLogsByContract(address));
+  }
+  function getAllLogsByContract(address) {
+    assert(logs[address], "no logs for address: " + address);
+    return logs[address];
+  }
+  function streamLogsByContract(address, start, end) {
+    return highland(getLogsByContract(address, start, end));
+  }
+  function getLogsByContract(address, start, end) {
+    assert(logs[address], "no logs for address: " + address);
+    return logs[address].filter(x => {
+      return x.block_timestamp >= start && x.block_timestamp <= end;
+    });
+  }
+  function streamBlocks(start, end) {
+    return highland(getBlocks(start, end));
+  }
+  function getBlocks(start, end) {
+    return blocks.filter(x => {
+      return x.timestamp >= start && x.timestamp <= end;
+    });
+  }
+  return {
+    streamLogsByContract,
+    streamAllLogsByContract,
+    streamBlocks,
+    getBlocks,
+    getLogsByContract,
+    getAllLogsByContract
+  };
+}
+function Coingecko({ prices = {} }) {
+  return {
+    getHistoricContractPrices(address, currency, start, end) {
+      assert(prices[address], "no prices found for address: " + address);
+      return prices[address].filter(x => {
+        return x[0] >= start && x[0] <= end;
+      });
+    }
+  };
+}
+
+function SynthPrices({ prices = {} }) {
+  return {
+    getHistoricSynthPrices(address, start, end) {
+      assert(prices[address], "no prices found for address: " + address);
+      return prices[address].filter(x => {
+        return x[0] >= start && x[0] <= end;
+      });
+    }
+  };
+}
+
+module.exports = {
+  Coingecko,
+  SynthPrices,
+  Queries
+};

--- a/packages/affiliates/libs/models.js
+++ b/packages/affiliates/libs/models.js
@@ -171,7 +171,7 @@ function History() {
   const history = [];
   // Used internally, but will insert a block into cache sorted by timestamp ascending
   function insert(data) {
-    assert(data.blockNumber === 0 || data.blockNumber > 0, "requires blockNumber");
+    assert(typeof data.blockNumber === "number" && data.blockNumber >= 0, "requires blockNumber");
     const index = lodash.sortedIndexBy(history, data, "blockNumber");
     history.splice(index, 0, data);
     return data;

--- a/packages/affiliates/libs/models.js
+++ b/packages/affiliates/libs/models.js
@@ -171,13 +171,14 @@ function History() {
   const history = [];
   // Used internally, but will insert a block into cache sorted by timestamp ascending
   function insert(data) {
-    assert(data.blockNumber, "requires blockNumber");
+    assert(data.blockNumber === 0 || data.blockNumber > 0, "requires blockNumber");
     const index = lodash.sortedIndexBy(history, data, "blockNumber");
     history.splice(index, 0, data);
     return data;
   }
   function lookup(blockNumber) {
     const index = lodash.sortedIndexBy(history, { blockNumber }, "blockNumber");
+    assert(history.length, "history is empty");
     if (history[index] && history[index].blockNumber === blockNumber) return history[index];
     const result = history[index - 1];
     assert(

--- a/packages/affiliates/libs/processors.js
+++ b/packages/affiliates/libs/processors.js
@@ -74,7 +74,7 @@ function EmpBalancesHistory() {
 
   // takes a snapshot of balances if the next event falls on a new block
   function handleEvent(blockNumber, event) {
-    assert(blockNumber, "requires blockNumber");
+    assert(blockNumber === 0 || blockNumber > 0, "requires blockNumber");
     if (lastBlockNumber == null) {
       lastBlockNumber = blockNumber;
       lastBlockTimestamp = event.blockTimestamp;

--- a/packages/affiliates/scripts/example-dataset-playback.js
+++ b/packages/affiliates/scripts/example-dataset-playback.js
@@ -1,0 +1,29 @@
+const highland = require("highland");
+
+const Datasets = require("../libs/datasets");
+const { DecodeLog } = require("../libs/contracts");
+const Path = require("path");
+const datasetPath = Path.join(__dirname, "../test/datasets/set1");
+const params = require(Path.join(datasetPath, "/config.json"));
+const { getAbi } = require("@uma/core");
+
+const { Queries } = Datasets.mocks;
+const queries = Queries(datasetPath);
+const empCreatorAbi = getAbi("ExpiringMultiPartyCreator");
+
+const { empCreator } = params;
+
+async function run() {
+  const logstream = queries.streamLogsByContract(empCreator);
+  const decode = DecodeLog(empCreatorAbi);
+  await highland(logstream)
+    .doto(log => {
+      const result = decode(log);
+      console.log(result.name, result.args, log);
+    })
+    .resume();
+}
+
+run()
+  .then(console.log)
+  .catch(console.log);

--- a/packages/affiliates/test/mocha/affiliates.js
+++ b/packages/affiliates/test/mocha/affiliates.js
@@ -1,13 +1,24 @@
 const { DeployerRewards } = require("../../libs/affiliates");
+const lodash = require("lodash");
 const { assert } = require("chai");
 const { getAbi } = require("@uma/core");
+const { Prices } = require("../../libs/models");
+// Dataset based mocks that know how to load data from files. This is not the same as the libs/mocks file.
 const { mocks } = require("../../libs/datasets");
 const Path = require("path");
 
 const empAbi = getAbi("ExpiringMultiParty");
 const empCreatorAbi = getAbi("ExpiringMultiPartyCreator");
+
+const { EmpBalancesHistory } = require("../../libs/processors");
+
 const datasetPath = Path.join(__dirname, "../datasets/set1");
 const params = require(Path.join(datasetPath, "/config.json"));
+
+const { getWeb3 } = require("@uma/common");
+const web3 = getWeb3();
+const { toWei } = web3.utils;
+
 const {
   empCreator,
   empContracts,
@@ -21,129 +32,249 @@ const devRewardsToDistribute = "50000";
 // mocks
 const { Queries, Coingecko, SynthPrices } = mocks;
 
-const { getWeb3 } = require("@uma/common");
-const web3 = getWeb3();
-const { toWei } = web3.utils;
-
 describe("DeployerRewards", function() {
-  let affiliates;
-  before(function() {
-    const queries = Queries(datasetPath);
-    const coingecko = Coingecko(datasetPath);
-    const synthPrices = SynthPrices(datasetPath);
-    affiliates = DeployerRewards({
-      queries,
-      empAbi,
-      empCreatorAbi,
-      coingecko,
-      synthPrices
+  describe("CalculateRewards Simple Data", function() {
+    let balanceHistories, params, totalRewards, affiliates;
+    before(function() {
+      const queries = Queries(datasetPath);
+      const coingecko = Coingecko(datasetPath);
+      const synthPrices = SynthPrices(datasetPath);
+      affiliates = DeployerRewards({
+        queries,
+        empAbi: empAbi,
+        empCreatorAbi: empCreatorAbi,
+        coingecko,
+        synthPrices
+      });
+
+      function makePricesWithValue(count) {
+        return [makePrices(count), affiliates.utils.calculateValue];
+      }
+      function makePrices(count) {
+        return Prices(
+          lodash.times(count, i => {
+            // [timestamp, price]: we ensure price here is not 0 so that calculations come out whole
+            return [i, toWei((i + 1).toString()).toString()];
+          })
+        );
+      }
+      const startTime = 0;
+      const endTime = 10;
+      const empWhitelist = ["a", "b", "c", "d", "e", "f"];
+      balanceHistories = empWhitelist.map(x => [x, EmpBalancesHistory()]);
+      const empDeployers = empWhitelist.map(x => [x, { deployer: x + x }]);
+      totalRewards = "100";
+
+      params = {
+        startTime,
+        endTime,
+        empWhitelist,
+        empCreatorAddress: "creator",
+        snapshotSteps: 1,
+        collateralTokenPrices: empWhitelist.map(() => makePrices(endTime - startTime)),
+        collateralTokenDecimals: empWhitelist.map(() => 18),
+        syntheticTokenPricesWithValueCalculation: empWhitelist.map(() => makePricesWithValue(endTime - startTime)),
+        syntheticTokenDecimals: empWhitelist.map(() => 18),
+        blocks: lodash.times(endTime - startTime, i => ({ timestamp: i, number: i })),
+        balanceHistories,
+        empDeployers,
+        totalRewards
+      };
+    });
+    it("should work with basic test cases", function() {
+      // add some balance histories to the emp contracts. this is really what ends up adjusting the distribution.
+      // this adds a single balance history event starting at time 0 for the first emp
+      balanceHistories[0][1].handleEvent(0, {
+        name: "PositionCreated",
+        // creating a position for address "aa" with 2 collateral 1 synthetic
+        args: ["aa", "2", "1"],
+        blockTimestamp: 0
+      });
+      balanceHistories[0][1].finalize();
+      const result = affiliates.utils.calculateRewards(params);
+      assert.equal(result.empPayouts["a"], totalRewards);
+    });
+    it("should work with basic test cases", function() {
+      // update balance history for emp a user aa
+      balanceHistories[0][1].handleEvent(0, {
+        name: "PositionCreated",
+        // creating a position for address "aa" with 2 collateral 1 synthetic
+        args: ["aa", "2", "1"],
+        blockTimestamp: 0
+      });
+      balanceHistories[0][1].finalize();
+
+      // update balance history for emp b user bb
+      balanceHistories[1][1].handleEvent(0, {
+        name: "PositionCreated",
+        // creating a position for address "aa" with 2 collateral 1 synthetic
+        args: ["bb", "2", "1"],
+        blockTimestamp: 0
+      });
+      balanceHistories[1][1].finalize();
+
+      const result = affiliates.utils.calculateRewards(params);
+      assert.equal(result.empPayouts["a"], totalRewards / 2);
+      assert.equal(result.empPayouts["b"], totalRewards / 2);
     });
   });
-  it("getBalanceHistory", async function() {
-    this.timeout(10000);
-    const result = await affiliates.utils.getBalanceHistory(empContracts[0], startingTimestamp, endingTimestamp);
-    assert.ok(result);
-    assert.ok(result.history.length());
-  });
-  it("getAllBalanceHistory", async function() {
-    this.timeout(10000);
-    const result = await affiliates.utils.getAllBalanceHistories(empContracts, startingTimestamp, endingTimestamp);
-    assert.equal(result.length, empContracts.length);
-    result.forEach(([address, history]) => {
-      assert.ok(address);
-      assert.ok(history);
-      assert.ok(history.history.length());
+  describe("running dataset 1", function() {
+    let affiliates;
+    before(function() {
+      const queries = Queries(datasetPath);
+      const coingecko = Coingecko(datasetPath);
+      const synthPrices = SynthPrices(datasetPath);
+      affiliates = DeployerRewards({
+        queries,
+        empAbi,
+        empCreatorAbi,
+        coingecko,
+        synthPrices
+      });
     });
-  });
-  it("getCoingeckoPriceHistory", async function() {
-    this.timeout(10000);
-    const [, address] = collateralTokens;
-    const result = await affiliates.utils.getCoingeckoPriceHistory(address, "usd", startingTimestamp, endingTimestamp);
-    assert.ok(result.prices.length);
-  });
-  it("getSyntheticPriceHistory", async function() {
-    this.timeout(10000);
-    const [, address] = empContracts;
-    const result = await affiliates.utils.getSyntheticPriceHistory(address, startingTimestamp, endingTimestamp);
-    assert.ok(result.prices.length);
-  });
-  it("getBlocks", async function() {
-    this.timeout(30000);
-    const result = await affiliates.utils.getBlocks(startingTimestamp, startingTimestamp + 60 * 1000 * 5);
-    assert.ok(result.length);
-    const [first] = result;
-    assert(first.timestamp > 0);
-    assert(first.number > 0);
-  });
-  it("getEmpDeployerHistory", async function() {
-    this.timeout(10000);
-    const result = await affiliates.utils.getEmpDeployerHistory(empCreator, startingTimestamp);
-    assert(result.length);
-  });
-  it("calculateValue", async function() {
-    // these are all stable coins so they should roughly be around 1 dollar
-    // epsilon is high because variations could be nearly a dollar in any direction
-    const epsilon = 10n ** 17n;
-    const target = 10n ** 18n;
-    // btc example
-    let result = affiliates.utils.calculateValue(target, "15437.012543625458", "65019421301142", 8, 18).toString();
-    let diff = BigInt(result) - target;
-    assert(diff > 0 ? diff : -diff < epsilon);
-    // eth example
-    result = affiliates.utils.calculateValue(target, "452.1007409061987", "2201527860335072", 18, 18).toString();
-    diff = BigInt(result) - target;
-    assert(diff > 0 ? diff : -diff < epsilon);
-    // perlin example
-    result = affiliates.utils.calculateValue(target, "0.021647425848012932", "45829514207149404216", 18, 18).toString();
-    diff = BigInt(result) - target;
-    assert(diff > 0 ? diff : -diff < epsilon);
-  });
-  it("calculateValueFromUsd", async function() {
-    // these are all stable coins so they should roughly be around 1 dollar
-    // epsilon is high because variations could be nearly a dollar in any direction
-    const target = 10n ** 18n;
-    const syntheticPrice = 26.358177384415466;
-    let result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 18, 18).toString();
-    assert.equal(result, toWei(syntheticPrice.toFixed(18)));
-
-    result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 0, 8).toString();
-    assert.equal(result, toWei(syntheticPrice.toFixed(18)));
-  });
-  it("calculateRewards", async function() {
-    this.timeout(1000000);
-    // small value to give floating math some wiggle room
-    const epsilon = 0.001;
-
-    const result = await affiliates.getRewards({
-      totalRewards: devRewardsToDistribute,
-      startTime: startingTimestamp,
-      endTime: endingTimestamp,
-      empWhitelist: empContracts,
-      empCreatorAddress: empCreator,
-      collateralTokens: collateralTokens,
-      collateralTokenDecimals: collateralTokenDecimals,
-      syntheticTokenDecimals: syntheticTokenDecimals
+    it("getAllBalanceHistory", async function() {
+      this.timeout(10000);
+      const result = await affiliates.utils.getAllBalanceHistories(empContracts, startingTimestamp, endingTimestamp);
+      assert.equal(result.length, empContracts.length);
+      result.forEach(([address, history]) => {
+        assert.ok(address);
+        assert.ok(history);
+        assert.ok(history.history.length());
+      });
     });
+    it("getCoingeckoPriceHistory", async function() {
+      this.timeout(10000);
+      const [, address] = collateralTokens;
+      const result = await affiliates.utils.getCoingeckoPriceHistory(
+        address,
+        "usd",
+        startingTimestamp,
+        endingTimestamp
+      );
+      assert.ok(result.prices.length);
+    });
+    it("getSyntheticPriceHistory", async function() {
+      this.timeout(10000);
+      const [, address] = empContracts;
+      const result = await affiliates.utils.getSyntheticPriceHistory(address, startingTimestamp, endingTimestamp);
+      assert.ok(result.prices.length);
+    });
+    it("getBlocks", async function() {
+      this.timeout(30000);
+      const result = await affiliates.utils.getBlocks(startingTimestamp, startingTimestamp + 60 * 1000 * 5);
+      assert.ok(result.length);
+      const [first] = result;
+      assert(first.timestamp > 0);
+      assert(first.number > 0);
+    });
+    it("getEmpDeployerHistory", async function() {
+      this.timeout(10000);
+      const result = await affiliates.utils.getEmpDeployerHistory(empCreator, startingTimestamp);
+      assert(result.length);
+    });
+    it("calculateValue", async function() {
+      // these are all stable coins so they should roughly be around 1 dollar
+      // epsilon is high because variations could be nearly a dollar in any direction
+      const epsilon = 10n ** 17n;
+      const target = 10n ** 18n;
+      // btc example
+      let result = affiliates.utils.calculateValue(target, "15437.012543625458", "65019421301142", 8, 18).toString();
+      let diff = BigInt(result) - target;
+      assert(diff > 0 ? diff : -diff < epsilon);
+      // eth example
+      result = affiliates.utils.calculateValue(target, "452.1007409061987", "2201527860335072", 18, 18).toString();
+      diff = BigInt(result) - target;
+      assert(diff > 0 ? diff : -diff < epsilon);
+      // perlin example
+      result = affiliates.utils
+        .calculateValue(target, "0.021647425848012932", "45829514207149404216", 18, 18)
+        .toString();
+      diff = BigInt(result) - target;
+      assert(diff > 0 ? diff : -diff < epsilon);
+    });
+    it("calculateValueFromUsd", async function() {
+      // these are all stable coins so they should roughly be around 1 dollar
+      // epsilon is high because variations could be nearly a dollar in any direction
+      const target = 10n ** 18n;
+      const syntheticPrice = 26.358177384415466;
+      let result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 18, 18).toString();
+      assert.equal(result, toWei(syntheticPrice.toFixed(18)));
 
-    assert.equal(Object.keys(result.deployerPayouts).length, 2); // There should be 2 deplorers for the 3 EMPs.
-    assert.equal(Object.keys(result.empPayouts).length, empContracts.length); // There should be 3 emps
+      result = affiliates.utils.calculateValueFromUsd(target, 0, syntheticPrice, 0, 8).toString();
+      assert.equal(result, toWei(syntheticPrice.toFixed(18)));
+    });
+    it("getBalanceHistory", async function() {
+      this.timeout(10000);
+      const result = await affiliates.utils.getBalanceHistory(empContracts[0], startingTimestamp, endingTimestamp);
+      assert.ok(result);
+      assert.ok(result.history.length());
+    });
+    it("getCoingeckoPriceHistory", async function() {
+      this.timeout(10000);
+      const [, address] = collateralTokens;
+      const result = await affiliates.utils.getCoingeckoPriceHistory(
+        address,
+        "usd",
+        startingTimestamp,
+        endingTimestamp
+      );
+      assert.ok(result.prices.length);
+    });
+    it("getSyntheticPriceHistory", async function() {
+      this.timeout(10000);
+      const [, address] = empContracts;
+      const result = await affiliates.utils.getSyntheticPriceHistory(address, startingTimestamp, endingTimestamp);
+      assert.ok(result.prices.length);
+    });
+    it("getBlocks", async function() {
+      this.timeout(30000);
+      const result = await affiliates.utils.getBlocks(startingTimestamp, startingTimestamp + 60 * 1000 * 5);
+      assert.ok(result.length);
+      const [first] = result;
+      assert(first.timestamp > 0);
+      assert(first.number > 0);
+    });
+    it("getEmpDeployerHistory", async function() {
+      this.timeout(10000);
+      const result = await affiliates.utils.getEmpDeployerHistory(empCreator, startingTimestamp);
+      assert(result.length);
+    });
+    it("calculateRewards", async function() {
+      this.timeout(1000000);
+      // small value to give floating math some wiggle room
+      const epsilon = 0.001;
 
-    assert.isBelow(
-      // compare floats with an epsilon
-      Math.abs(
-        Object.values(result.deployerPayouts).reduce((total, value) => {
-          return Number(total) + Number(value);
-        }, 0) - Number(devRewardsToDistribute)
-      ),
-      epsilon
-    ); // the total rewards distributed should equal the number specified
-    assert.isBelow(
-      Math.abs(
-        Object.values(result.empPayouts).reduce((total, value) => {
-          return Number(total) + Number(value);
-        }, 0) - Number(devRewardsToDistribute)
-      ),
-      epsilon
-    ); // the total rewards distributed should equal the number specified
+      const result = await affiliates.getRewards({
+        totalRewards: devRewardsToDistribute,
+        startTime: startingTimestamp,
+        endTime: endingTimestamp,
+        empWhitelist: empContracts,
+        empCreatorAddress: empCreator,
+        collateralTokens: collateralTokens,
+        collateralTokenDecimals: collateralTokenDecimals,
+        syntheticTokenDecimals: syntheticTokenDecimals
+      });
+
+      assert.equal(Object.keys(result.deployerPayouts).length, 2); // There should be 2 deplorers for the 3 EMPs.
+      assert.equal(Object.keys(result.empPayouts).length, empContracts.length); // There should be 3 emps
+
+      assert.isBelow(
+        // compare floats with an epsilon
+        Math.abs(
+          Object.values(result.deployerPayouts).reduce((total, value) => {
+            return Number(total) + Number(value);
+          }, 0) - Number(devRewardsToDistribute)
+        ),
+        epsilon
+      ); // the total rewards distributed should equal the number specified
+      assert.isBelow(
+        Math.abs(
+          Object.values(result.empPayouts).reduce((total, value) => {
+            return Number(total) + Number(value);
+          }, 0) - Number(devRewardsToDistribute)
+        ),
+        epsilon
+      ); // the total rewards distributed should equal the number specified
+    });
   });
 });


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2175 


**Summary**

This adds some very basic tests based on easy to reason about scenarios
- scenario 1: 2 emps and only 1 has had a balance: 100% of rewards go to emp with balance
- scenario 2: bunch of emps, and 2 have equal balance: 50% of rewards get split between emps with balance

There is some extra code here around mocking libraries which did not end up getting used. It was too complicated to mock on chain transaction data with custom values. 

There were a bunch of nasty merge issues in the tests/mocha/affiliates. I will leave a comment on the only part that changed.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2175
