### PR TITLE
improve(node-deploy): update node deployment script

### DIFF
--- a/scripts/DeployNode.sh
+++ b/scripts/DeployNode.sh
@@ -9,7 +9,9 @@
 # This script has the following preconditions:
 # 1. You have a GCE SSD disk called node-disk with enough space for a geth db.
 # 2. node-disk is writable by most/all users (rw filesystem permissions have been granted).
-# 3. node-disk contains a folder called ethereum (can be empty).
+# 3. node-disk contains a folder called ethereum.
+# 4. ethereum folder must contain a file called config.toml, which can optionally have additional config options not
+#    specified below (for instance, custom request timeouts must be set in this config).
 
 MACHINE_TYPE=$1
 : ${MACHINE_TYPE:=n1-highmem-8}

--- a/scripts/DeployNode.sh
+++ b/scripts/DeployNode.sh
@@ -24,12 +24,17 @@ gcloud compute instances create-with-container geth-node \
     --container-mount-disk=mount-path=/node-disk \
     --machine-type $MACHINE_TYPE \
     --container-privileged \
-    --container-arg="--rpc" \
-    --container-arg="--rpcaddr" \
+    --container-arg="--http" \
+    --container-arg="--http.addr" \
     --container-arg="0.0.0.0" \
+    --container-arg="--http.port" \
+    --container-arg="3565" \
     --container-arg="--ws" \
-    --container-arg="--wsaddr" \
+    --container-arg="--ws.addr" \
     --container-arg="0.0.0.0" \
+    --container-arg="--ws.port" \
+    --container-arg="3566" \
     --container-arg="--ipcdisable" \
     --container-arg="--datadir" \
-    --container-arg="/node-disk/ethereum"
+    --container-arg="/node-disk/ethereum" \
+    --tags="http-server"

--- a/scripts/DeployNode.sh
+++ b/scripts/DeployNode.sh
@@ -37,4 +37,6 @@ gcloud compute instances create-with-container geth-node \
     --container-arg="--ipcdisable" \
     --container-arg="--datadir" \
     --container-arg="/node-disk/ethereum" \
+    --container-arg="--config" \
+    --container-arg="/node-disk/ethereum/config.toml" \
     --tags="http-server"


### PR DESCRIPTION
**Motivation**

Add minor improvements to the geth deployment script.

**Summary**

Changes the http and ws port to a nonstandard port to help avoid port scanners from hitting our node. Also adds a tags the instance as an "http-server", which by default opens port 80, but can be customized to include additional ports in the firewall.

**Issue(s)**

N/A
