### PR TITLE
fix(optimistic-oracle): add future time require to optimistic oracle

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -156,7 +156,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         require(getState(msg.sender, identifier, timestamp, ancillaryData) == State.Invalid, "requestPrice: Invalid");
         require(_getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
-        require(timestamp <= getCurrentTime().add(90), "Timestamp in future"); // Give 90 seconds of leeway.
+        require(timestamp <= getCurrentTime(), "Timestamp in future"); // Give 90 seconds of leeway.
         uint256 finalFee = _getStore().computeFinalFee(address(currency)).rawValue;
         requests[_getId(msg.sender, identifier, timestamp, ancillaryData)] = Request({
             proposer: address(0),

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -156,6 +156,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         require(getState(msg.sender, identifier, timestamp, ancillaryData) == State.Invalid, "requestPrice: Invalid");
         require(_getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
+        require(timestamp <= getCurrentTime().add(90), "Timestamp in future"); // Give 90 seconds of leeway.
         uint256 finalFee = _getStore().computeFinalFee(address(currency)).rawValue;
         requests[_getId(msg.sender, identifier, timestamp, ancillaryData)] = Request({
             proposer: address(0),

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -156,7 +156,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         require(getState(msg.sender, identifier, timestamp, ancillaryData) == State.Invalid, "requestPrice: Invalid");
         require(_getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
-        require(timestamp <= getCurrentTime(), "Timestamp in future"); // Give 90 seconds of leeway.
+        require(timestamp <= getCurrentTime(), "Timestamp in future");
         uint256 finalFee = _getStore().computeFinalFee(address(currency)).rawValue;
         requests[_getId(msg.sender, identifier, timestamp, ancillaryData)] = Request({
             proposer: address(0),

--- a/packages/core/test/financial-templates/common/FundingRateApplier.js
+++ b/packages/core/test/financial-templates/common/FundingRateApplier.js
@@ -38,7 +38,6 @@ contract("FundingRateApplier", function(accounts) {
   const initialUserBalance = toWei("100");
   const defaultProposal = toWei("0.0000001"); // 1 percent every 100_000 seconds.
   const tokenScaling = toWei("1");
-  const proposalTimeFutureLimit = 90;
   const proposalTimePastLimit = 1800; // 30 mins.
   const delay = 10000; // 10_000 seconds.
   let startTime;
@@ -101,7 +100,7 @@ contract("FundingRateApplier", function(accounts) {
         timelockLiveness: 86400, // 1 day
         rewardRatePerSecond: { rawValue: rewardRate },
         proposerBondPct: { rawValue: bondPercentage },
-        proposalTimeFutureLimit: proposalTimeFutureLimit,
+        proposalTimeFutureLimit: 90, // Note: this doesn't affect the contract due to the stricter limits imposed by the optimistic oracle.
         proposalTimePastLimit: proposalTimePastLimit // 30 mins
       },
       timer.address
@@ -214,10 +213,8 @@ contract("FundingRateApplier", function(accounts) {
     // Time must be within the past and future bounds around the current time.
     assert(await didContractThrow(fundingRateApplier.proposeNewRate(newRate, currentTime - proposalTimePastLimit - 1)));
     await fundingRateApplier.proposeNewRate.call(newRate, currentTime - proposalTimePastLimit);
-    assert(
-      await didContractThrow(fundingRateApplier.proposeNewRate(newRate, currentTime + proposalTimeFutureLimit + 1))
-    );
-    await fundingRateApplier.proposeNewRate(newRate, currentTime + proposalTimeFutureLimit);
+    assert(await didContractThrow(fundingRateApplier.proposeNewRate(newRate, currentTime + 1)));
+    await fundingRateApplier.proposeNewRate(newRate, currentTime);
   });
 
   describe("Undisputed proposal", async () => {

--- a/packages/core/test/oracle/OptimisticOracle.js
+++ b/packages/core/test/oracle/OptimisticOracle.js
@@ -122,7 +122,7 @@ contract("OptimisticOracle", function(accounts) {
     await verifyState(OptimisticOracleRequestStatesEnum.INVALID);
   });
 
-  it("Future request", async function() {
+  it("Request timestamp in the future", async function() {
     const currentTime = (await optimisticOracle.getCurrentTime()).toNumber();
 
     // 90 seconds in the future is okay.

--- a/packages/core/test/oracle/OptimisticOracle.js
+++ b/packages/core/test/oracle/OptimisticOracle.js
@@ -125,14 +125,12 @@ contract("OptimisticOracle", function(accounts) {
   it("Request timestamp in the future", async function() {
     const currentTime = (await optimisticOracle.getCurrentTime()).toNumber();
 
-    // 90 seconds in the future is okay.
-    await optimisticRequester.requestPrice(identifier, currentTime + 90, "0x", collateral.address, 0);
+    // Request for current time is okay.
+    await optimisticRequester.requestPrice(identifier, currentTime, "0x", collateral.address, 0);
 
-    // 91 seconds in the future is not okay.
+    // 1 second in the future is not okay.
     assert(
-      await didContractThrow(
-        optimisticRequester.requestPrice(identifier, currentTime + 91, "0x", collateral.address, 0)
-      )
+      await didContractThrow(optimisticRequester.requestPrice(identifier, currentTime + 1, "0x", collateral.address, 0))
     );
   });
 

--- a/packages/core/test/oracle/OptimisticOracle.js
+++ b/packages/core/test/oracle/OptimisticOracle.js
@@ -122,6 +122,20 @@ contract("OptimisticOracle", function(accounts) {
     await verifyState(OptimisticOracleRequestStatesEnum.INVALID);
   });
 
+  it("Future request", async function() {
+    const currentTime = (await optimisticOracle.getCurrentTime()).toNumber();
+
+    // 90 seconds in the future is okay.
+    await optimisticRequester.requestPrice(identifier, currentTime + 90, "0x", collateral.address, 0);
+
+    // 91 seconds in the future is not okay.
+    assert(
+      await didContractThrow(
+        optimisticRequester.requestPrice(identifier, currentTime + 91, "0x", collateral.address, 0)
+      )
+    );
+  });
+
   it("No fee request", async function() {
     await optimisticRequester.requestPrice(identifier, requestTime, "0x", collateral.address, 0);
     await verifyState(OptimisticOracleRequestStatesEnum.REQUESTED);


### PR DESCRIPTION
**Motivation**

#2266.

**Summary**

Limit optimistic oracle requests to right now or the past. No future requests should be allowed.

**Issue(s)**
Fixes #2266 
