### PR TITLE
fix(PriceIdentifierUtils): Add correct AMPLUSD decimals

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -10,7 +10,8 @@ const IDENTIFIER_NON_18_PRECISION = {
   "STABLESPREAD/USDC": 6,
   "STABLESPREAD/BTC": 8,
   "ELASTIC_STABLESPREAD/USDC": 6,
-  BCHNBTC: 8
+  BCHNBTC: 8,
+  AMPLUSD: 6
 };
 
 const getPrecisionForIdentifier = identifier => {


### PR DESCRIPTION
**Motivation**

when https://github.com/UMAprotocol/protocol/pull/2454 was merged the `PriceIdentifierUtils` was not updated. This synthetic is intended to be collateralied in USDC and so the feed needs to be scaled accordingly. This can be seen within UMIP-33 [here](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-33.md#technical-specification).

**Summary**

updated `PriceIdentiferUtils.js`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
