### PR TITLE
[RFC] improve(core): Upgrade @openzeppelin/contracts from 3.0.0 to 3.3.0

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingToken.sol
+++ b/packages/core/contracts/oracle/implementation/VotingToken.sol
@@ -22,23 +22,15 @@ contract VotingToken is ExpandedERC20, ERC20Snapshot {
         return _snapshot();
     }
 
-    // _transfer, _mint and _burn are ERC20 internal methods that are overridden by ERC20Snapshot,
-    // therefore the compiler will complain that VotingToken must override these methods
-    // because the two base classes (ERC20 and ERC20Snapshot) both define the same functions
+    // _beforeTokenTransfer is an ERC20 internal method that is overridden by ERC20Snapshot,
+    // therefore the compiler will complain that VotingToken must override this method
+    // because the two base classes (ERC20 and ERC20Snapshot) both define the same function
 
-    function _transfer(
+    function _beforeTokenTransfer(
         address from,
         address to,
-        uint256 value
-    ) internal override(ERC20, ERC20Snapshot) {
-        super._transfer(from, to, value);
-    }
-
-    function _mint(address account, uint256 value) internal override(ERC20, ERC20Snapshot) {
-        super._mint(account, value);
-    }
-
-    function _burn(address account, uint256 value) internal override(ERC20, ERC20Snapshot) {
-        super._burn(account, value);
+        uint256 amount
+    ) internal virtual override(ERC20, ERC20Snapshot) {
+        super._beforeTokenTransfer(from, to, amount);
     }
 }

--- a/packages/core/hardhat.config.js
+++ b/packages/core/hardhat.config.js
@@ -14,4 +14,11 @@ const configOverride = {
   }
 };
 
-module.exports = getHardhatConfig(configOverride);
+// `getHardhatConfig` has a `configOverrides` parameter, but we can't use it
+// since it does a shallow merge and we want to override a single nested field.
+const config = getHardhatConfig(configOverride);
+
+// The default is 199. FiXME - comment out this line to see what goes wrong:
+config.solidity.settings.optimizer.runs = 25;
+
+module.exports = config;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@awaitjs/express": "^0.3.0",
     "@ethersproject/units": "^5.0.3",
-    "@openzeppelin/contracts": "3.0.0",
+    "@openzeppelin/contracts": "3.3.0",
     "@sendgrid/mail": "^6.4.0",
     "@uma/financial-templates-lib": "^1.2.0",
     "bip39": "^3.0.2",

--- a/packages/core/truffle-config.js
+++ b/packages/core/truffle-config.js
@@ -1,1 +1,6 @@
-module.exports = require("@uma/common").getTruffleConfig(__dirname);
+const config = require("@uma/common").getTruffleConfig(__dirname);
+
+// The default is 199. FiXME - comment out this line to see what goes wrong:
+config.compilers.solc.settings.optimizer.runs = 25;
+
+module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,10 +3719,10 @@
     hex2dec "^1.0.1"
     uuid "^3.2.1"
 
-"@openzeppelin/contracts@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.0.0.tgz#89bc0d32fc9eb257cf6499f2497a1b4a6715f186"
-  integrity sha512-u7oATjUK6jffDOoIjVQ7vJ2fnFKlfDS1CJzrMpp+YtGQ2fhdSk0kXjZTxk8Pj1SPVZRNES3yo0r144v8BsuRhQ==
+"@openzeppelin/contracts@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.3.0.tgz#ffdb693c5c349fc33bba420248dd3ac0a2d7c408"
+  integrity sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
**Motivation**

*This is more of a RFC (request for comments) than an actual pull request, though getting this PR merged in some form as a result of the fruitful discussion, would certainly be considered a happy ending.*

