### PR TITLE
feat(perp-position-manager): Add trim excess 

### DIFF
--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -162,6 +162,7 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
      * @notice Removes excess collateral balance not counted in the PfC by distributing it out pro-rata to all sponsors.
      * @dev Multiplying the `cumulativeFeeMultiplier` by the ratio of non-PfC-collateral :: PfC-collateral effectively
      * pays all sponsors a pro-rata portion of the excess collateral.
+     * @dev This will revert if PfC is 0.
      */
     function gulp() external nonReentrant() {
         _gulp();

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -33,6 +33,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
     // Immutable params for perpetual contract.
     struct Params {
         address collateralAddress;
+        address excessTokenBeneficiary;
         bytes32 priceFeedIdentifier;
         bytes32 fundingRateIdentifier;
         string syntheticName;
@@ -121,6 +122,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         // Enforce configuration constraints.
         require(params.withdrawalLiveness != 0, "Withdrawal liveness cannot be 0");
         require(params.liquidationLiveness != 0, "Liquidation liveness cannot be 0");
+        require(params.excessTokenBeneficiary != address(0), "Token Beneficiary cannot be 0x0");
         _requireWhitelistedCollateral(params.collateralAddress);
 
         // We don't want perpetual deployers to be able to intentionally or unintentionally set
@@ -153,6 +155,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         constructorParams.withdrawalLiveness = params.withdrawalLiveness;
         constructorParams.liquidationLiveness = params.liquidationLiveness;
         constructorParams.tokenScaling = params.tokenScaling;
+        constructorParams.excessTokenBeneficiary = params.excessTokenBeneficiary;
     }
 
     // IERC20Standard.decimals() will revert if the collateral contract has not implemented the decimals() method,

--- a/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/Perpetual.js
@@ -48,6 +48,7 @@ contract("Perpetual", function(accounts) {
       minSponsorTokens: { rawValue: toWei("1") },
       timerAddress: timer.address,
       configStoreAddress: configStore.address,
+      excessTokenBeneficiary: accounts[0],
       tokenScaling: { rawValue: toWei("1") }
     };
 


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2281

This PR ensures that no ERC20 tokens that are not included in the `PfC` will be stuck within the Perp. `trimExcess` can also be used to drain excess collateral arising from precision loss. 

Moreover, this adds a note to `gulp()` that it will revert if `PfC` is 0. I don't think we need to specially handle this case because no other methods are dependent on `_gulp()` succeeding.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2281
