### PR TITLE
feat(default-price-feed) Add BCH-BTC Default price feed

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -61,6 +61,16 @@ const defaultConfigs = {
     invertPrice: true,
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [{ type: "cryptowatch", exchange: "binance", pair: "perlusdt" }]
+  },
+  BCHNBTC: {
+    type: "medianizer",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "BCHBTC" },
+      { type: "cryptowatch", exchange: "binance", pair: "BCHBTC" },
+      { type: "cryptowatch", exchange: "huobi", pair: "BCHBTC" }
+    ]
   }
 };
 


### PR DESCRIPTION
**Motivation**

Dev mining for Mario.cash requires the BCH-BTC default price feed. This PR adds this to DefaultPriceFeedConfigs.js

**Summary**

SImply adds the price feed. This feed follows [UMIP-23](https://github.com/chicfilabae/UMIPs/blob/549bf9cb37558bcd77cb6db44661ad9c9910ef32/UMIPs/umip-23.md)'s implementation details.
