### PR TITLE
fix(dec-20-audit): [L02] Complex Repay Function

### DIFF
--- a/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -459,7 +459,7 @@ contract PricelessPositionManager is FeePayer {
      * This is done by a sponsor to increase position CR. Resulting size is bounded by minSponsorTokens.
      * @dev Can only be called by token sponsor. This contract must be approved to spend `numTokens` of `tokenCurrency`.
      * @dev This contract must have the Burner role for the `tokenCurrency`.
-     * @param numTokens is the number of tokens to be burnt for a commensurate amount of collateral.
+     * @param numTokens is the number of tokens to be burnt from the sponsor's debt position.
      */
     function repay(FixedPoint.Unsigned memory numTokens)
         public

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -420,7 +420,7 @@ contract PerpetualPositionManager is FundingRateApplier {
      * This is done by a sponsor to increase position CR. Resulting size is bounded by minSponsorTokens.
      * @dev Can only be called by token sponsor. This contract must be approved to spend `numTokens` of `tokenCurrency`.
      * @dev This contract must have the Burner role for the `tokenCurrency`.
-     * @param numTokens is the number of tokens to be burnt for a commensurate amount of collateral.
+     * @param numTokens is the number of tokens to be burnt from the sponsor's debt position.
      */
     function repay(FixedPoint.Unsigned memory numTokens)
         public

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -87,6 +87,7 @@ contract PerpetualPositionManager is FundingRateApplier {
     event NewSponsor(address indexed sponsor);
     event EndedSponsorPosition(address indexed sponsor);
     event Redeem(address indexed sponsor, uint256 indexed collateralAmount, uint256 indexed tokenAmount);
+    event Repay(address indexed sponsor, uint256 indexed numTokensRepaid, uint256 indexed newTokenCount);
     event EmergencyShutdown(address indexed caller, uint256 shutdownTimestamp);
     event SettleEmergencyShutdown(
         address indexed caller,
@@ -343,9 +344,9 @@ contract PerpetualPositionManager is FundingRateApplier {
             "Insufficient collateral"
         );
 
-        require(positionData.withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
+        require(positionData.withdrawalRequestPassTimestamp == 0);
         if (positionData.tokensOutstanding.isEqual(0)) {
-            require(numTokens.isGreaterThanOrEqual(minSponsorTokens), "Below minimum sponsor position");
+            require(numTokens.isGreaterThanOrEqual(minSponsorTokens));
             emit NewSponsor(msg.sender);
         }
 
@@ -399,7 +400,7 @@ contract PerpetualPositionManager is FundingRateApplier {
 
             // Decrease the sponsors position tokens size. Ensure it is above the min sponsor size.
             FixedPoint.Unsigned memory newTokenCount = positionData.tokensOutstanding.sub(numTokens);
-            require(newTokenCount.isGreaterThanOrEqual(minSponsorTokens), "Below minimum sponsor position");
+            require(newTokenCount.isGreaterThanOrEqual(minSponsorTokens));
             positionData.tokensOutstanding = newTokenCount;
 
             // Update the totalTokensOutstanding after redemption.
@@ -421,8 +422,29 @@ contract PerpetualPositionManager is FundingRateApplier {
      * @dev This contract must have the Burner role for the `tokenCurrency`.
      * @param numTokens is the number of tokens to be burnt for a commensurate amount of collateral.
      */
-    function repay(FixedPoint.Unsigned memory numTokens) public {
-        deposit(redeem(numTokens));
+    function repay(FixedPoint.Unsigned memory numTokens)
+        public
+        notEmergencyShutdown()
+        noPendingWithdrawal(msg.sender)
+        fees()
+        nonReentrant()
+    {
+        PositionData storage positionData = _getPositionData(msg.sender);
+        require(numTokens.isLessThanOrEqual(positionData.tokensOutstanding));
+
+        // Decrease the sponsors position tokens size. Ensure it is above the min sponsor size.
+        FixedPoint.Unsigned memory newTokenCount = positionData.tokensOutstanding.sub(numTokens);
+        require(newTokenCount.isGreaterThanOrEqual(minSponsorTokens));
+        positionData.tokensOutstanding = newTokenCount;
+
+        // Update the totalTokensOutstanding after redemption.
+        totalTokensOutstanding = totalTokensOutstanding.sub(numTokens);
+
+        emit Repay(msg.sender, numTokens.rawValue, newTokenCount.rawValue);
+
+        // Transfer the tokens back from the sponsor and burn them.
+        tokenCurrency.safeTransferFrom(msg.sender, address(this), numTokens.rawValue);
+        tokenCurrency.burn(numTokens.rawValue);
     }
 
     /**
@@ -594,10 +616,7 @@ contract PerpetualPositionManager is FundingRateApplier {
 
         // Ensure that the sponsor will meet the min position size after the reduction.
         positionData.tokensOutstanding = positionData.tokensOutstanding.sub(tokensToRemove);
-        require(
-            positionData.tokensOutstanding.isGreaterThanOrEqual(minSponsorTokens),
-            "Below minimum sponsor position"
-        );
+        require(positionData.tokensOutstanding.isGreaterThanOrEqual(minSponsorTokens));
 
         // Decrement the position's withdrawal amount.
         positionData.withdrawalRequestAmount = positionData.withdrawalRequestAmount.sub(withdrawalAmountToRemove);
@@ -732,7 +751,7 @@ contract PerpetualPositionManager is FundingRateApplier {
     // `create` method because it is possible that `create` is called on a new position (i.e. one without any collateral
     // or tokens outstanding) which would fail the `onlyCollateralizedPosition` modifier on `_getPositionData`.
     function _positionHasNoPendingWithdrawal(address sponsor) internal view {
-        require(_getPositionData(sponsor).withdrawalRequestPassTimestamp == 0, "Pending withdrawal");
+        require(_getPositionData(sponsor).withdrawalRequestPassTimestamp == 0);
     }
 
     /****************************************


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2307

The `repay` function of the `PerpetualPositionManager` contract simply redeems the tokens and then deposits the retrieved collateral. This should have no net effect on the collateral token. This produces clean code but introduces unnecessary fragilities and complexities:

- the deposit function pulls the collateral, so the user needs to have previously granted the relevant collateral token allowance to the contract before either having the collateral or knowing the amount of the deposit. Confusingly, they need to do this for an operation that ostensibly has nothing to do with the collateral token.
- the matching transfers correctly result in the same collateral balances, but they unexpectedly emit opposing Transfer events
- the transfer may be unexpectedly effected by idiosyncrasies of the collateral token, which could include transfer fees or recipient blacklists (like USDC)
- the repay operation unexpectedly emits Redeem and Deposit events

Consider directly implementing the repay function to avoid unnecessarily involving the collateral token and the sponsor’s collateral balance.


**Summary**

Directly implements `repay` and adds it to the ExpiringMultiParty as well. Updates unit tests + adds one check that the caller has set their token allowance.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2307
