### PR TITLE
fix(FindContractVersion): address inconsistent provider behavior

### DIFF
--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -22,10 +22,7 @@ async function findContractVersion(contractAddress, web3) {
   } else {
     // This is run literally anywhere else.
     const providers = require("ethers").providers;
-    const { getNodeUrl } = require("./TruffleConfig");
-    const argv = require("minimist")(process.argv.slice());
-
-    const provider = new providers.JsonRpcProvider(getNodeUrl(argv.network));
+    const provider = new providers.Web3Provider(web3.currentProvider);
     contractCode = await provider.getCode(contractAddress);
   }
 


### PR DESCRIPTION
**Motivation**

`FindContractVersion.js` depends on ethers.js. The previous implementation only worked with `http` and `https` web3 providers and not `wss` ones. This means that the script broke in production, where we use WebSockets. 

This PR changes the implementation to rely on the existing web3 provider with the ethers `Web3Provider` provider.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
