### PR TITLE
feat(financial-templates-lib): make getHistoricalPrice async

### DIFF
--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -75,7 +75,7 @@ async function getMedianHistoricalPrice(callback) {
 
     // The default exchanges to fetch prices for (and from which the median is derived) are based on UMIP's and can be found in:
     // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
-    const queryPrice = medianizerPriceFeed.getHistoricalPrice(queryTime, true);
+    const queryPrice = await medianizerPriceFeed.getHistoricalPrice(queryTime, true);
     const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
     console.log(`\n⚠️ Truncating price to ${precisionToUse} decimals`);
     console.log(

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -119,7 +119,7 @@ class Disputer {
             price = this.toBN(disputerOverridePrice);
           } else {
             try {
-              price = this.priceFeed.getHistoricalPrice(liquidationTime);
+              price = await this.priceFeed.getHistoricalPrice(liquidationTime);
             } catch (error) {
               this.logger.error({
                 at: "Disputer",

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -94,57 +94,59 @@ class Disputer {
 
     // Get the latest disputable liquidations from the client.
     const undisputedLiquidations = this.empClient.getUndisputedLiquidations();
-    const disputeableLiquidations = await Promise.all(
-      undisputedLiquidations.map(async liquidation => {
-        // If liquidation time is before the price feed's lookback window, then we can skip this liquidation
-        // because we will not be able to get a historical price. If a dispute override price is provided then
-        // we can ignore this check.
-        const liquidationTime = parseInt(liquidation.liquidationTime.toString());
-        const historicalLookbackWindow =
-          Number(this.priceFeed.getLastUpdateTime()) - Number(this.priceFeed.getLookback());
-        if (!disputerOverridePrice && liquidationTime < historicalLookbackWindow) {
-          this.logger.debug({
-            at: "Disputer",
-            message: "Cannot dispute: liquidation time before earliest price feed historical timestamp",
-            liquidationTime,
-            historicalLookbackWindow
-          });
-          return null;
-        }
-
-        // If an override is provided, use that price. Else, get the historic price at the liquidation time.
-        let price;
-        if (disputerOverridePrice) {
-          price = this.toBN(disputerOverridePrice);
-        } else {
-          try {
-            price = this.priceFeed.getHistoricalPrice(liquidationTime);
-          } catch (error) {
-            this.logger.error({
+    const disputeableLiquidations = (
+      await Promise.all(
+        undisputedLiquidations.map(async liquidation => {
+          // If liquidation time is before the price feed's lookback window, then we can skip this liquidation
+          // because we will not be able to get a historical price. If a dispute override price is provided then
+          // we can ignore this check.
+          const liquidationTime = parseInt(liquidation.liquidationTime.toString());
+          const historicalLookbackWindow =
+            Number(this.priceFeed.getLastUpdateTime()) - Number(this.priceFeed.getLookback());
+          if (!disputerOverridePrice && liquidationTime < historicalLookbackWindow) {
+            this.logger.debug({
               at: "Disputer",
-              message: "Cannot dispute: price feed returned invalid value",
-              error: error.message
+              message: "Cannot dispute: liquidation time before earliest price feed historical timestamp",
+              liquidationTime,
+              historicalLookbackWindow
             });
             return null;
           }
-        }
 
-        // Price is available, use it to determine if the liquidation is disputable
-        if (
-          this.empClient.isDisputable(liquidation, price) &&
-          this.empClient.getLastUpdateTime() >= Number(liquidationTime) + this.disputeDelay
-        ) {
-          this.logger.debug({
-            at: "Disputer",
-            message: "Detected a disputable liquidation",
-            price: price.toString(),
-            liquidation: JSON.stringify(liquidation)
-          });
-          return liquidation;
-        } else {
-          return null;
-        }
-      })
+          // If an override is provided, use that price. Else, get the historic price at the liquidation time.
+          let price;
+          if (disputerOverridePrice) {
+            price = this.toBN(disputerOverridePrice);
+          } else {
+            try {
+              price = this.priceFeed.getHistoricalPrice(liquidationTime);
+            } catch (error) {
+              this.logger.error({
+                at: "Disputer",
+                message: "Cannot dispute: price feed returned invalid value",
+                error: error.message
+              });
+              return null;
+            }
+          }
+
+          // Price is available, use it to determine if the liquidation is disputable
+          if (
+            this.empClient.isDisputable(liquidation, price) &&
+            this.empClient.getLastUpdateTime() >= Number(liquidationTime) + this.disputeDelay
+          ) {
+            this.logger.debug({
+              at: "Disputer",
+              message: "Detected a disputable liquidation",
+              price: price.toString(),
+              liquidation: JSON.stringify(liquidation)
+            });
+            return liquidation;
+          } else {
+            return null;
+          }
+        })
+      )
     ).filter(liquidation => liquidation !== null);
 
     if (disputeableLiquidations.length === 0) {

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -124,7 +124,7 @@ class Disputer {
               this.logger.error({
                 at: "Disputer",
                 message: "Cannot dispute: price feed returned invalid value",
-                error: error.message
+                error
               });
             }
           }

--- a/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js
@@ -70,7 +70,7 @@ class BalancerPriceFeed extends PriceFeedInterface {
     this.convertPoolDecimalsToPriceFeedDecimals = ConvertDecimals(this.poolDecimals, this.priceFeedDecimals, this.web3);
   }
 
-  getHistoricalPrice(time) {
+  async getHistoricalPrice(time) {
     if (time < this.lastUpdateTime - this.lookback) {
       // Requesting an historical TWAP earlier than the lookback.
       return null;

--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -104,10 +104,14 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
     return this._getSpreadFromBasketPrices(experimentalPrices, baselinePrices, denominatorPrice);
   }
 
-  getHistoricalPrice(time) {
-    const experimentalPrices = this.experimentalPriceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
-    const baselinePrices = this.baselinePriceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time));
-    const denominatorPrice = this.denominatorPriceFeed && this.denominatorPriceFeed.getHistoricalPrice(time);
+  async getHistoricalPrice(time) {
+    const experimentalPrices = await Promise.all(
+      this.experimentalPriceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time))
+    );
+    const baselinePrices = await Promise.all(
+      this.baselinePriceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time))
+    );
+    const denominatorPrice = this.denominatorPriceFeed && (await this.denominatorPriceFeed.getHistoricalPrice(time));
 
     return this._getSpreadFromBasketPrices(experimentalPrices, baselinePrices, denominatorPrice);
   }

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -65,7 +65,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
   }
 
-  getHistoricalPrice(time, verbose = false) {
+  async getHistoricalPrice(time, verbose = false) {
     if (this.lastUpdateTime === undefined) {
       return null;
     }

--- a/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
@@ -9,7 +9,7 @@ class DominationFinancePriceFeed extends PriceFeedInterface {
    * @param {Object} web3 Instance used for Web3 utilities and conversions.
    * @param {String} pair Representation of the pair the price feed is tracking.
    *    The string should be the representation used by the DomFi API to identify this pair.
-   * @param {Integer} lookback How far in the past the historical prices will be available using getHistoricalPrice.
+   * @param {Integer} lookback How far in the past the historical prices will be available using await  getHistoricalPrice.
    * @param {Object} networker Used to send the API requests.
    * @param {Function} getTime Returns the Unix timestamp in seconds.
    * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
@@ -64,7 +64,7 @@ class DominationFinancePriceFeed extends PriceFeedInterface {
     return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
   }
 
-  getHistoricalPrice(time, verbose = false) {
+  async getHistoricalPrice(time, verbose = false) {
     if (this.lastUpdateTime === undefined) {
       return null;
     }

--- a/packages/financial-templates-lib/src/price-feed/InvalidPriceFeedMock.js
+++ b/packages/financial-templates-lib/src/price-feed/InvalidPriceFeedMock.js
@@ -11,7 +11,7 @@ class InvalidPriceFeedMock extends PriceFeedInterface {
     this.currentPrice = null;
     this.lastUpdateTime = null;
   }
-  getHistoricalPrice() {
+  async getHistoricalPrice() {
     return null;
   }
   getLastUpdateTime() {

--- a/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/MedianizerPriceFeed.js
@@ -35,8 +35,10 @@ class MedianizerPriceFeed extends PriceFeedInterface {
   }
 
   // Takes the median of all of the constituent price feeds' historical prices.
-  getHistoricalPrice(time, verbose = false) {
-    const historicalPrices = this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time, verbose));
+  async getHistoricalPrice(time, verbose = false) {
+    const historicalPrices = await Promise.all(
+      this.priceFeeds.map(priceFeed => priceFeed.getHistoricalPrice(time, verbose))
+    );
 
     if (historicalPrices.some(element => element === undefined || element === null)) {
       return null;

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js
@@ -21,7 +21,7 @@ class PriceFeedInterface {
   // return `null` or `undefined`. If the historical price could not be computed for any other reason, this method
   // should return `null` or `undefined`.
   // Note: derived classes *must* override this method.
-  getHistoricalPrice(/* time */) {
+  async getHistoricalPrice(/* time */) {
     this._abstractFunctionCalled();
   }
 

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedMock.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedMock.js
@@ -23,7 +23,7 @@ class PriceFeedMock extends PriceFeedInterface {
     this.currentPrice = currentPrice ? toBN(currentPrice) : currentPrice;
   }
 
-  // Store an array of historical prices [{timestamp, price}] so that getHistoricalPrice can return
+  // Store an array of historical prices [{timestamp, price}] so that await  getHistoricalPrice can return
   // a price for a specific timestamp if found in this array.
   setHistoricalPrices(historicalPrices) {
     historicalPrices.forEach(_price => {
@@ -51,7 +51,7 @@ class PriceFeedMock extends PriceFeedInterface {
     return this.currentPrice;
   }
 
-  getHistoricalPrice(time) {
+  async getHistoricalPrice(time) {
     // If a price for `time` was set via `setHistoricalPrices`, then return that price, otherwise return the mocked
     // historical price.
     if (time in this.historicalPrices) {

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedMockScaled.js
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedMockScaled.js
@@ -31,7 +31,7 @@ class PriceFeedMockScaled extends PriceFeedInterface {
   }
 
   // only available in mock
-  // Store an array of historical prices [{timestamp, price}] so that getHistoricalPrice can return
+  // Store an array of historical prices [{timestamp, price}] so that await  getHistoricalPrice can return
   // a price for a specific timestamp if found in this array.
   // this will convert to correct "wei" representation based on decimals in constructor
   setHistoricalPrices(historicalPrices) {
@@ -57,7 +57,7 @@ class PriceFeedMockScaled extends PriceFeedInterface {
     return this.currentPrice;
   }
 
-  getHistoricalPrice(time) {
+  async getHistoricalPrice(time) {
     // If a price for `time` was set via `setHistoricalPrices`, then return that price, otherwise return the mocked
     // historical price.
     if (time in this.historicalPrices) {

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -11,7 +11,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
    * @param {Object} web3 Provider from Truffle instance to connect to Ethereum network.
    * @param {String} uniswapAddress Ethereum address of the Uniswap market the price feed is monitoring.
    * @param {Integer} twapLength Duration of the time weighted average computation used by the price feed.
-   * @param {Integer} historicalLookback How far in the past historical prices will be available using getHistoricalPrice.
+   * @param {Integer} historicalLookback How far in the past historical prices will be available using await  getHistoricalPrice.
    * @param {Function} getTime Returns the current time.
    * @param {Bool} invertPrice Indicates if the Uniswap pair is computed as reserve0/reserve1 (true) or
    * @param {Integer} poolDecimals Precision that prices are reported in on-chain
@@ -61,7 +61,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
     return this.currentTwap && this.convertPoolDecimalsToPriceFeedDecimals(this.currentTwap);
   }
 
-  getHistoricalPrice(time) {
+  async getHistoricalPrice(time) {
     if (time < this.lastUpdateTime - this.historicalLookback) {
       // Requesting an historical TWAP earlier than the lookback.
       return null;

--- a/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
@@ -228,7 +228,7 @@ contract("BasketSpreadPriceFeed.js", function() {
       );
       const arbitraryHistoricalTimestamp = 1000;
       assert.equal(
-        basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
+        await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
         toBN(toWei("0.125"))
           .div(toBN(10).pow(toBN(18 - 8)))
           .toString()
@@ -249,7 +249,7 @@ contract("BasketSpreadPriceFeed.js", function() {
       );
       const arbitraryHistoricalTimestamp = 1000;
       assert.equal(
-        basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
+        await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
         toBN(toWei("1.25"))
           .div(toBN(10).pow(toBN(18 - 6)))
           .toString()
@@ -429,7 +429,7 @@ contract("BasketSpreadPriceFeed.js", function() {
       // (because we're using mocks, the timestamp doesn't matter).
       const arbitraryHistoricalTimestamp = 1000;
       assert.equal(
-        basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
+        await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
         toBN(toWei("0.2"))
           .div(toBN(10).pow(toBN(18 - 8)))
           .toString()

--- a/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/BasketSpreadPriceFeed.js
@@ -210,7 +210,7 @@ contract("BasketSpreadPriceFeed.js", function() {
       // - Denominator price: 10
       // ===> Spread price divided by denominator: 0.125
       const arbitraryHistoricalTimestamp = 1000;
-      assert.equal(basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("0.125"));
+      assert.equal(await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("0.125"));
 
       // Should return the *maximum* lastUpdatedTime.
       assert.equal(basketSpreadPriceFeed.getLastUpdateTime(), 650000);
@@ -325,7 +325,7 @@ contract("BasketSpreadPriceFeed.js", function() {
 
       // Should return 0 for historical price as well (because we're using mocks, the timestamp doesn't matter).
       const arbitraryHistoricalTimestamp = 1000;
-      assert.equal(basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), "0");
+      assert.equal(await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), "0");
 
       // Should return the *maximum* lastUpdatedTime.
       assert.equal(basketSpreadPriceFeed.getLastUpdateTime(), 400);
@@ -338,7 +338,7 @@ contract("BasketSpreadPriceFeed.js", function() {
 
       // Should return the same for historical price (because we're using mocks, the timestamp doesn't matter).
       const arbitraryHistoricalTimestamp = 1000;
-      assert.equal(basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), "0");
+      assert.equal(await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), "0");
 
       // Should return the *maximum* lastUpdatedTime.
       assert.equal(basketSpreadPriceFeed.getLastUpdateTime(), 400);
@@ -409,7 +409,7 @@ contract("BasketSpreadPriceFeed.js", function() {
 
       // Should return the same for historical price (because we're using mocks, the timestamp doesn't matter).
       const arbitraryHistoricalTimestamp = 1000;
-      assert.equal(basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("0.2"));
+      assert.equal(await basketSpreadPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("0.2"));
 
       // Should return the *maximum* lastUpdatedTime.
       assert.equal(basketSpreadPriceFeed.getLastUpdateTime(), 400);

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -107,7 +107,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // During period 1.
     assert.equal(
       // Should be equal to: toWei(1/1.1)
-      invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(),
+      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.1")))
@@ -118,7 +118,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // During period 2.
     assert.equal(
       // Should be equal to: toWei(1/1.2)
-      invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(),
+      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.2")))
@@ -129,7 +129,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // During period 3.
     assert.equal(
       // Should be equal to: toWei(1/1.3)
-      invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(),
+      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.3")))
@@ -140,7 +140,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // After period 3 should return the most recent price.
     assert.equal(
       // Should be equal to: toWei(1/1.5)
-      invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376521),
+      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376521),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.5")))

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -102,7 +102,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     await invertedCryptoWatchPriceFeed.update();
 
     // Before period 1 should return null.
-    assert.equal(invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376339), null);
+    assert.equal(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376339), null);
 
     // During period 1.
     assert.equal(
@@ -151,7 +151,7 @@ contract("CryptoWatchPriceFeed.js", function() {
 
   it("No update", async function() {
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1000), undefined);
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1000), undefined);
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), undefined);
     assert.equal(cryptoWatchPriceFeed.getLookback(), 120);
   });
@@ -163,19 +163,19 @@ contract("CryptoWatchPriceFeed.js", function() {
     await cryptoWatchPriceFeed.update();
 
     // Before period 1 should return null.
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376339), null);
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376339), null);
 
     // During period 1.
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(), toWei("1.1"));
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(), toWei("1.1"));
 
     // During period 2.
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(), toWei("1.2"));
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(), toWei("1.2"));
 
     // During period 3.
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(), toWei("1.3"));
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(), toWei("1.3"));
 
     // After period 3 should return the most recent price.
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376521).toString(), toWei("1.5"));
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376521).toString(), toWei("1.5"));
   });
 
   it("Basic current price", async function() {
@@ -218,9 +218,9 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
+    assert.equal(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
 
     // Bad historical ohlc response.
     networker.getJsonReturns = [
@@ -237,7 +237,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await cryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(cryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
+    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
 
     // Inverted price feed returns undefined for prices equal to 0 since it cannot divide by 0
     networker.getJsonReturns = [
@@ -254,7 +254,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
+    assert.equal(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515), undefined);
   });
 
   it("Update frequency", async function() {

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -110,7 +110,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // During period 1.
     assert.equal(
       // Should be equal to: toWei(1/1.1)
-      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(),
+      (await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376340)).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.1")))
@@ -121,7 +121,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // During period 2.
     assert.equal(
       // Should be equal to: toWei(1/1.2)
-      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(),
+      (await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376405)).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.2")))
@@ -132,7 +132,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     // During period 3.
     assert.equal(
       // Should be equal to: toWei(1/1.3)
-      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(),
+      (await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515)).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.3")))
@@ -175,16 +175,16 @@ contract("CryptoWatchPriceFeed.js", function() {
     );
 
     // During period 1.
-    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(), toWei("1.1"));
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376340)).toString(), toWei("1.1"));
 
     // During period 2.
-    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376405).toString(), toWei("1.2"));
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376405)).toString(), toWei("1.2"));
 
     // During period 3.
-    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).toString(), toWei("1.3"));
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376515)).toString(), toWei("1.3"));
 
     // After period 3 should return the most recent price.
-    assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376521).toString(), toWei("1.5"));
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.5"));
   });
 
   it("Basic current price", async function() {
@@ -272,7 +272,10 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(() => assert.fail());
+    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
+      () => assert.fail(),
+      () => {}
+    );
   });
 
   it("Update frequency", async function() {

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -102,10 +102,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     await invertedCryptoWatchPriceFeed.update();
 
     // Before period 1 should fail.
-    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376339).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376339).catch(() => true));
 
     // During period 1.
     assert.equal(
@@ -154,10 +151,7 @@ contract("CryptoWatchPriceFeed.js", function() {
 
   it("No update", async function() {
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await cryptoWatchPriceFeed.getHistoricalPrice(1000).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(1000).catch(() => true));
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), undefined);
     assert.equal(cryptoWatchPriceFeed.getLookback(), 120);
   });
@@ -169,10 +163,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     await cryptoWatchPriceFeed.update();
 
     // Before period 1 should fail.
-    await cryptoWatchPriceFeed.getHistoricalPrice(1588376339).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(1588376339).catch(() => true));
 
     // During period 1.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376340)).toString(), toWei("1.1"));
@@ -227,15 +218,9 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).catch(() => true));
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).catch(() => true));
 
     // Bad historical ohlc response.
     networker.getJsonReturns = [
@@ -252,10 +237,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await cryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).catch(() => true));
 
     // Inverted price feed returns undefined for prices equal to 0 since it cannot divide by 0
     networker.getJsonReturns = [
@@ -272,10 +254,7 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).catch(() => true));
   });
 
   it("Update frequency", async function() {

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -102,7 +102,10 @@ contract("CryptoWatchPriceFeed.js", function() {
     await invertedCryptoWatchPriceFeed.update();
 
     // Before period 1 should fail.
-    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376339).then(() => assert.fail());
+    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376339).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // During period 1.
     assert.equal(
@@ -151,7 +154,10 @@ contract("CryptoWatchPriceFeed.js", function() {
 
   it("No update", async function() {
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await cryptoWatchPriceFeed.getHistoricalPrice(1000).then(() => assert.fail());
+    await cryptoWatchPriceFeed.getHistoricalPrice(1000).then(
+      () => assert.fail(),
+      () => {}
+    );
     assert.equal(cryptoWatchPriceFeed.getLastUpdateTime(), undefined);
     assert.equal(cryptoWatchPriceFeed.getLookback(), 120);
   });
@@ -163,7 +169,10 @@ contract("CryptoWatchPriceFeed.js", function() {
     await cryptoWatchPriceFeed.update();
 
     // Before period 1 should fail.
-    await cryptoWatchPriceFeed.getHistoricalPrice(1588376339).then(() => assert.fail());
+    await cryptoWatchPriceFeed.getHistoricalPrice(1588376339).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // During period 1.
     assert.equal(await cryptoWatchPriceFeed.getHistoricalPrice(1588376340).toString(), toWei("1.1"));
@@ -218,9 +227,15 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await invertedCryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(() => assert.fail());
+    await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
+      () => assert.fail(),
+      () => {}
+    );
     assert.equal(invertedCryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(() => assert.fail());
+    await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // Bad historical ohlc response.
     networker.getJsonReturns = [
@@ -237,7 +252,10 @@ contract("CryptoWatchPriceFeed.js", function() {
     assert.isTrue(await cryptoWatchPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(cryptoWatchPriceFeed.getCurrentPrice(), undefined);
-    await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(() => assert.fail());
+    await cryptoWatchPriceFeed.getHistoricalPrice(1588376515).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // Inverted price feed returns undefined for prices equal to 0 since it cannot divide by 0
     networker.getJsonReturns = [

--- a/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
@@ -97,7 +97,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // During period 1.
     assert.equal(
       // Should be equal to: toWei(1/1.1)
-      invertedPriceFeed.getHistoricalPrice(earliestTick).toString(),
+      await invertedPriceFeed.getHistoricalPrice(earliestTick).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.1")))
@@ -108,7 +108,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // During period 2.
     assert.equal(
       // Should be equal to: toWei(1/1.2)
-      invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5).toString(),
+      await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.2")))
@@ -119,7 +119,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // During period 3.
     assert.equal(
       // Should be equal to: toWei(1/1.3)
-      invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5).toString(),
+      await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.3")))
@@ -130,7 +130,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // After period 3 should return the most recent price.
     assert.equal(
       // Should be equal to: toWei(1/1.5)
-      invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 95),
+      await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 95),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.5")))

--- a/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
@@ -100,7 +100,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // During period 1.
     assert.equal(
       // Should be equal to: toWei(1/1.1)
-      await invertedPriceFeed.getHistoricalPrice(earliestTick).toString(),
+      (await invertedPriceFeed.getHistoricalPrice(earliestTick)).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.1")))
@@ -111,7 +111,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // During period 2.
     assert.equal(
       // Should be equal to: toWei(1/1.2)
-      await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5).toString(),
+      (await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5)).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.2")))
@@ -122,7 +122,7 @@ contract("DominationFinancePriceFeed.js", function() {
     // During period 3.
     assert.equal(
       // Should be equal to: toWei(1/1.3)
-      await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5).toString(),
+      (await invertedPriceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5)).toString(),
       toBN(toWei("1"))
         .mul(toBN(toWei("1")))
         .div(toBN(toWei("1.3")))
@@ -166,16 +166,19 @@ contract("DominationFinancePriceFeed.js", function() {
     );
 
     // During period 1.
-    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[0][0] + 5).toString(), toWei("1.1"));
+    assert.equal((await priceFeed.getHistoricalPrice(historicalResponse.data.rows[0][0] + 5)).toString(), toWei("1.1"));
 
     // During period 2.
-    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5).toString(), toWei("1.2"));
+    assert.equal((await priceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5)).toString(), toWei("1.2"));
 
     // During period 3.
-    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5).toString(), toWei("1.3"));
+    assert.equal((await priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5)).toString(), toWei("1.3"));
 
     // After period 3 should return the most recent price.
-    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 90).toString(), toWei("1.5"));
+    assert.equal(
+      (await priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 90)).toString(),
+      toWei("1.5")
+    );
   });
 
   it("Basic current price", async function() {

--- a/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
@@ -92,7 +92,7 @@ contract("DominationFinancePriceFeed.js", function() {
 
     // Before period 1 should return null.
     assert.equal(earliestTick, historicalResponse.data.rows[0][0]);
-    assert.equal(invertedPriceFeed.getHistoricalPrice(earliestTick - 15), null);
+    assert.equal(await invertedPriceFeed.getHistoricalPrice(earliestTick - 15), null);
 
     // During period 1.
     assert.equal(
@@ -141,7 +141,7 @@ contract("DominationFinancePriceFeed.js", function() {
 
   it("No update", async function() {
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    assert.equal(priceFeed.getHistoricalPrice(1000), undefined);
+    assert.equal(await priceFeed.getHistoricalPrice(1000), undefined);
     assert.equal(priceFeed.getLastUpdateTime(), undefined);
     assert.equal(priceFeed.getLookback(), lookback);
   });
@@ -154,19 +154,19 @@ contract("DominationFinancePriceFeed.js", function() {
 
     // Before period 1 should return null.
     assert.equal(earliestTick, historicalResponse.data.rows[0][0]);
-    assert.equal(priceFeed.getHistoricalPrice(earliestTick - 15), null);
+    assert.equal(await priceFeed.getHistoricalPrice(earliestTick - 15), null);
 
     // During period 1.
-    assert.equal(priceFeed.getHistoricalPrice(historicalResponse.data.rows[0][0] + 5).toString(), toWei("1.1"));
+    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[0][0] + 5).toString(), toWei("1.1"));
 
     // During period 2.
-    assert.equal(priceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5).toString(), toWei("1.2"));
+    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[1][0] + 5).toString(), toWei("1.2"));
 
     // During period 3.
-    assert.equal(priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5).toString(), toWei("1.3"));
+    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 5).toString(), toWei("1.3"));
 
     // After period 3 should return the most recent price.
-    assert.equal(priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 90).toString(), toWei("1.5"));
+    assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[2][0] + 90).toString(), toWei("1.5"));
   });
 
   it("Basic current price", async function() {
@@ -208,9 +208,9 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await invertedPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    assert.equal(priceFeed.getHistoricalPrice(earliestTick), undefined);
+    assert.equal(await priceFeed.getHistoricalPrice(earliestTick), undefined);
     assert.equal(invertedPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(invertedPriceFeed.getHistoricalPrice(earliestTick), undefined);
+    assert.equal(await invertedPriceFeed.getHistoricalPrice(earliestTick), undefined);
 
     // Bad historical ohlc response.
     networker.getJsonReturns = [
@@ -226,7 +226,7 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await priceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    assert.equal(priceFeed.getHistoricalPrice(earliestTick), undefined);
+    assert.equal(await priceFeed.getHistoricalPrice(earliestTick), undefined);
 
     // Inverted price feed returns undefined for prices equal to 0 since it cannot divide by 0
     networker.getJsonReturns = [
@@ -242,7 +242,7 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await invertedPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedPriceFeed.getCurrentPrice(), undefined);
-    assert.equal(invertedPriceFeed.getHistoricalPrice(earliestTick), undefined);
+    assert.equal(await invertedPriceFeed.getHistoricalPrice(earliestTick), undefined);
   });
 
   it("Update frequency", async function() {

--- a/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
@@ -92,10 +92,7 @@ contract("DominationFinancePriceFeed.js", function() {
 
     // Before period 1 should return fail.
     assert.equal(earliestTick, historicalResponse.data.rows[0][0]);
-    await invertedPriceFeed.getHistoricalPrice(earliestTick - 15).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await invertedPriceFeed.getHistoricalPrice(earliestTick - 15).catch(() => true));
 
     // During period 1.
     assert.equal(
@@ -144,10 +141,7 @@ contract("DominationFinancePriceFeed.js", function() {
 
   it("No update", async function() {
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    await priceFeed.getHistoricalPrice(1000).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await priceFeed.getHistoricalPrice(1000).catch(() => true));
     assert.equal(priceFeed.getLastUpdateTime(), undefined);
     assert.equal(priceFeed.getLookback(), lookback);
   });
@@ -160,10 +154,7 @@ contract("DominationFinancePriceFeed.js", function() {
 
     // Before period 1 should fail.
     assert.equal(earliestTick, historicalResponse.data.rows[0][0]);
-    await priceFeed.getHistoricalPrice(earliestTick - 15).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await priceFeed.getHistoricalPrice(earliestTick - 15).catch(() => true));
 
     // During period 1.
     assert.equal((await priceFeed.getHistoricalPrice(historicalResponse.data.rows[0][0] + 5)).toString(), toWei("1.1"));
@@ -220,15 +211,9 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await invertedPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    await priceFeed.getHistoricalPrice(earliestTick).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await priceFeed.getHistoricalPrice(earliestTick).catch(() => true));
     assert.equal(invertedPriceFeed.getCurrentPrice(), undefined);
-    await invertedPriceFeed.getHistoricalPrice(earliestTick).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await invertedPriceFeed.getHistoricalPrice(earliestTick).catch(() => true));
 
     // Bad historical ohlc response.
     networker.getJsonReturns = [
@@ -244,10 +229,7 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await priceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    await priceFeed.getHistoricalPrice(earliestTick).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await priceFeed.getHistoricalPrice(earliestTick).catch(() => true));
 
     // Inverted price feed returns undefined for prices equal to 0 since it cannot divide by 0
     networker.getJsonReturns = [
@@ -263,10 +245,7 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await invertedPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedPriceFeed.getCurrentPrice(), undefined);
-    await invertedPriceFeed.getHistoricalPrice(earliestTick).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await invertedPriceFeed.getHistoricalPrice(earliestTick).catch(() => true));
   });
 
   it("Update frequency", async function() {

--- a/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/DominationFinancePriceFeed.js
@@ -92,7 +92,10 @@ contract("DominationFinancePriceFeed.js", function() {
 
     // Before period 1 should return fail.
     assert.equal(earliestTick, historicalResponse.data.rows[0][0]);
-    await invertedPriceFeed.getHistoricalPrice(earliestTick - 15).then(() => assert.fail());
+    await invertedPriceFeed.getHistoricalPrice(earliestTick - 15).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // During period 1.
     assert.equal(
@@ -141,7 +144,10 @@ contract("DominationFinancePriceFeed.js", function() {
 
   it("No update", async function() {
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    await priceFeed.getHistoricalPrice(1000).then(() => assert.fail());
+    await priceFeed.getHistoricalPrice(1000).then(
+      () => assert.fail(),
+      () => {}
+    );
     assert.equal(priceFeed.getLastUpdateTime(), undefined);
     assert.equal(priceFeed.getLookback(), lookback);
   });
@@ -154,7 +160,10 @@ contract("DominationFinancePriceFeed.js", function() {
 
     // Before period 1 should fail.
     assert.equal(earliestTick, historicalResponse.data.rows[0][0]);
-    await priceFeed.getHistoricalPrice(earliestTick - 15).then(() => assert.fail());
+    await priceFeed.getHistoricalPrice(earliestTick - 15).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // During period 1.
     assert.equal(await priceFeed.getHistoricalPrice(historicalResponse.data.rows[0][0] + 5).toString(), toWei("1.1"));
@@ -208,9 +217,15 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await invertedPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    await priceFeed.getHistoricalPrice(earliestTick).then(() => assert.fail());
+    await priceFeed.getHistoricalPrice(earliestTick).then(
+      () => assert.fail(),
+      () => {}
+    );
     assert.equal(invertedPriceFeed.getCurrentPrice(), undefined);
-    await invertedPriceFeed.getHistoricalPrice(earliestTick).then(() => assert.fail());
+    await invertedPriceFeed.getHistoricalPrice(earliestTick).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // Bad historical ohlc response.
     networker.getJsonReturns = [
@@ -226,7 +241,10 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await priceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(priceFeed.getCurrentPrice(), undefined);
-    await priceFeed.getHistoricalPrice(earliestTick).then(() => assert.fail());
+    await priceFeed.getHistoricalPrice(earliestTick).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // Inverted price feed returns undefined for prices equal to 0 since it cannot divide by 0
     networker.getJsonReturns = [
@@ -242,7 +260,10 @@ contract("DominationFinancePriceFeed.js", function() {
     assert.isTrue(await invertedPriceFeed.update().catch(() => true), "Update didn't throw");
 
     assert.equal(invertedPriceFeed.getCurrentPrice(), undefined);
-    await invertedPriceFeed.getHistoricalPrice(earliestTick).then(() => assert.fail());
+    await invertedPriceFeed.getHistoricalPrice(earliestTick).then(
+      () => assert.fail(),
+      () => {}
+    );
   });
 
   it("Update frequency", async function() {

--- a/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -136,7 +136,10 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should throw since there was an undefined price output.
     const arbitraryHistoricalTimestamp = 1000;
-    await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).catch(() => assert.fail());
+    await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).then(
+      () => assert.fail(),
+      () => {}
+    );
 
     // Should return null since there was an undefined output.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), null);

--- a/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -136,10 +136,7 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should throw since there was an undefined price output.
     const arbitraryHistoricalTimestamp = 1000;
-    await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).then(
-      () => assert.fail(),
-      () => {}
-    );
+    assert.isTrue(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).catch(() => true));
 
     // Should return null since there was an undefined output.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), null);

--- a/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/MedianizerPriceFeed.js
@@ -29,7 +29,7 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should return the median historical price (because we're using mocks, the timestamp doesn't matter).
     const arbitraryHistoricalTimestamp = 1000;
-    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("25"));
+    assert.equal(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("25"));
 
     // Should return the *maximum* lastUpdatedTime.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), 50000);
@@ -51,7 +51,7 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should return the mean historical price (because we're using mocks, the timestamp doesn't matter).
     const arbitraryHistoricalTimestamp = 1000;
-    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("31"));
+    assert.equal(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("31"));
 
     // Should return the *maximum* lastUpdatedTime.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), 50000);
@@ -74,7 +74,7 @@ contract("MedianizerPriceFeed.js", function() {
     // Should return the average of 58 and 45 since there are an even number of elements.
     // Note: because we're using mocks, the timestamp doesn't matter.
     const arbitraryHistoricalTimestamp = 1000;
-    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("51.5"));
+    assert.equal(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("51.5"));
   });
 
   it("Even count means", async function() {
@@ -91,7 +91,7 @@ contract("MedianizerPriceFeed.js", function() {
     // Should return the mean, which is not neccessarily the average of 3 and 2.
     assert.equal(medianizerPriceFeed.getCurrentPrice(), toWei("2.5"));
     const arbitraryHistoricalTimestamp = 1000;
-    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("55"));
+    assert.equal(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("55"));
   });
 
   it("null inputs", async function() {
@@ -108,7 +108,7 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should return null since there was a null price output.
     const arbitraryHistoricalTimestamp = 1000;
-    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), null);
+    assert.equal(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), null);
 
     // Should return null since there was a null input.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), null);
@@ -128,7 +128,7 @@ contract("MedianizerPriceFeed.js", function() {
 
     // Should return null since there was an undefined price output.
     const arbitraryHistoricalTimestamp = 1000;
-    assert.equal(medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), null);
+    assert.equal(await medianizerPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), null);
 
     // Should return null since there was an undefined output.
     assert.equal(medianizerPriceFeed.getLastUpdateTime(), null);

--- a/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
@@ -206,19 +206,19 @@ contract("BalancerPriceFeed.js", function(accounts) {
     await dexPriceFeed.update();
 
     // The historical TWAP for 1 hour ago (the earliest allowed query) should be 100 for the first half and then 90 for the second half -> 95.
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 3600).toString(), toWei("95"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(), toWei("95"));
 
     // The historical TWAP for 45 mins ago should be 100 for the first quarter, 90 for the middle half, and 80 for the last quarter -> 90.
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 2700).toString(), toWei("90"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime - 2700)).toString(), toWei("90"));
 
     // The historical TWAP for 30 minutes ago should be 90 for the first half and then 80 for the second half -> 85.
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 1800).toString(), toWei("85"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime - 1800)).toString(), toWei("85"));
 
     // The historical TWAP for 15 minutes ago should be 90 for the first quarter, 80 for the middle half, and 70 for the last quarter -> 80.
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 900).toString(), toWei("80"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime - 900)).toString(), toWei("80"));
 
     // The historical TWAP for now should be 80 for the first half and then 70 for the second half -> 75.
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime).toString(), toWei("75"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime)).toString(), toWei("75"));
   });
 
   it("Historical time earlier than TWAP window", async function() {
@@ -231,8 +231,8 @@ contract("BalancerPriceFeed.js", function(accounts) {
     await dexPriceFeed.update();
 
     // The TWAP lookback is 1 hour (3600 seconds). The price feed should return null if we attempt to go any further back than that.
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 3599), toWei("1"));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 3601));
+    assert.equal(await dexPriceFeed.getHistoricalPrice(currentTime - 3599), toWei("1"));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 3601).catch(() => true));
   });
   it("TWAP length of 0 returns non-TWAP'd current and historical prices", async function() {
     dexPriceFeed = new BalancerPriceFeed(
@@ -262,8 +262,8 @@ contract("BalancerPriceFeed.js", function(accounts) {
     await dexPriceFeed.update();
 
     // Historical prices should be equal to latest price at timestamp
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 3600).toString(), toWei("80"));
-    assert.equal(dexPriceFeed.getHistoricalPrice(currentTime - 1800).toString(), toWei("70"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(), toWei("80"));
+    assert.equal((await dexPriceFeed.getHistoricalPrice(currentTime - 1800)).toString(), toWei("70"));
     assert.equal(dexPriceFeed.getCurrentPrice().toString(), toWei("70"));
     assert.equal(dexPriceFeed.getSpotPrice().toString(), toWei("70"));
   });
@@ -295,10 +295,10 @@ contract("BalancerPriceFeed.js", function(accounts) {
     await dexPriceFeed.update();
 
     // Historical prices should be equal to latest price at timestamp
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 3600));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 2700));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 1800));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 900));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 3600).catch(() => true));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 2700).catch(() => true));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 1800).catch(() => true));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 900).catch(() => true));
     assert.equal(dexPriceFeed.getCurrentPrice().toString(), toWei("70"));
     assert.equal(dexPriceFeed.getSpotPrice().toString(), toWei("70"));
   });
