### PR TITLE
docs: add package readmes for half of remaining packages

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,19 +13,20 @@ yarn add @uma/cli
 Note: this is a local installation, meaning it instructs yarn to install into the current package/directory. It can be
 installed globally if you'd like the executable to be accessible everywhere.
 
-## Running the package
+## Running the package with default (empty) keys and node
 
 ```bash
 yarn uma-cli --network mainnet_mnemonic
 ```
 
-## Using your own node URL
+## Using a custom node URL and mnemonic
 
 By default, this package uses a default infura account that often exceeds its daily quota. To plug in your own node
-node ULR, export the following env variable:
+node URL, set the `CUSTOM_NODE_URL` env variable. It also comes with a default mnemonic -- to override, provide your
+mnemonic (seed phrase) using the `MNEMONIC` env variable.
 
 ```bash
-CUSTOM_NODE_URL=https://your.node.url.io yarn uma-cli --network mainnet_mnemonic
+CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic (12-word seed phrase) here" yarn uma-cli --network mainnet_mnemonic
 ```
 
 ## Using your private keys

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-# UMA CLI Tool
+# @uma/cli
 
 This package contains the UMA CLI tool. This tool works, but is deprecated, so its use is discouraged. It can be useful
 for certain tasks, like viewing governance/admin proposals, but it is usually preferred to use tools.umaproject.org or

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,13 +7,16 @@ vote.umaproject.org.
 ## Installing the package
 
 ```bash
-yarn global add @uma/cli
+yarn add @uma/cli
 ```
+
+Note: this is a local installation, meaning it instructs yarn to install into the current package/directory. It can be
+installed globally if you'd like the executable to be accessible everywhere.
 
 ## Running the package
 
 ```bash
-uma-cli --network mainnet_mnemonic
+yarn uma-cli --network mainnet_mnemonic
 ```
 
 ## Using your own node URL
