### PR TITLE
fix(FindContractVersion): address web3.js inconsistant production behaviour with ethers.js

### DIFF
--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -21,7 +21,7 @@ async function findContractVersion(contractAddress, web3) {
     const { getNodeUrl } = require("./TruffleConfig");
     const argv = require("minimist")(process.argv.slice());
 
-    const provider = new providers.JsonRpcProvider(getNodeUrl(argv.network || "test"));
+    const provider = new providers.JsonRpcProvider(getNodeUrl(argv.network));
     contractCode = await provider.getCode(contractAddress);
   } else {
     contractCode = await web3.eth.getCode(contractAddress);

--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -29,6 +29,7 @@ async function findContractVersion(contractAddress, web3) {
 
   const contractCodeHash = web3.utils.soliditySha3(contractCode);
 
+  // Return the version from the versionMap OR details on the address,hash & code to help debug a mismatch.
   versionMap[contractCodeHash] || { contractAddress, contractCodeHash, contractCode: contractCode.substring(0, 1000) };
 }
 

--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -16,15 +16,17 @@ async function findContractVersion(contractAddress, web3) {
   // this module to work while we find a better long term solution for the web3.js issue. If running within unit tests
   // then the web3.js version is required as it is scope according to the unit test.
   let contractCode;
-  if (require("minimist")(process.argv.slice())?.network?.includes("mainnet")) {
+  if (global.web3) {
+    // This is run inside of truffle or hardhat test.
+    contractCode = await web3.eth.getCode(contractAddress);
+  } else {
+    // This is run literally anywhere else.
     const providers = require("ethers").providers;
     const { getNodeUrl } = require("./TruffleConfig");
     const argv = require("minimist")(process.argv.slice());
 
     const provider = new providers.JsonRpcProvider(getNodeUrl(argv.network));
     contractCode = await provider.getCode(contractAddress);
-  } else {
-    contractCode = await web3.eth.getCode(contractAddress);
   }
 
   const contractCodeHash = web3.utils.soliditySha3(contractCode);

--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -30,7 +30,9 @@ async function findContractVersion(contractAddress, web3) {
   const contractCodeHash = web3.utils.soliditySha3(contractCode);
 
   // Return the version from the versionMap OR details on the address,hash & code to help debug a mismatch.
-  versionMap[contractCodeHash] || { contractAddress, contractCodeHash, contractCode: contractCode.substring(0, 1000) };
+  return (
+    versionMap[contractCodeHash] || { contractAddress, contractCodeHash, contractCode: contractCode.substring(0, 1000) }
+  );
 }
 
 const versionMap = {

--- a/packages/common/src/MultiVersionTestHelpers.js
+++ b/packages/common/src/MultiVersionTestHelpers.js
@@ -16,8 +16,8 @@ const SUPPORTED_CONTRACT_VERSIONS = [
 // Versions that unit tests will test against. Note that there is no need to re-test anything less than 1.2.2 as
 // functionally therese versions are identical to 1.2.2.
 const TESTED_CONTRACT_VERSIONS = [
-  // { contractType: "ExpiringMultiParty", contractVersion: "1.2.2" },
-  // { contractType: "ExpiringMultiParty", contractVersion: "latest" },
+  { contractType: "ExpiringMultiParty", contractVersion: "1.2.2" },
+  { contractType: "ExpiringMultiParty", contractVersion: "latest" },
   { contractType: "Perpetual", contractVersion: "latest" }
 ];
 

--- a/packages/common/src/MultiVersionTestHelpers.js
+++ b/packages/common/src/MultiVersionTestHelpers.js
@@ -16,8 +16,8 @@ const SUPPORTED_CONTRACT_VERSIONS = [
 // Versions that unit tests will test against. Note that there is no need to re-test anything less than 1.2.2 as
 // functionally therese versions are identical to 1.2.2.
 const TESTED_CONTRACT_VERSIONS = [
-  { contractType: "ExpiringMultiParty", contractVersion: "1.2.2" },
-  { contractType: "ExpiringMultiParty", contractVersion: "latest" },
+  // { contractType: "ExpiringMultiParty", contractVersion: "1.2.2" },
+  // { contractType: "ExpiringMultiParty", contractVersion: "latest" },
   { contractType: "Perpetual", contractVersion: "latest" }
 ];
 

--- a/packages/common/src/ProviderUtils.js
+++ b/packages/common/src/ProviderUtils.js
@@ -48,8 +48,8 @@ function createBasicProvider(url) {
  * @notice Gets a web3 instance based on the network argument using the truffle config in this package.
  * Use this for compatibility for running with or without truffle.
  * @example
- * // If a node app uses getWeb3() and you want to load network 1 with a default wallet
- * // For full list of potential network names see common/src/TruffleConfig
+ *  If a node app uses getWeb3() and you want to load network 1 with a default wallet
+ *  For full list of potential network names see common/src/TruffleConfig
  * node app --network=mainnet_mnemonic
  *
  * @notice You can also specify environment variables

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -89,9 +89,11 @@ async function run({
       ).length == 0
     )
       throw new Error(
-        `Contract version specified or inferred is not supported by this bot. Provided/inferred config: ${JSON.stringify(
+        `Contract version specified or inferred is not supported by this bot. Liquidator config:${JSON.stringify(
           liquidatorConfig
-        )}. is not part of ${JSON.stringify(SUPPORTED_CONTRACT_VERSIONS)}`
+        )} & detectedContractVersion:${JSON.stringify(detectedContract)} is not part of ${JSON.stringify(
+          SUPPORTED_CONTRACT_VERSIONS
+        )}`
       );
 
     // Setup contract instances. This uses the contract version pulled in from previous step. Voting is hardcoded to latest main net version.
@@ -350,7 +352,7 @@ async function Poll(callback) {
       //   "defenseActivationPercent": undefined -> How far along a withdraw must be in % before defense strategy kicks in.
       //   "logOverrides":{"positionLiquidated":"warn"}, -> override specific events log levels.
       //   "contractType":"ExpiringMultiParty", -> override the kind of contract the liquidator is pointing at.
-      //   "contractVersion":"1.2.2"":"ExpiringMultiParty"} -> override the contract version the liquidator is pointing at.
+      //   "contractVersion":"1.2.2"} -> override the contract version the liquidator is pointing at.
       liquidatorConfig: process.env.LIQUIDATOR_CONFIG ? JSON.parse(process.env.LIQUIDATOR_CONFIG) : {},
       // If there is a LIQUIDATOR_OVERRIDE_PRICE environment variable then the liquidator will disregard the price from the
       // price feed and preform liquidations at this override price. Use with caution as wrong input could cause invalid liquidations.

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -79,8 +79,8 @@ async function run({
     ]);
     // Append the contract version and type to the liquidatorConfig, if the liquidatorConfig does not already contain one.
     if (!liquidatorConfig) liquidatorConfig = {};
-    if (!liquidatorConfig.contractVersion) liquidatorConfig.contractVersion = detectedContract.contractVersion;
-    if (!liquidatorConfig.contractType) liquidatorConfig.contractType = detectedContract.contractType;
+    if (!liquidatorConfig.contractVersion) liquidatorConfig.contractVersion = detectedContract?.contractVersion;
+    if (!liquidatorConfig.contractType) liquidatorConfig.contractType = detectedContract?.contractType;
 
     // Check that the version and type is supported. Note if either is null this check will also catch it.
     if (

--- a/packages/liquidator/package.json
+++ b/packages/liquidator/package.json
@@ -32,7 +32,7 @@
   "bin": "index.js",
   "scripts": {
     "test": "yarn mocha-test && yarn hardhat-test",
-    "hardhat-test": "hardhat test --network hardhat",
+    "hardhat-test": "hardhat test",
     "mocha-test": "mocha mocha-test",
     "test-log": "truffle test ./test/*.js --network=test logInTest",
     "test-fork": "truffle test --network mainnet-fork $(find test-fork -name '*.js')"

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -31,9 +31,9 @@ const { Liquidator } = require("../src/liquidator.js");
 // 2) non-matching 8 collateral & 18 synthetic for legacy UMA synthetics.
 // 3) matching 8 collateral & 8 synthetic for current UMA synthetics.
 const configs = [
-  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 }
-  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
-  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
+  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 },
+  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
+  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
 ];
 
 let iterationTestVersion; // store the test version between tests that is currently being tested.


### PR DESCRIPTION
**Motivation**

The most recent functionality with the perpetual bot support included the ability to automatically detect what contract version we are using. For some or other reason this failed to work in production.

**Summary**

After much painful testing, I was able to get this method to work in production by using ethers.js over web3.js. I'm not actually sure why this works, but it does 🤷 


**Details**


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested

