### PR TITLE
improve(price-feed-interface): Disputer should not throw warning if trying to lookup liquidation time beyond price feed lookback

### DIFF
--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -106,7 +106,7 @@ class Disputer {
           liquidationTime,
           priceFeedEarliestTime: this.priceFeed.getEarliestTime()
         });
-        return false;
+        return;
       }
 
       // If an override is provided, use that price. Else, get the historic price at the liquidation time.

--- a/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
@@ -89,6 +89,10 @@ class BalancerPriceFeed extends PriceFeedInterface {
     return this.lastUpdateTime;
   }
 
+  getEarliestTime() {
+    return this.earliestTime;
+  }
+
   getCurrentPrice() {
     let currentPrice;
     // If twap window is 0, then return last price
@@ -143,6 +147,7 @@ class BalancerPriceFeed extends PriceFeedInterface {
     await Promise.all(blocks.map(this.priceHistory.update));
 
     this.lastUpdateTime = currentTime;
+    this.earliestTime = this.blockHistory.earliest().timestamp;
   }
   // If priceHistory only encompasses 1 block, which happens if the `lookback` window is 0,
   // then this should return the last and only price.

--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -123,6 +123,18 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
     return Math.max(...lastUpdateTimes);
   }
 
+  // Gets the latest, earliest time for all constituent price feeds, as this is first time
+  // that a historical price could be available.
+  getEarliestTime() {
+    const earliestTimes = this.allPriceFeeds.map(priceFeed => priceFeed.getEarliestTime());
+    if (earliestTimes.some(element => element === undefined || element === null)) {
+      return null;
+    }
+
+    // Take the most recent update time.
+    return Math.max(...earliestTimes);
+  }
+
   getPriceFeedDecimals() {
     // Check that every price feeds decimals are the same.
     const priceFeedDecimals = this.allPriceFeeds.map(priceFeed => priceFeed.getPriceFeedDecimals());

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -145,6 +145,10 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       });
   }
 
+  getEarliestTime() {
+    return this.earliestTime;
+  }
+
   getLastUpdateTime() {
     return this.lastUpdateTime;
   }
@@ -178,6 +182,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     // Round down to the nearest ohlc period so the queries captures the OHLC of the period *before* this earliest
     // timestamp (because the close of that OHLC may be relevant).
     const earliestHistoricalTimestamp = Math.floor((currentTime - this.lookback) / this.ohlcPeriod) * this.ohlcPeriod;
+    this.earliestTime = earliestHistoricalTimestamp;
 
     // 1. Construct URLs.
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.

--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -85,6 +85,18 @@ class MedianizerPriceFeed extends PriceFeedInterface {
     return Math.max(...lastUpdateTimes);
   }
 
