### PR TITLE
fix(dec-2020-audit): [N09] Unnecessary imports

### DIFF
--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -10,8 +10,8 @@ import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/FixedPoint.sol";
 import "../../common/implementation/Testable.sol";
 
-import "../../oracle/interfaces/StoreInterface.sol";
-import "../../oracle/interfaces/FinderInterface.sol";
+
+
 import "../../oracle/implementation/Constants.sol";
 import "../../oracle/interfaces/OptimisticOracleInterface.sol";
 import "../perpetual-multiparty/ConfigStoreInterface.sol";

--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -10,8 +10,6 @@ import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/FixedPoint.sol";
 import "../../common/implementation/Testable.sol";
 
-
-
 import "../../oracle/implementation/Constants.sol";
 import "../../oracle/interfaces/OptimisticOracleInterface.sol";
 import "../perpetual-multiparty/ConfigStoreInterface.sol";

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -13,7 +13,6 @@ import "../../oracle/interfaces/OracleInterface.sol";
 import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
 import "../../oracle/implementation/Constants.sol";
 
-import "../common/FeePayer.sol";
 import "../common/FundingRateApplier.sol";
 
 /**


### PR DESCRIPTION
**Problem:**

In the PerpetualPositionManager.sol file, consider removing the import statement for FeePayer.sol, as it is never used in the PerpetualPositionManager contract.

Also, in the FundingRateApplier.sol file, consider removing the import statements for StoreInterface.sol and FinderInterface.sol, as they are never used in the FundingRateApplier contract.

**Solution in this PR**
These redundant imports were removed.