### PR TITLE
improve(fee-payer) Remove trimExcess from EMP and add gulp edge case unit tests

### DIFF
--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -162,6 +162,7 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
      * @notice Removes excess collateral balance not counted in the PfC by distributing it out pro-rata to all sponsors.
      * @dev Multiplying the `cumulativeFeeMultiplier` by the ratio of non-PfC-collateral :: PfC-collateral effectively
      * pays all sponsors a pro-rata portion of the excess collateral.
+     * @dev This will revert if PfC is 0.
      */
     function gulp() external nonReentrant() {
         _gulp();

--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -162,7 +162,7 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
      * @notice Removes excess collateral balance not counted in the PfC by distributing it out pro-rata to all sponsors.
      * @dev Multiplying the `cumulativeFeeMultiplier` by the ratio of non-PfC-collateral :: PfC-collateral effectively
      * pays all sponsors a pro-rata portion of the excess collateral.
-     * @dev This will revert if PfC is 0.
+     * @dev This will revert if PfC is 0 and this contract's collateral balance > 0.
      */
     function gulp() external nonReentrant() {
         _gulp();

--- a/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
@@ -42,7 +42,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
         FixedPoint.Unsigned minSponsorTokens;
         uint256 withdrawalLiveness;
         uint256 liquidationLiveness;
-        address excessTokenBeneficiary;
         address financialProductLibraryAddress;
     }
     // Address of TokenFactory used to create a new synthetic token.
@@ -110,7 +109,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
         // Enforce configuration constraints.
         require(params.withdrawalLiveness != 0, "Withdrawal liveness cannot be 0");
         require(params.liquidationLiveness != 0, "Liquidation liveness cannot be 0");
-        require(params.excessTokenBeneficiary != address(0), "Token Beneficiary cannot be 0x0");
         require(params.expirationTimestamp > now, "Invalid expiration time");
         _requireWhitelistedCollateral(params.collateralAddress);
 
@@ -134,7 +132,6 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
         constructorParams.minSponsorTokens = params.minSponsorTokens;
         constructorParams.withdrawalLiveness = params.withdrawalLiveness;
         constructorParams.liquidationLiveness = params.liquidationLiveness;
-        constructorParams.excessTokenBeneficiary = params.excessTokenBeneficiary;
         constructorParams.financialProductLibraryAddress = params.financialProductLibraryAddress;
     }
 

