### PR TITLE
fix(dec-20-audit): [L06] Inconsistent hasPrice determination

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -488,12 +488,12 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
     }
 
     /**
-     * @notice Checks if a given request has resolved or been settled (i.e the optimistic oracle has a price).
+     * @notice Checks if a given request has resolved, expired or been settled (i.e the optimistic oracle has a price).
      * @param requester sender of the initial price request.
      * @param identifier price identifier to identify the existing request.
      * @param timestamp timestamp to identify the existing request.
      * @param ancillaryData ancillary data of the price being requested.
-     * @return the State.
+     * @return boolean indicating true if price exists and false if not.
      */
     function hasPrice(
         address requester,
@@ -501,9 +501,8 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         uint256 timestamp,
         bytes memory ancillaryData
     ) public view override returns (bool) {
-        return
-            getState(requester, identifier, timestamp, ancillaryData) == State.Settled ||
-            getState(requester, identifier, timestamp, ancillaryData) == State.Resolved;
+        State state = getState(requester, identifier, timestamp, ancillaryData);
+        return state == State.Settled || state == State.Resolved || state == State.Expired;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

[L06] Inconsistent hasPrice determination
The hasPrice function of the OptimisticOracle contract returns true if the request is either Settled or Resolved. Although the internal state of the contract does not record the price in the Resolved state, this makes sense because retrieving the price will settle the request. This means that from a user’s point of view, a Resolved price request can be considered to have a price. However, the same reasoning suggests that an Expired price request can also be considered to have a price.

Consider adding another condition to the hasPrice function so it returns true for Expired price requests.


**Summary**

This adds an additional state check to resolve hasPrice to true if price proposal is also expired. Adds in several tests to make sure hasPrice works as intended in various scenarios, including the scenario indicated above where price proposal is expired but not settled. 

