### PR TITLE
ci(slither): remove slither from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,38 +60,6 @@ jobs:
           command: ./scripts/build_docs_site.sh
       - store_artifacts:
           path: build/site
-  slither:
-    docker:
-      - image: trailofbits/eth-security-toolbox
-    working_directory: ~/protocol
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v7-sec-toolbox-deps-{{ checksum "yarn.lock" }}
-            - v7-sec-toolbox-deps-
-      - run:
-          name: Install node and NPM
-          command: ./ci/install_node_npm.sh
-      - run:
-          name: Change user
-          command: sudo su ethsec
-      - run:
-          name: Reclaim ownership
-          command: sudo chown -R $(whoami) ~/.npm ~/.config
-      - run:
-          name: Install Prereqs
-          command: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev python-dev
-      - run:
-          name: Install Dependencies
-          command: sudo npm install -g yarn && npx lerna bootstrap -- --frozen-lockfile
-      - save_cache:
-          key: v7-sec-toolbox-deps-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
-      - run:
-          name: Slither
-          command: ./ci/run_slither.sh
   test:
     docker:
       - image: circleci/node:lts
@@ -190,7 +158,6 @@ workflows:
   build_and_test:
     jobs:
       - checkout_and_install
-      - slither
       - build:
           requires:
             - checkout_and_install


### PR DESCRIPTION
**Motivation**

Slither tends to cause more problems than it solves in ci. We run it in a separate docker image and it consistently breaks when interacting with our toolchain. It also doesn't seem to provide a lot of value -- by my understanding, it has never caught a smart contract bug -- it has caught some minor stylistic or readability issues.

**Summary**

This PR removes slither from ci, but leaves the run script in place in case we want to run it in the future.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
