### PR TITLE
fix(smart-contracts): fixed audit PR typos 

### DIFF
--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -104,7 +104,7 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
         uint256 time = getCurrentTime();
         FixedPoint.Unsigned memory collateralPool = _pfc();
 
-        // Fetch the regualar fees, late penatly and the max posible to pay given the current collateral within the contract.
+        // Fetch the regualar fees, late penalty and the max posible to pay given the current collateral within the contract.
         (
             FixedPoint.Unsigned memory regularFee,
             FixedPoint.Unsigned memory latePenalty,
@@ -137,7 +137,7 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
      * @notice Fetch any regular fees that the contract has pending but has not yet paid. If the fees to be paid are more
      * than the total collateral within the contract then the totalPaid returned is full contract collateral amount.
      * @dev This returns 0 and exit early if there is no pfc, fees were already paid during the current block, or the fee rate is 0.
-     * @return regularFee outstanding unpaid regualr fee.
+     * @return regularFee outstanding unpaid regular fee.
      * @return latePenalty outstanding unpaid late fee for being late in previous fee payments.
      * @return totalPaid Amount of collateral that the contract paid (sum of the amount paid to the Store and caller).
      */

--- a/packages/core/contracts/financial-templates/common/FeePayer.sol
+++ b/packages/core/contracts/financial-templates/common/FeePayer.sol
@@ -104,7 +104,7 @@ abstract contract FeePayer is AdministrateeInterface, Testable, Lockable {
         uint256 time = getCurrentTime();
         FixedPoint.Unsigned memory collateralPool = _pfc();
 
-        // Fetch the regualar fees, late penalty and the max posible to pay given the current collateral within the contract.
+        // Fetch the regular fees, late penalty and the max possible to pay given the current collateral within the contract.
         (
             FixedPoint.Unsigned memory regularFee,
             FixedPoint.Unsigned memory latePenalty,

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -352,8 +352,8 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
     }
 
     /**
-     * @notice Disputes a liquidation, if the caller has enough collateral to post a dispute bond
-     * and pay a fixed final fee charged on each price request.
+     * @notice Disputes a liquidation, if the caller has enough collateral to post a dispute bond and pay a fixed final
+     // fee charged on each price request.
      * @dev Can only dispute a liquidation before the liquidation expires and if there are no other pending disputes.
      * This contract must be approved to spend at least the dispute bond amount of `collateralCurrency`. This dispute
      * bond amount is calculated from `disputeBondPercentage` times the collateral in the liquidation.

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -424,8 +424,8 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
 
         // Calculate rewards as a function of the TRV.
         // Note1: all payouts are scaled by the unit collateral value so all payouts are charged the fees pro rata.
-        // Note2: the tokenRedemptionValue uses the tokensOutstanding which was calculating using the funding rate at
-        // liquidation time from _getFundingRateAppliedTokenDebt.Therefore the TRV consideres the full debt value at that time.
+        // Note2: the tokenRedemptionValue uses the tokensOutstanding which was calculated using the funding rate at
+        // liquidation time from _getFundingRateAppliedTokenDebt. Therefore the TRV considers the full debt value at that time.
         FixedPoint.Unsigned memory feeAttenuation = _getFeeAdjustedCollateral(liquidation.rawUnitCollateral);
         FixedPoint.Unsigned memory settlementPrice = liquidation.settlementPrice;
         FixedPoint.Unsigned memory tokenRedemptionValue =

--- a/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
+++ b/packages/core/contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol
@@ -353,7 +353,7 @@ contract PerpetualLiquidatable is PerpetualPositionManager {
 
     /**
      * @notice Disputes a liquidation, if the caller has enough collateral to post a dispute bond and pay a fixed final
-     // fee charged on each price request.
+     * fee charged on each price request.
      * @dev Can only dispute a liquidation before the liquidation expires and if there are no other pending disputes.
      * This contract must be approved to spend at least the dispute bond amount of `collateralCurrency`. This dispute
      * bond amount is calculated from `disputeBondPercentage` times the collateral in the liquidation.


### PR DESCRIPTION
PR2327 introduced a few small typos. This PR addresses these. In particular:

- penatly in FeePayer:107
- regualr in FeePayer:140
- calculating instead of calculated and a missing space after the full stop in PerpetualLiquidatable:424-425