### PR TITLE
fix(dec-2020-audit): [L10] Functions not failing early

### DIFF
--- a/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -309,8 +309,8 @@ contract PricelessPositionManager is FeePayer {
         nonReentrant()
         returns (FixedPoint.Unsigned memory amountWithdrawn)
     {
-        PositionData storage positionData = _getPositionData(msg.sender);
         require(collateralAmount.isGreaterThan(0));
+        PositionData storage positionData = _getPositionData(msg.sender);
 
         // Decrement the sponsor's collateral and global collateral amounts. Check the GCR between decrement to ensure
         // position remains above the GCR within the witdrawl. If this is not the case the caller must submit a request.

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -82,7 +82,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         // Create new config settings store for this contract and reset ownership to the deployer.
         ConfigStore configStore = new ConfigStore(configSettings, timerAddress);
         configStore.transferOwnership(msg.sender);
-        CreatedConfigStore(address(configStore), configStore.owner());
+        emit CreatedConfigStore(address(configStore), configStore.owner());
 
         // Create a new synthetic token using the params.
         TokenFactory tf = TokenFactory(tokenFactoryAddress);

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -76,14 +76,15 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         nonReentrant()
         returns (address)
     {
+        require(bytes(params.syntheticName).length != 0, "Missing synthetic name");
+        require(bytes(params.syntheticSymbol).length != 0, "Missing synthetic symbol");
+
         // Create new config settings store for this contract and reset ownership to the deployer.
         ConfigStore configStore = new ConfigStore(configSettings, timerAddress);
         configStore.transferOwnership(msg.sender);
         CreatedConfigStore(address(configStore), configStore.owner());
 
         // Create a new synthetic token using the params.
-        require(bytes(params.syntheticName).length != 0, "Missing synthetic name");
-        require(bytes(params.syntheticSymbol).length != 0, "Missing synthetic symbol");
         TokenFactory tf = TokenFactory(tokenFactoryAddress);
 
         // If the collateral token does not have a `decimals()` method,

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -82,7 +82,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         // Create new config settings store for this contract and reset ownership to the deployer.
         ConfigStore configStore = new ConfigStore(configSettings, timerAddress);
         configStore.transferOwnership(msg.sender);
-        emit CreatedConfigStore(address(configStore), configStore.owner());
+        CreatedConfigStore(address(configStore), configStore.owner());
 
         // Create a new synthetic token using the params.
         TokenFactory tf = TokenFactory(tokenFactoryAddress);

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -222,8 +222,8 @@ contract PerpetualPositionManager is FundingRateApplier {
         nonReentrant()
         returns (FixedPoint.Unsigned memory amountWithdrawn)
     {
-        PositionData storage positionData = _getPositionData(msg.sender);
         require(collateralAmount.isGreaterThan(0));
+        PositionData storage positionData = _getPositionData(msg.sender);
 
         // Decrement the sponsor's collateral and global collateral amounts. Check the GCR between decrement to ensure
         // position remains above the GCR within the witdrawl. If this is not the case the caller must submit a request.


### PR DESCRIPTION
**Problem:**
The `createPerpetual` function of the PerpetualCreator contract will run most of its logic before eventually reverting when the `params.collateralAddress` is not approved. Similarly, the withdraw function of the PerpetualPositionManager contract reverts when `collateralAmount` is equal to zero, but only after already getting the positionData using the nontrivial _getPositionData.

**Solution in this PR:**
This PR moves the required checks to the top of the function to follow the Checks-Effects-Interactions pattern. 

Note that the audit recommends checking that an identifier is registered within the `IdentifierWhitelist` to preserve gas within the `PerpetualCreator` in the case of a reverting call. This change was chosen to _not_ be implemented as this function is not called very often (only by perpetual deployers) so reverting calls will be far less common than other public methods. Additionally, to enable the `PerpetualCreator` to be able to verify if an identifier is registered the `PerpetualCreator` would need to import two additional interfaces (`OracleInterfaces` & `IdentifierWhitelistInterface`) as well as implement additional methods and logic to repeat an existing check that occurs within the constructor of the `PerpetualPositionManager`. This additional complexity & code is not warranted to save a small amount of gas for a perpetual deployer.