+  // Gets the latest, earliest time for all constituent price feeds, as this is first time
+  // that a historical price could be available.
+  getEarliestTime() {
+    const earliestTimes = this.priceFeeds.map(priceFeed => priceFeed.getEarliestTime());
+    if (earliestTimes.some(element => element === undefined || element === null)) {
+      return null;
+    }
+
+    // Take the most recent update time.
+    return Math.max(...earliestTimes);
+  }
+
   // Gets the decimals of the medianized price feeds. Errors out if any price feed had a different number of decimals.
   getPriceFeedDecimals() {
     const priceFeedDecimals = this.priceFeeds.map(priceFeed => priceFeed.getPriceFeedDecimals());

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js
@@ -38,6 +38,13 @@ class PriceFeedInterface {
     this._abstractFunctionCalled();
   }
 
+  // Returns the earliest time possible for a historical price query. This timestamp might still fail if passed into
+  // `getHistoricalPrice` but any timestamps earlier than it will definitely fail. This method can make clients more
+  // efficient by catching timestamps that are surely going to not have historical prices available..
+  getEarliestTime() {
+    this._abstractFunctionCalled();
+  }
+
   // Common function to throw an error if an interface method is called.
   _abstractFunctionCalled() {
     throw new Error("Abstract function called -- derived class should implement this function");

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedMock.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedMock.js
@@ -7,12 +7,13 @@ class PriceFeedMock extends PriceFeedInterface {
   // priceFeeds a list of priceFeeds to medianize. All elements must be of type PriceFeedInterface. Must be an array of
   // at least one element. Note that no decimals are included in this price feed. It simply stores the exact input number
   // provided by the test suite. Therefore, decimal conversion is expected to occur within the tests themselves.
-  constructor(currentPrice, historicalPrice, lastUpdateTime, priceFeedDecimals = 18) {
+  constructor(currentPrice, historicalPrice, lastUpdateTime, priceFeedDecimals = 18, earliestTime) {
     super();
     this.updateCalled = 0;
     this.currentPrice = currentPrice;
     this.historicalPrice = historicalPrice;
     this.lastUpdateTime = lastUpdateTime;
+    this.earliestTime = earliestTime;
     this.priceFeedDecimals = priceFeedDecimals;
     this.historicalPrices = [];
   }
@@ -42,6 +43,10 @@ class PriceFeedMock extends PriceFeedInterface {
     this.lastUpdateTime = lastUpdateTime;
   }
 
+  setEarliestTime(earliestTime) {
+    this.earliestTime = earliestTime;
+  }
+
   getCurrentPrice() {
     return this.currentPrice;
   }
@@ -57,6 +62,10 @@ class PriceFeedMock extends PriceFeedInterface {
 
   getLastUpdateTime() {
     return this.lastUpdateTime;
+  }
+
+  getEarliestTime() {
+    return this.earliestTime;
   }
 
   getPriceFeedDecimals() {

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -49,6 +49,10 @@ class UniswapPriceFeed extends PriceFeedInterface {
     return this.lastUpdateTime;
   }
 
+  getEarliestTime() {
+    return this.earliestTime;
+  }
+
   // Not part of the price feed interface. Can be used to pull the uniswap price at the most recent block.
   getLastBlockPrice() {
     return this.lastBlockPrice;
@@ -117,6 +121,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
     this.currentTwap = this._computeTwap(this.events, currentTime - this.twapLength, currentTime);
 
     this.lastUpdateTime = currentTime;
+    this.earliestTime = this.events[0].timestamp;
   }
 
   _getPriceFromSyncEvent(event) {

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -18,6 +18,10 @@ exports.BlockHistory = (getBlock, blocks = []) => {
     return blocks[blocks.length - 1];
   }
 
+  function earliest() {
+    return blocks[0];
+  }
+
   // Used internally, but will insert a block into cache sorted by timestamp
   function insert(block) {
     const index = lodash.sortedIndexBy(blocks, block, "timestamp");
@@ -89,7 +93,8 @@ exports.BlockHistory = (getBlock, blocks = []) => {
     has,
     insert,
     listBlocks,
-    latest
+    latest,
+    earliest
   };
 };
 

--- a/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
@@ -51,19 +51,22 @@ contract("BasketSpreadPriceFeed.js", function() {
             toBN(toWei("1")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("0.2")).div(toBN(10).pow(toBN(18 - precision))),
             200,
-            precision
+            precision,
+            1
           ),
           new PriceFeedMock(
             toBN(toWei("1.5")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("1.3")).div(toBN(10).pow(toBN(18 - precision))),
             55000,
-            precision
+            precision,
+            2
           ),
           new PriceFeedMock(
             toBN(toWei("9")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("2")).div(toBN(10).pow(toBN(18 - precision))),
             50,
-            precision
+            precision,
+            3
           )
         ],
         false
@@ -78,19 +81,22 @@ contract("BasketSpreadPriceFeed.js", function() {
             toBN(toWei("1.1")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("0.6")).div(toBN(10).pow(toBN(18 - precision))),
             200,
-            precision
+            precision,
+            4
           ),
           new PriceFeedMock(
             toBN(toWei("2")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("0.8")).div(toBN(10).pow(toBN(18 - precision))),
             55000,
-            precision
+            precision,
+            5
           ),
           new PriceFeedMock(
             toBN(toWei("2.3")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("2.2")).div(toBN(10).pow(toBN(18 - precision))),
             50,
-            precision
+            precision,
+            6
           )
         ],
         true
@@ -111,19 +117,22 @@ contract("BasketSpreadPriceFeed.js", function() {
             toBN(toWei("1.1")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("0.6")).div(toBN(10).pow(toBN(18 - precision))),
             400,
-            precision
+            precision,
+            7
           ),
           new PriceFeedMock(
             toBN(toWei("1.2")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("2")).div(toBN(10).pow(toBN(18 - precision))),
             60000,
-            precision
+            precision,
+            8
           ),
           new PriceFeedMock(
             toBN(toWei("1.3")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("66")).div(toBN(10).pow(toBN(18 - precision))),
             100,
-            precision
+            precision,
+            9
           )
         ],
         false
@@ -138,19 +147,22 @@ contract("BasketSpreadPriceFeed.js", function() {
             toBN(toWei("0.9")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("0.25")).div(toBN(10).pow(toBN(18 - precision))),
             800,
-            precision
+            precision,
+            10
           ),
           new PriceFeedMock(
             toBN(toWei("1.3")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("0.75")).div(toBN(10).pow(toBN(18 - precision))),
             650000,
-            precision
+            precision,
+            11
           ),
           new PriceFeedMock(
             toBN(toWei("2")).div(toBN(10).pow(toBN(18 - precision))),
             toBN(toWei("2")).div(toBN(10).pow(toBN(18 - precision))),
             200,
-            precision
+            precision,
+            12
           )
         ],
         true
@@ -170,13 +182,15 @@ contract("BasketSpreadPriceFeed.js", function() {
           toBN(toWei("1")).div(toBN(10).pow(toBN(18 - precision))),
           toBN(toWei("8")).div(toBN(10).pow(toBN(18 - precision))),
           6,
-          precision
+          precision,
+          13
         ),
         new PriceFeedMock(
           toBN(toWei("9")).div(toBN(10).pow(toBN(18 - precision))),
           toBN(toWei("12")).div(toBN(10).pow(toBN(18 - precision))),
           7,
-          precision
+          precision,
+          14
         )
       ]);
       // Computes the median:
@@ -214,6 +228,9 @@ contract("BasketSpreadPriceFeed.js", function() {
 
       // Should return the *maximum* lastUpdatedTime.
       assert.equal(basketSpreadPriceFeed.getLastUpdateTime(), 650000);
+
+      // Should return the *maximum* earliestTime.
+      assert.equal(basketSpreadPriceFeed.getEarliestTime(), 14);
     });
     it("Custom price precision", async function() {
       // (same calculations and results as previous test, but precision should be different)

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -153,6 +153,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
     assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1000), undefined);
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), undefined);
+    assert.equal(cryptoWatchPriceFeed.getEarliestTime(), undefined);
   });
 
   it("Basic historical price", async function() {
@@ -187,14 +188,18 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice().toString(), toWei("1.5"));
   });
 
-  it("Last update time", async function() {
+  it("Last update and earliest available time", async function() {
     // Inject data.
     networker.getJsonReturns = [...validResponses];
 
     await cryptoWatchPriceFeed.update();
 
-    // Should return the mock time.
+    // Last update was the mock time.
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), mockTime);
+
+    // Earliest available timestamp is:
+    // Math.floor((mock time - lookback) / OHLC period) * OHLC period =
+    assert.equal(cryptoWatchPriceFeed.getEarliestTime(), Math.floor((mockTime - lookback) / 60) * 60);
   });
 
   it("No or bad response", async function() {

--- a/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -33,6 +33,12 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should return the *maximum* lastUpdatedTime.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), 50000);
+
+    // Should return the *maximum* earliestTime.
+    priceFeeds[0].setEarliestTime(1);
+    priceFeeds[1].setEarliestTime(2);
+    priceFeeds[2].setEarliestTime(3);
+    assert.equal(medianizerPriceFeed.getEarliestTime(), 3);
   });
 
   it("Basic means", async function() {

--- a/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
@@ -192,6 +192,9 @@ contract("BalancerPriceFeed.js", function(accounts) {
 
     // The historical TWAP for now should be 80 for the first half and then 70 for the second half -> 75.
     assert.equal(dexPriceFeed.getHistoricalPrice(currentTime).toString(), toWei("75"));
+
+    // This test creates price events across multiple blocks, make sure that the earliest block timestamp is expected.
+    assert.equal(dexPriceFeed.getEarliestTime(), dexPriceFeed.blockHistory.earliest().timestamp);
   });
 
   it("Historical TWAP too far back", async function() {

--- a/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
@@ -215,6 +215,9 @@ contract("UniswapPriceFeed.js", function(accounts) {
 
     // The historical TWAP for now should be 80 for the first half and then 70 for the second half -> 75.
     assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime).toString(), toWei("75"));
+
+    // This test creates price events across multiple blocks, make sure that the earliest block timestamp is expected.
+    assert.equal(uniswapPriceFeed.getEarliestTime(), uniswapPriceFeed.events[0].timestamp);
   });
 
   it("Historical TWAP too far back", async function() {

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -188,6 +188,18 @@ class ContractMonitor {
 
     for (let event of newLiquidationEvents) {
       const liquidationTime = (await this.web3.eth.getBlock(event.blockNumber)).timestamp;
+      // If liquidation time is before the earliest possible historical price, then we can skip this liquidation
+      // because we will not be able to get a historical price.
+      if (liquidationTime < this.priceFeed.getEarliestTime()) {
+        this.logger.debug({
+          at: "Disputer",
+          message: "Cannot get historical price: liquidation time before earliest price feed historical timestamp",
+          liquidationTime,
+          priceFeedEarliestTime: this.priceFeed.getEarliestTime()
+        });
+        continue;
+      }
+
       const price = this.priceFeed.getHistoricalPrice(parseInt(liquidationTime.toString()));
       let collateralizationString;
       let maxPriceToBeDisputableString;

--- a/packages/monitors/test/ContractMonitor.js
+++ b/packages/monitors/test/ContractMonitor.js
@@ -271,7 +271,20 @@ contract("ContractMonitor.js", function(accounts) {
         await eventClient.update();
         priceFeedMock.setHistoricalPrice(convertPrice("1"));
 
+        // Liquidations before pricefeed's earliest timestamp are not considered:
+        const earliestLiquidationTime = (await web3.eth.getBlock(eventClient.getAllLiquidationEvents()[0].blockNumber))
+          .timestamp;
+        // Set earliest time to AFTER the liquidation time:
+        priceFeedMock.setEarliestTime(Number(earliestLiquidationTime) + 1);
         // Check for liquidation events
+        await contractMonitor.checkForNewLiquidations();
+        assert.equal(spy.getCalls().length, 0);
+
+        // Check for liquidation events which should now be captured since the liquidation time is equal to
+        // the earliest time. Note that we need to reset the internal `lastLiquidationBlockNumber` value so
+        // that we can "re-query" these events:
+        contractMonitor.lastLiquidationBlockNumber = 0;
+        priceFeedMock.setEarliestTime(Number(earliestLiquidationTime));
         await contractMonitor.checkForNewLiquidations();
 
         // Ensure that the spy correctly captured the liquidation events key information.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

- Adds `earliestTimestamp` to PriceFeedInterface which is the earliest possible timestamp for which a historical price could be available
- Use `pricefeed.earliestTimestamp` in `disputer` and don't throw warning if trying to fetch price for liquidation time earlier than this `earliestTimestamp`. This is possible if the user explicitly sets a shorter `lookback` than the EMP's `liquidationLiveness` window. e.g. This avoids sending out warnings if a liquidation occurred earlier than the pricefeed's lookback window and its liveness has not expired.
