### PR TITLE
improve(pricefeed): Add getHistoricalPricePeriods to BasketSpread and Uniswap

### DIFF
--- a/packages/affiliates/libs/affiliates/devmining.js
+++ b/packages/affiliates/libs/affiliates/devmining.js
@@ -87,25 +87,14 @@ module.exports = ({ queries, empAbi, coingecko, synthPrices, firstEmpDate }) => 
     }
   }
 
-  function decodeMedianizerPrice(input) {
+  // Need to convert seconds to MS
+  function decodePrice(input) {
     return [input[0] * 1000, input[1]];
-  }
-  function decodeOtherPrice(input) {
-    return [input.closeTime * 1000, input.closePrice.toString()];
-  }
-  function isMedianizerPrice(input) {
-    return input.length === 2;
   }
   // Gets the value of synthetics in collateral currency.
   async function getSyntheticPriceHistory(address, start, end) {
     const result = await synthPrices.getHistoricSynthPrices(address, start, end);
-    // Turns out getHistoricPriceFeed differs between price feed classes.
-    // This needs to be fixed but for now we will detect it and switch between decodings.
-    // TODO: Fix this behavior, see issue #2461
-    const fixedPrices = result.map(price => {
-      if (isMedianizerPrice(price)) return decodeMedianizerPrice(price);
-      return decodeOtherPrice(price);
-    });
+    const fixedPrices = result.map(decodePrice);
     return Prices(fixedPrices);
   }
 

--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -135,7 +135,9 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
       return this._getSpreadFromBasketPrices(experimentalPrices, baselinePrices, denominatorPrice);
     }
   }
