### PR TITLE
fix(monitor,disputer,liquidator bots): correctly pass in bot config objects into bots

### DIFF
--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -15,7 +15,7 @@ class Disputer {
    * @param {String} account Ethereum account from which to send txns.
    * @param {Object} empProps Contains EMP contract state data. Expected:
    *      { priceIdentifier: hex("ETH/BTC") }
-   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults.
+   * @param {Object} [disputerConfig] Contains fields with which constructor will attempt to override defaults.
    */
   constructor({
     logger,
@@ -25,7 +25,7 @@ class Disputer {
     priceFeed,
     account,
     empProps,
-    config
+    disputerConfig
   }) {
     this.logger = logger;
     this.account = account;
@@ -55,7 +55,7 @@ class Disputer {
     this.GAS_LIMIT_BUFFER = 1.25;
 
     // Default config settings. Disputer deployer can override these settings by passing in new
-    // values via the `config` input object. The `isValid` property is a function that should be called
+    // values via the `disputerConfig` input object. The `isValid` property is a function that should be called
     // before resetting any config settings. `isValid` must return a Boolean.
     const defaultConfig = {
       disputeDelay: {
@@ -76,7 +76,7 @@ class Disputer {
     };
 
     // Validate and set config settings to class state.
-    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
+    Object.assign(this, createObjectFromDefaultProps(disputerConfig, defaultConfig));
   }
 
   // Update the client and gasEstimator clients.

--- a/packages/disputer/test/Disputer.js
+++ b/packages/disputer/test/Disputer.js
@@ -188,7 +188,7 @@ contract("Disputer.js", function(accounts) {
         gasEstimator = new GasEstimator(spyLogger);
 
         // Create a new instance of the disputer to test
-        const config = {
+        const disputerConfig = {
           disputeDelay: 0
         };
 
@@ -203,7 +203,7 @@ contract("Disputer.js", function(accounts) {
           priceFeed: priceFeedMock,
           account: accounts[0],
           empProps,
-          config
+          disputerConfig
         });
       });
 
@@ -519,7 +519,7 @@ contract("Disputer.js", function(accounts) {
         it("Cannot set `disputeDelay` < 0", async function() {
           let errorThrown;
           try {
-            const config = {
+            const disputerConfig = {
               disputeDelay: -1
             };
             disputer = new Disputer({
@@ -530,7 +530,7 @@ contract("Disputer.js", function(accounts) {
               priceFeed: priceFeedMock,
               account: accounts[0],
               empProps,
-              config
+              disputerConfig
             });
             errorThrown = false;
           } catch (err) {
@@ -540,7 +540,7 @@ contract("Disputer.js", function(accounts) {
         });
 
         it("Sets `disputeDelay` to 60 seconds", async function() {
-          const config = {
+          const disputerConfig = {
             disputeDelay: 60
           };
           disputer = new Disputer({
@@ -551,7 +551,7 @@ contract("Disputer.js", function(accounts) {
             priceFeed: priceFeedMock,
             account: accounts[0],
             empProps,
-            config
+            disputerConfig
           });
 
           // sponsor1 creates a position with 150 units of collateral, creating 100 synthetic tokens.
@@ -591,7 +591,7 @@ contract("Disputer.js", function(accounts) {
           assert.equal((await emp.getLiquidations(sponsor1))[0].state, LiquidationStatesEnum.PRE_DISPUTE);
 
           // Advance contract time and attempt to dispute again.
-          await emp.setCurrentTime(Number(liquidationTime) + config.disputeDelay);
+          await emp.setCurrentTime(Number(liquidationTime) + disputerConfig.disputeDelay);
 
           priceFeedMock.setHistoricalPrice(convertPrice("1.1"));
           await disputer.update();

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -18,12 +18,11 @@ class Liquidator {
    * @param {Object} syntheticToken Synthetic token (tokenCurrency).
    * @param {Object} priceFeed Module used to query the current token price.
    * @param {String} account Ethereum account from which to send txns.
-   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults.
    * @param {Object} empProps Contains EMP contract state data. Expected:
    *      { crRatio: 1.5e18,
             minSponsorSize: 10e18,
             priceIdentifier: hex("ETH/BTC") }
-   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults.
+   * @param {Object} [liquidatorConfig] Contains fields with which constructor will attempt to override defaults.
    */
   constructor({
     logger,
@@ -34,7 +33,7 @@ class Liquidator {
     priceFeed,
     account,
     empProps,
-    config
+    liquidatorConfig
   }) {
     this.logger = logger;
     this.account = account;
@@ -73,7 +72,7 @@ class Liquidator {
     this.GAS_LIMIT_BUFFER = 1.25;
 
     // Default config settings. Liquidator deployer can override these settings by passing in new
-    // values via the `config` input object. The `isValid` property is a function that should be called
+    // values via the `liquidatorConfig` input object. The `isValid` property is a function that should be called
     // before resetting any config settings. `isValid` must return a Boolean.
     const defaultConfig = {
       crThreshold: {
@@ -139,7 +138,7 @@ class Liquidator {
     };
 
     // Validate and set config settings to class state.
-    const configWithDefaults = createObjectFromDefaultProps(config, defaultConfig);
+    const configWithDefaults = createObjectFromDefaultProps(liquidatorConfig, defaultConfig);
     Object.assign(this, configWithDefaults);
 
     // generalize log emitter, use it to attach default data to all logs

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -210,7 +210,7 @@ contract("Liquidator.js", function(accounts) {
           priceFeed: priceFeedMock,
           account: accounts[0],
           empProps,
-          config: liquidatorConfig
+          liquidatorConfig
         });
       });
       it("Can correctly detect undercollateralized positions and liquidate them", async function() {
@@ -639,7 +639,7 @@ contract("Liquidator.js", function(accounts) {
               priceFeed: priceFeedMock,
               account: accounts[0],
               empProps,
-              config: liquidatorConfig
+              liquidatorConfig
             });
             errorThrown = false;
           } catch (err) {
@@ -663,7 +663,7 @@ contract("Liquidator.js", function(accounts) {
               priceFeed: priceFeedMock,
               account: accounts[0],
               empProps,
-              config: liquidatorConfig
+              liquidatorConfig
             });
             errorThrown = false;
           } catch (err) {
@@ -685,7 +685,7 @@ contract("Liquidator.js", function(accounts) {
             priceFeed: priceFeedMock,
             account: accounts[0],
             empProps,
-            config: liquidatorConfig
+            liquidatorConfig
           });
 
           // sponsor1 creates a position with 115 units of collateral, creating 100 synthetic tokens.
@@ -754,7 +754,7 @@ contract("Liquidator.js", function(accounts) {
               priceFeed: priceFeedMock,
               account: accounts[0],
               empProps,
-              config: liquidatorConfig
+              liquidatorConfig
             });
             errorThrown = false;
           } catch (err) {
@@ -1058,7 +1058,7 @@ contract("Liquidator.js", function(accounts) {
               priceFeed: priceFeedMock,
               account: accounts[0],
               empProps,
-              config: liquidatorConfig
+              liquidatorConfig
             });
 
             // sponsor1 creates a position with 115 units of collateral, creating 100 synthetic tokens.
@@ -1160,7 +1160,7 @@ contract("Liquidator.js", function(accounts) {
             priceFeed: priceFeedMock,
             account: accounts[0],
             empProps,
-            config: liquidatorConfig
+            liquidatorConfig
           });
           assert.ok(liquidator);
         });
@@ -1183,7 +1183,7 @@ contract("Liquidator.js", function(accounts) {
             priceFeed: priceFeedMock,
             account: accounts[0],
             empProps,
-            config: liquidatorConfig
+            liquidatorConfig
           });
           // sponsor1 creates a position with 125 units of collateral, creating 100 synthetic tokens.
           await emp.create(
@@ -1288,7 +1288,7 @@ contract("Liquidator.js", function(accounts) {
             priceFeed: priceFeedMock,
             account: accounts[0],
             empProps,
-            config: liquidatorConfig
+            liquidatorConfig
           });
           // sponsor1 creates a position with 120 units of collateral, creating 100 synthetic tokens.
           await emp.create(
@@ -1345,7 +1345,7 @@ contract("Liquidator.js", function(accounts) {
             priceFeed: priceFeedMock,
             account: accounts[0],
             empProps,
-            config: liquidatorConfig
+            liquidatorConfig
           });
           await emp.create(
             { rawValue: convertCollateral("120") },

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -172,7 +172,7 @@ async function run({
       logger,
       expiringMultiPartyEventClient: empEventClient,
       priceFeed: medianizerPriceFeed,
-      config: monitorConfig,
+      monitorConfig,
       empProps,
       voting
     });
@@ -189,7 +189,7 @@ async function run({
     const balanceMonitor = new BalanceMonitor({
       logger,
       tokenBalanceClient,
-      config: monitorConfig,
+      monitorConfig,
       empProps
     });
 
@@ -200,7 +200,7 @@ async function run({
       logger,
       expiringMultiPartyClient: empClient,
       priceFeed: medianizerPriceFeed,
-      config: monitorConfig,
+      monitorConfig,
       empProps
     });
 
@@ -211,7 +211,7 @@ async function run({
       uniswapPriceFeed: tokenPriceFeed,
       medianizerPriceFeed,
       denominatorPriceFeed,
-      config: monitorConfig,
+      monitorConfig,
       empProps
     });
 

--- a/packages/monitors/src/BalanceMonitor.js
+++ b/packages/monitors/src/BalanceMonitor.js
@@ -13,7 +13,7 @@ class BalanceMonitor {
    * @param {Object} tokenBalanceClient Client used to query token balances for monitored bots and wallets.
    * @param tokenBalanceClient Instance of the TokenBalanceClient from the `financial-templates lib.
    * which provides synchronous access to address balances for a given expiring multi party contract.
-   * @param {Object} config Object containing configuration for the balance monitor. Only option is a `botsToMonitor` 
+   * @param {Object} monitorConfig Object containing configuration for the balance monitor. Only option is a `botsToMonitor` 
    * which is defines an array of bot objects to monitor. Each bot's `botName` `address`, `CollateralThreshold`
    *      and`syntheticThreshold` must be given. Example:
    *      { botsToMonitor:[{ name: "Liquidator Bot",
@@ -31,7 +31,7 @@ class BalanceMonitor {
             syntheticDecimals: 18,
             networkId:1 }
    */
-  constructor({ logger, tokenBalanceClient, config, empProps }) {
+  constructor({ logger, tokenBalanceClient, monitorConfig, empProps }) {
     this.logger = logger;
 
     // Instance of the tokenBalanceClient to read account balances from last change update.
@@ -80,9 +80,9 @@ class BalanceMonitor {
       }
     };
 
-    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
+    Object.assign(this, createObjectFromDefaultProps(monitorConfig, defaultConfig));
 
-    // Loop over all bots in the provided config and register them in the tokenBalanceClient. This will ensure that
+    // Loop over all bots in the provided monitorConfig and register them in the tokenBalanceClient. This will ensure that
     // the addresses are populated on the first fire of the clients `update` function enabling stateless execution.
     this.client.batchRegisterAddresses(this.botsToMonitor.map(bot => this.web3.utils.toChecksumAddress(bot.address)));
 

--- a/packages/monitors/src/CRMonitor.js
+++ b/packages/monitors/src/CRMonitor.js
@@ -28,7 +28,7 @@ class CRMonitor {
             priceIdentifier: "ETH/BTC",
             networkId:1 }
    */
-  constructor({ logger, expiringMultiPartyClient, priceFeed, config, empProps }) {
+  constructor({ logger, expiringMultiPartyClient, priceFeed, monitorConfig, empProps }) {
     this.logger = logger;
 
     this.empClient = expiringMultiPartyClient;
@@ -80,7 +80,7 @@ class CRMonitor {
       }
     };
 
-    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
+    Object.assign(this, createObjectFromDefaultProps(monitorConfig, defaultConfig));
 
     // Validate the EMPProps object. This contains a set of important info within it so need to be sure it's structured correctly.
     const defaultEmpProps = {

--- a/packages/monitors/src/CRMonitor.js
+++ b/packages/monitors/src/CRMonitor.js
@@ -13,7 +13,7 @@ class CRMonitor {
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} expiringMultiPartyClient Client used to query EMP status for monitored wallets position info.
    * @param {Object} priceFeed Module used to query the current token price.
-   * @param {Object} config Object containing an array of wallets to Monitor. Each wallet's `walletName`, `address`,
+   * @param {Object} monitorConfig Object containing an array of wallets to Monitor. Each wallet's `walletName`, `address`,
    * `crAlert` must be given. Example:
    *      { walletsToMonitor: [{ name: "Market Making bot", // Friendly bot name
    *            address: "0x12345",                         // Bot address

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -15,7 +15,7 @@ class ContractMonitor {
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} expiringMultiPartyEventClient Client used to query EMP events for contract state updates.
    * @param {Object} priceFeed Module used to query the current token price.
-   * @param {Object} config Object containing two arrays of monitored liquidator and disputer bots to inform logs Example:
+   * @param {Object} monitorConfig Object containing two arrays of monitored liquidator and disputer bots to inform logs Example:
    *      { "monitoredLiquidators": ["0x1234","0x5678"],
    *        "monitoredDisputers": ["0x1234","0x5678"] }
    * @param {Object} empProps Configuration object used to inform logs of key EMP information. Example:
@@ -28,7 +28,7 @@ class ContractMonitor {
             networkId:1 }
    * @param {Object} votingContract DVM to query price requests.
    */
-  constructor({ logger, expiringMultiPartyEventClient, priceFeed, config, empProps, votingContract }) {
+  constructor({ logger, expiringMultiPartyEventClient, priceFeed, monitorConfig, empProps, votingContract }) {
     this.logger = logger;
 
     // Offchain price feed to get the price for liquidations.
@@ -58,7 +58,7 @@ class ContractMonitor {
     // Formats an 18 decimal point string with a define number of decimals and precision for use in message generation.
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4, false);
 
-    // Bot and ecosystem accounts to monitor, overridden by config parameter.
+    // Bot and ecosystem accounts to monitor, overridden by monitorConfig parameter.
     const defaultConfig = {
       // By default monitor no liquidator bots (empty array).
       monitoredLiquidators: {
@@ -87,7 +87,7 @@ class ContractMonitor {
       }
     };
 
-    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
+    Object.assign(this, createObjectFromDefaultProps(monitorConfig, defaultConfig));
 
     // Validate the EMPProps object. This contains a set of important info within it so need to be sure it's structured correctly.
     const defaultEmpProps = {
@@ -114,7 +114,15 @@ class ContractMonitor {
         }
       }
     };
-    Object.assign(this, createObjectFromDefaultProps({ empProps }, defaultEmpProps));
+    Object.assign(
+      this,
+      createObjectFromDefaultProps(
+        {
+          empProps
+        },
+        defaultEmpProps
+      )
+    );
 
     // Helper functions from web3.
     this.toWei = this.web3.utils.toWei;

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -13,7 +13,7 @@ class SyntheticPegMonitor {
    * @param {Object} medianizerPriceFeed Module used to query the median price among selected price feeds.
    * @param {Object} denominatorPriceFeed Optional module that can be used to divide the price returned by the
    * `medianizerPriceFeed` in order to "denominator" that price in a new currency.
-   * @param {Object} [config] Contains fields with which constructor will attempt to override defaults. Example:
+   * @param {Object} [monitorConfig] Contains fields with which constructor will attempt to override defaults. Example:
   *      { deviationAlertThreshold:0.2,           // Threshold used to compare observed and expected token prices.
            volatilityWindow: 600,                 // Length of time (in seconds) to snapshot volatility.
            pegVolatilityAlertThreshold: 0.2,      // Threshold for synthetic peg price volatility.
@@ -25,7 +25,7 @@ class SyntheticPegMonitor {
             priceIdentifier: "ETH/BTC",
             priceFeedDecimals: 18, }
    */
-  constructor({ logger, web3, uniswapPriceFeed, medianizerPriceFeed, denominatorPriceFeed, config, empProps }) {
+  constructor({ logger, web3, uniswapPriceFeed, medianizerPriceFeed, denominatorPriceFeed, monitorConfig, empProps }) {
     this.logger = logger;
 
     // Instance of price feeds used to check for deviation of synthetic token price.
@@ -40,7 +40,7 @@ class SyntheticPegMonitor {
     this.formatDecimalString = createFormatFunction(this.web3, 2, 4);
 
     // Default config settings. SyntheticPegMonitor deployer can override these settings by passing in new
-    // values via the `config` input object. The `isValid` property is a function that should be called
+    // values via the `monitorConfig` input object. The `isValid` property is a function that should be called
     // before resetting any config settings. `isValid` must return a Boolean. If the associated price feed is missing
     // then the defaults to 0 thresholds. This will skip the check in the respective functions.
     const defaultConfig = {
@@ -84,7 +84,7 @@ class SyntheticPegMonitor {
         }
       }
     };
-    Object.assign(this, createObjectFromDefaultProps(config, defaultConfig));
+    Object.assign(this, createObjectFromDefaultProps(monitorConfig, defaultConfig));
 
     // Validate the EMPProps object. This contains a set of important info within it so need to be sure it's structured correctly.
     const defaultEmpProps = {

--- a/packages/monitors/test/BalanceMonitor.js
+++ b/packages/monitors/test/BalanceMonitor.js
@@ -113,7 +113,7 @@ contract("BalanceMonitor.js", function(accounts) {
         balanceMonitor = new BalanceMonitor({
           logger: spyLogger,
           tokenBalanceClient,
-          config: monitorConfig,
+          monitorConfig,
           empProps
         });
 
@@ -294,7 +294,7 @@ contract("BalanceMonitor.js", function(accounts) {
           balanceMonitor = new BalanceMonitor({
             logger: spyLogger,
             tokenBalanceClient,
-            config: invalidMonitorConfig1,
+            monitorConfig: invalidMonitorConfig1,
             empProps
           });
           errorThrown1 = false;
@@ -323,7 +323,7 @@ contract("BalanceMonitor.js", function(accounts) {
           balanceMonitor = new BalanceMonitor({
             logger: spyLogger,
             tokenBalanceClient,
-            config: invalidMonitorConfig2,
+            monitorConfig: invalidMonitorConfig2,
             empProps
           });
           errorThrown2 = false;
@@ -339,7 +339,7 @@ contract("BalanceMonitor.js", function(accounts) {
           balanceMonitor = new BalanceMonitor({
             logger: spyLogger,
             tokenBalanceClient,
-            config: emptyConfig,
+            monitorConfig: emptyConfig,
             empProps
           });
           await balanceMonitor.checkBotBalances();
@@ -354,7 +354,7 @@ contract("BalanceMonitor.js", function(accounts) {
         balanceMonitor = new BalanceMonitor({
           logger: spyLogger,
           tokenBalanceClient,
-          config: alertOverrideConfig,
+          monitorConfig: alertOverrideConfig,
           empProps
         });
 
@@ -376,7 +376,7 @@ contract("BalanceMonitor.js", function(accounts) {
         balanceMonitor = new BalanceMonitor({
           logger: spyLogger,
           tokenBalanceClient,
-          config: alertOverrideConfig,
+          monitorConfig: alertOverrideConfig,
           empProps
         });
 
@@ -398,7 +398,7 @@ contract("BalanceMonitor.js", function(accounts) {
         balanceMonitor = new BalanceMonitor({
           logger: spyLogger,
           tokenBalanceClient,
-          config: alertOverrideConfig,
+          monitorConfig: alertOverrideConfig,
           empProps
         });
 

--- a/packages/monitors/test/CRMonitor.js
+++ b/packages/monitors/test/CRMonitor.js
@@ -186,7 +186,7 @@ contract("CRMonitor.js", function(accounts) {
           logger: spyLogger,
           expiringMultiPartyClient: empClient,
           priceFeed: priceFeedMock,
-          config: monitorConfig,
+          monitorConfig,
           empProps
         });
 
@@ -330,7 +330,7 @@ contract("CRMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyClient: empClient,
             priceFeed: priceFeedMock,
-            config: invalidMonitorConfig1,
+            monitorConfig: invalidMonitorConfig1,
             empProps
           });
           errorThrown1 = false;
@@ -358,7 +358,7 @@ contract("CRMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyClient: empClient,
             priceFeed: priceFeedMock,
-            config: invalidMonitorConfig2,
+            monitorConfig: invalidMonitorConfig2,
             empProps
           });
           errorThrown2 = false;
@@ -375,7 +375,7 @@ contract("CRMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyClient: empClient,
             priceFeed: priceFeedMock,
-            config: emptyConfig,
+            monitorConfig: emptyConfig,
             empProps
           });
           await crMonitor.checkWalletCrRatio();
@@ -391,7 +391,7 @@ contract("CRMonitor.js", function(accounts) {
           logger: spyLogger,
           expiringMultiPartyClient: empClient,
           priceFeed: priceFeedMock,
-          config: alertOverrideConfig,
+          monitorConfig: alertOverrideConfig,
           empProps
         });
 

--- a/packages/monitors/test/ContractMonitor.js
+++ b/packages/monitors/test/ContractMonitor.js
@@ -179,7 +179,7 @@ contract("ContractMonitor.js", function(accounts) {
           logger: spyLogger,
           expiringMultiPartyEventClient: eventClient,
           priceFeed: priceFeedMock,
-          config: monitorConfig,
+          monitorConfig,
           empProps,
           votingContract: mockOracle
         });
@@ -484,7 +484,7 @@ contract("ContractMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyEventClient: eventClient,
             priceFeed: priceFeedMock,
-            config: invalidConfig1,
+            monitorConfig: invalidConfig1,
             empProps
           });
           errorThrown1 = false;
@@ -501,7 +501,7 @@ contract("ContractMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyEventClient: eventClient,
             priceFeed: priceFeedMock,
-            config: invalidConfig2,
+            monitorConfig: invalidConfig2,
             empProps
           });
           errorThrown2 = false;
@@ -519,7 +519,7 @@ contract("ContractMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyEventClient: eventClient,
             priceFeed: priceFeedMock,
-            config: monitorConfig, // valid config
+            monitorConfig, // valid config
             empProps
           });
           errorThrown3 = false;
@@ -538,7 +538,7 @@ contract("ContractMonitor.js", function(accounts) {
             logger: spyLogger,
             expiringMultiPartyEventClient: eventClient,
             priceFeed: priceFeedMock,
-            config: emptyConfig,
+            monitorConfig: emptyConfig,
             empProps
           });
           await contractMonitor.checkForNewSponsors();

--- a/packages/monitors/test/SyntheticPegMonitor.js
+++ b/packages/monitors/test/SyntheticPegMonitor.js
@@ -78,7 +78,7 @@ contract("SyntheticPegMonitor", function() {
             web3,
             uniswapPriceFeed: uniswapPriceFeedMock,
             medianizerPriceFeed: medianizerPriceFeedMock,
-            config: monitorConfig,
+            monitorConfig,
             empProps
           });
         });
@@ -169,7 +169,7 @@ contract("SyntheticPegMonitor", function() {
             web3,
             uniswapPriceFeed: uniswapPriceFeedMock,
             medianizerPriceFeed: medianizerPriceFeedMock,
-            config: monitorConfig,
+            monitorConfig,
             empProps
           });
 
@@ -191,7 +191,7 @@ contract("SyntheticPegMonitor", function() {
             uniswapPriceFeed: uniswapPriceFeedMock,
             medianizerPriceFeed: medianizerPriceFeedMock,
             denominatorPriceFeed: denominatorPriceFeedMock,
-            config: monitorConfig,
+            monitorConfig,
             empProps
           });
 
@@ -232,7 +232,7 @@ contract("SyntheticPegMonitor", function() {
             web3,
             uniswapPriceFeed: uniswapPriceFeedMock,
             medianizerPriceFeed: medianizerPriceFeedMock,
-            config: monitorConfig,
+            monitorConfig,
             empProps
           });
         });
@@ -373,7 +373,7 @@ contract("SyntheticPegMonitor", function() {
             web3,
             uniswapPriceFeed: invalidPriceFeedMock,
             medianizerPriceFeed: invalidPriceFeedMock,
-            config: {},
+            monitorConfig: {},
             empProps
           });
 
@@ -444,7 +444,7 @@ contract("SyntheticPegMonitor", function() {
             web3,
             uniswapPriceFeed: uniswapPriceFeedMock,
             medianizerPriceFeed: medianizerPriceFeedMock,
-            config: monitorConfig,
+            monitorConfig,
             empProps
           });
 
@@ -488,7 +488,7 @@ contract("SyntheticPegMonitor", function() {
               web3,
               uniswapPriceFeed: uniswapPriceFeedMock,
               medianizerPriceFeed: medianizerPriceFeedMock,
-              config: invalidConfig1,
+              monitorConfig: invalidConfig1,
               empProps
             });
             errorThrown1 = false;
@@ -511,7 +511,7 @@ contract("SyntheticPegMonitor", function() {
               web3,
               uniswapPriceFeed: uniswapPriceFeedMock,
               medianizerPriceFeed: medianizerPriceFeedMock,
-              config: invalidConfig2,
+              monitorConfig: invalidConfig2,
               empProps
             });
             errorThrown2 = false;
@@ -530,7 +530,7 @@ contract("SyntheticPegMonitor", function() {
               web3,
               uniswapPriceFeed: uniswapPriceFeedMock,
               medianizerPriceFeed: medianizerPriceFeedMock,
-              config: emptyConfig,
+              monitorConfig: emptyConfig,
               empProps
             });
             await syntheticPegMonitor.checkPriceDeviation();
@@ -552,7 +552,7 @@ contract("SyntheticPegMonitor", function() {
               web3,
               uniswapPriceFeed: uniswapPriceFeedMock,
               medianizerPriceFeed: medianizerPriceFeedMock,
-              config: invalidConfig,
+              monitorConfig: invalidConfig,
               empProps
             });
 
@@ -569,7 +569,7 @@ contract("SyntheticPegMonitor", function() {
             web3,
             uniswapPriceFeed: uniswapPriceFeedMock,
             medianizerPriceFeed: medianizerPriceFeedMock,
-            config: alertOverrideConfig,
+            monitorConfig: alertOverrideConfig,
             empProps
           });
 


### PR DESCRIPTION
**Motivation**
While working on the perp liquidator bot I found a subtle but substantial bug present within the Liquidator & Disputer bots regards to how configs are passed around.


**Summary**

PR https://github.com/UMAprotocol/protocol/pull/1924 merged on 2 Sep 2020 refactored the bots to pass around bot parameters as named values. However, this PR introduced a bug by incorrectly naming the `liquidatorConfig`. This bug can be seen in the following places:

1) in the `index.js` we feed in the `liquidatorConfig` as a named type `liquidatorConfig` here: https://github.com/UMAprotocol/protocol/blob/d782c56503a220a7eaa14baa8d03d925b5e956b6/packages/liquidator/index.js#L184
2) HOWEVER the `liquidator.js` file refers to this variable as `config`, here: https://github.com/UMAprotocol/protocol/blob/d782c56503a220a7eaa14baa8d03d925b5e956b6/packages/liquidator/src/liquidator.js#L37

The same exact issue is present within the disputer between `disputerConfig` and `config` in the `disputer/index.js` and `disputer.js` files respectively. The bug was not presented within the monitor bot but the bots were updated for consistency with the liquidator and disputer.

**Bug implications**
As a result of the bug, no `LiquidatorConfigs` are _actually_ passed into the bots! This means that the following are not passed in:
a) `crThreshold`
b) `liquidationMinPrice`
d) `defenseActivationPercent`
e) `whaleDefenseFundWei`
g) `logOverrides`
h) `liquidationDeadline`
i) `txnGasLimit`

Note that almost none of these overrides were used in production. However, two pretty important ones were, namely: a) the `logOverrides` which was meant to change liquidation events from `info` to `error` (as specified in the bot configs and was not. b) More worryingly all of the `whaleDefenseFund` configs were not correctly passed in.

In the case of the disputer this means the following configs were not correctly passed in:
a) txnGasLimit
b) disputeDelay

Neither of these vars are used in production.

**Details**

To fix this, this PR simply re-maps the key-value pairs correctly.