We at @jarvis-network are facing issues with getting all of our contracts verified on Etherscan. After extensive debugging and investigation me and @Aleione noticed a difference in the bytecode between the published artifacts in the npm package of our fork of UMAProtocol and when building the same contracts from our project, even the though the compiler version and optimization settings are the same. After more investigation we narrowed down the problem to the version of openzeppelin used. In our case we have `@openzeppelin/contracts@3.3.0` and the core package is using `@openzeppelin/contracts@3.0.0 `. Downgrading is not an option for us, since we use features released in version `3.3.0`.
To make sure that compiling UMA contracts both from this repo (well actually our fork) and our project that includes it as an npm dependency yields the same bytecode (when compiled with the same solc version and same optimization settings), we decided to upgrade `@openzeppelin/contracts` to `3.3.0`. Getting the code to compile was simple enough - I just had to address one [breaking change](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md#breaking-changes) introduced by `@openzeppelin/contracts` `3.1.0` (yeah, so much for having semantic versioning...), however we immediately faced an issue with `hardhat test`. It seems like the upgrade of `@openzeppelin/contracts` alone is enough to tip over the deployment over the limit:

<details><summary>Click to expand the output of <code>hardhat test</code>:</summary>

```sh
➤ cd packages/core
➤ node --max-old-space-size=1024 (yarn bin hardhat) test --verbose
...
hardhat:core:hre Creating HardhatRuntimeEnvironment +0ms
...
...
hardhat:core:hre Running task compile:solidity:log:run-compiler-start +0ms
Compiling 105 files with 0.6.12
  hardhat:core:hre Running task compile:solidity:solc:run +1ms
...
...
Compilation finished successfully
...
...
Contract: Lockable
  hardhat:core:hre Running task run-truffle-fixture +19s
  hardhat:core:hre Creating provider for network hardhat +6ms

    1) "before all" hook: Running truffle fixture if available in "Contract: Lockable"

  Contract: MultiRole
  hardhat:core:hre Running task run-truffle-fixture +4s

    2) "before all" hook: Running truffle fixture if available for "Exclusive Self-managed role"
...
...
  0 passing (59s)
  36 failing

  1) Contract: Lockable
       "before all" hook: Running truffle fixture if available in "Contract: Lockable":
     Error: Transaction reverted: trying to deploy a contract whose code is too large
      at ExpiringMultiPartyLib.constructor (contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol:11)
      at $USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/truffle-contract/lib/execute.js:229:26
      at Function.new ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/truffle-contract/lib/contract/constructorMethods.js:58:53)
      at deploy ($USER/code/repos/blockchain/eth/UMAprotocol/packages/common/src/MigrationUtils.js:94:46)
      at module.exports (migrations/15_deploy_expiring_multi_party_creator.js:51:40)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at module.exports (test/truffle-fixture.js:34:3)
      at SimpleTaskDefinition.action ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/hardhat-truffle5/src/index.ts:185:5)
      at Environment._runTaskDefinition ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/hardhat/src/internal/core/runtime-environment.ts:217:14)
      at Environment.run ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/hardhat/src/internal/core/runtime-environment.ts:130:14)
      at Context.<anonymous> ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/hardhat-truffle5/src/index.ts:145:9)

  2) Contract: MultiRole
       "before all" hook: Running truffle fixture if available for "Exclusive Self-managed role":
     Error: Transaction reverted: trying to deploy a contract whose code is too large
      at ExpiringMultiPartyLib.constructor (contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol:11)
      at $USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/truffle-contract/lib/execute.js:229:26
      at Function.new ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/truffle-contract/lib/contract/constructorMethods.js:58:53)
      at deploy ($USER/code/repos/blockchain/eth/UMAprotocol/packages/common/src/MigrationUtils.js:94:46)
      at module.exports (migrations/15_deploy_expiring_multi_party_creator.js:51:40)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at module.exports (test/truffle-fixture.js:34:3)
      at SimpleTaskDefinition.action ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/hardhat-truffle5/src/index.ts:185:5)
      at Environment._runTaskDefinition ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/hardhat/src/internal/core/runtime-environment.ts:217:14)
      at Environment.run ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/hardhat/src/internal/core/runtime-environment.ts:130:14)
      at Context.<anonymous> ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/@nomiclabs/hardhat-truffle5/src/index.ts:145:9)
...
...
```

</details>

And `truffle test` yields the following:

<details><summary>Click to expand the output of <code>truffle test</code>:</summary>


```
➤ yarn truffle test
$ $USER/code/repos/blockchain/eth/UMAprotocol/node_modules/.bin/truffle test
Using network 'test'.


Compiling your contracts...
===========================
> Compiling ./contracts/Migrations.sol
> Compiling ./contracts/common/implementation/AddressWhitelist.sol
> Compiling ./contracts/common/implementation/ExpandedERC20.sol
> Compiling ./contracts/common/implementation/FixedPoint.sol
> Compiling ./contracts/common/implementation/Lockable.sol
> Compiling ./contracts/common/implementation/MultiRole.sol
> Compiling ./contracts/common/implementation/Testable.sol
> Compiling ./contracts/common/implementation/TestnetERC20.sol
> Compiling ./contracts/common/implementation/Timer.sol
> Compiling ./contracts/common/implementation/Withdrawable.sol
> Compiling ./contracts/common/interfaces/Balancer.sol
> Compiling ./contracts/common/interfaces/ExpandedIERC20.sol
> Compiling ./contracts/common/interfaces/IERC20Standard.sol
> Compiling ./contracts/common/interfaces/OneSplit.sol
> Compiling ./contracts/common/interfaces/TransactionBatcher.sol
> Compiling ./contracts/common/interfaces/Uniswap.sol
> Compiling ./contracts/common/test/BalancerMock.sol
> Compiling ./contracts/common/test/BasicERC20.sol
> Compiling ./contracts/common/test/MultiRoleTest.sol
> Compiling ./contracts/common/test/OneSplitMock.sol
> Compiling ./contracts/common/test/ReentrancyAttack.sol
> Compiling ./contracts/common/test/ReentrancyChecker.sol
> Compiling ./contracts/common/test/ReentrancyMock.sol
> Compiling ./contracts/common/test/SignedFixedPointTest.sol
> Compiling ./contracts/common/test/TestableTest.sol
> Compiling ./contracts/common/test/UniswapMock.sol
> Compiling ./contracts/common/test/UnsignedFixedPointTest.sol
> Compiling ./contracts/common/test/WithdrawableTest.sol
> Compiling ./contracts/financial-templates/common/EmergencyShutdownable.sol
> Compiling ./contracts/financial-templates/common/FeePayer.sol
> Compiling ./contracts/financial-templates/common/FundingRateApplier.sol
> Compiling ./contracts/financial-templates/common/SyntheticToken.sol
> Compiling ./contracts/financial-templates/common/TokenFactory.sol
> Compiling ./contracts/financial-templates/common/WETH9.sol
> Compiling ./contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol
> Compiling ./contracts/financial-templates/common/financial-product-libraries/PreExpirationIdentifierTransformationFinancialProductLibrary.sol
> Compiling ./contracts/financial-templates/common/financial-product-libraries/StructuredNoteFinancialProductLibrary.sol
> Compiling ./contracts/financial-templates/demo/DepositBox.sol
> Compiling ./contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol
> Compiling ./contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.sol
> Compiling ./contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol
> Compiling ./contracts/financial-templates/expiring-multiparty/Liquidatable.sol
> Compiling ./contracts/financial-templates/expiring-multiparty/PricelessPositionManager.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/ConfigStore.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/ConfigStoreInterface.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/Perpetual.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/PerpetualCreator.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
> Compiling ./contracts/financial-templates/perpetual-multiparty/PerpetualPositionManager.sol
> Compiling ./contracts/financial-templates/test/ExpiringMultiPartyMock.sol
> Compiling ./contracts/financial-templates/test/FinancialProductLibraryTest.sol
> Compiling ./contracts/financial-templates/test/FundingRateApplierTest.sol
> Compiling ./contracts/oracle/implementation/Constants.sol
> Compiling ./contracts/oracle/implementation/ContractCreator.sol
> Compiling ./contracts/oracle/implementation/DesignatedVoting.sol
> Compiling ./contracts/oracle/implementation/DesignatedVotingFactory.sol
> Compiling ./contracts/oracle/implementation/FinancialContractsAdmin.sol
> Compiling ./contracts/oracle/implementation/Finder.sol
> Compiling ./contracts/oracle/implementation/Governor.sol
> Compiling ./contracts/oracle/implementation/IdentifierWhitelist.sol
> Compiling ./contracts/oracle/implementation/OptimisticOracle.sol
> Compiling ./contracts/oracle/implementation/Registry.sol
> Compiling ./contracts/oracle/implementation/ResultComputation.sol
> Compiling ./contracts/oracle/implementation/Store.sol
> Compiling ./contracts/oracle/implementation/TokenMigrator.sol
> Compiling ./contracts/oracle/implementation/VoteTiming.sol
> Compiling ./contracts/oracle/implementation/Voting.sol
> Compiling ./contracts/oracle/implementation/VotingToken.sol
> Compiling ./contracts/oracle/implementation/test/GovernorTest.sol
> Compiling ./contracts/oracle/implementation/test/MockAdministratee.sol
> Compiling ./contracts/oracle/implementation/test/OptimisticRequesterTest.sol
> Compiling ./contracts/oracle/implementation/test/ResultComputationTest.sol
> Compiling ./contracts/oracle/implementation/test/VoteTimingTest.sol
> Compiling ./contracts/oracle/implementation/test/VotingTest.sol
> Compiling ./contracts/oracle/interfaces/AdministrateeInterface.sol
> Compiling ./contracts/oracle/interfaces/FinderInterface.sol
> Compiling ./contracts/oracle/interfaces/IdentifierWhitelistInterface.sol
> Compiling ./contracts/oracle/interfaces/OptimisticOracleInterface.sol
> Compiling ./contracts/oracle/interfaces/OracleAncillaryInterface.sol
> Compiling ./contracts/oracle/interfaces/OracleInterface.sol
> Compiling ./contracts/oracle/interfaces/RegistryInterface.sol
> Compiling ./contracts/oracle/interfaces/StoreInterface.sol
> Compiling ./contracts/oracle/interfaces/VotingAncillaryInterface.sol
> Compiling ./contracts/oracle/interfaces/VotingInterface.sol
> Compiling ./contracts/oracle/test/MockOracle.sol
> Compiling ./contracts/oracle/test/MockOracleAncillary.sol
> Compiling ./contracts/oracle/test/VotingAncillaryInterfaceTest.sol
> Compiling ./contracts/oracle/test/VotingInterfaceTest.sol
> Compiling ./contracts/umips/Umip15Upgrader.sol
> Compiling ./contracts/umips/Umip3Upgrader.sol
> Compiling @openzeppelin/contracts/GSN/Context.sol
> Compiling @openzeppelin/contracts/access/Ownable.sol
> Compiling @openzeppelin/contracts/cryptography/ECDSA.sol
> Compiling @openzeppelin/contracts/math/Math.sol
> Compiling @openzeppelin/contracts/math/SafeMath.sol
> Compiling @openzeppelin/contracts/math/SignedSafeMath.sol
> Compiling @openzeppelin/contracts/token/ERC20/ERC20.sol
> Compiling @openzeppelin/contracts/token/ERC20/ERC20Snapshot.sol
> Compiling @openzeppelin/contracts/token/ERC20/IERC20.sol
> Compiling @openzeppelin/contracts/token/ERC20/SafeERC20.sol
> Compiling @openzeppelin/contracts/utils/Address.sol
> Compiling @openzeppelin/contracts/utils/Arrays.sol
> Compiling @openzeppelin/contracts/utils/Counters.sol
> Compiling @openzeppelin/contracts/utils/SafeCast.sol
> Compilation warnings encountered:

    $USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/PreExpirationIdentifierTransformationFinancialProductLibrary.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/StructuredNoteFinancialProductLibrary.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/ExpiringMultiPartyMock.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/BalancerMock.sol:13:34: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function getSpotPriceSansFee(address tokenIn, address tokenOut)
                                 ^-------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/BalancerMock.sol:13:51: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function getSpotPriceSansFee(address tokenIn, address tokenOut)
                                                  ^--------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:31:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256 parts,
        ^-----------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:32:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256 flags // See constants in IOneSplit.sol
        ^-----------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:44:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256[] memory distribution,
        ^---------------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:45:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256 flags
        ^-----------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:46:40: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    ) public payable override returns (uint256 returnAmount) {
                                       ^------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:23:69: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
                                                                    ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:39:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        FixedPoint.Unsigned memory oraclePrice,
        ^------------------------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:51:64: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
                                                               ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:28:69: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
                                                                    ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:40:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        FixedPoint.Unsigned memory price,
        ^------------------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:48:39: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
                                      ^---------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:48:64: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
                                                               ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:23:5: Warning: Function state mutability can be restricted to pure
    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
    ^ (Relevant source part starts here and spans across multiple lines).
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:38:5: Warning: Function state mutability can be restricted to pure
    function transformCollateralRequirement(
    ^ (Relevant source part starts here and spans across multiple lines).
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:51:5: Warning: Function state mutability can be restricted to pure
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
    ^ (Relevant source part starts here and spans across multiple lines).

> Artifacts written to /tmp/nix-shell.3Jntob/test--20340-goigwYIM5Jpa
> Compiled successfully using:
   - solc: 0.6.12+commit.27d51765.Emscripten.clang

> Compilation warnings encountered:

    $USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/PreExpirationIdentifierTransformationFinancialProductLibrary.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/StructuredNoteFinancialProductLibrary.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/ExpiringMultiPartyMock.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol: Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/BalancerMock.sol:13:34: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function getSpotPriceSansFee(address tokenIn, address tokenOut)
                                 ^-------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/BalancerMock.sol:13:51: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function getSpotPriceSansFee(address tokenIn, address tokenOut)
                                                  ^--------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:31:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256 parts,
        ^-----------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:32:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256 flags // See constants in IOneSplit.sol
        ^-----------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:44:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256[] memory distribution,
        ^---------------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:45:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        uint256 flags
        ^-----------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/common/test/OneSplitMock.sol:46:40: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    ) public payable override returns (uint256 returnAmount) {
                                       ^------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:23:69: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
                                                                    ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:39:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        FixedPoint.Unsigned memory oraclePrice,
        ^------------------------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:51:64: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
                                                               ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:28:69: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
                                                                    ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:40:9: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
        FixedPoint.Unsigned memory price,
        ^------------------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:48:39: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
                                      ^---------------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/test/FinancialProductLibraryTest.sol:48:64: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
                                                               ^-----------------^
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:23:5: Warning: Function state mutability can be restricted to pure
    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
    ^ (Relevant source part starts here and spans across multiple lines).
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:38:5: Warning: Function state mutability can be restricted to pure
    function transformCollateralRequirement(
    ^ (Relevant source part starts here and spans across multiple lines).
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/common/financial-product-libraries/FinancialProductLibrary.sol:51:5: Warning: Function state mutability can be restricted to pure
    function transformPriceIdentifier(bytes32 priceIdentifier, uint256 requestTime)
    ^ (Relevant source part starts here and spans across multiple lines).
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol:11:1: Warning: Contract code size exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
library ExpiringMultiPartyLib {
^ (Relevant source part starts here and spans across multiple lines).
,$USER/code/repos/blockchain/eth/UMAprotocol/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol:11:1: Warning: Contract code size exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
library PerpetualLib {
^ (Relevant source part starts here and spans across multiple lines).

> Artifacts written to /tmp/nix-shell.3Jntob/test--20543-jU548WNnJrvT
> Compiled successfully using:
   - solc: 0.6.12+commit.27d51765.Emscripten.clang

Error: while migrating ExpiringMultiPartyLib: Returned error: base fee exceeds gas limit
    at $USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/deployer/src/deployment.js:364:1
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at deploy ($USER/code/repos/blockchain/eth/UMAprotocol/packages/common/src/MigrationUtils.js:100:5)
    at module.exports ($USER/code/repos/blockchain/eth/UMAprotocol/packages/core/migrations/15_deploy_expiring_multi_party_creator.js:62:5)
    at Migration._deploy ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/Migration.js:73:1)
    at Migration._load ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/Migration.js:55:1)
    at Migration.run ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/Migration.js:171:1)
    at Object.runMigrations ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/index.js:150:1)
    at Object.runFrom ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/index.js:110:1)
    at Object.runAll ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/index.js:114:1)
    at Object.run ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/migrate/index.js:79:1)
    at Object.run ($USER/code/repos/blockchain/eth/UMAprotocol/node_modules/truffle/build/webpack:/packages/core/lib/test.js:117:1)
Truffle v5.1.41 (core: 5.1.41)
Node v12.18.4
```

</details>

After some more investigation, trial & error, we found out that reducing the solc `runs` from `199` to `25` "fixes" the issue (we tried other values like 1000, 100, 50, etc. but they didn't work). Obviously, this a very unstable hack, but at this point it was already 3 AM so we decided to leave it at that for now.

**Summary**

* Upgrade @openzeppelin/contracts from `3.0.0` to `3.3.0` in `packages/core/package.json` and `yarn.lock`
* Address `ERC20Snapshot` breaking change in `packages/core/contracts/oracle/implementation/VotingToken.sol`
* Change `solidity.settings.optimizer.runs` from `199` to `25` in both:
  * `packages/core/hardhat.config.js`
  * `packages/core/truffle-config.js`

We open this PR to request help with narrowing down the problems with the upgrade as we're not deeply familiar yet with the inner workings of the project setup.