### PR TITLE
fix(financial-templates-lib): fix domination finance feed decimals

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
@@ -43,6 +43,8 @@ class DominationFinancePriceFeed extends PriceFeedInterface {
     this.invertPrice = invertPrice;
 
     this.toBN = this.web3.utils.toBN;
+
+    this.priceFeedDecimals = priceFeedDecimals;
     this.convertPriceFeedDecimals = number => {
       // Converts price result to wei
       // returns price conversion to correct decimals as a big number


### PR DESCRIPTION
**Motivation**

The domination price feeds return undefined for their decimals value.


**Summary**

Save the priceFeedDecimals value in the price feed object.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