@@ -330,10 +330,10 @@ contract("BalancerPriceFeed.js", function(accounts) {
     await dexPriceFeed.update();
 
     // Historical prices should be equal to latest price at timestamp
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 3600));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 2700));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 1800));
-    assert.throws(() => dexPriceFeed.getHistoricalPrice(currentTime - 900));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 3600).catch(() => true));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 2700).catch(() => true));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 1800).catch(() => true));
+    assert.isTrue(await dexPriceFeed.getHistoricalPrice(currentTime - 900).catch(() => true));
     assert.equal(dexPriceFeed.getCurrentPrice().toString(), toWei("70"));
     assert.equal(dexPriceFeed.getSpotPrice().toString(), toWei("70"));
   });
@@ -438,13 +438,13 @@ contract("BalancerPriceFeed.js", function(accounts) {
 
       // The historical TWAP for 1 hour ago (the earliest allowed query) should be 100 for the first half and then 90 for the second half -> 95.
       assert.equal(
-        await scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        (await scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(),
         toBN(toWei("95"))
           .muln(10 ** 6)
           .toString()
       );
       assert.equal(
-        await scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        (await scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(),
         toBN(toWei("95"))
           .divn(10 ** 2)
           .toString()

--- a/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/BalancerPriceFeed.js
@@ -408,13 +408,13 @@ contract("BalancerPriceFeed.js", function(accounts) {
 
       // The historical TWAP for 1 hour ago (the earliest allowed query) should be 100 for the first half and then 90 for the second half -> 95.
       assert.equal(
-        scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        await scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
         toBN(toWei("95"))
           .muln(10 ** 6)
           .toString()
       );
       assert.equal(
-        scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        await scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
         toBN(toWei("95"))
           .divn(10 ** 2)
           .toString()

--- a/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
@@ -362,13 +362,13 @@ contract("UniswapPriceFeed.js", function(accounts) {
 
       // The historical TWAP for 1 hour ago (the earliest allowed query) should be 100 for the first half and then 90 for the second half -> 95.
       assert.equal(
-        scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        await scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
         toBN(toWei("95"))
           .muln(10 ** 6)
           .toString()
       );
       assert.equal(
-        scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        await scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
         toBN(toWei("95"))
           .divn(10 ** 2)
           .toString()

--- a/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/test/truffle/UniswapPriceFeed.js
@@ -249,19 +249,19 @@ contract("UniswapPriceFeed.js", function(accounts) {
     await uniswapPriceFeed.update();
 
     // The historical TWAP for 1 hour ago (the earliest allowed query) should be 100 for the first half and then 90 for the second half -> 95.
-    assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime - 3600).toString(), toWei("95"));
+    assert.equal((await uniswapPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(), toWei("95"));
 
     // The historical TWAP for 45 mins ago should be 100 for the first quarter, 90 for the middle half, and 80 for the last quarter -> 90.
-    assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime - 2700).toString(), toWei("90"));
+    assert.equal((await uniswapPriceFeed.getHistoricalPrice(currentTime - 2700)).toString(), toWei("90"));
 
     // The historical TWAP for 30 minutes ago should be 90 for the first half and then 80 for the second half -> 85.
-    assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime - 1800).toString(), toWei("85"));
+    assert.equal((await uniswapPriceFeed.getHistoricalPrice(currentTime - 1800)).toString(), toWei("85"));
 
     // The historical TWAP for 15 minutes ago should be 90 for the first quarter, 80 for the middle half, and 70 for the last quarter -> 80.
-    assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime - 900).toString(), toWei("80"));
+    assert.equal((await uniswapPriceFeed.getHistoricalPrice(currentTime - 900)).toString(), toWei("80"));
 
     // The historical TWAP for now should be 80 for the first half and then 70 for the second half -> 75.
-    assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime).toString(), toWei("75"));
+    assert.equal((await uniswapPriceFeed.getHistoricalPrice(currentTime)).toString(), toWei("75"));
   });
 
   it("Historical time earlier than TWAP window", async function() {
@@ -279,8 +279,8 @@ contract("UniswapPriceFeed.js", function(accounts) {
     await uniswapPriceFeed.update();
 
     // The TWAP lookback is 1 hour (3600 seconds). The price feed should throw if we attempt to go any further back than that.
-    assert.equal(uniswapPriceFeed.getHistoricalPrice(currentTime - 3599), toWei("1"));
-    assert.throws(() => uniswapPriceFeed.getHistoricalPrice(currentTime - 3601));
+    assert.equal(await uniswapPriceFeed.getHistoricalPrice(currentTime - 3599), toWei("1"));
+    assert.isTrue(await uniswapPriceFeed.getHistoricalPrice(currentTime - 3601).catch(() => true));
   });
 
   it("Invert price", async function() {
@@ -417,13 +417,13 @@ contract("UniswapPriceFeed.js", function(accounts) {
 
       // The historical TWAP for 1 hour ago (the earliest allowed query) should be 100 for the first half and then 90 for the second half -> 95.
       assert.equal(
-        await scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        (await scaleUpPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(),
         toBN(toWei("95"))
           .muln(10 ** 6)
           .toString()
       );
       assert.equal(
-        await scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600).toString(),
+        (await scaleDownPriceFeed.getHistoricalPrice(currentTime - 3600)).toString(),
         toBN(toWei("95"))
           .divn(10 ** 2)
           .toString()

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -223,7 +223,7 @@ class ContractMonitor {
         continue;
       }
 
-      const price = this.priceFeed.getHistoricalPrice(parseInt(liquidationTime.toString()));
+      const price = await this.priceFeed.getHistoricalPrice(parseInt(liquidationTime.toString()));
       let collateralizationString;
       let maxPriceToBeDisputableString;
       const crRequirement = await this.empContract.methods.collateralRequirement().call();

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -287,7 +287,7 @@ class SyntheticPegMonitor {
     // Get all historical prices from `volatilityWindow` seconds before the last update time and
     // record the minimum and maximum.
     const latestTime = pricefeed.getLastUpdateTime();
-    const volData = this._calculateHistoricalVolatility(pricefeed, latestTime, this.volatilityWindow);
+    const volData = await this._calculateHistoricalVolatility(pricefeed, latestTime, this.volatilityWindow);
     if (!volData) {
       return {
         errorData: {
@@ -299,7 +299,7 @@ class SyntheticPegMonitor {
     // @dev: This is not `getCurrentTime` in order to enforce that the volatility calculation is counting back from
     // precisely the same timestamp as the "latest price". This would prevent inaccurate volatility readings where
     // `currentTime` differs from `lastUpdateTime`.
-    const pricefeedLatestPrice = pricefeed.getHistoricalPrice(latestTime);
+    const pricefeedLatestPrice = await pricefeed.getHistoricalPrice(latestTime);
 
     return {
       pricefeedVolatility: volData.volatility,
@@ -324,7 +324,7 @@ class SyntheticPegMonitor {
 
   // Find difference between minimum and maximum prices for given pricefeed from `lookback` seconds in the past
   // until `mostRecentTime`. Returns volatility as (max - min)/min %. Also Identifies the direction volatility movement.
-  _calculateHistoricalVolatility(pricefeed, mostRecentTime, lookback) {
+  async _calculateHistoricalVolatility(pricefeed, mostRecentTime, lookback) {
     let min, max;
 
     // Store the timestamp of the max and min value to infer the direction of the movement over the interval.
@@ -333,7 +333,7 @@ class SyntheticPegMonitor {
     // Iterate over all time series values to fine the maximum and minimum values.
     for (let i = 0; i < lookback; i++) {
       const timestamp = mostRecentTime - i;
-      const _price = pricefeed.getHistoricalPrice(timestamp);
+      const _price = await pricefeed.getHistoricalPrice(timestamp);
       if (!_price) {
         continue;
       }

--- a/packages/monitors/test/SyntheticPegMonitor.js
+++ b/packages/monitors/test/SyntheticPegMonitor.js
@@ -262,9 +262,9 @@ contract("SyntheticPegMonitor", function() {
           // and the volatility should be (3 / 10 = 0.3) or 30%. Note that the output is scaled according to toWei (1e18).// This is because a volitility is a unitless number and is scaled independently of the price scalling.
           medianizerPriceFeedMock.setLastUpdateTime(103);
           assert.equal(
-            syntheticPegMonitor
-              ._calculateHistoricalVolatility(medianizerPriceFeedMock, 103, volatilityWindow)
-              .volatility.toString(),
+            (
+              await syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 103, volatilityWindow)
+            ).volatility.toString(),
             toBN(toWei("0.3")).toString()
           );
 
@@ -273,9 +273,9 @@ contract("SyntheticPegMonitor", function() {
           // and the volatility should be 0%.
           medianizerPriceFeedMock.setLastUpdateTime(100);
           assert.equal(
-            syntheticPegMonitor
-              ._calculateHistoricalVolatility(medianizerPriceFeedMock, 100, volatilityWindow)
-              .volatility.toString(),
+            (
+              await syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 100, volatilityWindow)
+            ).volatility.toString(),
             "0"
           );
 
@@ -291,9 +291,9 @@ contract("SyntheticPegMonitor", function() {
           // and the volatility should be (4 / 12 = 0.3333) or 33%.
           medianizerPriceFeedMock.setLastUpdateTime(107);
           assert.equal(
-            syntheticPegMonitor
-              ._calculateHistoricalVolatility(medianizerPriceFeedMock, 106, volatilityWindow)
-              .volatility.toString(),
+            (
+              await syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 106, volatilityWindow)
+            ).volatility.toString(),
             toBN(toWei("0.333333333333333333")).toString() // 18 3's is max that can be represented with Wei.
           );
         });

--- a/packages/monitors/test/SyntheticPegMonitor.js
+++ b/packages/monitors/test/SyntheticPegMonitor.js
@@ -282,8 +282,10 @@ contract("SyntheticPegMonitor", function() {
           // Test when volatility window captures only one historical price. The last update time is 200,
           // so this should read the volatility from no timestamps. This should throw.
           medianizerPriceFeedMock.setLastUpdateTime(200);
-          assert.throws(() =>
-            syntheticPegMonitor._calculateHistoricalVolatility(medianizerPriceFeedMock, 200, volatilityWindow)
+          assert.isTrue(
+            await syntheticPegMonitor
+              ._calculateHistoricalVolatility(medianizerPriceFeedMock, 200, volatilityWindow)
+              .catch(() => true)
           );
 
           // Test when volatility window is smaller than the amount of historical prices. The last update time is 106,


### PR DESCRIPTION
**Motivation**

Some price feeds cannot do a full 2 hour lookup during `update()` as it would be too inefficient.

**Summary**

Make the standard `getHistoricalPrice` fn async.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
