### PR TITLE
fix(WDF): add warning if wdf threshold is more than token balance

### DIFF
--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -265,7 +265,7 @@ async function run({
     // Create a execution loop that will run indefinitely (or yield early if in serverless mode)
     for (;;) {
       // Check if EMP expired before running current iteration.
-      let isExpiredOrShutdown = await checkIsExpiredOrShutdownPromise();
+      const isExpiredOrShutdown = await checkIsExpiredOrShutdownPromise();
 
       await retry(
         async () => {

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -213,6 +213,20 @@ class Liquidator {
       at: "Liquidator",
       message: "Checking for liquidatable positions and preforming liquidations"
     });
+    if (
+      maxTokensToLiquidateWei &&
+      this.whaleDefenseFundWei &&
+      this.toBN(this.whaleDefenseFundWei).gte(this.toBN(maxTokensToLiquidateWei))
+    ) {
+      this.logger.info({
+        at: "Liquidator",
+        message:
+          "The whale defense fund reserve amount is greater than the liquidators synthetic balance. This might result in unintended consequences. Consider changing this param or adding more synthetics.",
+        botTokenBalance: maxTokensToLiquidateWei.toString(),
+        whaleDefenseFundWei: this.whaleDefenseFundWei.toString()
+      });
+    }
+
     // If an override is provided, use that price. Else, get the latest price from the price feed.
     const price = liquidatorOverridePrice
       ? this.toBN(liquidatorOverridePrice.toString())
@@ -294,9 +308,8 @@ class Liquidator {
         inputPrice: scaledPrice.toString()
       });
 
-      // we couldnt liquidate, this typically would only happen if our balance is 0 or the withdrawal liveness
-      // has not passed the WDF's activation threshold.
-      // This gets logged as an event, see constructor
+      // We couldnt liquidate, this typically would only happen if our balance is 0 or the withdrawal liveness
+      // has not passed the WDF's activation threshold. This gets logged as an event, see constructor.
       if (!liquidationArgs) {
         // If WDF is active but liveness hasn't passed activation %, then send customized log:
         if (

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -221,7 +221,7 @@ class Liquidator {
       this.logger.info({
         at: "Liquidator",
         message:
-          "The whale defense fund reserve amount is greater than the liquidators synthetic balance. This might result in unintended consequences. Consider changing this param or adding more synthetics.",
+          "The whale defense fund reserve amount is greater than the liquidators synthetic balance. This might result in skipped liquidations. Consider reducing this threshold or adding more synthetics.",
         botTokenBalance: maxTokensToLiquidateWei.toString(),
         whaleDefenseFundWei: this.whaleDefenseFundWei.toString()
       });


### PR DESCRIPTION

**Motivation**

The WDF can behave in unexpected ways if the threshold is set to more than the total number of synthetics the bot is holding. This should warn the bot operator.

**Summary**

Added some branching logic to send an `info` alert if the synthetic balance of the bot is less than the whale defense fund amount.


**Details**

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
