### PR TITLE
feat(default-price-feed): add TraderMadePriceFeed

### DIFF
--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -14,6 +14,7 @@
     "mathjs": "^9.2.0",
     "minimist": "^1.2.0",
     "node-fetch": "^2.6.0",
+    "moment": "^2.29.1",
     "node-pagerduty": "^1.2.0",
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0"

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -6,6 +6,7 @@ const { UniswapPriceFeed } = require("./UniswapPriceFeed");
 const { BalancerPriceFeed } = require("./BalancerPriceFeed");
 const { DominationFinancePriceFeed } = require("./DominationFinancePriceFeed");
 const { BasketSpreadPriceFeed } = require("./BasketSpreadPriceFeed");
+const { TraderMadePriceFeed } = require("./TraderMadePriceFeed");
 const { PriceFeedMockScaled } = require("./PriceFeedMockScaled");
 const { InvalidPriceFeedMock } = require("./InvalidPriceFeedMock");
 const { defaultConfigs } = require("./DefaultPriceFeedConfigs");
@@ -165,6 +166,31 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.denominatorPriceFeed && (await _createMedianizerPriceFeed(config.denominatorPriceFeed));
 
     return new BasketSpreadPriceFeed(web3, logger, baselinePriceFeeds, experimentalPriceFeeds, denominatorPriceFeed);
