### PR TITLE
fix(dec-2020-audit): [N10] Unnecessary type cast

### DIFF
--- a/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
@@ -87,9 +87,9 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
 
         _registerContract(new address[](0), address(derivative));
 
-        emit CreatedExpiringMultiParty(address(derivative), msg.sender);
+        emit CreatedExpiringMultiParty(derivative, msg.sender);
 
-        return address(derivative);
+        return derivative;
     }
 
     /****************************************

--- a/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
@@ -85,7 +85,7 @@ contract ExpiringMultiPartyCreator is ContractCreator, Testable, Lockable {
         tokenCurrency.addBurner(derivative);
         tokenCurrency.resetOwner(derivative);
 
-        _registerContract(new address[](0), address(derivative));
+        _registerContract(new address[](0), derivative);
 
         emit CreatedExpiringMultiParty(derivative, msg.sender);
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -97,7 +97,7 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
         tokenCurrency.addBurner(derivative);
         tokenCurrency.resetOwner(derivative);
 
-        _registerContract(new address[](0), address(derivative));
+        _registerContract(new address[](0), derivative);
 
         emit CreatedPerpetual(derivative, msg.sender);
 

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
@@ -99,9 +99,9 @@ contract PerpetualCreator is ContractCreator, Testable, Lockable {
 
         _registerContract(new address[](0), address(derivative));
 
-        emit CreatedPerpetual(address(derivative), msg.sender);
+        emit CreatedPerpetual(derivative, msg.sender);
 
-        return address(derivative);
+        return derivative;
     }
 
     /****************************************


### PR DESCRIPTION
**Problem identified in audit:**

In lines 102 and 104 of PerpetualCreator.sol the derivative variable is cast to the address type. Since it is defined as address type, the casts are unnecessary.

**Solution in this PR**
The redundant type casting was removed. This change was also made to the EMP creator, which was not audited but the change was made for consistency.