### PR TITLE
improve(dec-20-audit): [N02] Consider ERC777 tokens

### DIFF
--- a/packages/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
+++ b/packages/core/contracts/financial-templates/expiring-multiparty/Liquidatable.sol
@@ -18,6 +18,9 @@ import "../../common/implementation/FixedPoint.sol";
  * a DVM price. The contract enforces dispute rewards in order to incentivize disputers to correctly dispute false
  * liquidations and compensate position sponsors who had their position incorrectly liquidated. Importantly, a
  * prospective disputer must deposit a dispute bond that they can lose in the case of an unsuccessful dispute.
+ * NOTE: this contract does _not_ work with ERC777 collateral currencies or any others that call into the receiver on
+ * transfer(). Using an ERC777 token would allow a user to maliciously grief other participants (while also losing
+ * money themselves).
  */
 contract Liquidatable is PricelessPositionManager {
     using FixedPoint for FixedPoint.Unsigned;

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -17,6 +17,9 @@ import "../../common/implementation/FixedPoint.sol";
  * a DVM price. The contract enforces dispute rewards in order to incentivize disputers to correctly dispute false
  * liquidations and compensate position sponsors who had their position incorrectly liquidated. Importantly, a
  * prospective disputer must deposit a dispute bond that they can lose in the case of an unsuccessful dispute.
+ * NOTE: this contract does _not_ work with ERC777 collateral currencies or any others that call into the receiver on
+ * transfer(). Using an ERC777 token would allow a user to maliciously grief other participants (while also losing
+ * money themselves).
  */
 contract PerpetualLiquidatable is PerpetualPositionManager {
     using FixedPoint for FixedPoint.Unsigned;


### PR DESCRIPTION
**Motivation**

The ERC777 token standard extends ERC20 tokens to include send and receive hooks on every balance update. Although the standard is intended to be backwards compatible, it can introduce unexpected risks into systems designed to work with ERC20s.

In this case, the Liquidatable contract has been refactored to distribute funds to all participants in the same transaction. The same pattern is used in the PerpetualLiquidatable contract. If any of those addresses have a receive hook that reverts, none of the participants could withdraw their funds.

Similarly, if an address that requests a price from the Optimistic oracle prevents the dispute refund transfer, they will disable the dispute functionality.

If the system should support ERC777 tokens, consider isolating the transfer logic so that maliciously constructed send or receive hooks cannot disable any functionality. Otherwise, consider explicitly documenting that ERC777 tokens should not be used as collateral or oracle rewards.

**Summary**

This PR just adds a note on contracts that explicitly do not work with ERC777 tokens. In the future, we may consider handling ERC777 specifically, but since it isn't particularly common, we are opting not to modify the code.

**Issue(s)**

N/A