### PR TITLE
fix(default-price-feed-config): specify pool decimals

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -78,7 +78,12 @@ const defaultConfigs = {
         computeMean: true,
         medianizedFeeds: [
           { type: "cryptowatch", exchange: "bittrex", pair: "ustusdt" },
-          { type: "cryptowatch", exchange: "uniswap-v2", pair: "ustusdt" }
+          {
+            type: "uniswap",
+            uniswapAddress: "0xc50ef7861153c51d383d9a7d48e6c9467fb90c38",
+            twapLength: 2,
+            poolDecimals: 6
+          }
         ]
       },
       {
@@ -86,7 +91,12 @@ const defaultConfigs = {
         computeMean: true,
         medianizedFeeds: [
           { type: "cryptowatch", exchange: "binance", pair: "busdusdt" },
-          { type: "cryptowatch", exchange: "uniswap-v2", pair: "busdusdt" }
+          {
+            type: "uniswap",
+            uniswapAddress: "0xa0abda1f980e03d7eadb78aed8fc1f2dd0fe83dd",
+            twapLength: 2,
+            poolDecimals: 6
+          }
         ]
       },
       {
@@ -141,7 +151,12 @@ const defaultConfigs = {
         computeMean: true,
         medianizedFeeds: [
           { type: "cryptowatch", exchange: "bittrex", pair: "ustusdt" },
-          { type: "cryptowatch", exchange: "uniswap-v2", pair: "ustusdt" }
+          {
+            type: "uniswap",
+            uniswapAddress: "0xc50ef7861153c51d383d9a7d48e6c9467fb90c38",
+            twapLength: 2,
+            poolDecimals: 6
+          }
         ]
       },
       {
@@ -149,7 +164,12 @@ const defaultConfigs = {
         computeMean: true,
         medianizedFeeds: [
           { type: "cryptowatch", exchange: "binance", pair: "busdusdt" },
-          { type: "uniswap", uniswapAddress: "0xa0abda1f980e03d7eadb78aed8fc1f2dd0fe83dd", twapLength: 2 }
+          {
+            type: "uniswap",
+            uniswapAddress: "0xa0abda1f980e03d7eadb78aed8fc1f2dd0fe83dd",
+            twapLength: 2,
+            poolDecimals: 6
+          }
         ]
       },
       {
@@ -197,7 +217,12 @@ const defaultConfigs = {
         computeMean: true,
         medianizedFeeds: [
           { type: "cryptowatch", exchange: "bittrex", pair: "ustusdt" },
-          { type: "cryptowatch", exchange: "uniswap-v2", pair: "ustusdt" }
+          {
+            type: "uniswap",
+            uniswapAddress: "0xc50ef7861153c51d383d9a7d48e6c9467fb90c38",
+            twapLength: 2,
+            poolDecimals: 6
+          }
         ]
       },
       {
@@ -205,7 +230,12 @@ const defaultConfigs = {
         computeMean: true,
         medianizedFeeds: [
           { type: "cryptowatch", exchange: "binance", pair: "busdusdt" },
-          { type: "cryptowatch", exchange: "uniswap-v2", pair: "busdusdt" }
+          {
+            type: "uniswap",
+            uniswapAddress: "0xa0abda1f980e03d7eadb78aed8fc1f2dd0fe83dd",
+            twapLength: 2,
+            poolDecimals: 6
+          }
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Uniswap pools need to specify `poolDecimals` if non-18 decimals
Use UniswapPriceFeed whereever `uniswap-v2` is listed on CryptoWatch due to flaky CW api.

