### PR TITLE
ci: move coverage to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,10 +189,6 @@ workflows:
   build_and_test:
     jobs:
       - checkout_and_install
-      - coverage:
-          context: api_keys
-          requires:
-            - checkout_and_install
       - slither
       - build:
           requires:
@@ -226,3 +222,17 @@ workflows:
           filters:
             branches:
               only: master
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - checkout_and_install
+      - coverage:
+          context: api_keys
+          requires:
+            - checkout_and_install


### PR DESCRIPTION
**Motivation**

Coverage takes a long time to run on each build, so we'd like to move it to nightly. It can still be run manually if desired on a particular PR.

**Summary**

Add a new nightly workflow that runs at midnight each night and includes checkout and install + coverage.

**Issue(s)**

N/A
