### PR TITLE
improve(voter-helper-script): Add more information to script that helps voters resolve prices

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -97,6 +97,15 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     // If there is no match, that means that the time was past the last data point.
     // In this case, the best match for this price is the current price.
     if (match === undefined) {
+      let returnPrice = this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
+      if (verbose) {
+        console.group(`\n(${this.exchange}:${this.pair}) No OHLC available @ ${time}`);
+        console.log(`- ✅ Falling back to Current Price:${this.web3.utils.fromWei(returnPrice.toString())}`);
+        console.log(
+          `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price`
+        );
+        console.groupEnd();
+      }
       return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
     }
 

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -100,7 +100,11 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       let returnPrice = this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
       if (verbose) {
         console.group(`\n(${this.exchange}:${this.pair}) No OHLC available @ ${time}`);
-        console.log(`- ✅ Falling back to Current Price:${this.web3.utils.fromWei(returnPrice.toString())}`);
+        console.log(
+          `- ✅ Time is later than earliest historical time, fetching current price: ${this.web3.utils.fromWei(
+            returnPrice.toString()
+          )}`
+        );
         console.log(
           `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price`
         );


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

- Adds verbose logs for CryptoWatch's `getCurrentPrice()` method. 
- Prints out how many decimals it is truncating the median price to.
- Adds ability for user to specify a `PRICE_FEED_CONFIG` in their environment which could include params like "apiKey" for CryptoWatch

Example run:
```
yarn truffle exec ./packages/core/scripts/local/getMedianHistoricalPrice.js --network mainnet_mnemonic --identifier USDETH
Using network 'mainnet_mnemonic'.

Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): 1609431280
⏰ Fetching nearest prices for the timestamp: Thu, 31 Dec 2020 16:14:40 GMT

(coinbase-pro:ethusd) No OHLC available @ 1609431280
  - ✅ Falling back to Current Price:0.001362082351498971
  - ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: 
  - https://api.cryptowat.ch/markets/coinbase-pro/ethusd/price

(binance:ethusdt) No OHLC available @ 1609431280
  - ✅ Falling back to Current Price:0.001363754142403207
  - ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: 
  - https://api.cryptowat.ch/markets/binance/ethusdt/price

(kraken:ethusd) No OHLC available @ 1609431280
  - ✅ Falling back to Current Price:0.001362750575762118
  - ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: 
  - https://api.cryptowat.ch/markets/kraken/ethusd/price

⚠️ Truncating price to 5 decimals

💹 Median USDETH price @ 1609431280 = 0.00136
✨  Done in 4.15s.

```
