### PR TITLE
fix(dec-20-audit): [N01] Add notes about Approximate compounding

### DIFF
--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -60,6 +60,11 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
 
     // modifier that calls payRegularFees().
     modifier fees virtual {
+        // Note: the regular fee is applied on every fee-accruing transaction, where the total change is simply the
+        // regular fee applied linearly since the last update. This implies that the compounding rate depends on the
+        // frequency of update transactions that have this modifier, and it never reaches the ideal of continuous
+        // compounding. This approximate-compounding pattern is common in the Ethereum ecosystem because of the
+        // complexity of compounding data on-chain.
         payRegularFees();
         _;
     }

--- a/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
+++ b/packages/core/contracts/financial-templates/common/FundingRateApplier.sol
@@ -70,6 +70,11 @@ abstract contract FundingRateApplier is EmergencyShutdownable, FeePayer {
 
     // This is overridden to both pay fees (which is done by applyFundingRate()) and apply the funding rate.
     modifier fees override {
+        // Note: the funding rate is applied on every fee-accruing transaction, where the total change is simply the
+        // rate applied linearly since the last update. This implies that the compounding rate depends on the frequency
+        // of update transactions that have this modifier, and it never reaches the ideal of continuous compounding.
+        // This approximate-compounding pattern is common in the Ethereum ecosystem because of the complexity of
+        // compounding data on-chain.
         applyFundingRate();
         _;
     }

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -183,11 +183,8 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
             params.timerAddress
         )
     {
-        require(params.collateralRequirement.isGreaterThan(1), "CR must be more than 100%");
-        require(
-            params.sponsorDisputeRewardPct.add(params.disputerDisputeRewardPct).isLessThan(1),
-            "Rewards are more than 100%"
-        );
+        require(params.collateralRequirement.isGreaterThan(1));
+        require(params.sponsorDisputeRewardPct.add(params.disputerDisputeRewardPct).isLessThan(1));
 
         // Set liquidatable specific variables.
         liquidationLiveness = params.liquidationLiveness;

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
@@ -148,7 +148,7 @@ contract PerpetualPositionManager is FundingRateApplier {
             _timerAddress
         )
     {
-        require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier), "Unsupported price identifier");
+        require(_getIdentifierWhitelist().isIdentifierSupported(_priceIdentifier));
 
         withdrawalLiveness = _withdrawalLiveness;
         tokenCurrency = ExpandedIERC20(_tokenAddress);


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

In the Perpetual Multiparty template, the funding rate is applied on every fee-accruing transaction, where the total change is simply the rate applied evenly since the last update. This implies that the compounding rate depends on the frequency of update transactions, and it never reaches the ideal of continuous compounding.

This approximate-compounding pattern is common in the Ethereum ecosystem, and the discrepancy is likely unimportant in this case. Nevertheless, in the interest of clarity, we believe it is worth noting. Consider documenting this behavior in the FundingRateApplier comments.

**Summary**

Added notes to `FeePayer` and `FundingRateApplier` which both implement approximate-compounding for continuous computations.
