### PR TITLE
feat(affiliates): emps which expire do not contribute to rewards after expiry

### DIFF
--- a/packages/affiliates/libs/affiliates/devmining.js
+++ b/packages/affiliates/libs/affiliates/devmining.js
@@ -165,8 +165,14 @@ module.exports = ({ queries, empAbi, coingecko, synthPrices, firstEmpDate }) => 
       const { timestamp, number } = block;
       const valueByEmp = empWhitelist.reduce((result, [empAddress], empIndex) => {
         try {
+          const { tokens, isExpired } = balanceHistories.get(empAddress).history.lookup(number);
+
+          // if EMP was expired this block, dont include it in further calculations.
+          if (isExpired) {
+            return result;
+          }
+
           const [syntheticTokenPrices, syntheticValueCalculation] = syntheticTokenPricesWithValueCalculation[empIndex];
-          const { tokens } = balanceHistories.get(empAddress).history.lookup(number);
           const [, closestCollateralPrice] = collateralTokenPrices[empIndex].closest(timestamp);
           const [, closestSyntheticPrice] = syntheticTokenPrices.closest(timestamp);
           const totalTokens = Object.values(tokens).reduce((result, value) => {

--- a/packages/affiliates/libs/processors.js
+++ b/packages/affiliates/libs/processors.js
@@ -47,7 +47,8 @@ function EmpBalancesHistory() {
         blockNumber: lastBlockNumber,
         blockTimestamp: event.blockTimestamp,
         tokens: balances.tokens.snapshot(),
-        collateral: balances.collateral.snapshot()
+        collateral: balances.collateral.snapshot(),
+        isExpired: balances.isExpired()
       });
       lastBlockNumber = blockNumber;
       lastBlockTimestamp = event.blockTimestamp;
@@ -62,7 +63,8 @@ function EmpBalancesHistory() {
       blockNumber: lastBlockNumber,
       blockTimestamp: lastBlockTimestamp,
       tokens: balances.tokens.snapshot(),
-      collateral: balances.collateral.snapshot()
+      collateral: balances.collateral.snapshot(),
+      isExpired: balances.isExpired()
     });
   }
 
@@ -80,6 +82,12 @@ function EmpBalances(handlers = {}, { collateral, tokens } = {}) {
   // If not enabled expired emps may calculate larger totals overall than in actuality.
   collateral = collateral || Balances({ allowNegative: true });
   tokens = tokens || Balances({ allowNegative: true });
+
+  // Doesnt quite fit under umbrella of "balances" but this is the easiest place to set an expired flag.
+  let expired = false;
+  function isExpired() {
+    return expired;
+  }
 
   handlers = {
     RequestTransferPosition(/* oldSponsor*/) {
@@ -127,6 +135,7 @@ function EmpBalances(handlers = {}, { collateral, tokens } = {}) {
       tokens.sub(sponsor, tokenAmount).toString();
     },
     ContractExpired(/* caller*/) {
+      expired = true;
       // nothing
     },
     // looking at the emp code, i think anyone can call this even if they never had a position
@@ -172,7 +181,8 @@ function EmpBalances(handlers = {}, { collateral, tokens } = {}) {
   return {
     handleEvent,
     collateral,
-    tokens
+    tokens,
+    isExpired
   };
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2416 

**Summary**

This adds an "isExpired" flag to the emp balances state which gets toggled on expiry event. This flag is snapshotted along with balances every block and checked before balances are contributed to total value. If expired, emp balances are ignored. A test is added to verify this works in a very simple case. This was also tested manually against 2020-12-28 through 2021-01-4, where 2 contracts expire. 

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2416 
