### PR TITLE
feat(default-price-feed) Add AMPL-USD Default price feed

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -351,6 +351,16 @@ const defaultConfigs = {
     pair: "ALTDOM",
     minTimeBetweenUpdates: 60,
     lookback: 7200
+  },
+  AMPLUSD: {
+    type: "medianizer",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "ftx", pair: "amplusdt" },
+      { type: "cryptowatch", exchange: "gateio", pair: "amplusdt" },
+      { type: "cryptowatch", exchange: "bitfinex", pair: "amplusd" }
+    ]
   }
 };
 


### PR DESCRIPTION
**Motivation**

This PR adds AMPL-USD to DefaultPriceFeedConfigs.js

**Summary**

Simply adds the price feed. This feed follows UMIP-33's implementation details.