+  } else if (config.type === "tradermade") {
+    const requiredFields = ["pair", "apiKey", "minTimeBetweenUpdates"];
+
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating TraderMadePriceFeed",
+      config
+    });
+
+    return new TraderMadePriceFeed(
+      logger,
+      web3,
+      config.apiKey,
+      config.pair,
+      config.minuteLookback,
+      config.hourlyLookback,
+      networker,
+      getTime,
+      config.minTimeBetweenUpdates,
+      config.priceFeedDecimals // Defaults to 18 unless supplied. Informs how the feed should be scaled to match a DVM response.
+    );
   } else if (config.type === "test") {
     const requiredFields = ["currentPrice", "historicalPrice"];
     if (isMissingField(config, requiredFields, logger)) {

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -189,7 +189,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       networker,
       getTime,
       config.minTimeBetweenUpdates,
-      config.priceFeedDecimals // Defaults to 18 unless supplied. Informs how the feed should be scaled to match a DVM response.
+      config.priceFeedDecimals, // Defaults to 18 unless supplied. Informs how the feed should be scaled to match a DVM response.
+      config.ohlcPeriod
     );
   } else if (config.type === "test") {
     const requiredFields = ["currentPrice", "historicalPrice"];

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -1,0 +1,364 @@
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+const { parseFixed } = require("@uma/common");
+const moment = require("moment");
+
+// An implementation of PriceFeedInterface that uses TraderMade api to retrieve prices.
+class TraderMadePriceFeed extends PriceFeedInterface {
+  /**
+   * @notice Constructs the TraderMadePriceFeed.
+   * @param {Object} logger Winston module used to send logs.
+   * @param {Object} web3 Provider from truffle instance to connect to Ethereum network.
+   * @param {String} pair Representation of the pair the price feed is tracking.
+   * @param {String} apiKey TraderMade Data API key.
+   * @param {Integer} minuteLookback How far in the past the historical prices will be available using getHistoricalPrice.
+   * @param {Integer} hourlyLookback How far in the past the historical prices will be available using getHistoricalPricePeriods.
+   * @param {Object} networker Used to send the API requests.
+   * @param {Function} getTime Returns the current time.
+   * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
+   *      this number of seconds has passed, it will be a no-op.
+   * @param {Number} priceFeedDecimals Number of priceFeedDecimals to use to convert price to wei.
+   * @param {Number} ohlcPeriod Number of minutes interval between ohlc prices requested from TraderMade.
+   */
+  constructor(
+    logger,
+    web3,
+    apiKey,
+    pair,
+    minuteLookback,
+    hourlyLookback,
+    networker,
+    getTime,
+    minTimeBetweenUpdates,
+    priceFeedDecimals = 18,
+    ohlcPeriod = 10 // Only 5, 10, 15 minutes is supported by TraderMade.
+  ) {
+    super();
+    this.logger = logger;
+    this.web3 = web3;
+
+    this.apiKey = apiKey;
+    this.pair = pair;
+
+    this.minuteLookback = minuteLookback;
+    this.hourlyLookback = hourlyLookback;
+    this.uuid = `TraderMade-${pair}`;
+    this.networker = networker;
+    this.getTime = getTime;
+    this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+
+    this.toBN = this.web3.utils.toBN;
+    this.ohlcPeriod = ohlcPeriod;
+
+    this.priceFeedDecimals = priceFeedDecimals;
+    this.ohlcPeriod = ohlcPeriod;
+
+    this.convertPriceFeedDecimals = number => {
+      // Converts price result to wei
+      // returns price conversion to correct decimals as a big number
+      return this.toBN(parseFixed(number.toString(), priceFeedDecimals).toString());
+    };
+  }
+
+  getCurrentPrice() {
+    return this.currentPrice;
+  }
+
+  async getHistoricalPrice(time, verbose = false) {
+    if (this.lastUpdateTime === undefined) {
+      throw new Error(`${this.uuid}: undefined lastUpdateTime`);
+    }
+
+    // Set first price time in `historicalPrices` to first non-null price.
+    let firstPriceTime;
+    for (let p in this.historicalPricesMinute) {
+      if (this.historicalPricesMinute[p] && this.historicalPricesMinute[p].openTime) {
+        firstPriceTime = this.historicalPricesMinute[p];
+        break;
+      }
+    }
+
+    // If there are no valid price time, return null.
+    if (!firstPriceTime) {
+      throw new Error(`${this.uuid}: no valid price time`);
+    }
+
+    // If the time is before the first piece of data in the set, return null because
+    // the price is before the lookback window.
+    if (time < firstPriceTime.openTime) {
+      throw new Error(`${this.uuid}: time ${time} is before firstPriceTime.openTime`);
+    }
+
+    // historicalPrices are ordered from oldest to newest.
+    // This finds the first priceTime whose closeTime is after the provided time.
+    const match = this.historicalPricesMinute.find(price => {
+      return time < price.closeTime;
+    });
+
+    // If there is no match, that means that the time was past the last data point.
+    // In this case, the best match for this price is the current price.
+    let returnPrice;
+    if (match === undefined) {
+      returnPrice = this.currentPrice;
+      if (verbose) {
+        console.group(`\n(${this.pair}) No OHLC available @ ${time}`);
+        console.log(
+          `- ✅ Time is later than earliest historical time, fetching current price: ${this.web3.utils.fromWei(
+            returnPrice.toString()
+          )}`
+        );
+        console.log(
+          `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://marketdata.tradermade.com/api/v1/live?currency=${this.pair}&api_key={api-key}`
+        );
+        console.groupEnd();
+      }
+      return this.currentPrice;
+    }
+
+    returnPrice = match.closePrice;
+    if (verbose) {
+      console.group(`\n(${this.pair}) Historical OHLC @ ${match.closeTime}`);
+      console.log(`- ✅ Close Price:${this.web3.utils.fromWei(returnPrice.toString())}`);
+      console.log(
+        `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://marketdata.tradermade.com/api/v1/timeseries?currency=${this.pair}&api_key={api-key}&start_date=${time}&end_date=${match.closeTime}&format=records&interval=minute&period=${this.ohlcPeriod}`
+      );
+      console.groupEnd();
+    }
+    return returnPrice;
+  }
+
+  getHistoricalPricePeriods() {
+    return this.historicalPricesHourly;
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  getMinuteLookback() {
+    return this.minuteLookback;
+  }
+
+  getHourlyLookback() {
+    return this.hourlyLookback;
+  }
+
+  getPriceFeedDecimals() {
+    return this.priceFeedDecimals;
+  }
+
+  async updateLatest(lastUpdateTime) {
+    const currentTime = this.getTime();
+
+    // Return early if the last call was too recent.
+    if (this.lastUpdateTime !== undefined && lastUpdateTime + this.minTimeBetweenUpdates > currentTime) {
+      this.logger.debug({
+        at: "TraderMadePriceFeed",
+        message: "Update skipped because the last one was too recent",
+        currentTime: currentTime,
+        lastUpdateTimestamp: this.lastUpdateTime,
+        timeRemainingUntilUpdate: this.lastUpdateTimes + this.minTimeBetweenUpdates - currentTime
+      });
+      return;
+    }
+
+    this.logger.debug({
+      at: "TraderMade_PriceFeed",
+      message: "Updating Latest Price",
+      currentTime: currentTime,
+      lastUpdateTimestamp: this.lastUpdateTime
+    });
+
+    // 1. Construct URLs.
+    const priceUrl = `https://marketdata.tradermade.com/api/v1/live?currency=${this.pair}&api_key=${this.apiKey}`;
+
+    // 2. Send requests.
+    const priceResponse = await this.networker.getJson(priceUrl);
+
+    // 4. Parse results.
+    // Return data structure:
+    //  {
+    //     "endpoint": "live",
+    //     "quotes": [
+    //       {
+    //         "ask": 0.15431,
+    //         "base_currency": "CNY",
+    //         "bid": 0.15431,
+    //         "mid": 0.15431,
+    //         "quote_currency": "USD"
+    //       }
+    //     ],
+    //     "requested_time": "Tue, 26 Jan 2021 01:29:52 GMT",
+    //     "timestamp": 1611624593
+    //   }
+    // For more info, see: https://marketdata.tradermade.com/documentation
+    const newPrice = this.convertPriceFeedDecimals(priceResponse.quotes[0].ask);
+
+    // 5. Store results.
+    this.currentPrice = newPrice;
+    this.lastUpdateTime = currentTime;
+  }
+
+  async updateMinute(lastUpdateTime) {
+    const currentTime = this.getTime();
+
+    // Return early if the last call was too recent.
+    if (this.lastUpdateTime !== undefined && lastUpdateTime + this.minTimeBetweenUpdates > currentTime) {
+      return;
+    }
+
+    this.logger.debug({
+      at: "TraderMade_PriceFeed",
+      message: "Updating Minute Price",
+      currentTime: currentTime,
+      lastUpdateTimestamp: this.lastUpdateTime
+    });
+
+    // Round down to the nearest ohlc period so the queries captures the OHLC of the period *before* this earliest
+    // timestamp (because the close of that OHLC may be relevant).
+    const earliestMinuteHistoricalTimestamp =
+      Math.floor((currentTime - this.minuteLookback) / (this.ohlcPeriod * 60)) * (this.ohlcPeriod * 60);
+    const endDate = this._secondToDateTime(currentTime);
+    const startMinuteDate = this._secondToDateTime(earliestMinuteHistoricalTimestamp);
+
+    // 1. Construct URLs.
+    const ohlcMinuteUrl = `https://marketdata.tradermade.com/api/v1/timeseries?currency=${this.pair}&api_key=${this.apiKey}&start_date=${startMinuteDate}&end_date=${endDate}&format=records&interval=minute&period=${this.ohlcPeriod}`;
+
+    // 2. Send requests.
+    const ohlcMinuteResponse = await this.networker.getJson(ohlcMinuteUrl);
+
+    // 3. Check responses.
+    if (!ohlcMinuteResponse || !ohlcMinuteResponse.quotes || !ohlcMinuteResponse.quotes[0].close) {
+      throw new Error(
+        `🚨Could not parse ohlc minute price result from url ${ohlcMinuteUrl}: ${JSON.stringify(ohlcMinuteResponse)}`
+      );
+    }
+
+    // Return data structure:
+    // {
+    //   "base_currency": "CNY",
+    //   "end_date": "2021-01-26 03:31:00",
+    //   "endpoint": "timeseries",
+    //   "quote_currency": "USD",
+    //   "quotes": [
+    //     {
+    //       "close": 0.1543,
+    //       "date": "2021-01-26 00:01:00",
+    //       "high": 0.1543,
+    //       "low": 0.1543,
+    //       "open": 0.1543
+    //     },
+    //     ...
+    //   ]
+    //   "request_time": "Wed, 27 Jan 2021 01:45:28 GMT",
+    //   "start_date": "2021-01-26-00:01"
+    // }
+    // For more info, see: https://marketdata.tradermade.com/documentation
+    const newHistoricalPricesMinute = ohlcMinuteResponse.quotes
+      .map(ohlcMinute => ({
+        // Output data should be a list of objects with only the open and close times and prices.
+        closePrice: this.convertPriceFeedDecimals(ohlcMinute.close),
+        openTime: this._dateTimeToSecond(ohlcMinute.date) - this.ohlcPeriod * 60,
+        closeTime: this._dateTimeToSecond(ohlcMinute.date)
+      }))
+      .sort((a, b) => {
+        // Sorts the data such that the oldest elements come first.
+        return a.openTime - b.openTime;
+      });
+
+    // 5. Store results.
+    this.historicalPricesMinute = newHistoricalPricesMinute;
+  }
+
+  async updateHourly(lastUpdateTime) {
+    const currentTime = this.getTime();
+
+    // Return early if the last call was too recent.
+    if (this.lastUpdateTime !== undefined && lastUpdateTime + this.minTimeBetweenUpdates > currentTime) {
+      return;
+    }
+
+    this.logger.debug({
+      at: "TraderMade_PriceFeed",
+      message: "Updating Hourly Price",
+      currentTime: currentTime,
+      lastUpdateTimestamp: this.lastUpdateTime
+    });
+
+    // Round down to the nearest ohlc period so the queries captures the OHLC of the period *before* this earliest
+    // timestamp (because the close of that OHLC may be relevant).
+    const earliestHourlyHistoricalTimestamp = Math.floor((currentTime - this.hourlyLookback) / 3600) * 3600;
+    const endDate = this._secondToDateTime(currentTime);
+    const startHourlyDate = this._secondToDateTime(earliestHourlyHistoricalTimestamp);
+
+    // 1. Construct URLs.
+    const ohlcHourlyUrl = `https://marketdata.tradermade.com/api/v1/timeseries?currency=${this.pair}&api_key=${this.apiKey}&start_date=${startHourlyDate}&end_date=${endDate}&format=records&interval=hourly`;
+
+    // 2. Send requests.
+    const ohlcHourlyResponse = await this.networker.getJson(ohlcHourlyUrl);
+
+    // 3. Check responses.
+    if (!ohlcHourlyResponse || !ohlcHourlyResponse.quotes || !ohlcHourlyResponse.quotes[0].close) {
+      throw new Error(
+        `🚨Could not parse ohlc hourly price result from url ${ohlcHourlyUrl}: ${JSON.stringify(ohlcHourlyResponse)}`
+      );
+    }
+
+    // Return data structure:
+    // {
+    //   "base_currency": "CNY",
+    //   "end_date": "2021-01-26 03:31:00",
+    //   "endpoint": "timeseries",
+    //   "quote_currency": "USD",
+    //   "quotes": [
+    //     {
+    //       "close": 0.1543,
+    //       "date": "2021-01-26 00:00:00",
+    //       "high": 0.1543,
+    //       "low": 0.1543,
+    //       "open": 0.1543
+    //     },
+    //     ...
+    //   ]
+    //   "request_time": "Wed, 27 Jan 2021 01:45:28 GMT",
+    //   "start_date": "2021-01-26-00:01"
+    // }
+    // For more info, see: https://marketdata.tradermade.com/documentation
+    const newHistoricalPricesHourly = ohlcHourlyResponse.quotes
+      .map(ohlcHourly => ({
+        // Output data should be a list of objects with only the open and close times and prices.
+        closePrice: this.convertPriceFeedDecimals(ohlcHourly.close),
+        openTime: this._dateTimeToSecond(ohlcHourly.date) - 3600,
+        closeTime: this._dateTimeToSecond(ohlcHourly.date)
+      }))
+      .sort((a, b) => {
+        // Sorts the data such that the oldest elements come first.
+        return a.closeTime - b.closeTime;
+      });
+
+    // 5. Store results.
+    this.historicalPricesHourly = newHistoricalPricesHourly;
+  }
+
+  async update() {
+    const lastUpdateTime = this.lastUpdateTime;
+    await this.updateLatest(lastUpdateTime);
+    if (this.minuteLookback) {
+      await this.updateMinute(lastUpdateTime);
+    }
+    if (this.hourlyLookback) {
+      await this.updateHourly(lastUpdateTime);
+    }
+  }
+
+  _secondToDateTime(inputSecond) {
+    return moment.unix(inputSecond).format("YYYY-MM-DD-HH:mm");
+  }
+
+  _dateTimeToSecond(inputDateTime) {
+    return moment(inputDateTime, "YYYY-MM-DD HH:mm").unix();
+  }
+}
+
+module.exports = {
+  TraderMadePriceFeed
+};

--- a/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
@@ -109,16 +109,16 @@ contract("TraderMadePriceFeed.js", function() {
 
     const expectOhlcHourlyPrices = [
       {
-        closeTime: 1611637200,
-        openTime: 1611633600
+        closeTime: 1611608400,
+        openTime: 1611604800
       },
       {
-        closeTime: 1611640800,
-        openTime: 1611637200
+        closeTime: 1611612000,
+        openTime: 1611608400
       },
       {
-        closeTime: 1611644400,
-        openTime: 1611640800
+        closeTime: 1611615600,
+        openTime: 1611612000
       }
     ];
     const actualOhlcHourlyPrices = traderMadePriceFeed.getHistoricalPricePeriods();

--- a/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
@@ -1,0 +1,274 @@
+const { TraderMadePriceFeed } = require("../../src/price-feed/TraderMadePriceFeed");
+const { NetworkerMock } = require("../../src/price-feed/NetworkerMock");
+const winston = require("winston");
+
+contract("TraderMadePriceFeed.js", function() {
+  let traderMadePriceFeed;
+  let mockTime = 1614314000;
+  let networker;
+
+  const apiKey = "test-api-key";
+  const pair = "test-pair";
+  const minuteLookback = 600; // 10 minutes
+  const hourlyLookback = 172800; // 2 days
+  const getTime = () => mockTime;
+  const minTimeBetweenUpdates = 600;
+
+  const { toWei } = web3.utils;
+
+  // Fake data to inject.
+  // Note: the first element is the live pice, the second is the ohlc minute price, and the third is ohlc hourly price.
+  const validResponses = [
+    {
+      quotes: [
+        {
+          ask: 0.1553
+        }
+      ]
+    },
+    {
+      quotes: [
+        {
+          close: 0.1543,
+          date: "2021-01-25 21:00:00"
+        },
+        {
+          close: 0.1533,
+          date: "2021-01-25 21:10:00"
+        },
+        {
+          close: 0.1523,
+          date: "2021-01-25 21:20:00"
+        }
+      ]
+    },
+    {
+      quotes: [
+        {
+          close: 0.1543,
+          date: "2021-01-25 21:00:00"
+        },
+        {
+          close: 0.1533,
+          date: "2021-01-25 22:00:00"
+        },
+        {
+          close: 0.1523,
+          date: "2021-01-25 23:00:00"
+        }
+      ]
+    }
+  ];
+
+  beforeEach(async function() {
+    networker = new NetworkerMock();
+    const dummyLogger = winston.createLogger({
+      level: "info",
+      transports: [new winston.transports.Console()]
+    });
+    traderMadePriceFeed = new TraderMadePriceFeed(
+      dummyLogger,
+      web3,
+      apiKey,
+      pair,
+      minuteLookback,
+      hourlyLookback,
+      networker,
+      getTime,
+      minTimeBetweenUpdates,
+      18
+    );
+  });
+
+  it("No update", async function() {
+    assert.equal(traderMadePriceFeed.getCurrentPrice(), undefined);
+    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1000).catch(() => true));
+    assert.equal(traderMadePriceFeed.getLastUpdateTime(), undefined);
+  });
+
+  it("Basic historical price", async function() {
+    // Inject data.
+    networker.getJsonReturns = [...validResponses];
+
+    await traderMadePriceFeed.update();
+
+    // Before period 1 should fail.
+    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1611607700).catch(() => true));
+
+    // During period 1.
+    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611608300)).toString(), toWei("0.1543"));
+
+    // During period 2.
+    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611608900)).toString(), toWei("0.1533"));
+
+    // During period 3.
+    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611609500)).toString(), toWei("0.1523"));
+
+    // After period 3 should return the most recent price.
+    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611610100)).toString(), toWei("0.1553"));
+
+    const expectOhlcHourlyPrices = [
+      {
+        closeTime: 1611637200,
+        openTime: 1611633600
+      },
+      {
+        closeTime: 1611640800,
+        openTime: 1611637200
+      },
+      {
+        closeTime: 1611644400,
+        openTime: 1611640800
+      }
+    ];
+    const actualOhlcHourlyPrices = traderMadePriceFeed.getHistoricalPricePeriods();
+    for (let i = 0; i < expectOhlcHourlyPrices.length; i++) {
+      assert.equal(expectOhlcHourlyPrices[i].closeTime, actualOhlcHourlyPrices[i].closeTime);
+      assert.equal(expectOhlcHourlyPrices[i].openTime, actualOhlcHourlyPrices[i].openTime);
+    }
+  });
+
+  it("Basic current price", async function() {
+    // Inject data.
+    networker.getJsonReturns = [...validResponses];
+
+    await traderMadePriceFeed.update();
+
+    // Should return the current price in the data.
+    assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+  });
+
+  it("Last update time", async function() {
+    // Inject data.
+    networker.getJsonReturns = [...validResponses];
+
+    await traderMadePriceFeed.update();
+
+    // Should return the mock time.
+    assert.equal(traderMadePriceFeed.getLastUpdateTime(), mockTime);
+  });
+
+  it("No or bad response", async function() {
+    // Bad price response.
+    networker.getJsonReturns = [
+      {
+        quotes: [
+          {
+            error: "test"
+          }
+        ]
+      },
+      {
+        quotes: [
+          {
+            close: 0.1543,
+            date: "2021-01-26 00:00:00"
+          },
+          {
+            close: 0.1533,
+            date: "2021-01-26 00:00:00"
+          },
+          {
+            close: 0.1523,
+            date: "2021-01-26 00:00:00"
+          }
+        ]
+      },
+      {
+        quotes: [
+          {
+            close: 0.1543,
+            date: "2021-01-26 00:00:00"
+          },
+          {
+            close: 0.1533,
+            date: "2021-01-26 00:00:00"
+          },
+          {
+            close: 0.1523,
+            date: "2021-01-26 00:00:00"
+          }
+        ]
+      }
+    ];
+
+    // Update should throw errors in both cases.
+    assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+
+    assert.equal(traderMadePriceFeed.getCurrentPrice(), undefined);
+    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1614319100).catch(() => true));
+    assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+
+    // Bad historical ohlc response.
+    networker.getJsonReturns = [
+      {
+        quotes: [
+          {
+            ask: 0.1553
+          }
+        ]
+      },
+      {
+        quotes: [
+          {
+            error: "test"
+          }
+        ]
+      },
+      {
+        quotes: [
+          {
+            error: "test"
+          }
+        ]
+      }
+    ];
+
+    assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+
+    assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1614319100).catch(() => true));
+    assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+  });
+
+  it("Update frequency", async function() {
+    networker.getJsonReturns = [...validResponses];
+
+    await traderMadePriceFeed.update();
+
+    networker.getJsonReturns = [...validResponses];
+
+    // Update the return price to ensure it new data doesn't show up in the output.
+    networker.getJsonReturns[0].quotes[0].ask = 1.4;
+
+    const originalMockTime = mockTime;
+    mockTime += minTimeBetweenUpdates - 1;
+
+    await traderMadePriceFeed.update();
+    assert.equal(traderMadePriceFeed.getLastUpdateTime(), originalMockTime);
+    assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+  });
+
+  it("apiKey present", async function() {
+    networker.getJsonReturns = [...validResponses];
+    await traderMadePriceFeed.update();
+
+    assert.deepStrictEqual(networker.getJsonInputs, [
+      "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=test-api-key&start_date=2021-02-24-04:00&end_date=2021-02-26-04:43&format=records&interval=hourly",
+      "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=test-api-key&start_date=2021-02-26-04:30&end_date=2021-02-26-04:43&format=records&interval=minute&period=10",
+      "https://marketdata.tradermade.com/api/v1/live?currency=test-pair&api_key=test-api-key"
+    ]);
+  });
+
+  it("apiKey absent", async function() {
+    traderMadePriceFeed.apiKey = undefined;
+    networker.getJsonReturns = [...validResponses];
+    await traderMadePriceFeed.update();
+
+    assert.deepStrictEqual(networker.getJsonInputs, [
+      "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=undefined&start_date=2021-02-24-04:00&end_date=2021-02-26-04:43&format=records&interval=hourly",
+      "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=undefined&start_date=2021-02-26-04:30&end_date=2021-02-26-04:43&format=records&interval=minute&period=10",
+      "https://marketdata.tradermade.com/api/v1/live?currency=test-pair&api_key=undefined"
+    ]);
+  });
+});


### PR DESCRIPTION
**Motivation**
Follow up on UMAProtocol/UMIPs#97, [umip-32](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-32.md).
Similar to CryptoWatch price feed implementation, this PR can help us to get CNYUSD exchange rate from TraderMade


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [✅ ]  Ran end-to-end test, running the code as in production
- [✅ ]  New unit tests created
- [✅ ]  All existing tests pass
