### PR TITLE
improve(liquidator): Send log when WDF is purposefully not activated

### DIFF
--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -126,6 +126,13 @@ async function run({
       withdrawLiveness
     };
 
+    // Add block window into `liquidatorConfig`
+    let overriddenLiquidatorConfig = {
+      ...liquidatorConfig,
+      startingBlock,
+      endingBlock
+    };
+
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
     logger[pollingDelay === 0 ? "debug" : "info"]({
@@ -136,7 +143,7 @@ async function run({
       errorRetries,
       errorRetriesTimeout,
       priceFeedConfig,
-      liquidatorConfig,
+      liquidatorConfig: overriddenLiquidatorConfig,
       liquidatorOverridePrice
     });
 
@@ -185,9 +192,7 @@ async function run({
       priceFeed,
       account: accounts[0],
       empProps,
-      liquidatorConfig,
-      startingBlock,
-      endingBlock
+      liquidatorConfig: overriddenLiquidatorConfig
     });
 
     logger.debug({

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -34,6 +34,8 @@ const { getWeb3 } = require("@uma/common");
  * @param {Object} priceFeedConfig Configuration to construct the price feed object.
  * @param {Object} [liquidatorConfig] Configuration to construct the liquidator.
  * @param {String} [liquidatorOverridePrice] Optional String representing a Wei number to override the liquidator price feed.
+ * @param {Number} [startingBlock] Earliest block to query for contract events that the bot will log about.
+ * @param {Number} [endingBlock] Latest block to query for contract events that the bot will log about.
  * @return None or throws an Error.
  */
 async function run({
@@ -46,7 +48,9 @@ async function run({
   errorRetriesTimeout,
   priceFeedConfig,
   liquidatorConfig,
-  liquidatorOverridePrice
+  liquidatorOverridePrice,
+  startingBlock,
+  endingBlock
 }) {
   try {
     const { toBN } = web3.utils;
@@ -181,7 +185,9 @@ async function run({
       priceFeed,
       account: accounts[0],
       empProps,
-      liquidatorConfig
+      liquidatorConfig,
+      startingBlock,
+      endingBlock
     });
 
     logger.debug({
@@ -315,7 +321,13 @@ async function Poll(callback) {
       liquidatorConfig: process.env.LIQUIDATOR_CONFIG ? JSON.parse(process.env.LIQUIDATOR_CONFIG) : null,
       // If there is a LIQUIDATOR_OVERRIDE_PRICE environment variable then the liquidator will disregard the price from the
       // price feed and preform liquidations at this override price. Use with caution as wrong input could cause invalid liquidations.
-      liquidatorOverridePrice: process.env.LIQUIDATOR_OVERRIDE_PRICE
+      liquidatorOverridePrice: process.env.LIQUIDATOR_OVERRIDE_PRICE,
+      // Block number to search for events from. If set, acts to offset the search to ignore events in the past. If
+      // either startingBlock or endingBlock is not sent, then the bot will search for event.
+      startingBlock: process.env.STARTING_BLOCK_NUMBER,
+      // Block number to search for events to. If set, acts to limit from where the monitor bot will search for events up
+      // until. If either startingBlock or endingBlock is not sent, then the bot will search for event.
+      endingBlock: process.env.ENDING_BLOCK_NUMBER
     };
 
     await run({ logger: Logger, web3: getWeb3(), ...executionParameters });

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -127,7 +127,7 @@ async function run({
     };
 
     // Add block window into `liquidatorConfig`
-    let overriddenLiquidatorConfig = {
+    liquidatorConfig = {
       ...liquidatorConfig,
       startingBlock,
       endingBlock
@@ -143,7 +143,7 @@ async function run({
       errorRetries,
       errorRetriesTimeout,
       priceFeedConfig,
-      liquidatorConfig: overriddenLiquidatorConfig,
+      liquidatorConfig,
       liquidatorOverridePrice
     });
 
@@ -192,7 +192,7 @@ async function run({
       priceFeed,
       account: accounts[0],
       empProps,
-      liquidatorConfig: overriddenLiquidatorConfig
+      liquidatorConfig
     });
 
     logger.debug({

--- a/packages/liquidator/src/liquidationStrategy.js
+++ b/packages/liquidator/src/liquidationStrategy.js
@@ -228,10 +228,9 @@ module.exports = (
         .lt(empMinSponsorSize)
     )
       return false;
-    // liveness timer on withdraw has not passed time
-    if (!passedDefenseActivationPercent({ position, currentBlockTime })) return false;
-    // all conditions passed and we should minimally liquidate to extend timer
-    return true;
+    // all conditions passed and we should minimally liquidate to extend timer as long as the
+    // liveness timer on withdraw has passed the activation threshold.
+    return passedDefenseActivationPercent({ position, currentBlockTime });
   }
 
   // Any new constraints can be added here, but for now

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -279,7 +279,7 @@ class Liquidator {
             message: "Withdrawal liveness has not passed WDF activation threshold, skipping✋",
             sponsor: position.sponsor,
             inputPrice: scaledPrice.toString(),
-            position: position,
+            position,
             minLiquidationPrice: this.liquidationMinPrice,
             maxLiquidationPrice: maxCollateralPerToken.toString(),
             syntheticTokenBalance: syntheticTokenBalance.toString(),

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -22,10 +22,6 @@ class Liquidator {
    *      { crRatio: 1.5e18,
             minSponsorSize: 10e18,
             priceIdentifier: hex("ETH/BTC") }
-   * @param {Number} startingBlock Earliest block to query for contract events that the bot will log about. 
-   *      If "undefined", then the bot will not provide detailed logs about these contract events.
-   * @param {Number} endingBlock Latest block to query for contract events that the bot will log about. 
-   *      If "undefined", then the bot will not provide detailed logs about these contract events.
    * @param {Object} [liquidatorConfig] Contains fields with which constructor will attempt to override defaults.
    */
   constructor({
@@ -37,9 +33,7 @@ class Liquidator {
     priceFeed,
     account,
     empProps,
-    liquidatorConfig,
-    startingBlock,
-    endingBlock
+    liquidatorConfig
   }) {
     this.logger = logger;
     this.account = account;
@@ -76,10 +70,6 @@ class Liquidator {
 
     // Multiplier applied to Truffle's estimated gas limit for a transaction to send.
     this.GAS_LIMIT_BUFFER = 1.25;
-
-    // Block window used to filter for contract events.
-    this.startingBlock = startingBlock;
-    this.endingBlock = endingBlock;
 
     // Default config settings. Liquidator deployer can override these settings by passing in new
     // values via the `liquidatorConfig` input object. The `isValid` property is a function that should be called
@@ -143,6 +133,21 @@ class Liquidator {
         isValid: x => {
           if (x === undefined) return true;
           return parseFloat(x) >= 0 && parseFloat(x) <= 100;
+        }
+      },
+      // Start and end block define a window used to filter for contract events.
+      startingBlock: {
+        value: undefined,
+        isValid: x => {
+          if (x === undefined) return true;
+          return Number(x) >= 0;
+        }
+      },
+      endingBlock: {
+        value: undefined,
+        isValid: x => {
+          if (x === undefined) return true;
+          return Number(x) >= 0;
         }
       }
     };

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -276,7 +276,7 @@ class Liquidator {
         ) {
           this.logger.info({
             at: "Liquidator",
-            message: "Withdrawal liveness has not passed WDF activation threshold, skipping✋",
+            message: "Withdrawal liveness has not passed WDF activation threshold, skipping😴",
             sponsor: position.sponsor,
             inputPrice: scaledPrice.toString(),
             position,

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1394,14 +1394,11 @@ contract("Liquidator.js", function(accounts) {
           await liquidator.update();
           const startingLogLength = spy.getCalls().length;
           await liquidator.liquidatePositions();
-          // Logger should emit a log specific about skipping this liquidation because the defense activation
-          // percent has not passed yet.
+          // Logger should NOT emit a log specific about skipping this liquidation, because the defense activation
+          // percent has not passed yet, because the start and end block window were NOT specified when creating
+          // the liquidator.
           // No other logs should be emitted.
-          assert.equal(startingLogLength + 1, spy.getCalls().length);
-          assert.equal(spyLogLevel(spy, -1), "info");
-          assert.isTrue(
-            spyLogIncludes(spy, -1, "Withdrawal liveness has not passed WDF activation threshold, skipping")
-          );
+          assert.equal(startingLogLength, spy.getCalls().length);
 
           let sponsor2Liquidations = await emp.getLiquidations(sponsor2);
           sponsor2Positions = await emp.positions(sponsor2);
@@ -1457,6 +1454,80 @@ contract("Liquidator.js", function(accounts) {
           assert.equal(sponsor2Liquidations.length, 4);
           // show position has been fully liquidated
           assert.equal(sponsor2Positions.tokensOutstanding, "0");
+        });
+        it("logs about skipping liquidations because of the defense activation threshold are only emitted if the withdrawal took place within a specified block window", async () => {
+          const liquidatorConfig = {
+            // entire fund dedicated to strategy, allows 3 extensions
+            whaleDefenseFundWei: toBN(empProps.minSponsorSize)
+              .mul(toBN(10))
+              .toString(),
+            // will extend even if withdraw progress is 80% complete
+            defenseActivationPercent: 80
+          };
+          const withdrawLiveness = empProps.withdrawLiveness.toNumber();
+
+          await emp.create(
+            { rawValue: convertCollateral("120") },
+            { rawValue: convertSynthetic("100") },
+            { from: sponsor1 }
+          );
+          // we need to keep at least 50 tokens for the WDF so we can only partially liquidate sponsor1
+          await emp.create(
+            { rawValue: convertCollateral("1000") },
+            { rawValue: convertSynthetic("100") },
+            { from: liquidatorBot }
+          );
+
+          // Start with a mocked price of 1 usd per token.
+          // This puts sponsor1 over collateralized so no liquidations should occur.
+          priceFeedMock.setCurrentPrice(convertPrice("1"));
+
+          // sponsor is now under collateralized
+          const startingBlock = await web3.eth.getBlockNumber();
+          await emp.requestWithdrawal({ rawValue: convertCollateral("10") }, { from: sponsor1 });
+          const endingBlock = (await web3.eth.getBlockNumber()) + 1;
+
+          // Create a Liquidator bot with a start and end block specified
+          const liquidator = new Liquidator({
+            logger: spyLogger,
+            expiringMultiPartyClient: empClient,
+            gasEstimator,
+            votingContract: mockOracle.contract,
+            syntheticToken: syntheticToken.contract,
+            priceFeed: priceFeedMock,
+            account: accounts[0],
+            empProps,
+            liquidatorConfig,
+            startingBlock,
+            endingBlock
+          });
+
+          // First, run the liquidator with no block window specified, this should NOT emit a log
+          // that the spyLogger can catch.
+          await liquidator.update();
+          await liquidator.liquidatePositions();
+
+          let sponsor1Liquidation = (await emp.getLiquidations(sponsor1))[0];
+          // 120 - 10 / 2 (half tokens liquidated)
+          assert.equal(sponsor1Liquidation.liquidatedCollateral, convertCollateral("55"));
+
+          // advance time to 50% of withdraw. This should not trigger extension until 80%
+          let sponsor1Positions = await emp.positions(sponsor1);
+          let nextTime = Math.ceil(Number(sponsor1Positions.withdrawalRequestPassTimestamp) - withdrawLiveness * 0.5);
+
+          await emp.setCurrentTime(nextTime);
+          await liquidator.update();
+          const startingLogLength = spy.getCalls().length;
+          await liquidator.liquidatePositions();
+          assert.equal((await emp.getLiquidations(sponsor1)).length, 1);
+          // Logger should emit a log specific about skipping this liquidation because the defense activation
+          // percent has not passed yet.
+          // No other logs should be emitted.
+          assert.equal(startingLogLength + 1, spy.getCalls().length);
+          assert.equal(spyLogLevel(spy, -1), "info");
+          assert.isTrue(
+            spyLogIncludes(spy, -1, "Withdrawal liveness has not passed WDF activation threshold, skipping")
+          );
         });
       });
     });

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1397,7 +1397,8 @@ contract("Liquidator.js", function(accounts) {
           // Logger should NOT emit a log specific about skipping this liquidation, because the defense activation
           // percent has not passed yet, because the start and end block window were NOT specified when creating
           // the liquidator.
-          // No other logs should be emitted.
+          // Importantly, No WARN or ERROR logs should be emitted about "missing" this liquidation because
+          // we are purposefully ignoring it.
           assert.equal(startingLogLength, spy.getCalls().length);
 
           let sponsor2Liquidations = await emp.getLiquidations(sponsor2);

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1457,14 +1457,6 @@ contract("Liquidator.js", function(accounts) {
           assert.equal(sponsor2Positions.tokensOutstanding, "0");
         });
         it("logs about skipping liquidations because of the defense activation threshold are only emitted if the withdrawal took place within a specified block window", async () => {
-          const liquidatorConfig = {
-            // entire fund dedicated to strategy, allows 3 extensions
-            whaleDefenseFundWei: toBN(empProps.minSponsorSize)
-              .mul(toBN(10))
-              .toString(),
-            // will extend even if withdraw progress is 80% complete
-            defenseActivationPercent: 80
-          };
           const withdrawLiveness = empProps.withdrawLiveness.toNumber();
 
           await emp.create(
@@ -1489,6 +1481,16 @@ contract("Liquidator.js", function(accounts) {
           const endingBlock = (await web3.eth.getBlockNumber()) + 1;
 
           // Create a Liquidator bot with a start and end block specified
+          const liquidatorConfig = {
+            // entire fund dedicated to strategy, allows 3 extensions
+            whaleDefenseFundWei: toBN(empProps.minSponsorSize)
+              .mul(toBN(10))
+              .toString(),
+            // will extend even if withdraw progress is 80% complete
+            defenseActivationPercent: 80,
+            startingBlock,
+            endingBlock
+          };
           const liquidator = new Liquidator({
             logger: spyLogger,
             expiringMultiPartyClient: empClient,

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1392,7 +1392,16 @@ contract("Liquidator.js", function(accounts) {
           await emp.setCurrentTime(nextTime);
           // running again, should have no change
           await liquidator.update();
+          const startingLogLength = spy.getCalls().length;
           await liquidator.liquidatePositions();
+          // Logger should emit a log specific about skipping this liquidation because the defense activation
+          // percent has not passed yet.
+          // No other logs should be emitted.
+          assert.equal(startingLogLength + 1, spy.getCalls().length);
+          assert.equal(spyLogLevel(spy, -1), "info");
+          assert.isTrue(
+            spyLogIncludes(spy, -1, "Withdrawal liveness has not passed WDF activation threshold, skipping")
+          );
 
           let sponsor2Liquidations = await emp.getLiquidations(sponsor2);
           sponsor2Positions = await emp.positions(sponsor2);

--- a/packages/liquidator/test/index.js
+++ b/packages/liquidator/test/index.js
@@ -431,4 +431,36 @@ contract("index.js", function(accounts) {
       assert.notEqual(spyLogLevel(spy, i), "error");
     }
   });
+  it("Liquidator config packed correctly", async function() {
+    // We will also create a new spy logger, listening for debug events to validate the liquidatorConfig.
+    spyLogger = winston.createLogger({
+      level: "debug",
+      transports: [new SpyTransport({ level: "debug" }, { spy: spy })]
+    });
+
+    // We test that startingBlock and endingBlock params get packed into
+    // the liquidatorConfig correctly by the Liquidator bot.
+    const liquidatorConfig = {
+      whaleDefenseFundWei: "1000000",
+      defenseActivationPercent: 50
+    };
+    const startingBlock = 9;
+    const endingBlock = 10;
+    await Poll.run({
+      logger: spyLogger,
+      web3,
+      empAddress: emp.address,
+      pollingDelay,
+      errorRetries,
+      errorRetriesTimeout,
+      priceFeedConfig: defaultPriceFeedConfig,
+      liquidatorConfig,
+      startingBlock,
+      endingBlock
+    });
+
+    // First log should list the liquidatorConfig with the expected starting and ending block.
+    assert.equal(spy.getCall(0).lastArg.liquidatorConfig.startingBlock, startingBlock);
+    assert.equal(spy.getCall(0).lastArg.liquidatorConfig.endingBlock, endingBlock);
+  });
 });


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:
  
  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Problem mentioned as part of #2419

Previously, this error log is being emitted even if the WDF is not being activated on purpose (i.e there is no error):
<img width="435" alt="Screen Shot 2021-01-19 at 13 06 30" src="https://user-images.githubusercontent.com/9457025/105087064-ee3c6980-5a67-11eb-9d4c-615cc2019271.png">

**Summary**

Liquidator queries `LiquidatorStrategy` to determine if it should emit a specialized log about the WDF not being activated yet.