@@ -22,8 +25,7 @@ By default, this package uses a default infura account that often exceeds its da
 node ULR, export the following env variable:
 
 ```bash
-export CUSTOM_NODE_URL=your.node.url.io
-uma-cli --network mainnet_mnemonic
+CUSTOM_NODE_URL=https://your.node.url.io yarn uma-cli --network mainnet_mnemonic
 ```
 
 ## Using your private keys

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,32 @@
+# UMA CLI Tool
+
+This package contains the UMA CLI tool. This tool works, but is deprecated, so its use is discouraged. It can be useful
+for certain tasks, like viewing governance/admin proposals, but it is usually preferred to use tools.umaproject.org or
+vote.umaproject.org.
+
+## Installing the package
+
+```bash
+yarn global add @uma/cli
+```
+
+## Running the package
+
+```bash
+uma-cli --network mainnet_mnemonic
+```
+
+## Using your own node URL
+
+By default, this package uses a default infura account that often exceeds its daily quota. To plug in your own node
+node ULR, export the following env variable:
+
+```bash
+export CUSTOM_NODE_URL=your.node.url.io
+uma-cli --network mainnet_mnemonic
+```
+
+## Using your private keys
+
+Check out [the docs](https://docs.umaproject.org/developers/setup#keys-and-networks) for more options on how to plug in
+your private keys in different ways or use different networks.

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,17 @@
+# @uma/common
+
+This package contains common javascript utilities and files used by other `@uma` packages. It is rarely used outside of
+that context.
+
+## Installing the package
+
+```bash
+yarn add @uma/common
+```
+
+## Importing the package
+
+```js
+// One of many possible possible functions to import.
+{ getTruffleConfig } = require("@uma/core");
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,71 @@
+# @uma/core
+
+This package contains contract artifacts for all UMA smart contracts.
+
+## Installing the package
+
+```bash
+yarn add @uma/core
+```
+
+## Importing artifacts directly
+
+The easiest way to import contracts is to do so by importing the file from
+`@uma/core/build/contracts/ContractName.json`. This is especially useful in certain contexts where imports cannot be
+dynamically loaded (generally non-nodejs contexts):
+
+```js
+import { abi as expiringMultiPartyAbi } from "@uma/core/build/contracts/ExpiringMultiParty.json"
+import VotingArtifact from "@uma/core/build/contracts/Voting.json"
+
+// Grab the mainnet voting address.
+const networkId = 1
+const mainnetVotingAddress = VotingArtifact.networks[networkId].address
+```
+
+## Importing Artifacts via index.js
+
+Helper methods are available for importing artifacts in nodejs:
+
+```js
+const { getAbi, getAddress, getTruffleContract } = require("@uma/core")
+
+// Grabs the EMP abi.
+const expiringMultiPartyAbi = getAbi("ExpiringMultiParty")
+
+// Gets the address of the mainnet Voting contract.
+const mainnetVotingAddress = getAddress("Voting", 1)
+
+// Initializes a truffle contract instance for the Governor contract.
+// web3 should be initialied and connected to a node.
+const Web3 = require("web3")
+const web3 = new Web3("your.node.url.io")
+const Governor = getTruffleContract("Governor", web3)
+const governor = await governor.deployed()
+```
+
+## Advanced Usage
+
+Older core abis and addresses are available by specifying a version string. The following example does exactly the same
+as the above, but it dynamically grabs contract artifacts from version 1.1.0 rather than the imported version of the
+package:
+
+```js
+const { getAbi, getAddress, getTruffleContract } = require("@uma/core");
+
+// Grabs the EMP abi.
+const expiringMultiPartyAbi = getAbi("ExpiringMultiParty", "1.1.0");
+
+// Gets the address of the mainnet Voting contract.
+const mainnetVotingAddress = getAddress("Voting", 1, "1.1.0');
+
+// Initializes a truffle contract instance for the Governor contract.
+// web3 should be initialied and connected to a node.
+const Web3 = require("web3");
+const web3 = new Web3("your.node.url.io");
+const Governor = getTruffleContract("Governor", web3, "1.1.0");
+const governor = await governor.deployed();
+```
+
+Note: this use case is not particularly common, but it is sometimes useful to have access to multiple abi versions
+side-by-side.

--- a/packages/disputer/README.md
+++ b/packages/disputer/README.md
@@ -8,15 +8,18 @@ For more information about running a dispute bot, see the [docs](https://docs.um
 ## Installing the package
 
 ```bash
-yarn global add @uma/disputer
+yarn add @uma/disputer
 ```
+
+Note: this is a local installation, meaning it instructs yarn to install into the current package/directory. It can be
+installed globally if you'd like the executable to be accessible everywhere.
 
 ## Running the disputer
 
 The simplest way to run the disputer (with default parameters and price feeds) is:
 
 ```bash
-EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=your.node.url MNEMONIC="your mnemonic here" disputer --network mainnet_mnemonic
+EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic here" disputer --network mainnet_mnemonic
 ```
 
 ## Other networks and private keys

--- a/packages/disputer/README.md
+++ b/packages/disputer/README.md
@@ -1,0 +1,26 @@
+# @uma/disputer
+
+This package contains the UMA Dispute bot reference implementation. This executable will watch an ExpiringMultiParty
+contract for liquidations and dispute any that it deems to be invalid.
+
+## Installing the package
+
+```bash
+yarn global add @uma/disputer
+```
+
+## Running the disputer
+
+The simplest way to run the disputer (with default parameters and price feeds) is:
+
+```bash
+EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=your.node.url MNEMONIC="your mnemonic here" disputer --network mainnet_mnemonic
+```
+
+## Other networks and private keys
+
+Check out [the docs](https://docs.umaproject.org/developers/setup#keys-and-networks) for more options on how to plug in your private keys in different ways or use different networks.
+
+## More customization options
+
+See [here](index.js#L189-L209) for a full list of environment variables that can be provided to customize the disputer.

--- a/packages/disputer/README.md
+++ b/packages/disputer/README.md
@@ -3,6 +3,8 @@
 This package contains the UMA Dispute bot reference implementation. This executable will watch an ExpiringMultiParty
 contract for liquidations and dispute any that it deems to be invalid.
 
+For more information about running a dispute bot, see the [docs](https://docs.umaproject.org/developers/bots).
+
 ## Installing the package
 
 ```bash

--- a/packages/disputer/README.md
+++ b/packages/disputer/README.md
@@ -19,7 +19,7 @@ installed globally if you'd like the executable to be accessible everywhere.
 The simplest way to run the disputer (with default parameters and price feeds) is:
 
 ```bash
-EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic here" disputer --network mainnet_mnemonic
+EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic (12-word seed phrase) here" disputer --network mainnet_mnemonic
 ```
 
 ## Other networks and private keys

--- a/packages/financial-templates-lib/README.md
+++ b/packages/financial-templates-lib/README.md
@@ -1,0 +1,83 @@
+# @uma/financial-templates-lib
+
+This package contains various clients and helpers to interact with UMA's financial templates. It is primarily used to
+power the disputer, liquidator, and monitor bots.
+
+## Installing the package
+
+```bash
+yarn add @uma/financial-templates-lib
+```
+
+## Importing the package
+
+```js
+const { ExpiringMultiPartyClient, GasEstimator } = require("@uma/financial-templates-lib")
+```
+
+## Clients
+
+The three clients available are:
+
+1. The `ExpiringMultiPartyClient` can be used to access information about EMP sponsors and their collateralization
+   ratios. To understand how to interact with the client, see the class documentation
+   [here](./src/clients/ExpiringMultiPartyClient.js).
+
+1. The `ExpiringMultiPartyEventClient` can be used to access historical events that were emitted by an EMP. To
+   understand how to interact with the client, see the class documentation
+   [here](./src/clients/ExpiringMultiPartyEventClient.js).
+
+1. The `TokenBalanceClient` tracks the collateral and synthetic balances for a list of wallets. To understand how to
+   interact with the client, see the class documentation
+   [here](./src/clients/TokenBalanceClient.js).
+
+## Price Feeds
+
+The package offers a variety of price feed implementations that adere to the `PriceFeedInterface` (docs can be found in
+the interface file [here](./src/price-feed/PriceFeedInterface.js)):
+
+- The `CryptoWatchPriceFeed`, found [here](./src/price-feed/CryptoWatchPriceFeed.js), uses https://cryptowat.ch/ as a
+  source of CEX price data.
+- The `UniswapPriceFeed`, found [here](./src/price-feed/UniswapPriceFeed.js), uses a Uniswap (v2) market TWAP as the
+  price source. Note: the TWAP length can be set to 0 to make this an instantaneous price.
+- THe `BalancerPriceFeed`, found [here](./src/price-feed/BalancerPriceFeed.js), uses a Balancer market as the price
+  source.
+- The `MedianizerPriceFeed`, found [here](./src/price-feed/MedianizerPriceFeed.js), takes multiple price feeds and
+  returns the median of their prices.
+
+There are a few other helper/utility files that are relevant:
+
+- [CreatePriceFeed.js](./src/price-feed/CreatePriceFeed.js) has a variety of factory utilities that will create a
+  price feed given an input configuration.
+- [DefaultPriceFeedConfigs.js](./src/price-feed/DefaultPriceFeedConfigs.js) contains a list of default price feeds
+  for different identifiers in the UMA ecosystem. These are used by `CreatePriceFeed.js` to create price feeds with
+  no or incomplete input configurations.
+- [Networker.js](./src/price-feed/CreatePriceFeed.js) has a mockable object that sends network requests and is used by
+  many objects in financial-templates-lib to send requests.
+
+## Logger
+
+The [Logger](./src/logger) directory contains helpers and factories for logging with winston. To get the default
+logger:
+
+```js
+const { Logger, createPriceFeed, Networker } = require("@uma/financial-templates-lib");
+
+// A winston logger is required for createPriceFeed, networker and other objects in financial-templates-lib.
+const networker = new Networker(Logger);
+const priceFeed = createPriceFeed(Logger, web3, networker, ...);
+
+// You can also log directly using the winston logger.
+Logger.debug({
+    at: "createPriceFeed",
+    message: "Creating CryptoWatchPriceFeed",
+    otherParam: 5
+});
+```
+
+## Helpers
+
+There are two helper files that are available in financial-templates-lib:
+
+- [delay.js](./src/helpers/delay.js): simple file containing a function to "sleep".
+- [GasEstimator.js](./src/helpers/GasEstimator.js): `GasEstimator` provides an estimate of the current fast gas price.

--- a/packages/financial-templates-lib/README.md
+++ b/packages/financial-templates-lib/README.md
@@ -57,7 +57,7 @@ There are a few other helper/utility files that are relevant:
 
 ## Logger
 
-The [Logger](./src/logger) directory contains helpers and factories for logging with winston. To get the default
+The [Logger](./src/logger) directory contains helpers and factories for logging with Winston. To get the default
 logger:
 
 ```js

--- a/packages/liquidator/README.md
+++ b/packages/liquidator/README.md
@@ -8,15 +8,18 @@ For more information about running a liquidator bot, see the [docs](https://docs
 ## Installing the package
 
 ```bash
-yarn global add @uma/liquidator
+yarn add @uma/liquidator
 ```
+
+Note: this is a local installation, meaning it instructs yarn to install into the current package/directory. It can be
+installed globally if you'd like the executable to be accessible everywhere.
 
 ## Running the liquidator
 
 The simplest way to run the liquidator (with default parameters and price feeds) is:
 
 ```bash
-EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=your.node.url MNEMONIC="your mnemonic here" liquidator --network mainnet_mnemonic
+EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic here" yarn liquidator --network mainnet_mnemonic
 ```
 
 ## Other networks and private keys

--- a/packages/liquidator/README.md
+++ b/packages/liquidator/README.md
@@ -19,7 +19,7 @@ installed globally if you'd like the executable to be accessible everywhere.
 The simplest way to run the liquidator (with default parameters and price feeds) is:
 
 ```bash
-EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic here" yarn liquidator --network mainnet_mnemonic
+EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=https://your.node.url.io MNEMONIC="your mnemonic (12-word seed phrase) here" yarn liquidator --network mainnet_mnemonic
 ```
 
 ## Other networks and private keys

--- a/packages/liquidator/README.md
+++ b/packages/liquidator/README.md
@@ -1,0 +1,26 @@
+# @uma/liquidator
+
+This package contains the UMA Liquidation bot reference implementation. This executable will watch an
+ExpiringMultiParty contract for undercollateralized positions and liquidate them.
+
+## Installing the package
+
+```bash
+yarn global add @uma/liquidator
+```
+
+## Running the liquidator
+
+The simplest way to run the liquidator (with default parameters and price feeds) is:
+
+```bash
+EMP_ADDRESS=0x1234 CUSTOM_NODE_URL=your.node.url MNEMONIC="your mnemonic here" liquidator --network mainnet_mnemonic
+```
+
+## Other networks and private keys
+
+Check out [the docs](https://docs.umaproject.org/developers/setup#keys-and-networks) for more options on how to plug in your private keys in different ways or use different networks.
+
+## More customization options
+
+See [here](index.js#L189-L209) for a full list of environment variables that can be provided to customize the disputer.

--- a/packages/liquidator/README.md
+++ b/packages/liquidator/README.md
@@ -3,6 +3,8 @@
 This package contains the UMA Liquidation bot reference implementation. This executable will watch an
 ExpiringMultiParty contract for undercollateralized positions and liquidate them.
 
+For more information about running a liquidator bot, see the [docs](https://docs.umaproject.org/developers/bots).
+
 ## Installing the package
 
 ```bash


### PR DESCRIPTION
**Motivation**

Packages don't have READMEs.

**Summary**

Adds READMEs for core, financial-templates-lib, common, disputer, and liquidator. Packages remaining without READMEs (cc @pemulis): reporter, monitors, and serverless-orchestration.

**Issue(s)**

N/A
