### PR TITLE
improve(core): update deploy script to use patched deployment

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,8 @@
     "@truffle/contract": "^4.2.20",
     "@uma/common": "^1.1.0",
     "@uma/core-1-1-0": "npm:@uma/core@1.1.0",
-    "@uma/core-1-2-0": "npm:@uma/core@1.2.0"
+    "@uma/core-1-2-0": "npm:@uma/core@1.2.0",
+    "@uma/core-1-2-1": "npm:@uma/core@1.2.1"
   },
   "devDependencies": {
     "@awaitjs/express": "^0.3.0",

--- a/packages/core/scripts/local/DeployEMP.js
+++ b/packages/core/scripts/local/DeployEMP.js
@@ -28,7 +28,7 @@ const argv = require("minimist")(process.argv.slice(), {
   boolean: ["test"],
   string: ["identifier", "collateral", "cversion"]
 });
-const abiVersion = argv.cversion || "1.1.0"; // Default to most recent mainnet deployment, 1.1.0.
+const abiVersion = argv.cversion || "1.2.1"; // Default to most recent mainnet deployment, 1.1.0.
 
 // Deployed contract ABI's and addresses we need to fetch.
 const ExpiringMultiPartyCreator = getTruffleContract("ExpiringMultiPartyCreator", web3, abiVersion);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4667,6 +4667,15 @@
     "@uma/common" "^1.1.0"
     "@uma/core-1-1-0" "npm:@uma/core@1.1.0"
 
+"@uma/core-1-2-1@npm:@uma/core@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@uma/core/-/core-1.2.1.tgz#1085984633a2e4aa15f471d01bb08bcf6a34ba64"
+  integrity sha512-8j9Rgk3V9bXO2izdBS6rXLlqNVtBEPRv6frcT7J/Btv8bjrcf+29tuH1GO66FUWb7kMrxgirFSU0LGNPRHJcbg==
+  dependencies:
+    "@truffle/contract" "^4.2.20"
+    "@uma/common" "^1.1.0"
+    "@uma/core-1-1-0" "npm:@uma/core@1.1.0"
+
 "@umaprotocol/react-plugin@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@umaprotocol/react-plugin/-/react-plugin-1.5.5.tgz#c378fe8534c9df9a0ec02e16250fd59891cbb37f"


### PR DESCRIPTION
**Motivation**

The deployment script should use core@1.2.1 that includes the patched ExpiringMultiPartyCreator.

**Summary**

This adds a new version to the package.json and points the DeployEmp.js script at v1.2.1.

**Issue(s)**

N/A
