### PR TITLE
fix(voter-dapp): Query identifier directly from subgraph

### DIFF
--- a/packages/voter-dapp/src/apollo/queries.js
+++ b/packages/voter-dapp/src/apollo/queries.js
@@ -4,6 +4,9 @@ export const PRICE_REQUEST_VOTING_DATA = gql`
   query priceRequestRounds {
     priceRequestRounds {
       id
+      identifier {
+        id
+      }
       roundId
       time
       totalSupplyAtSnapshot

--- a/packages/voter-dapp/src/containers/VoteData.js
+++ b/packages/voter-dapp/src/containers/VoteData.js
@@ -32,7 +32,7 @@ function useVoteData() {
 
       // Load data into `newVoteData` synchronously
       data.priceRequestRounds.forEach(dataForRequest => {
-        const identifier = dataForRequest.id.split("-")[0];
+        const identifier = dataForRequest.identifier.id;
         const newRoundKey = getRequestKey(dataForRequest.time, identifier, dataForRequest.roundId);
 
         // Commit vote data:


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

"Vote Stats" button not working for the price request with identifier "GASETH-TWAP-1Mx1M".


**Summary**

The VoteData container erroneously assumes that you can determine the price request's identifier by delimiting the struct's `id` by the "-" symbol and grabbing the first element. This doesn't work if the identifier has "-" in it! Instead, we grab the identifier directly from the subgraph by modifying the graphql query.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
