### PR TITLE
improve(price-feed-interface): Add getLookback to interface

### DIFF
--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -98,16 +98,15 @@ class Disputer {
       // If liquidation time is before the price feed's lookback window, then we can skip this liquidation
       // because we will not be able to get a historical price. If a dispute override price is provided then
       // we can ignore this check.
-      let liquidationTime = parseInt(liquidation.liquidationTime.toString());
-      if (
-        !disputerOverridePrice &&
-        liquidationTime < this.priceFeed.getLastUpdateTime() - Number(this.priceFeed.getLookback())
-      ) {
+      const liquidationTime = parseInt(liquidation.liquidationTime.toString());
+      const historicalLookbackWindow =
+        Number(this.priceFeed.getLastUpdateTime()) - Number(this.priceFeed.getLookback());
+      if (!disputerOverridePrice && liquidationTime < historicalLookbackWindow) {
         this.logger.debug({
           at: "Disputer",
           message: "Cannot dispute: liquidation time before earliest price feed historical timestamp",
           liquidationTime,
-          priceFeedEarliestTime: this.priceFeed.getLastUpdateTime() - this.priceFeed.getLookback()
+          historicalLookbackWindow
         });
         return;
       }

--- a/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
@@ -89,6 +89,10 @@ class BalancerPriceFeed extends PriceFeedInterface {
     return this.lastUpdateTime;
   }
 
+  getLookback() {
+    return this.lookback;
+  }
+
   getCurrentPrice() {
     let currentPrice;
     // If twap window is 0, then return last price

--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -123,6 +123,15 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
     return Math.max(...lastUpdateTimes);
   }
 
+  // Returns the shortest lookback window of the constituent price feeds.
+  getLookback() {
+    const lookbacks = this.allPriceFeeds.map(priceFeed => priceFeed.getLookback());
+    if (lookbacks.some(element => element === undefined || element === null)) {
+      return null;
+    }
+    return Math.min(...lookbacks);
+  }
+
   getPriceFeedDecimals() {
     // Check that every price feeds decimals are the same.
     const priceFeedDecimals = this.allPriceFeeds.map(priceFeed => priceFeed.getPriceFeedDecimals());

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -149,6 +149,10 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     return this.lastUpdateTime;
   }
 
+  getLookback() {
+    return this.lookback;
+  }
+
   getPriceFeedDecimals() {
     return this.priceFeedDecimals;
   }

--- a/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
@@ -141,6 +141,10 @@ class DominationFinancePriceFeed extends PriceFeedInterface {
     return this.lastUpdateTime;
   }
 
+  getLookback() {
+    return this.lookback;
+  }
+
   getPriceFeedDecimals() {
     return this.priceFeedDecimals;
   }

--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -96,6 +96,15 @@ class MedianizerPriceFeed extends PriceFeedInterface {
     return priceFeedDecimals[0];
   }
 
+  // Returns the shortest lookback window of the constituent price feeds.
+  getLookback() {
+    const lookbacks = this.priceFeeds.map(priceFeed => priceFeed.getLookback());
+    if (lookbacks.some(element => element === undefined || element === null)) {
+      return null;
+    }
+    return Math.min(...lookbacks);
+  }
+
   // Updates all constituent price feeds.
   async update() {
     await Promise.all(this.priceFeeds.map(priceFeed => priceFeed.update()));

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js
@@ -38,6 +38,11 @@ class PriceFeedInterface {
     this._abstractFunctionCalled();
   }
 
+  // Returns the lookback window for a historical price query. Timestamps before (currentTime - lookback) will fail if passed into
+  // `getHistoricalPrice`. This method can make clients more efficient by catching invalid historical timestamps early.
+  getLookback() {
+    this._abstractFunctionCalled();
+  }
   // Common function to throw an error if an interface method is called.
   _abstractFunctionCalled() {
     throw new Error("Abstract function called -- derived class should implement this function");

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedMock.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedMock.js
@@ -7,7 +7,7 @@ class PriceFeedMock extends PriceFeedInterface {
   // priceFeeds a list of priceFeeds to medianize. All elements must be of type PriceFeedInterface. Must be an array of
   // at least one element. Note that no decimals are included in this price feed. It simply stores the exact input number
   // provided by the test suite. Therefore, decimal conversion is expected to occur within the tests themselves.
-  constructor(currentPrice, historicalPrice, lastUpdateTime, priceFeedDecimals = 18) {
+  constructor(currentPrice, historicalPrice, lastUpdateTime, priceFeedDecimals = 18, lookback = 3600) {
     super();
     this.updateCalled = 0;
     this.currentPrice = currentPrice;
@@ -15,6 +15,7 @@ class PriceFeedMock extends PriceFeedInterface {
     this.lastUpdateTime = lastUpdateTime;
     this.priceFeedDecimals = priceFeedDecimals;
     this.historicalPrices = [];
+    this.lookback = lookback;
   }
 
   setCurrentPrice(currentPrice) {
@@ -42,6 +43,10 @@ class PriceFeedMock extends PriceFeedInterface {
     this.lastUpdateTime = lastUpdateTime;
   }
 
+  setLookback(lookback) {
+    this.lookback = lookback;
+  }
+
   getCurrentPrice() {
     return this.currentPrice;
   }
@@ -57,6 +62,10 @@ class PriceFeedMock extends PriceFeedInterface {
 
   getLastUpdateTime() {
     return this.lastUpdateTime;
+  }
+
+  getLookback() {
+    return this.lookback;
   }
 
   getPriceFeedDecimals() {

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -49,6 +49,10 @@ class UniswapPriceFeed extends PriceFeedInterface {
     return this.lastUpdateTime;
   }
 
+  getLookback() {
+    return this.lookback;
+  }
+
   // Not part of the price feed interface. Can be used to pull the uniswap price at the most recent block.
   getLastBlockPrice() {
     return this.lastBlockPrice;

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -50,7 +50,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
   }
 
   getLookback() {
-    return this.lookback;
+    return this.historicalLookback;
   }
 
   // Not part of the price feed interface. Can be used to pull the uniswap price at the most recent block.

--- a/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
@@ -214,6 +214,7 @@ contract("BasketSpreadPriceFeed.js", function() {
 
       // Should return the *maximum* lastUpdatedTime.
       assert.equal(basketSpreadPriceFeed.getLastUpdateTime(), 650000);
+      assert.equal(basketSpreadPriceFeed.getLookback(), 3600);
     });
     it("Custom price precision", async function() {
       // (same calculations and results as previous test, but precision should be different)

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -153,6 +153,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
     assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1000), undefined);
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), undefined);
+    assert.equal(cryptoWatchPriceFeed.getLookback(), 120);
   });
 
   it("Basic historical price", async function() {

--- a/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
@@ -143,6 +143,7 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.equal(priceFeed.getCurrentPrice(), undefined);
     assert.equal(priceFeed.getHistoricalPrice(1000), undefined);
     assert.equal(priceFeed.getLastUpdateTime(), undefined);
+    assert.equal(priceFeed.getLookback(), lookback);
   });
 
   it("Basic historical price", async function() {

--- a/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -33,6 +33,7 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should return the *maximum* lastUpdatedTime.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), 50000);
+    assert.equal(medianizerPriceFeed.getLookback(), 3600);
   });
 
   it("Basic means", async function() {

--- a/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
@@ -48,6 +48,8 @@ contract("BalancerPriceFeed.js", function(accounts) {
     await dexPriceFeed.update();
 
     assert.equal(dexPriceFeed.getSpotPrice().toString(), toWei("0.5"));
+    assert.equal(dexPriceFeed.getLastUpdateTime(), mockTime);
+    assert.equal(dexPriceFeed.getLookback(), 3600);
   });
 
   it("Correctly selects most recent price", async function() {

--- a/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
@@ -46,7 +46,7 @@ contract("UniswapPriceFeed.js", function(accounts) {
     await uniswapPriceFeed.update();
 
     assert.equal(uniswapPriceFeed.getLastBlockPrice().toString(), toWei("0.5"));
-    assert.equal(uniswapPriceFeed.getlastUpdateTime(), mockTime);
+    assert.equal(uniswapPriceFeed.getLastUpdateTime(), mockTime);
     assert.equal(uniswapPriceFeed.getLookback(), 3600);
   });
 

--- a/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
@@ -46,6 +46,8 @@ contract("UniswapPriceFeed.js", function(accounts) {
     await uniswapPriceFeed.update();
 
     assert.equal(uniswapPriceFeed.getLastBlockPrice().toString(), toWei("0.5"));
+    assert.equal(uniswapPriceFeed.getlastUpdateTime(), mockTime);
+    assert.equal(uniswapPriceFeed.getLookback(), 3600);
   });
 
   it("Correctly selects most recent price", async function() {

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -188,6 +188,18 @@ class ContractMonitor {
 
     for (let event of newLiquidationEvents) {
       const liquidationTime = (await this.web3.eth.getBlock(event.blockNumber)).timestamp;
+      // If liquidation time is before historical lookback window, then we can skip this liquidation
+      // because we will not be able to get a historical price.
+      if (liquidationTime < this.priceFeed.getLastUpdateTime() - this.priceFeed.getLookback()) {
+        this.logger.debug({
+          at: "Disputer",
+          message: "Cannot get historical price: liquidation time before earliest price feed historical timestamp",
+          liquidationTime,
+          priceFeedEarliestTime: this.priceFeed.getLastUpdateTime() - this.priceFeed.getLookback()
+        });
+        continue;
+      }
+
       const price = this.priceFeed.getHistoricalPrice(parseInt(liquidationTime.toString()));
       let collateralizationString;
       let maxPriceToBeDisputableString;

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -188,6 +188,21 @@ class ContractMonitor {
 
     for (let event of newLiquidationEvents) {
       const liquidationTime = (await this.web3.eth.getBlock(event.blockNumber)).timestamp;
+      const historicalLookbackWindow =
+        Number(this.priceFeed.getLastUpdateTime()) - Number(this.priceFeed.getLookback());
+
+      // If liquidation time is before the earliest possible historical price, then we can skip this liquidation
+      // because we will not be able to get a historical price.
+      if (liquidationTime < historicalLookbackWindow) {
+        this.logger.debug({
+          at: "Disputer",
+          message: "Cannot get historical price: liquidation time before earliest price feed historical timestamp",
+          liquidationTime,
+          historicalLookbackWindow
+        });
+        continue;
+      }
+
       // If liquidation time is before historical lookback window, then we can skip this liquidation
       // because we will not be able to get a historical price.
       if (liquidationTime < this.priceFeed.getLastUpdateTime() - this.priceFeed.getLookback()) {

--- a/packages/monitors/test/ContractMonitor.js
+++ b/packages/monitors/test/ContractMonitor.js
@@ -271,21 +271,21 @@ contract("ContractMonitor.js", function(accounts) {
         await eventClient.update();
         priceFeedMock.setHistoricalPrice(convertPrice("1"));
 
-        // Liquidations before pricefeed's earliest timestamp are not considered:
-        const earliestLiquidationTime = (await web3.eth.getBlock(eventClient.getAllLiquidationEvents()[0].blockNumber))
-          .timestamp;
-        // Set earliest time to AFTER the liquidation time:
-        priceFeedMock.setEarliestTime(Number(earliestLiquidationTime) + 1);
+        // Liquidations before pricefeed's lookback window (lastUpdateTime - lookback) are not considered:
+        const earliestLiquidationTime = Number(
+          (await web3.eth.getBlock(eventClient.getAllLiquidationEvents()[0].blockNumber)).timestamp
+        );
+        priceFeedMock.setLastUpdateTime(earliestLiquidationTime + 2);
+        priceFeedMock.setLookback(1);
 
         // Check for liquidation events
         await contractMonitor.checkForNewLiquidations();
         assert.equal(spy.getCalls().length, 0);
 
-        // Check for liquidation events which should now be captured since the liquidation time is equal to
-        // the earliest time. Note that we need to reset the internal `lastLiquidationBlockNumber` value so
-        // that we can "re-query" these events:
+        // Check for liquidation events which should now be captured since the lookback now covers the liquidation time.
+        // Note that we need to reset the internal `lastLiquidationBlockNumber` value so that we can "re-query" these events:
         contractMonitor.lastLiquidationBlockNumber = 0;
-        priceFeedMock.setEarliestTime(Number(earliestLiquidationTime));
+        priceFeedMock.setLookback(2);
         await contractMonitor.checkForNewLiquidations();
 
         // Ensure that the spy correctly captured the liquidation events key information.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

`Disputer` should not throw warning if trying to lookup liquidation time beyond price feed lookback (`lastUpdateTimestamp` - `lookback`):

- Adds `getLookback` to PriceFeedInterface which is the earliest possible timestamp for which a historical price could be available
- Usethis information in `disputer` and `ContractMonitor` and don't throw warning if trying to fetch price for liquidation time earlier than historical lookback. This is possible if the user explicitly sets a shorter lookback than the EMP's liquidationLiveness window. e.g. This avoids sending out warnings if a liquidation occurred earlier than the pricefeed's lookback window and its liveness has not expired.