--- a/packages/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
@@ -63,7 +63,6 @@ contract Liquidatable is PricelessPositionManager {
         address tokenAddress;
         address finderAddress;
         address timerAddress;
-        address excessTokenBeneficiary;
         address financialProductLibraryAddress;
         bytes32 priceFeedIdentifier;
         FixedPoint.Unsigned minSponsorTokens;
@@ -181,7 +180,6 @@ contract Liquidatable is PricelessPositionManager {
             params.priceFeedIdentifier,
             params.minSponsorTokens,
             params.timerAddress,
-            params.excessTokenBeneficiary,
             params.financialProductLibraryAddress
         )
         nonReentrant()

--- a/packages/core/test/financial-templates/expiring-multiparty/ExpiringMultiParty.js
+++ b/packages/core/test/financial-templates/expiring-multiparty/ExpiringMultiParty.js
@@ -37,7 +37,6 @@ contract("ExpiringMultiParty", function(accounts) {
       disputerDisputeRewardPct: { rawValue: toWei("0.1") },
       minSponsorTokens: { rawValue: toWei("1") },
       timerAddress: timer.address,
-      excessTokenBeneficiary: accounts[0],
       financialProductLibraryAddress: ZERO_ADDRESS
     };
 

--- a/packages/core/test/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.js
+++ b/packages/core/test/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.js
@@ -14,7 +14,6 @@ const Registry = artifacts.require("Registry");
 const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
 const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
 const AddressWhitelist = artifacts.require("AddressWhitelist");
-const Store = artifacts.require("Store");
 const StructuredNoteFinancialProductLibrary = artifacts.require("StructuredNoteFinancialProductLibrary");
 
 contract("ExpiringMultiPartyCreator", function(accounts) {
@@ -25,7 +24,6 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
   let expiringMultiPartyCreator;
   let registry;
   let collateralTokenWhitelist;
-  let store;
 
   // Re-used variables
   let constructorParams;
@@ -38,8 +36,6 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
     // Whitelist collateral currency
     collateralTokenWhitelist = await AddressWhitelist.deployed();
     await collateralTokenWhitelist.addToWhitelist(collateralToken.address, { from: contractCreator });
-
-    store = await Store.deployed();
 
     constructorParams = {
       expirationTimestamp: "1898918401", // 2030-03-05T05:20:01.000Z
@@ -54,7 +50,6 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
       minSponsorTokens: { rawValue: toWei("1") },
       liquidationLiveness: 7200,
       withdrawalLiveness: 7200,
-      excessTokenBeneficiary: store.address,
       financialProductLibraryAddress: ZERO_ADDRESS
     };
 
@@ -160,18 +155,6 @@ contract("ExpiringMultiPartyCreator", function(accounts) {
   it("Liquidation liveness cannot be too large", async function() {
     // Change only the liquidation liveness
     constructorParams.liquidationLiveness = MAX_UINT_VAL;
-    assert(
-      await didContractThrow(
-        expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, {
-          from: contractCreator
-        })
-      )
-    );
-  });
-
-  it("Beneficiary cannot be 0x0", async function() {
-    // Change only the beneficiary address.
-    constructorParams.excessTokenBeneficiary = ZERO_ADDRESS;
     assert(
       await didContractThrow(
         expiringMultiPartyCreator.createExpiringMultiParty(constructorParams, {

--- a/packages/core/test/financial-templates/expiring-multiparty/PricelessPositionManager.js
+++ b/packages/core/test/financial-templates/expiring-multiparty/PricelessPositionManager.js
@@ -27,8 +27,7 @@ contract("PricelessPositionManager", function(accounts) {
   const tokenHolder = accounts[2];
   const other = accounts[3];
   const collateralOwner = accounts[4];
-  const beneficiary = accounts[5];
-  const proposer = accounts[6];
+  const proposer = accounts[5];
 
   // Contracts
   let collateral;
@@ -76,25 +75,6 @@ contract("PricelessPositionManager", function(accounts) {
     );
     assert.equal((await pricelessPositionManager.totalTokensOutstanding()).toString(), expectedTotalTokens.toString());
     assert.equal(await collateral.balanceOf(pricelessPositionManager.address), expectedTotalCollateral.toString());
-  };
-
-  const expectNoExcessCollateralToTrim = async () => {
-    let collateralTrimAmount = await pricelessPositionManager.trimExcess.call(collateral.address);
-    await pricelessPositionManager.trimExcess(collateral.address);
-    let beneficiaryCollateralBalance = await collateral.balanceOf(beneficiary);
-
-    assert.equal(collateralTrimAmount.toString(), "0");
-    assert.equal(beneficiaryCollateralBalance.toString(), "0");
-  };
-
-  const expectAndDrainExcessCollateral = async () => {
-    // Drains the collateral from the contract and transfers it all back to the sponsor account to leave the beneficiary empty.
-    await pricelessPositionManager.trimExcess(collateral.address);
-    let beneficiaryCollateralBalance = await collateral.balanceOf(beneficiary);
-    collateral.transfer(sponsor, beneficiaryCollateralBalance.toString(), { from: beneficiary });
-
-    // Assert that nonzero collateral was drained.
-    assert.notEqual(beneficiaryCollateralBalance.toString(), "0");
   };
 
   const proposeAndSettleOptimisticOraclePrice = async (priceFeedIdentifier, requestTime, price) => {
@@ -188,7 +168,6 @@ contract("PricelessPositionManager", function(accounts) {
       priceFeedIdentifier, // _priceFeedIdentifier
       { rawValue: minSponsorTokens }, // _minSponsorTokens
       timer.address, // _timerAddress
-      beneficiary, // _excessTokenBeneficiary
       ZERO_ADDRESS, // _financialProductLibraryAddress
       { from: contractDeployer }
     );
@@ -198,11 +177,6 @@ contract("PricelessPositionManager", function(accounts) {
 
     ancillaryData = tokenCurrency.address;
   });
-
-  afterEach(async () => {
-    await expectNoExcessCollateralToTrim();
-  });
-
   it("Valid constructor params", async function() {
     // Expiration timestamp must be greater than contract current time.
     assert(
@@ -216,7 +190,6 @@ contract("PricelessPositionManager", function(accounts) {
           priceFeedIdentifier, // _priceFeedIdentifier
           { rawValue: minSponsorTokens }, // _minSponsorTokens
           timer.address, // _timerAddress
-          beneficiary, // _excessTokenBeneficiary
           { from: contractDeployer }
         )
       )
@@ -234,7 +207,6 @@ contract("PricelessPositionManager", function(accounts) {
           utf8ToHex("UNREGISTERED"), // _priceFeedIdentifier
           { rawValue: minSponsorTokens }, // _minSponsorTokens
           timer.address, // _timerAddress
-          beneficiary, // _excessTokenBeneficiary
           { from: contractDeployer }
         )
       )
@@ -267,7 +239,6 @@ contract("PricelessPositionManager", function(accounts) {
           utf8ToHex("UNKNOWN"), // Some identifier that the whitelist tracker does not know
           { rawValue: minSponsorTokens }, // _minSponsorTokens (unchanged)
           timer.address, // _timerAddress (unchanged)
-          beneficiary, // _excessTokenBeneficiary (unchanged)
           ZERO_ADDRESS, // _financialProductLibraryAddress (unchanged)
           { from: contractDeployer }
         )
@@ -294,7 +265,6 @@ contract("PricelessPositionManager", function(accounts) {
       priceFeedIdentifier, // _priceFeedIdentifier
       { rawValue: minSponsorTokens }, // _minSponsorTokens
       timer.address, // _timerAddress
-      beneficiary, // _excessTokenBeneficiary
       ZERO_ADDRESS, // _financialProductLibraryAddress
       { from: contractDeployer }
     );
@@ -327,9 +297,6 @@ contract("PricelessPositionManager", function(accounts) {
       { from: other }
     );
 
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
-
     // Create the initial pricelessPositionManager.
     const createTokens = toWei("100");
     const createCollateral = toWei("150");
@@ -360,9 +327,6 @@ contract("PricelessPositionManager", function(accounts) {
 
     await checkBalances(expectedSponsorTokens, expectedSponsorCollateral);
 
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
-
     // Deposit.
     const depositCollateral = toWei("50");
     expectedSponsorCollateral = expectedSponsorCollateral.add(toBN(depositCollateral));
@@ -376,9 +340,6 @@ contract("PricelessPositionManager", function(accounts) {
     await pricelessPositionManager.deposit({ rawValue: depositCollateral }, { from: sponsor });
     await checkBalances(expectedSponsorTokens, expectedSponsorCollateral);
 
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
-
     // Withdraw.
     const withdrawCollateral = toWei("20");
     expectedSponsorCollateral = expectedSponsorCollateral.sub(toBN(withdrawCollateral));
@@ -391,9 +352,6 @@ contract("PricelessPositionManager", function(accounts) {
     let sponsorFinalBalance = await collateral.balanceOf(sponsor);
     assert.equal(sponsorFinalBalance.sub(sponsorInitialBalance).toString(), withdrawCollateral);
     await checkBalances(expectedSponsorTokens, expectedSponsorCollateral);
-
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
 
     // Redeem 50% of the tokens for 50% of the collateral.
     const redeemTokens = toWei("50");
@@ -425,9 +383,6 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(sponsorFinalBalance.sub(sponsorInitialBalance).toString(), expectedSponsorCollateral);
     await checkBalances(expectedSponsorTokens, expectedSponsorCollateral);
 
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
-
     // Create additional.
     const createAdditionalTokens = toWei("10");
     const createAdditionalCollateral = toWei("110");
@@ -454,9 +409,6 @@ contract("PricelessPositionManager", function(accounts) {
     );
     await checkBalances(expectedSponsorTokens, expectedSponsorCollateral);
 
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
-
     // Redeem full.
     const redeemRemainingTokens = toWei("60");
     await tokenCurrency.approve(pricelessPositionManager.address, redeemRemainingTokens, { from: sponsor });
@@ -476,9 +428,6 @@ contract("PricelessPositionManager", function(accounts) {
     sponsorFinalBalance = await collateral.balanceOf(sponsor);
     assert.equal(sponsorFinalBalance.sub(sponsorInitialBalance).toString(), expectedSponsorCollateral);
     await checkBalances(toBN("0"), toBN("0"));
-
-    // Periodic check for no excess collateral.
-    await expectNoExcessCollateralToTrim();
 
     // Contract state should not have changed.
     assert.equal(await pricelessPositionManager.contractState(), PositionStatesEnum.OPEN);
@@ -868,9 +817,6 @@ contract("PricelessPositionManager", function(accounts) {
       return ev.caller == other;
     });
 
-    // No excess collateral post expiry.
-    await expectNoExcessCollateralToTrim();
-
     // Settling an expired position should revert if the contract has expired but the DVM has not yet returned a price.
     assert(await didContractThrow(pricelessPositionManager.settleExpired({ from: tokenHolder })));
 
@@ -895,9 +841,6 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(await pricelessPositionManager.contractState(), PositionStatesEnum.EXPIRED_PRICE_RECEIVED);
     const tokenHolderFinalCollateral = await collateral.balanceOf(tokenHolder);
     const tokenHolderFinalSynthetic = await tokenCurrency.balanceOf(tokenHolder);
-
-    // No excess collateral post settlement.
-    await expectNoExcessCollateralToTrim();
 
     // The token holder should gain the value of their synthetic tokens in underlying.
     // The value in underlying is the number of tokens they held in the beginning * settlement price as TRV
@@ -988,9 +931,6 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
-
-    // No excess collateral after all have settled.
-    await expectNoExcessCollateralToTrim();
   });
   describe("Financial Product Library", () => {
     it("Custom price transformation", async function() {
@@ -1014,7 +954,6 @@ contract("PricelessPositionManager", function(accounts) {
         priceFeedIdentifier, // _priceFeedIdentifier
         { rawValue: minSponsorTokens }, // _minSponsorTokens
         timer.address, // _timerAddress
-        beneficiary, // _excessTokenBeneficiary
         financialProductLibraryTest.address, // _financialProductLibraryAddress
         { from: contractDeployer }
       );
@@ -1063,9 +1002,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal(await pricelessPositionManager.contractState(), PositionStatesEnum.EXPIRED_PRICE_RECEIVED);
       const tokenHolderFinalCollateral = await collateral.balanceOf(tokenHolder);
       const tokenHolderFinalSynthetic = await tokenCurrency.balanceOf(tokenHolder);
-
-      // No excess collateral post settlement.
-      await expectNoExcessCollateralToTrim();
 
       // The token holder should gain the value of their synthetic tokens in underlying.
       // The value in underlying is the number of tokens they held in the beginning * settlement price as TRV
@@ -1160,9 +1096,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
-
-      // No excess collateral after all have settled.
-      await expectNoExcessCollateralToTrim();
     });
 
     it("Correctly handles reverting price transformation function ", async function() {
@@ -1188,7 +1121,6 @@ contract("PricelessPositionManager", function(accounts) {
         priceFeedIdentifier, // _priceFeedIdentifier
         { rawValue: minSponsorTokens }, // _minSponsorTokens
         timer.address, // _timerAddress
-        beneficiary, // _excessTokenBeneficiary
         financialProductLibraryTest.address, // _financialProductLibraryAddress
         { from: contractDeployer }
       );
@@ -1235,7 +1167,6 @@ contract("PricelessPositionManager", function(accounts) {
         priceFeedIdentifier, // _priceFeedIdentifier
         { rawValue: minSponsorTokens }, // _minSponsorTokens
         timer.address, // _timerAddress
-        beneficiary, // _excessTokenBeneficiary
         financialProductLibraryTest.address, // _financialProductLibraryAddress
         { from: contractDeployer }
       );
@@ -1310,9 +1241,6 @@ contract("PricelessPositionManager", function(accounts) {
       const tokenHolderFinalCollateral = await collateral.balanceOf(tokenHolder);
       const tokenHolderFinalSynthetic = await tokenCurrency.balanceOf(tokenHolder);
 
-      // No excess collateral post settlement.
-      await expectNoExcessCollateralToTrim();
-
       // The token holder should gain the value of their synthetic tokens in underlying.
       // The value in underlying is the number of tokens they held in the beginning * settlement price as TRV
       // When redeeming 50 tokens at a price of 1.2 we expect to receive 60 collateral tokens (50 * 1.2)
@@ -1406,9 +1334,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
-
-      // No excess collateral after all have settled.
-      await expectNoExcessCollateralToTrim();
     });
     it("Correctly handles invalid financial product library", async function() {
       // Set the financial product library to a contract that is NOT a valid financial contract library, such as the
@@ -1423,7 +1348,6 @@ contract("PricelessPositionManager", function(accounts) {
         priceFeedIdentifier, // _priceFeedIdentifier
         { rawValue: minSponsorTokens }, // _minSponsorTokens
         timer.address, // _timerAddress
-        beneficiary, // _excessTokenBeneficiary
         mockOracle.address, // _financialProductLibraryAddress
         { from: contractDeployer }
       );
@@ -1493,9 +1417,6 @@ contract("PricelessPositionManager", function(accounts) {
       const tokenHolderFinalCollateral = await collateral.balanceOf(tokenHolder);
       const tokenHolderFinalSynthetic = await tokenCurrency.balanceOf(tokenHolder);
 
-      // No excess collateral post settlement.
-      await expectNoExcessCollateralToTrim();
-
       // The token holder should gain the value of their synthetic tokens in underlying.
       // The value in underlying is the number of tokens they held in the beginning * settlement price as TRV
       // When redeeming 50 tokens at a price of 1.2 we expect to receive 60 collateral tokens (50 * 1.2)
@@ -1589,9 +1510,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
-
-      // No excess collateral after all have settled.
-      await expectNoExcessCollateralToTrim();
     });
 
     it("Correctly handles reverting identifier transformation", async function() {
@@ -1626,7 +1544,6 @@ contract("PricelessPositionManager", function(accounts) {
         priceFeedIdentifier, // _priceFeedIdentifier
         { rawValue: minSponsorTokens }, // _minSponsorTokens
         timer.address, // _timerAddress
-        beneficiary, // _excessTokenBeneficiary
         other, // _financialProductLibraryAddress
         { from: contractDeployer }
       );
@@ -2002,9 +1919,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal((await collateral.balanceOf(pricelessPositionManager.address)).toString(), "29");
       assert.equal((await pricelessPositionManager.totalPositionCollateral()).toString(), "28");
       assert.equal((await pricelessPositionManager.rawTotalPositionCollateral()).toString(), "30");
-
-      // Drain excess collateral left because of precesion loss.
-      await expectAndDrainExcessCollateral();
     });
     it("settleExpired() returns the same amount of collateral that totalPositionCollateral is decreased by", async () => {
       // Expire the contract
@@ -2097,9 +2011,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
       assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
-
-      // Drain excess collateral left because of precesion loss.
-      await expectAndDrainExcessCollateral();
     });
     it("withdraw() returns the same amount of collateral that totalPositionCollateral is decreased by", async () => {
       // The sponsor requests to withdraw 12 collateral.
@@ -2121,9 +2032,6 @@ contract("PricelessPositionManager", function(accounts) {
       assert.equal((await collateral.balanceOf(pricelessPositionManager.address)).toString(), "18");
       assert.equal((await pricelessPositionManager.totalPositionCollateral()).toString(), "17");
       assert.equal((await pricelessPositionManager.rawTotalPositionCollateral()).toString(), "18");
-
-      // Drain excess collateral left because of precesion loss.
-      await expectAndDrainExcessCollateral();
     });
     it("redeem() returns the same amount of collateral that totalPositionCollateral is decreased by", async () => {
       // The sponsor requests to redeem 9 tokens. (9/20 = 0.45) tokens should result in a proportional redemption of the totalPositionCollateral,
@@ -2145,9 +2053,6 @@ contract("PricelessPositionManager", function(accounts) {
 
       // Expected number of synthetic tokens are burned.
       assert.equal((await tokenCurrency.balanceOf(sponsor)).toString(), "11");
-
-      // Drain excess collateral left because of precesion loss.
-      await expectAndDrainExcessCollateral();
     });
   });
 
@@ -2462,36 +2367,6 @@ contract("PricelessPositionManager", function(accounts) {
     assert(await didContractThrow(pricelessPositionManager.redeem({ rawValue: "16" }, { from: sponsor })));
   });
 
-  it("Can withdraw excess collateral", async function() {
-    // Attempt to redeem a position smaller s.t. the resulting position is less than 5 wei tokens (the min sponsor
-    // position size)
-    await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
-    await tokenCurrency.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
-
-    await pricelessPositionManager.create({ rawValue: "40" }, { rawValue: "20" }, { from: sponsor });
-
-    // Transfer extra collateral in.
-    await collateral.transfer(pricelessPositionManager.address, web3.utils.toWei("10"), { from: sponsor });
-    let excessCollateral = await pricelessPositionManager.trimExcess.call(collateral.address);
-    await pricelessPositionManager.trimExcess(collateral.address);
-    let beneficiaryCollateralBalance = await collateral.balanceOf(beneficiary);
-    assert.equal(excessCollateral.toString(), web3.utils.toWei("10"));
-    assert.equal(beneficiaryCollateralBalance.toString(), web3.utils.toWei("10"));
-    await collateral.transfer(sponsor, web3.utils.toWei("10"), { from: beneficiary });
-
-    // Transfer extra tokens in.
-    await tokenCurrency.transfer(pricelessPositionManager.address, "10", { from: sponsor });
-    let excessTokens = await pricelessPositionManager.trimExcess.call(tokenCurrency.address);
-    await pricelessPositionManager.trimExcess(tokenCurrency.address);
-    let beneficiaryTokenBalance = await tokenCurrency.balanceOf(beneficiary);
-    assert.equal(excessTokens.toString(), "10");
-    assert.equal(beneficiaryTokenBalance.toString(), "10");
-
-    // Redeem still succeeds.
-    await tokenCurrency.transfer(sponsor, "10", { from: beneficiary });
-    await pricelessPositionManager.redeem({ rawValue: "20" }, { from: sponsor });
-  });
-
   it("Non-standard ERC20 delimitation", async function() {
     // To test non-standard ERC20 token delimitation a new ERC20 token is created which has 6 decimal points of precision.
     // A new priceless position manager is then created and and set to use this token as collateral. To generate values
@@ -2514,7 +2389,6 @@ contract("PricelessPositionManager", function(accounts) {
       priceFeedIdentifier, // _priceFeedIdentifier
       { rawValue: minSponsorTokens }, // _minSponsorTokens
       timer.address, // _timerAddress
-      beneficiary, // _excessTokenBeneficiary
       ZERO_ADDRESS, // _financialProductLibraryAddress
       { from: contractDeployer }
     );
@@ -2784,9 +2658,6 @@ contract("PricelessPositionManager", function(accounts) {
     const tokenHolderFinalCollateral = await collateral.balanceOf(tokenHolder);
     const tokenHolderFinalSynthetic = await tokenCurrency.balanceOf(tokenHolder);
 
-    // No excess collateral post settlement.
-    await expectNoExcessCollateralToTrim();
-
     // The token holder should gain the value of their synthetic tokens in underlying.
     // The value in underlying is the number of tokens they held in the beginning * settlement price as TRV
     // When redeeming 50 tokens at a price of 1.2 we expect to receive 60 collateral tokens (50 * 1.2)
@@ -2880,8 +2751,5 @@ contract("PricelessPositionManager", function(accounts) {
     assert.equal(sponsorsPosition.withdrawalRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.transferPositionRequestPassTimestamp.toString(), 0);
     assert.equal(sponsorsPosition.withdrawalRequestAmount.rawValue, 0);
-
-    // No excess collateral after all have settled.
-    await expectNoExcessCollateralToTrim();
   });
 });

--- a/packages/core/test/financial-templates/expiring-multiparty/PricelessPositionManager.js
+++ b/packages/core/test/financial-templates/expiring-multiparty/PricelessPositionManager.js
@@ -2367,6 +2367,39 @@ contract("PricelessPositionManager", function(accounts) {
     assert(await didContractThrow(pricelessPositionManager.redeem({ rawValue: "16" }, { from: sponsor })));
   });
 
+  it("Gulp edge cases", async function() {
+    // Gulp does not revert if PfC and collateral balance are both 0
+    await pricelessPositionManager.gulp();
+
+    // Send 1 wei of excess collateral to the contract.
+    await collateral.transfer(pricelessPositionManager.address, "1", { from: sponsor });
+
+    // Gulp reverts if PfC is 0 but collateral balance is > 0.
+    assert(await didContractThrow(pricelessPositionManager.gulp()));
+
+    // Create a position to gulp.
+    await collateral.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
+    await tokenCurrency.approve(pricelessPositionManager.address, toWei("100000"), { from: sponsor });
+    await pricelessPositionManager.create({ rawValue: toWei("10") }, { rawValue: "20" }, { from: sponsor });
+
+    // Gulp does not do anything if the intermediate calculation (collateral balance / PfC) has precision loss.
+    // For example:
+    // - collateral balance = 10e18 + 1
+    // - PfC = 10e18
+    // - Gulp ratio = (10e18 + 1) / 10e18 =  1.0000000000000000001, which is 1e18 + 1e-19, which gets truncated to 1e18
+    // - Therefore, the multiplier remains at 1e18.
+    await pricelessPositionManager.gulp();
+    assert.equal((await pricelessPositionManager.cumulativeFeeMultiplier()).toString(), web3.utils.toWei("1"));
+
+    // Gulp will shift the multiplier if enough excess collateral builds up in the contract to negate precision loss.
+    await collateral.transfer(pricelessPositionManager.address, "9", { from: sponsor });
+    await pricelessPositionManager.gulp();
+    assert.equal(
+      (await pricelessPositionManager.cumulativeFeeMultiplier()).toString(),
+      web3.utils.toWei("1.000000000000000001")
+    );
+  });
+
   it("Non-standard ERC20 delimitation", async function() {
     // To test non-standard ERC20 token delimitation a new ERC20 token is created which has 6 decimal points of precision.
     // A new priceless position manager is then created and and set to use this token as collateral. To generate values


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We closed #2283 after deciding that `gulp()` addresses the original problem that `trimExcess()` was supposed to solve, that of frozen collateral currency in the contract. With `gulp()` added, `trimExcess()` only addresses the additional concern of non-collateral currency frozen in the contract, which we deem unnecessary to address. 

For the sake of consistency between EMP and Perp interfaces, this PR removes `trimExcess` from the EMP and adds unit tests highlighting some "edge" cases for `gulp()` functionality.

Additionally, I have highlighted a "flash gulp" known vulnerability that the team has chosen to ignore in [this document](https://docs.google.com/document/d/19-BbHWfbdCRyDCxPTGr8fSla5zKWmqUbmQetkiVB4i4/edit).

