### PR TITLE
improve(median-pricefeed-script): Add decimals of precision for BCHNBTC

### DIFF
--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -18,7 +18,7 @@ const UMIP_PRECISION = {
   USDETH: 5,
   BTCDOM: 2,
   ALTDOM: 2,
-  BCHBTC: 8
+  BCHNBTC: 8
 };
 const DEFAULT_PRECISION = 5;
 

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -17,7 +17,8 @@ const UMIP_PRECISION = {
   USDBTC: 8,
   USDETH: 5,
   BTCDOM: 2,
-  ALTDOM: 2
+  ALTDOM: 2,
+  BCHBTC: 8
 };
 const DEFAULT_PRECISION = 5;
 


### PR DESCRIPTION
**Motivation**
Adding precision for BCHNBTC will allow for this script to be used to calculate the BCHNBTC expiry price.


**Summary**
Add 8 decimals of precision for BCHNBTC. This is defined in [umip-23](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-23.md).