### PR TITLE
fix(dec-2020-audit): [N08] Typographical errors

### DIFF
--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -130,7 +130,7 @@ abstract contract FundingRateApplier is FeePayer {
 
     /**
      * @notice Proposes a new funding rate. Proposer receives a reward if correct.
-     * @param rate funding rate to being proposed.
+     * @param rate funding rate being proposed.
      * @param timestamp time at which the funding rate was computed.
      */
     function proposeNewRate(FixedPoint.Signed memory rate, uint256 timestamp)

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/PreExpirationIdentifierTransformationFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/PreExpirationIdentifierTransformationFinancialProductLibrary.sol
@@ -7,7 +7,7 @@ import "../../../common/implementation/Lockable.sol";
 /**
  * @title Pre-Expiration Identifier Transformation Financial Product Library
  * @notice Adds custom identifier transformation to enable a financial contract to use two different identifiers, depending
- * on when a price request is made. If the request is made before expiration than a transformation is made to the identifier
+ * on when a price request is made. If the request is made before expiration then a transformation is made to the identifier
  * & if it is at or after expiration then the original identifier is returned. This library enables self referential
  * TWAP identifier to be used on synthetics pre-expiration, in conjunction with a separate identifier at expiration.
  */
@@ -18,9 +18,9 @@ contract PreExpirationIdentifierTransformationFinancialProductLibrary is Financi
      * @notice Enables the deployer of the library to set the transformed identifier for an associated financial product.
      * @param financialProduct address of the financial product.
      * @param transformedIdentifier the identifier for the financial product to be used if the contract is post expiration.
-     * @dev Note: a) Only the owner (deployer) of this library can set identifier transformations b) The identifier Cant
+     * @dev Note: a) Only the owner (deployer) of this library can set identifier transformations b) The identifier Can't
      * be set to blank. c) A transformed price can only be set once to prevent the deployer from changing it after the fact.
-     * d)  financialProduct must exposes an expirationTimestamp method.
+     * d)  financialProduct must expose an expirationTimestamp method.
      */
     function setFinancialProductTransformedIdentifier(address financialProduct, bytes32 transformedIdentifier)
         public

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/StructureNoteFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/StructureNoteFinancialProductLibrary.sol
@@ -11,7 +11,7 @@ import "../../../common/implementation/Lockable.sol";
  * ETHUSD is above that strike, the contract pays out a given dollar amount of ETH.
  * Example: expiry is DEC 31. Strike is $400. Each token is backed by 1 WETH
  * If ETHUSD < $400 at expiry, token is redeemed for 1 ETH.
- * If ETHUSD >= $400 at expiry, token is redeemed for $400 worth of ETH, as determine by the DVM.
+ * If ETHUSD >= $400 at expiry, token is redeemed for $400 worth of ETH, as determined by the DVM.
  */
 contract StructuredNoteFinancialProductLibrary is FinancialProductLibrary, Ownable, Lockable {
     mapping(address => FixedPoint.Unsigned) financialProductStrikes;
@@ -20,7 +20,7 @@ contract StructuredNoteFinancialProductLibrary is FinancialProductLibrary, Ownab
      * @notice Enables the deployer of the library to set the strike price for an associated financial product.
      * @param financialProduct address of the financial product.
      * @param strikePrice the strike price for the structured note to be applied to the financial product.
-     * @dev Note: a) Only the owner (deployer) of this library can set new strike prices b) A strike price can not be 0.
+     * @dev Note: a) Only the owner (deployer) of this library can set new strike prices b) A strike price cannot be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
      * d)  financialProduct must exposes an expirationTimestamp method.
      */

