### PR TITLE
feat(default-price-feed) Add GASETH-TWAP-1Mx1M, GASETH-FEB21, GASETH-MAR21

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -71,6 +71,24 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "binance", pair: "BCHBTC" },
       { type: "cryptowatch", exchange: "huobi", pair: "BCHBTC" }
     ]
+  },
+  "GASETH-TWAP-1Mx1M": {
+    type: "uniswap",
+    uniswapAddress: "0x25fb29D865C1356F9e95D621F21366d3a5DB6BB0",
+    twapLength: 7200,
+    lookback: 7200
+  },
+  "GASETH-FEB21": {
+    type: "uniswap",
+    uniswapAddress: "0x4a8a2ea3718964ed0551a3191c30e49ea38a5ade",
+    twapLength: 7200,
+    lookback: 7200
+  },
+  "GASETH-MAR21": {
+    type: "uniswap",
+    uniswapAddress: "0x683ea972ffa19b7bad6d6be0440e0a8465dba71c",
+    twapLength: 7200,
+    lookback: 7200
   }
 };
 


### PR DESCRIPTION
**Motivation**

Dev mining calculations and bots for uGAS-FEB21 and uGAS-MAR21 require default price feeds. This PR adds the necessary default price feeds to DefaultPriceFeedConfigs.js.

**Summary**

Adds the price feed. GASETH-FEB21, GASETH-MAR21 follow the implementation details from [UMIP-25](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-25.md), GASETH-TWAP-1Mx1M follows the implementation details from [UMIP-22](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-22.md).
