### PR TITLE
ci(nightly): fix nightly by removing privileged context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,5 @@ workflows:
     jobs:
       - checkout_and_install
       - coverage:
-          context: api_keys
           requires:
             - checkout_and_install


### PR DESCRIPTION
**Motivation**

coverage currently requires a privileged context to run, which causes the nightly build to fail because it cannot be run with privileged permissions: see https://circleci.canny.io/cloud-feature-requests/p/allow-restricted-contexts-within-scheduled-workflows.

**Summary**

Coverage seems to only require the coveralls token to run correctly, so I figure it isn't too dangerous to provide that variable to all ci jobs rather than making it privileged (it's not a paid service and the token can be regenerated if compromised). This update has been made in the circleci config.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