-  // This searches for closest time in a list of [time,price] data. Based on code in affiliates models/prices.
+  // This searches for closest time in a list of [[time,price]] data. Based on code in affiliates models/prices.
+  // input list is [[time,price]]
+  // output price as BN
   closestTime(list) {
     return time => {
       const result = list.reduce((a, b) => {
@@ -178,7 +180,7 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
       // Each parameter looks up and returns the closest price to the timestamp.
       const expPrices = experimentalPrices.map(lookup => lookup(time));
       const basePrices = baselinePrices.map(lookup => lookup(time));
-      const denomPrices = denominatorPrice ? denominatorPrice.map(lookup => lookup(time)) : null;
+      const denomPrices = denominatorPrice ? denominatorPrice(time) : null;
 
       // Takes in an array of prices for each basket and returns a single price
       return [time, this._getSpreadFromBasketPrices(expPrices, basePrices, denomPrices)];

--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -1,5 +1,6 @@
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 const { parseFixed } = require("@ethersproject/bignumber");
+const assert = require("assert");
 
 // An implementation of PriceFeedInterface that takes as input two sets ("baskets") of price feeds,
 // computes the average price feed for each basket, and returns the spread between the two averages.
@@ -134,28 +135,55 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
       return this._getSpreadFromBasketPrices(experimentalPrices, baselinePrices, denominatorPrice);
     }
   }
+  // This searches for closest time in a list of [time,price] data. Based on code in affiliates models/prices.
+  closestTime(list) {
+    return time => {
+      const result = list.reduce((a, b) => {
+        const aDiff = Math.abs(a[0] - time);
+        const bDiff = Math.abs(b[0] - time);
 
-  // Note: This method will arbitrarily fail if the first baseline pricefeed has not implemented `getHistoricalPricePeriods`
+        // if differences are equal, return larger? timestamp
+        if (aDiff == bDiff) {
+          return a < b ? a : b;
+        }
+        // if diffs are diff, return smallest diff
+        return bDiff < aDiff ? b : a;
+      });
+      assert(result, "no closest time found");
+      return this.toBN(result[1]);
+    };
+  }
+  // This function does something similar to get historicalprice, but does not have the luxury of only caring about a
+  // single point in time. It has to run the basketspread price across all timestamps available. This is complicated
+  // as there are multiple price histories which we must search through at each matching timestamp to find the closets
+  // prices to add into the basket calculation.
+  // Returns data in the form of [[time,price]]
   getHistoricalPricePeriods() {
-    // Arbitrarily use the first baseline pricefeed's price periods as the index for price periods to return.
-    // This function is hacky and makes an assumption that the baseline pricefeed is a Medianizer and therefore
-    // returns price periods as [time, price].
-    const pricePeriods = this.baselinePriceFeeds[0].getHistoricalPricePeriods();
+    const experimentalPrices = this.experimentalPriceFeeds.map(priceFeed => {
+      // This price history gets wrapped in "closestTime" which returns a searching function with timestamp input.
+      return this.closestTime(priceFeed.getHistoricalPricePeriods());
+    });
+    const baselinePrices = this.baselinePriceFeeds.map(priceFeed => {
+      return this.closestTime(priceFeed.getHistoricalPricePeriods());
+    });
+    let denominatorPrice;
+    if (this.denominatorPriceFeed) {
+      denominatorPrice = this.closestTime(this.denominatorPriceFeed.getHistoricalPricePeriods());
+    }
 
-    return pricePeriods.map(_pricePeriod => {
-      let timestamp = _pricePeriod[0];
-      // If we can fetch historical price for this timestamp we'll add it to the price periods array.
-      this.getHistoricalPrice(timestamp)
-        .then(price => {
-          // Add [time, price] entry to price periods array
-          return [timestamp, price];
-        })
-        .catch(() => {
-          // Ignore errors
-        });
+    // This uses the first baseline price feed as a reference for the historical timestamps to search for
+    const pricePeriods = this.baselinePriceFeeds[0].getHistoricalPricePeriods();
+    return pricePeriods.map(pricePeriod => {
+      const [time] = pricePeriod;
+      // Each parameter looks up and returns the closest price to the timestamp.
+      const expPrices = experimentalPrices.map(lookup => lookup(time));
+      const basePrices = baselinePrices.map(lookup => lookup(time));
+      const denomPrices = denominatorPrice ? denominatorPrice.map(lookup => lookup(time)) : null;
+
+      // Takes in an array of prices for each basket and returns a single price
+      return [time, this._getSpreadFromBasketPrices(expPrices, basePrices, denomPrices)];
     });
   }
-
   // Gets the *most recent* update time for all constituent price feeds.
   getLastUpdateTime() {
     const lastUpdateTimes = this.allPriceFeeds.map(priceFeed => priceFeed.getLastUpdateTime());

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -136,17 +136,15 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   }
 
   getHistoricalPricePeriods() {
-    if (!this.invertPrice) return this.historicalPricePeriods;
+    if (!this.invertPrice)
+      return this.historicalPricePeriods.map(historicalPrice => {
+        return [historicalPrice.closeTime, historicalPrice.closePrice];
+      });
     else
       return this.historicalPricePeriods.map(historicalPrice => {
-        return {
-          ...historicalPrice,
-          openPrice: this._invertPriceSafely(historicalPrice.openPrice),
-          closePrice: this._invertPriceSafely(historicalPrice.closePrice)
-        };
+        return [historicalPrice.closeTime, this._invertPriceSafely(historicalPrice.closePrice)];
       });
   }
-
   getLastUpdateTime() {
     return this.lastUpdateTime;
   }

--- a/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
@@ -131,13 +131,10 @@ class DominationFinancePriceFeed extends PriceFeedInterface {
   }
 
   getHistoricalPricePeriods() {
-    if (!this.invertPrice) return this.historicalPricePeriods;
+    if (!this.invertPrice) return this.historicalPricePeriods.map(x => [x.closeTime, x.closePrice]);
     else
       return this.historicalPricePeriods.map(historicalPrice => {
-        return {
-          ...historicalPrice,
-          closePrice: this._invertPriceSafely(historicalPrice.closePrice)
-        };
+        return [historicalPrice.closeTime, this._invertPriceSafely(historicalPrice.closePrice)];
       });
   }
 

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -72,6 +72,15 @@ class UniswapPriceFeed extends PriceFeedInterface {
     }
   }
 
+  getHistoricalPricePeriods() {
+    return this.events.map(event => {
+      return [
+        event.timestamp, // time
+        event.price
+      ];
+    });
+  }
+
   getLastUpdateTime() {
     return this.lastUpdateTime;
   }

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -12,7 +12,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
    * @param {Object} web3 Provider from Truffle instance to connect to Ethereum network.
    * @param {String} uniswapAddress Ethereum address of the Uniswap market the price feed is monitoring.
    * @param {Integer} twapLength Duration of the time weighted average computation used by the price feed.
-   * @param {Integer} historicalLookback How far in the past historical prices will be available using await  getHistoricalPrice.
+   * @param {Integer} historicalLookback How far in the past historical prices will be available using getHistoricalPrice.
    * @param {Function} getTime Returns the current time.
    * @param {Bool} invertPrice Indicates if the Uniswap pair is computed as reserve0/reserve1 (true) or
    * @param {Integer} priceFeedDecimals Precision that the caller wants precision to be reported in
@@ -58,7 +58,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
     return this.currentTwap && this.convertToPriceFeedDecimals(this.currentTwap);
   }
 
-  async getHistoricalPrice(time) {
+  getHistoricalPrice(time) {
     if (time < this.lastUpdateTime - this.historicalLookback) {
       // Requesting an historical TWAP earlier than the lookback.
       throw new Error(`${this.uuid} time ${time} is earlier than TWAP window`);
@@ -72,12 +72,12 @@ class UniswapPriceFeed extends PriceFeedInterface {
     }
   }
 
+  // This function does not return the same type of price data as getHistoricalPrice. It returns the raw
+  // price history from uniswap without a twap. This is by choice, since a twap calculation across the entire
+  // history is 1. complicated and 2. unecessary as this function is only needed for affliate calculations.
   getHistoricalPricePeriods() {
     return this.events.map(event => {
-      return [
-        event.timestamp, // time
-        event.price
-      ];
+      return [event.timestamp, this.convertToPriceFeedDecimals(event.price)];
     });
   }
 

--- a/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js
@@ -58,7 +58,7 @@ class UniswapPriceFeed extends PriceFeedInterface {
     return this.currentTwap && this.convertToPriceFeedDecimals(this.currentTwap);
   }
 
-  getHistoricalPrice(time) {
+  async getHistoricalPrice(time) {
     if (time < this.lastUpdateTime - this.historicalLookback) {
       // Requesting an historical TWAP earlier than the lookback.
       throw new Error(`${this.uuid} time ${time} is earlier than TWAP window`);


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Part of #2461


**Summary**

Implements `getHistoricalPricePeriods() => [time, price]` for Uniswap and BasketSpread price feeds.

**Testing**

TODO: Does this work for `affiliates`?

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

