### PR TITLE
improve(disputer): improve how pricefeed clients pass through errors

### DIFF
--- a/packages/disputer/test/Disputer.js
+++ b/packages/disputer/test/Disputer.js
@@ -267,8 +267,8 @@ contract("Disputer.js", function(accounts) {
         const earliestLiquidationTime = Number(empClient.getUndisputedLiquidations()[0].liquidationTime);
         priceFeedMock.setLastUpdateTime(earliestLiquidationTime);
         await disputer.dispute();
-        assert.equal(spy.callCount, 3); // 3 warn level logs should be sent for 3 missing prices
-        assert.equal(spy.getCall(-1).lastArg.error, "PriceFeedMock expected error thrown");
+        assert.equal(spy.callCount, 3); // 3 error level logs should be sent for 3 missing prices
+        assert.ok(spy.getCall(-1).lastArg.error); // error param should not be undefined.
 
         // Start with a mocked price of 1.75 usd per token.
         // This makes all sponsors undercollateralized, meaning no disputes are issued.

--- a/packages/financial-templates-lib/src/logger/Logger.js
+++ b/packages/financial-templates-lib/src/logger/Logger.js
@@ -42,9 +42,23 @@ async function waitForLogger(logger) {
 // If the log entry contains an error then extract the stack trace as the error message.
 function errorStackTracerFormatter(logEntry) {
   if (logEntry.error) {
-    logEntry.error = logEntry.error.stack;
+    logEntry.error = handleRecursiveErrorArray(logEntry.error);
   }
   return logEntry;
+}
+
+// Handle case where `error` is an array of errors and we want to display all
+// of the error stacks recursively. i.e. `error` is in the shape:
+// [[Error, Error], [Error], [Error, Error]]
+function handleRecursiveErrorArray(error) {
+  // If error has a `stack` param, then no need to recurse anymore:
+  if (error.stack) return error.stack;
+
+  let results = [];
+  error.forEach(_error => {
+    results.push(handleRecursiveErrorArray(_error));
+  });
+  return results;
 }
 
 // This formatter checks if the `BOT_IDENTIFIER` env variable is present. If it is, the name is appended to the message.

--- a/packages/financial-templates-lib/src/logger/Logger.js
+++ b/packages/financial-templates-lib/src/logger/Logger.js
@@ -51,14 +51,10 @@ function errorStackTracerFormatter(logEntry) {
 // of the error stacks recursively. i.e. `error` is in the shape:
 // [[Error, Error], [Error], [Error, Error]]
 function handleRecursiveErrorArray(error) {
-  // If error has a `stack` param, then no need to recurse anymore:
-  if (error.stack) return error.stack;
-
-  let results = [];
-  error.forEach(_error => {
-    results.push(handleRecursiveErrorArray(_error));
-  });
-  return results;
+  // If error is not an array, then just return the stack for there is no need to recurse further.
+  if (!Array.isArray(error)) return error.stack;
+  // Recursively add all errors to an array and flatten the output.
+  return error.map(handleRecursiveErrorArray).flat();
 }
 
 // This formatter checks if the `BOT_IDENTIFIER` env variable is present. If it is, the name is appended to the message.

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -188,7 +188,6 @@ class SyntheticPegMonitor {
       this.logger.warn({
         at: "SyntheticPegMonitor",
         message: "Unable to get volatility data, missing historical price data",
-        pricefeed: "Medianizer",
         error,
         lookback: this.volatilityWindow
       });
@@ -243,7 +242,6 @@ class SyntheticPegMonitor {
       this.logger.warn({
         at: "SyntheticPegMonitor",
         message: "Unable to get volatility data, missing historical price data",
-        pricefeed: "Uniswap",
         error,
         lookback: this.volatilityWindow
       });

--- a/packages/monitors/test/SyntheticPegMonitor.js
+++ b/packages/monitors/test/SyntheticPegMonitor.js
@@ -393,15 +393,13 @@ contract("SyntheticPegMonitor", function() {
 
           await syntheticPegMonitor.checkPegVolatility();
           assert.isTrue(lastSpyLogIncludes(spy, "missing historical price data"));
-          assert.isTrue(lastSpyLogIncludes(spy, "999")); // historical time for which we cannot retrieve price data for
           assert.isTrue(lastSpyLogIncludes(spy, "600")); // lookback window for which we cannot retrieve price data for
-          assert.isTrue(lastSpyLogIncludes(spy, "InvalidPriceFeedMock: expected missing historical price")); // Additional historical pricefeed logs sent
+          assert.ok(spy.getCall(-1).lastArg.error); // error logs should not be undefined.
 
           await syntheticPegMonitor.checkSyntheticVolatility();
           assert.isTrue(lastSpyLogIncludes(spy, "missing historical price data"));
-          assert.isTrue(lastSpyLogIncludes(spy, "999")); // historical time for which we cannot retrieve price data for
           assert.isTrue(lastSpyLogIncludes(spy, "600")); // lookback window for which we cannot retrieve price data for
-          assert.isTrue(lastSpyLogIncludes(spy, "InvalidPriceFeedMock: expected missing historical price")); // Additional historical pricefeed logs sent
+          assert.ok(spy.getCall(-1).lastArg.error); // error logs should not be undefined.
         });
 
         it("Stress testing with a lot of historical price data points", async function() {


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

- The `Disputer` unneccessarily computes `getHistoricalPrice()` twice, the second time it fails to check for errors. This PR refactors the disputer logic so that it caches the result of the first and only `getHistoricalPrice()` call
- The `SyntheticPegMonitor` handles errors from the pricefeed in an unncessarily complex manner. The other pricefeed clients all just send the `Error` object to the logger, which has error-parsing logic. This PR simplifies how this monitor reports errors.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
