### PR TITLE
fix(dec-20-audit): [L11] Propose or Dispute a price from the zero address

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -270,6 +270,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         bytes memory ancillaryData,
         int256 proposedPrice
     ) public override nonReentrant() returns (uint256 totalBond) {
+        require(proposer != address(0), "proposer address must be non 0");
         require(
             getState(requester, identifier, timestamp, ancillaryData) == State.Requested,
             "proposePriceFor: Requested"
@@ -335,6 +336,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         uint256 timestamp,
         bytes memory ancillaryData
     ) public override nonReentrant() returns (uint256 totalBond) {
+        require(disputer != address(0), "disputer address must be non 0");
         require(
             getState(requester, identifier, timestamp, ancillaryData) == State.Proposed,
             "disputePriceFor: Proposed"

--- a/packages/core/test/oracle/OptimisticOracle.js
+++ b/packages/core/test/oracle/OptimisticOracle.js
@@ -179,6 +179,19 @@ contract("OptimisticOracle", function(accounts) {
       await verifyBalanceSum(optimisticOracle.address, reward, totalCustomBond);
     });
 
+    it("Should Revert When Proposed For With 0 Address", async function() {
+      await collateral.approve(optimisticOracle.address, totalDefaultBond, { from: proposer });
+      const request = optimisticOracle.proposePriceFor(
+        "0x0000000000000000000000000000000000000000",
+        optimisticRequester.address,
+        identifier,
+        requestTime,
+        "0x",
+        correctPrice,
+        { from: proposer }
+      );
+      assert(await didContractThrow(request));
+    });
     it("Propose For", async function() {
       await collateral.approve(optimisticOracle.address, totalDefaultBond, { from: proposer });
       await optimisticOracle.proposePriceFor(
@@ -403,6 +416,20 @@ contract("OptimisticOracle", function(accounts) {
       assert.equal((await optimisticRequester.refund()).toString(), "0");
     });
 
+    it("Should Revert When Dispute For With 0 Address", async function() {
+      await collateral.approve(optimisticOracle.address, totalDefaultBond, { from: proposer });
+      const request = optimisticOracle.disputePriceFor(
+        "0x0000000000000000000000000000000000000000",
+        optimisticRequester.address,
+        identifier,
+        requestTime,
+        "0x",
+        {
+          from: disputer
+        }
+      );
+      assert(await didContractThrow(request));
+    });
     it("Dispute For", async function() {
       await collateral.approve(optimisticOracle.address, totalDefaultBond, { from: disputer });
       await optimisticOracle.disputePriceFor(rando, optimisticRequester.address, identifier, requestTime, "0x", {


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
The Optimistic oracle allows anyone to propose a price or dispute a proposal on behalf of the zero address. Since the state of the incentive mechanism is partially determined by whether the proposer or disputer addresses are non-zero, this won’t update the state machine, but it will set variables and emit events prematurely. For example, a client may incorrectly react to a DisputePrice event even though the dispute is not recognized by the oracle. Consider restricting the proposePriceFor and disputePriceFor function parameters to non-zero participants.

**Summary**

Adds 2 require statements in the appropriate functions and adds a tests to ensure calls fail when passing 0x0 address.

