### PR TITLE
fix(bots): Add feature to denominate synthetic price by another price feed + remove noisy BasketSpreadPriceFeed logs

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -64,22 +64,12 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
       return null;
     }
     const experimentalMean = this._computeMean(experimentalPrices);
-    this.logger.debug({
-      at: "BasketSpreadPriceFeed",
-      message: "Average of experimental prices",
-      mean: experimentalMean.toString()
-    });
 
     // Second, compute the average of the baseline pricefeeds.
     if (baselinePrices.length === 0 || baselinePrices.some(element => element === undefined || element === null)) {
       return null;
     }
     const baselineMean = this._computeMean(baselinePrices);
-    this.logger.debug({
-      at: "BasketSpreadPriceFeed",
-      message: "Average of baseline prices",
-      mean: baselineMean.toString()
-    });
 
     // All calculations within this if statement will produce unexpected results if any of the
     // experimental mean, baseline mean, or denominator price are NOT in the same precision as
@@ -89,11 +79,6 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
     // TODO: Parameterize the lower (0) and upper (2) bounds, as well as allow for custom "spreadValue" formulas,
     // for example we might not want to have the spread centered around 1, like it is here:
     let spreadValue = experimentalMean.sub(baselineMean).add(this.convertPriceFeedDecimals("1"));
-    this.logger.debug({
-      at: "BasketSpreadPriceFeed",
-      message: "Basket spread value",
-      spreadValue: spreadValue.toString()
-    });
 
     // Ensure non-negativity
     if (spreadValue.lt(this.toBN("0"))) {
@@ -106,11 +91,6 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
 
     // Optionally divide by denominator pricefeed.
     if (!denominatorPrice) return spreadValue;
-    this.logger.debug({
-      at: "BasketSpreadPriceFeed",
-      message: "Denominator price",
-      denominatorPrice: denominatorPrice.toString()
-    });
     spreadValue = spreadValue.mul(this.convertPriceFeedDecimals("1")).div(denominatorPrice);
 
     return spreadValue;

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -314,8 +314,8 @@ async function createReferencePriceFeedForEmp(logger, web3, networker, getTime, 
     defaultConfig
   });
 
