### PR TITLE
fix(voter-dapp): fix QA script

### DIFF
--- a/packages/core/scripts/mainnet/ProposeAdmin.js
+++ b/packages/core/scripts/mainnet/ProposeAdmin.js
@@ -31,9 +31,6 @@ async function propose(callback) {
      *********************************/
     const signingAccount = (await web3.eth.getAccounts())[0];
     console.group(`Proposer account: ${signingAccount}`);
-    if (signingAccount !== "0x2bAaA41d155ad8a4126184950B31F50A1513cE25") {
-      throw new Error("Cannot propose admin votes from this account");
-    }
     console.groupEnd();
 
     /** *******************************
@@ -83,6 +80,7 @@ async function propose(callback) {
         .propose([
           {
             to: identifierWhitelist.address,
+            value: 0,
             data: proposedTx
           }
         ])

--- a/packages/voter-dapp/run_tests.sh
+++ b/packages/voter-dapp/run_tests.sh
@@ -16,7 +16,6 @@ echo '# 0/16. Prerequisites                                              #'
 echo '#                                                                  #'
 echo -e '####################################################################\n'
 ## Will need to run some JS scripts from packages/core
-cd ../core
 
 # Prompt user to start Ganache in another window
 echo "- Have you started Ganache in a separate window at port 9545? Be sure to use the following mnemonic: \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" "
@@ -48,9 +47,9 @@ echo '#                                                                  #'
 echo '# 2/16. Submitting price requests                                  #'
 echo '#                                                                  #'
 echo -e '####################################################################\n'
-yarn run truffle exec ./scripts/local/RequestOraclePrice.js --network test --identifier USDETH-Commit+Reveal --time 1570000000
-yarn run truffle exec ./scripts/local/RequestOraclePrice.js --network test --identifier USDETH-2key-Commit+Reveal --time 1570000000
-yarn run truffle exec ./scripts/local/ProposeAdmin.js --network test
+yarn run truffle exec ../core/scripts/local/RequestOraclePrice.js --network test --identifier USDETH-Commit+Reveal --time 1570000000
+yarn run truffle exec ../core/scripts/local/RequestOraclePrice.js --network test --identifier USDETH-2key-Commit+Reveal --time 1570000000
+yarn run truffle exec ../core/scripts/mainnet/ProposeAdmin.js --network test --prod
 echo "- ✅ Price requests submitted!"
 
 # Advance to next commit phase
@@ -59,7 +58,7 @@ echo '#                                                                  #'
 echo '# 3/16. Advancing to start of next voting round                    #'
 echo '#                                                                  #'
 echo -e '####################################################################\n'
-yarn run truffle exec ./scripts/local/AdvanceToCommitPhase.js --network test
+yarn run truffle exec ../core/scripts/local/AdvanceToCommitPhase.js --network test
 echo "- ✅ Advanced to next commit phase!"
 
 # Prompt user to import account[0] from Ganache into Metamask
@@ -107,7 +106,7 @@ select yn in "Continue" "Help" "Exit"; do
     esac
 done
 echo "- Advancing to the Reveal phase of the current voting round"
-yarn run truffle exec ./scripts/local/AdvanceToNextVotingPhase.js --network test
+yarn run truffle exec ../core/scripts/local/AdvanceToNextVotingPhase.js --network test
 
 # Snapshot the current round
 echo -e '\n####################################################################'
@@ -139,7 +138,7 @@ select yn in "Continue" "Help" "Exit"; do
     esac
 done
 echo "- Advancing to the next Voting round"
-yarn run truffle exec ./scripts/local/AdvanceToNextVotingPhase.js --network test
+yarn run truffle exec ../core/scripts/local/AdvanceToNextVotingPhase.js --network test
 
 # Claim rewards
 echo -e '\n####################################################################'
@@ -201,7 +200,7 @@ select yn in "Continue" "Help" "Exit"; do
     esac
 done
 echo "- Advancing to the Reveal phase of the current voting round"
-yarn run truffle exec ./scripts/local/AdvanceToNextVotingPhase.js --network test
+yarn run truffle exec ../core/scripts/local/AdvanceToNextVotingPhase.js --network test
 
 # Snapshot the current round
 echo -e '\n####################################################################'
@@ -233,7 +232,7 @@ select yn in "Continue" "Help" "Exit"; do
     esac
 done
 echo "- Advancing to the next Voting round"
-yarn run truffle exec ./scripts/local/AdvanceToNextVotingPhase.js --network test
+yarn run truffle exec ../core/scripts/local/AdvanceToNextVotingPhase.js --network test
 
 # Claim rewards
 echo -e '\n####################################################################'

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -462,6 +462,7 @@ function ActiveRequests({ votingAccount, votingGateway, snapshotContract }) {
 
     let currentVote = "";
     if (voteStatus.committedValue && decryptedCommits[index].price) {
+      console.log(decryptedCommits[index].price);
       const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(pendingRequests[index].identifier));
       currentVote = formatFixed(decryptedCommits[index].price, identifierPrecision);
     }

--- a/packages/voter-dapp/src/ActiveRequests.js
+++ b/packages/voter-dapp/src/ActiveRequests.js
@@ -462,7 +462,6 @@ function ActiveRequests({ votingAccount, votingGateway, snapshotContract }) {
 
     let currentVote = "";
     if (voteStatus.committedValue && decryptedCommits[index].price) {
-      console.log(decryptedCommits[index].price);
       const identifierPrecision = getPrecisionForIdentifier(hexToUtf8(pendingRequests[index].identifier));
       currentVote = formatFixed(decryptedCommits[index].price, identifierPrecision);
     }


### PR DESCRIPTION
**Motivation**

The QA script was slightly out of date when I tried to use it.

**Summary**

- The `ProposeAdmin.js` script had been moved and args updated. The path and args were updated at the callsite.
- The `ProposeAdmin.js` script was modified to only work on mainnet (it depended on a hardcoded address). A minor update was made to make it work on any network.
- The `ProposeAdmin.js` script was missing an arg in its propose call.
- The voter-dapp depends on artifacts pulled from npm, so the migrate call needs to be made from the voter-dapp directory rather than the core directory. Otherwise, the migration will write to the local core artifacts, which are different from the ones the voter dapp reads from.

**Issue(s)**

N/A