--- a/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
@@ -313,7 +313,7 @@ contract PricelessPositionManager is FeePayer {
         require(collateralAmount.isGreaterThan(0));
 
         // Decrement the sponsor's collateral and global collateral amounts. Check the GCR between decrement to ensure
-        // position remains above the GCR within the witdrawl. If this is not the case the caller must submit a request.
+        // position remains above the GCR within the withdrawal. If this is not the case the caller must submit a request.
         amountWithdrawn = _decrementCollateralBalancesCheckGCR(positionData, collateralAmount);
 
         emit Withdrawal(msg.sender, amountWithdrawn.rawValue);

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
@@ -11,7 +11,7 @@ import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/FixedPoint.sol";
 
 /**
- * @notice ConfigStore stores configuration settings for a perpetual contract and provides and interface for it
+ * @notice ConfigStore stores configuration settings for a perpetual contract and provides an interface for it
  * to query settings such as reward rates, proposal bond sizes, etc. The configuration settings can be upgraded
  * by a privileged account and the upgraded changes are timelocked.
  */

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -17,7 +17,7 @@ import "./ConfigStore.sol";
  * @title Perpetual Contract creator.
  * @notice Factory contract to create and register new instances of perpetual contracts.
  * Responsible for constraining the parameters used to construct a new perpetual. This creator contains a number of constraints
- * that are applied to newly created  contract. These constraints can evolve over time and are
+ * that are applied to newly created contract. These constraints can evolve over time and are
  * initially constrained to conservative values in this first iteration. Technically there is nothing in the
  * Perpetual contract requiring these constraints. However, because `createPerpetual()` is intended
  * to be the only way to create valid financial contracts that are registered with the DVM (via _registerContract),

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -542,7 +542,7 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
         // The required collateral is the value of the tokens in underlying * required collateral ratio.
         FixedPoint.Unsigned memory requiredCollateral = tokenRedemptionValue.mul(collateralRequirement);
 
-        // If the position has more than the required collateral it is solvent and the dispute is valid(liquidation is invalid)
+        // If the position has more than the required collateral it is solvent and the dispute is valid (liquidation is invalid)
         // Note that this check uses the liquidatedCollateral not the lockedCollateral as this considers withdrawals.
         bool disputeSucceeded = liquidation.liquidatedCollateral.isGreaterThanOrEqual(requiredCollateral);
         liquidation.state = disputeSucceeded ? Status.DisputeSucceeded : Status.DisputeFailed;

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -226,7 +226,7 @@ contract PerpetualPositionManager is FundingRateApplier {
         require(collateralAmount.isGreaterThan(0));
 
         // Decrement the sponsor's collateral and global collateral amounts. Check the GCR between decrement to ensure
-        // position remains above the GCR within the witdrawl. If this is not the case the caller must submit a request.
+        // position remains above the GCR within the withdrawal. If this is not the case the caller must submit a request.
         amountWithdrawn = _decrementCollateralBalancesCheckGCR(positionData, collateralAmount);
 
         emit Withdrawal(msg.sender, amountWithdrawn.rawValue);
@@ -239,7 +239,7 @@ contract PerpetualPositionManager is FundingRateApplier {
     }
 
     /**
-     * @notice Starts a withdrawal request that, if passed, allows the sponsor to withdraw` from their position.
+     * @notice Starts a withdrawal request that, if passed, allows the sponsor to withdraw from their position.
      * @dev The request will be pending for `withdrawalLiveness`, during which the position can be liquidated.
      * @param collateralAmount the amount of collateral requested to withdraw
      */

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -210,7 +210,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
 
     /**
      * @notice Sets the request to refund the reward if the proposal is disputed. This can help to "hedge" the caller
-     * in the event of a dispute-caused delay. Note: in the event of a dispute, the winner still receives the others'
+     * in the event of a dispute-caused delay. Note: in the event of a dispute, the winner still receives the other's
      * bond, so there is still profit to be made even if the reward is refunded.
      * @param identifier price identifier to identify the existing request.
      * @param timestamp timestamp to identifiy the existing request.
@@ -326,7 +326,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @param timestamp timestamp to identifiy the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
-     * the disputer once settled if the dispute was value (the proposal was incorrect).
+     * the disputer once settled if the dispute was valid (the proposal was incorrect).
      */
     function disputePriceFor(
         address disputer,

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -188,7 +188,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
     /**
      * @notice Requests a new price.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param bond custom bond amount to set.
      * @return totalBond new bond + final fee that the proposer and disputer will be required to pay. This can be
@@ -213,7 +213,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * in the event of a dispute-caused delay. Note: in the event of a dispute, the winner still receives the other's
      * bond, so there is still profit to be made even if the reward is refunded.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      */
     function setRefundOnDispute(
@@ -232,7 +232,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Sets a custom liveness value for the request. Liveness is the amount of time a proposal must wait before
      * being auto-resolved.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param customLiveness new custom liveness.
      */
@@ -256,7 +256,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @param proposer address to set as the proposer.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param proposedPrice price being proposed.
      * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
@@ -300,7 +300,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Proposes a price value for an existing price request.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param proposedPrice price being proposed.
      * @return totalBond the amount that's pulled from the proposer's wallet as a bond. The bond will be returned to
@@ -323,7 +323,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @param disputer address to set as the disputer.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
      * the disputer once settled if the dispute was valid (the proposal was incorrect).
@@ -376,7 +376,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Disputes a price value for an existing price request with an active proposal.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return totalBond the amount that's pulled from the disputer's wallet as a bond. The bond will be returned to
      * the disputer once settled if the dispute was valid (the proposal was incorrect).
@@ -396,7 +396,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * or settleable. Note: this method is not view so that this call may actually settle the price request if it
      * hasn't been settled.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return resolved price.
      */
@@ -416,7 +416,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Attempts to settle an outstanding price request. Will revert if it isn't settleable.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return payout the amount that the "winner" (proposer or disputer) receives on settlement. This amount includes
      * the returned bonds as well as additional rewards.
@@ -434,7 +434,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Gets the current data structure containing all information about a price request.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return the Request data structure.
      */
@@ -451,7 +451,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Computes the current state of a price request. See the State enum for more details.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return the State.
      */
@@ -489,7 +489,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Checks if a given request has resolved or been settled (i.e the optimistic oracle has a price).
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return the State.
      */

--- a/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
@@ -64,7 +64,7 @@ abstract contract OptimisticOracleInterface {
     /**
      * @notice Requests a new price.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param bond custom bond amount to set.
      * @return totalBond new bond + final fee that the proposer and disputer will be required to pay. This can be
@@ -79,10 +79,10 @@ abstract contract OptimisticOracleInterface {
 
     /**
      * @notice Sets the request to refund the reward if the proposal is disputed. This can help to "hedge" the caller
-     * in the event of a dispute-caused delay. Note: in the event of a dispute, the winner still receives the others'
+     * in the event of a dispute-caused delay. Note: in the event of a dispute, the winner still receives the other's
      * bond, so there is still profit to be made even if the reward is refunded.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      */
     function setRefundOnDispute(
@@ -95,7 +95,7 @@ abstract contract OptimisticOracleInterface {
      * @notice Sets a custom liveness value for the request. Liveness is the amount of time a proposal must wait before
      * being auto-resolved.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param customLiveness new custom liveness.
      */
@@ -112,7 +112,7 @@ abstract contract OptimisticOracleInterface {
      * @param proposer address to set as the proposer.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param proposedPrice price being proposed.
      * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
@@ -131,7 +131,7 @@ abstract contract OptimisticOracleInterface {
      * @notice Proposes a price value for an existing price request.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @param proposedPrice price being proposed.
      * @return totalBond the amount that's pulled from the proposer's wallet as a bond. The bond will be returned to
@@ -151,7 +151,7 @@ abstract contract OptimisticOracleInterface {
      * @param disputer address to set as the disputer.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
      * the disputer once settled if the dispute was value (the proposal was incorrect).
@@ -168,7 +168,7 @@ abstract contract OptimisticOracleInterface {
      * @notice Disputes a price value for an existing price request with an active proposal.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return totalBond the amount that's pulled from the disputer's wallet as a bond. The bond will be returned to
      * the disputer once settled if the dispute was valid (the proposal was incorrect).
@@ -185,7 +185,7 @@ abstract contract OptimisticOracleInterface {
      * or settleable. Note: this method is not view so that this call may actually settle the price request if it
      * hasn't been settled.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return resolved price.
      */
@@ -199,7 +199,7 @@ abstract contract OptimisticOracleInterface {
      * @notice Attempts to settle an outstanding price request. Will revert if it isn't settleable.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return payout the amount that the "winner" (proposer or disputer) receives on settlement. This amount includes
      * the returned bonds as well as additional rewards.
@@ -215,7 +215,7 @@ abstract contract OptimisticOracleInterface {
      * @notice Gets the current data structure containing all information about a price request.
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return the Request data structure.
      */
@@ -237,7 +237,7 @@ abstract contract OptimisticOracleInterface {
      * @notice Checks if a given request has resolved or been settled (i.e the optimistic oracle has a price).
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
-     * @param timestamp timestamp to identifiy the existing request.
+     * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
      * @return the State.
      */


### PR DESCRIPTION
**Problem identified in Audit**

**In FundingRateApplier.sol:**
- line 142: “to” should be removed

**In PreExpirationIdentifierTransformationFinancialProductLibrary.sol:**
- line 10: “than” should be “then”
- line 21: “Cant” should be “can’t”
- line 23: “exposes” should be “expose”

**In StructureNoteFinancialProductLibrary.sol:**
- line 14: “determine” should be “determined”
- line 23: “can not” should be “cannot”
- line 25: “exposes” should be “expose”

**In ConfigStore.sol:**
- line 14: “and” should be “an”
- line 144: “can” should be removed

**In PerpetualCreator.sol:**
- line 20: there is an extra space

**In PerpetualLiquidatable.sol:**
- line 545: “valid(liquidation” should be “valid (liquidation”

**In PerpetualPositionManager.sol:**
- line 229: “witdrawl.” should be “withdrawal.”
- line 242: “withdraw`” should be “withdraw”

**In OptimisticOracle.sol:**
- line 211: “others'” should be “other’s”
- line 327: “value” should be “valid”
There are several places where “identifiy” should be “identify”

**In OptimisticOracleInterface.sol:**
- line 77: “others'” should be “other’s”
- line 152: “value” should be “valid”
There are several places where “identifiy” should be “identify”


**Problem solution in this PR:**

Each issue has been addressed in addition to a few small extras that were found along the way.