### PR TITLE
fix(dec-20-audit): [H01] fix optimistic oracle fee burning logic when final fee == 0

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -363,16 +363,22 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         }
 
         StoreInterface store = _getStore();
-        if (finalFee > 0) {
+
+        {
+            // Avoids stack too deep error
+
             // Along with the final fee, "burn" part of the loser's bond to ensure that a larger bond always makes it
             // proportionally more expensive to delay the resolution even if the proposer and disputer are the same
             // party.
             uint256 burnedBond = _computeBurnedBond(request);
 
-            // Pay the final fee and the burned bond to the store.
+            // The total fee is the burned bond and the final fee added together.
             uint256 totalFee = finalFee.add(burnedBond);
-            request.currency.safeIncreaseAllowance(address(store), totalFee);
-            _getStore().payOracleFeesErc20(address(request.currency), FixedPoint.Unsigned(totalFee));
+
+            if (totalFee > 0) {
+                request.currency.safeIncreaseAllowance(address(store), totalFee);
+                _getStore().payOracleFeesErc20(address(request.currency), FixedPoint.Unsigned(totalFee));
+            }
         }
 
         _getOracle().requestPrice(identifier, timestamp, _stampAncillaryData(ancillaryData, requester));

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -364,9 +364,8 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
 
         StoreInterface store = _getStore();
 
+        // Avoids stack too deep compilation error.
         {
-            // Avoids stack too deep error
-
             // Along with the final fee, "burn" part of the loser's bond to ensure that a larger bond always makes it
             // proportionally more expensive to delay the resolution even if the proposer and disputer are the same
             // party.

--- a/packages/core/test/financial-templates/common/FundingRateApplier.js
+++ b/packages/core/test/financial-templates/common/FundingRateApplier.js
@@ -368,8 +368,9 @@ contract("FundingRateApplier", function(accounts) {
       assert.equal((await collateral.balanceOf(owner)).toString(), toWei("99.99"));
       assert.equal((await collateral.balanceOf(disputer)).toString(), toWei("99.99"));
 
-      // The optimistic oracle should be escrowing that money.
-      assert.equal((await collateral.balanceOf(optimisticOracle.address)).toString(), toWei("0.02"));
+      // The optimistic oracle should be escrowing all the money minus the burned portion (1/2 of the 0.01 bond), which
+      // is paid to the store on dispute.
+      assert.equal((await collateral.balanceOf(optimisticOracle.address)).toString(), toWei("0.015"));
 
       // Move time forward to where the proposal would have expired (if not disputed).
       currentTime += delay;


### PR DESCRIPTION
**Motivation**

OpenZeppelin pointed out an issue in the [H01 fix](https://github.com/UMAprotocol/protocol/pull/2329). In the (admittedly unlikely) case that the final fee is 0, the burned portion of the bond gets trapped in the optimistic oracle contract and can never be retrieved.

**Summary**

This fixes the issue by conditioning the payout on the sum of the burned bond _and_ the final fee being > 0, which was the original intention of the code.

**Issue(s)**

N/A
