### PR TITLE
improve(core): remove toUpper in price feed script because some identifiers are lowercase

### DIFF
--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -27,12 +27,11 @@ async function getMedianHistoricalPrice(callback) {
     // If user did not specify an identifier, provide a default value.
     let queryIdentifier;
     if (!argv.identifier) {
-      queryIdentifier = "eth/btc";
+      queryIdentifier = "ETH/BTC";
       console.log(`Optional '--identifier' flag not specified, defaulting to: ${queryIdentifier}`);
     } else {
       queryIdentifier = argv.identifier;
     }
-    queryIdentifier = queryIdentifier.toUpperCase();
 
     // Function to get the current time.
     const getTime = () => Math.round(new Date().getTime() / 1000);


### PR DESCRIPTION
**Motivation**

The price feed script shouldn't uppercase the user input since some identifiers have lowercase characters.

**Summary**

Removed the toUpper call.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

**Issue(s)**

N/A
