### PR TITLE
fix(dec-2020-audit): [L05] Event missing emit keyword

### DIFF
--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -79,7 +79,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         // Create new config settings store for this contract and reset ownership to the deployer.
         ConfigStore configStore = new ConfigStore(configSettings, timerAddress);
         configStore.transferOwnership(msg.sender);
-        CreatedConfigStore(address(configStore), configStore.owner());
+        emit CreatedConfigStore(address(configStore), configStore.owner());
 
         // Create a new synthetic token using the params.
         require(bytes(params.syntheticName).length != 0, "Missing synthetic name");


### PR DESCRIPTION
**Problem:**
In the createPerpetual function of the PerpetualCreator contract, the CreatedConfigStore event is emitted without the emit keyword.

Since Solidity v0.4.21, the emit keyword has been recommended to distinguish events from other function calls.

**Solution in this PR**
The `PerpetualCreator` is updated to follow the correct specification by using the `emit` keyword.