### PR TITLE
docs(node-v): fixes node version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For detailed information on how to initialize and interact with our smart contra
 
 ### Install dependencies 👷‍♂️
 
-You'll need the latest LTS release of nodejs and yarn installed. Assuming that's done, run `yarn` with no args:
+You'll need to install a 12.x.x version of nodejs, since later versions will break the repo. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
 
 ```
 yarn

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For detailed information on how to initialize and interact with our smart contra
 
 ### Install dependencies 👷‍♂️
 
-You'll need to install a 12.x.x version of nodejs, since later versions will break the repo. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
+You'll need to install a 12.x.x version of nodejs, since other versions will break certain dependencies. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
 
 ```
 yarn


### PR DESCRIPTION
Signed-off-by: pemulis <john.d.shutt@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Main README says to install node `lts`, which is now a 14.x version that breaks the repo.


**Summary**

Notes in the main README that you need to install nodejs v12.x.x since later versions break the repo.


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
N/A
