### PR TITLE
improve(voter-dapp): add hardcoded precision for new identifiers

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -9,7 +9,8 @@ const IDENTIFIER_NON_18_PRECISION = {
   USDBTC: 8,
   "STABLESPREAD/USDC": 6,
   "STABLESPREAD/BTC": 8,
-  "ELASTIC_STABLESPREAD/USDC": 6
+  "ELASTIC_STABLESPREAD/USDC": 6,
+  BCHNBTC: 8
 };
 
 const getPrecisionForIdentifier = identifier => {

--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -6,7 +6,10 @@ const IDENTIFIER_BLACKLIST = {
 // Price identifiers that should resolve prices to non 18 decimal precision. Any identifiers
 // not on this list are assumed to resolve to 18 decimals.
 const IDENTIFIER_NON_18_PRECISION = {
-  USDBTC: 8
+  USDBTC: 8,
+  "STABLESPREAD/USDC": 6,
+  "STABLESPREAD/BTC": 8,
+  "ELASTIC_STABLESPREAD/USDC": 6
 };
 
 const getPrecisionForIdentifier = identifier => {

--- a/packages/core/config/identifiers.json
+++ b/packages/core/config/identifiers.json
@@ -24,5 +24,12 @@
   "XAU/USD": {},
   "SPX/USD": {},
   "XTI/USD": {},
-  "XAG/USD": {}
+  "XAG/USD": {},
+  "STABLESPREAD": {},
+  "STABLESPREAD/USDC": {},
+  "STABLESPREAD/BTC": {},
+  "ELASTIC_STABLESPREAD/USDC": {},
+  "EURUSD": {},
+  "CHFUSD": {},
+  "GBPUSD": {}
 }

--- a/packages/core/config/identifiers.json
+++ b/packages/core/config/identifiers.json
@@ -31,5 +31,6 @@
   "ELASTIC_STABLESPREAD/USDC": {},
   "EURUSD": {},
   "CHFUSD": {},
-  "GBPUSD": {}
+  "GBPUSD": {},
+  "BCHNBTC": {}
 }


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

New identifiers must resolve to same precision as collateral:
- ELASTIC_STABLESPREAD/USDC, STABLESPREAD/USDC ==> 6 decimals, same as USDC
- STABLESPREAD/BTC, BCHNBTC ==> 8 decimals, same as renBTC

Once the latest EMP factory is deployed, we will be able to assume that all identifiers can resolve to 18 decimals, but currently the identifier precision must match the EMP's collateral precision.