-  // Infer lookback from liquidation liveness.
-  if (emp && defaultConfig) {
+  // Infer lookback from liquidation liveness if user does not explicitly set a lookback.
+  if (emp && defaultConfig && !defaultConfig.lookback) {
     const lookback = Number((await emp.methods.liquidationLiveness().call()).toString());
     Object.assign(defaultConfig, { lookback });
   }

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -70,6 +70,7 @@ const defaultConfigs = {
   STABLESPREAD: {
     // This is alternatively known as "STABLESPREAD/ETH"
     type: "basketspread",
+    lookback: 7200,
     minTimeBetweenUpdates: 60,
     experimentalPriceFeeds: [
       {
@@ -132,6 +133,7 @@ const defaultConfigs = {
   },
   "STABLESPREAD/USDC": {
     type: "basketspread",
+    lookback: 7200,
     minTimeBetweenUpdates: 60,
     experimentalPriceFeeds: [
       {
@@ -187,6 +189,7 @@ const defaultConfigs = {
   },
   "STABLESPREAD/BTC": {
     type: "basketspread",
+    lookback: 7200,
     minTimeBetweenUpdates: 60,
     experimentalPriceFeeds: [
       {

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -41,6 +41,7 @@ const { getWeb3 } = require("@uma/common");
  * @param {Object} monitorConfig Configuration object to parameterize all monitor modules.
  * @param {Object} tokenPriceFeedConfig Configuration to construct the tokenPriceFeed (balancer or uniswap) price feed object.
  * @param {Object} medianizerPriceFeedConfig Configuration to construct the reference price feed object.
+ * @param {Object} medianizerPriceFeedConfig Configuration to construct the denominator price feed object.
  * @return None or throws an Error.
  */
 async function run({
@@ -54,7 +55,8 @@ async function run({
   endingBlock,
   monitorConfig,
   tokenPriceFeedConfig,
-  medianizerPriceFeedConfig
+  medianizerPriceFeedConfig,
+  denominatorPriceFeedConfig
 }) {
   try {
     const { hexToUtf8 } = web3.utils;
@@ -72,7 +74,8 @@ async function run({
       endingBlock,
       monitorConfig,
       tokenPriceFeedConfig,
-      medianizerPriceFeedConfig
+      medianizerPriceFeedConfig,
+      denominatorPriceFeedConfig
     });
 
     const getTime = () => Math.round(new Date().getTime() / 1000);
@@ -80,11 +83,13 @@ async function run({
     const networker = new Networker(logger);
 
     // 0. Setup EMP and token instances to monitor.
-    const [networkId, latestBlock, medianizerPriceFeed, tokenPriceFeed] = await Promise.all([
+    const [networkId, latestBlock, medianizerPriceFeed, tokenPriceFeed, denominatorPriceFeed] = await Promise.all([
       web3.eth.net.getId(),
       web3.eth.getBlock("latest"),
       createReferencePriceFeedForEmp(logger, web3, networker, getTime, empAddress, medianizerPriceFeedConfig),
-      createTokenPriceFeedForEmp(logger, web3, networker, getTime, empAddress, tokenPriceFeedConfig)
+      createTokenPriceFeedForEmp(logger, web3, networker, getTime, empAddress, tokenPriceFeedConfig),
+      denominatorPriceFeedConfig &&
+        createReferencePriceFeedForEmp(logger, web3, networker, getTime, empAddress, denominatorPriceFeedConfig)
     ]);
 
     if (!medianizerPriceFeed || !tokenPriceFeed) {
@@ -184,6 +189,7 @@ async function run({
       web3,
       uniswapPriceFeed: tokenPriceFeed,
       medianizerPriceFeed,
+      denominatorPriceFeed,
       config: monitorConfig,
       empProps
     });
@@ -198,7 +204,8 @@ async function run({
             empEventClient.update(),
             tokenBalanceClient.update(),
             medianizerPriceFeed.update(),
-            tokenPriceFeed.update()
+            tokenPriceFeed.update(),
+            denominatorPriceFeed && denominatorPriceFeed.update()
           ]);
 
           // Run all queries within the monitor bots modules.
@@ -261,6 +268,7 @@ async function Poll(callback) {
     // Deprecate UNISWAP_PRICE_FEED_CONFIG to favor TOKEN_PRICE_FEED_CONFIG, leaving in for compatibility.
     // If nothing defined, it will default to uniswap within createPriceFeed
     const tokenPriceFeedConfigEnv = process.env.TOKEN_PRICE_FEED_CONFIG || process.env.UNISWAP_PRICE_FEED_CONFIG;
+    const denominatorPriceFeedConfigEnv = process.env.TOKEN_DENOMINATOR_PRICE_FEED_CONFIG;
 
     // This object is spread when calling the `run` function below. It relies on the object enumeration order and must
     // match the order of parameters defined in the`run` function.
@@ -314,6 +322,7 @@ async function Poll(callback) {
       // Medianizer price feed averages over a set of different sources to get an average. Config defines the exchanges
       // to use. EG: {"type":"medianizer","pair":"ethbtc", "invertPrice":true, "lookback":7200,"minTimeBetweenUpdates":60,"medianizedFeeds":[
       // {"type":"cryptowatch","exchange":"coinbase-pro"},{"type":"cryptowatch","exchange":"binance"}]}
+      denominatorPriceFeedConfig: denominatorPriceFeedConfigEnv ? JSON.parse(denominatorPriceFeedConfigEnv) : null,
       medianizerPriceFeedConfig: process.env.MEDIANIZER_PRICE_FEED_CONFIG
         ? JSON.parse(process.env.MEDIANIZER_PRICE_FEED_CONFIG)
         : null

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -230,9 +230,9 @@ async function run({
         async () => {
           // Update all client and price feeds.
           await Promise.all([
-            // empClient.update(),
-            // empEventClient.update(),
-            // tokenBalanceClient.update(),
+            empClient.update(),
+            empEventClient.update(),
+            tokenBalanceClient.update(),
             medianizerPriceFeed.update(),
             tokenPriceFeed.update(),
             denominatorPriceFeed && denominatorPriceFeed.update()

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -132,9 +132,8 @@ class SyntheticPegMonitor {
     // (syntheticTokenPrice / denominatorPrice) against (pegTokenPrice).
     // If `denominatorPriceFeed` is undefined, then just compare:
     // (syntheticTokenPrice) against (pegTokenPrice).
-    let denominatorPrice;
     if (this.denominatorPriceFeed) {
-      denominatorPrice = this.denominatorPriceFeed.getCurrentPrice();
+      const denominatorPrice = this.denominatorPriceFeed.getCurrentPrice();
       // We need a "1" scaled in the same precision that the `denominatorPrice` is getting returned in, because
       // we want to apply the transformation:
       // - uniswapTokenPrice * denominatorPriceFeedScaledOne / denominatorPrice

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -1,8 +1,9 @@
 // This module monitors the synthetic peg of a given expiring multiparty contract and reports when: 1) the synthetic is
 // trading off peg 2) there is high volatility in the synthetic price or 3) there is high volatility in the reference price.
 
-const { createFormatFunction, formatHours, createObjectFromDefaultProps } = require("@uma/common");
+const { createFormatFunction, formatHours, createObjectFromDefaultProps, ConvertDecimals } = require("@uma/common");
 
+// TODO: Rename "medianizerPriceFeed" ==> "pegPriceFeed" and "uniswapPriceFeed" ==> "syntheticPriceFeed"
 class SyntheticPegMonitor {
   /**
    * @notice Constructs new synthetic peg monitor module.
@@ -10,6 +11,8 @@ class SyntheticPegMonitor {
    * @param {Object} web3 Instance of a web3 client provided by the class that initiates the monitor module.
    * @param {Object} uniswapPriceFeed Module used to query the current uniswap token price.
    * @param {Object} medianizerPriceFeed Module used to query the median price among selected price feeds.
+   * @param {Object} denominatorPriceFeed Optional module that can be used to divide the price returned by the
+   * `medianizerPriceFeed` in order to "denominator" that price in a new currency.
    * @param {Object} [config] Contains fields with which constructor will attempt to override defaults. Example:
   *      { deviationAlertThreshold:0.2,           // Threshold used to compare observed and expected token prices.
            volatilityWindow: 600,                 // Length of time (in seconds) to snapshot volatility.
@@ -23,12 +26,13 @@ class SyntheticPegMonitor {
             priceIdentifier: "ETH/BTC",
             networkId:1 }
    */
-  constructor({ logger, web3, uniswapPriceFeed, medianizerPriceFeed, config, empProps }) {
+  constructor({ logger, web3, uniswapPriceFeed, medianizerPriceFeed, denominatorPriceFeed, config, empProps }) {
     this.logger = logger;
 
     // Instance of price feeds used to check for deviation of synthetic token price.
     this.uniswapPriceFeed = uniswapPriceFeed;
     this.medianizerPriceFeed = medianizerPriceFeed;
+    this.denominatorPriceFeed = denominatorPriceFeed;
 
     this.web3 = web3;
 
@@ -93,7 +97,7 @@ class SyntheticPegMonitor {
   async checkPriceDeviation() {
     if (this.deviationAlertThreshold === 0) return; // return early if the threshold is zero.
     // Get the latest prices from the two price feeds.
-    const uniswapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
+    let uniswapTokenPrice = this.uniswapPriceFeed.getCurrentPrice();
     const cryptoWatchTokenPrice = this.medianizerPriceFeed.getCurrentPrice();
 
     if (!uniswapTokenPrice || !cryptoWatchTokenPrice) {
@@ -104,6 +108,20 @@ class SyntheticPegMonitor {
         cryptoWatchTokenPrice: cryptoWatchTokenPrice ? cryptoWatchTokenPrice.toString() : "N/A"
       });
       return;
+    }
+
+    // If config includes a `denominatorPriceFeed` then query its price. The peg deviation will compare:
+    // (syntheticTokenPrice / denominatorPrice) against (pegTokenPrice).
+    // If `denominatorPriceFeed` is undefined, then just compare:
+    // (syntheticTokenPrice) against (pegTokenPrice).
+    if (this.denominatorPriceFeed) {
+      const denominatorPrice = this.denominatorPriceFeed.getCurrentPrice();
+      const denominatorPriceFeedScaledOne = ConvertDecimals(
+        0,
+        this.denominatorPriceFeed.getPriceFeedDecimals(),
+        this.web3
+      )(this.toBN("1"));
+      uniswapTokenPrice = uniswapTokenPrice.mul(denominatorPriceFeedScaledOne).div(denominatorPrice);
     }
 
     this.logger.debug({

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -138,7 +138,7 @@ class SyntheticPegMonitor {
       // We need a "1" scaled in the same precision that the `denominatorPrice` is getting returned in, because
       // we want to apply the transformation:
       // - uniswapTokenPrice * denominatorPriceFeedScaledOne / denominatorPrice
-      // which ultimately maintains the `uniswapTokenPrice`'s precision.
+      // which ultimately should maintain the `uniswapTokenPrice`'s precision.
       const denominatorPriceFeedScaledOne = ConvertDecimals(
         0,
         this.denominatorPriceFeed.getPriceFeedDecimals(),


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently, the `SyntheticPegMonitor` assumes that the `TOKEN_PRICE_FEED` (i.e. the "synthetic") and the `MEDIANIZER_PRICE_FEED` (i.e. the "peg") are returning prices denominated in the same currency. However, consider the case where the synthetic market is (zeldaCash - USDC) and the peg market is tracking (STABLESPREAD/ETH). This can result in the following erroneous log:

![Screen Shot 2021-01-07 at 20 40 29](https://user-images.githubusercontent.com/9457025/103964091-9711cd00-5128-11eb-9867-c411f01fdb62.png)


**Summary**

Adds an optional construction parameter to this monitor called the `denominatorPriceFeed` which will divide the synthetic price if available.

Example environment variable to divide the synthetic price by the price of ETHUSD:

```
TOKEN_DENOMINATOR_PRICE_FEED_CONFIG={"type":"cryptowatch","apiKey":"XXX","exchange":"coinbase-pro","pair":"ethusd","lookback":"3600","minTimeBetweenUpdates":60}
```