### PR TITLE
fix(scripts): fix conversion in historical price feed script

### DIFF
--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -17,7 +17,8 @@ const UMIP_PRECISION = {
   USDBTC: 8,
   USDETH: 5,
   BTCDOM: 2,
-  ALTDOM: 2
+  ALTDOM: 2,
+  BCHNBTC: 8
 };
 const DEFAULT_PRECISION = 5;
 

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -43,6 +43,7 @@ async function getMedianHistoricalPrice(callback) {
     let priceFeedConfig = {
       // Empirically, Cryptowatch API only returns data up to ~4 days back.
       lookback: 345600,
+      priceFeedDecimals: 18, // Ensure all prices come out as 18-decimal denominated so the fromWei conversion works at the end.
       // Append price feed config params from environment such as "apiKey" for CryptoWatch price feeds.
       ...(process.env.PRICE_FEED_CONFIG ? JSON.parse(process.env.PRICE_FEED_CONFIG) : {})
     };


### PR DESCRIPTION
**Motivation**

Decimals are off in the getMedianHistoricalPrice script.


**Summary**

Ensures all price feeds are seeded with 18 as their decimals so the `fromWei` call at the end works as expected.


**Issue(s)**

N/A
