### PR TITLE
improve(liquidator): Ignore WDF if no withdrawal request to extend

### DIFF
--- a/packages/liquidator/mocha-test/liquidationStrategy.js
+++ b/packages/liquidator/mocha-test/liquidationStrategy.js
@@ -81,9 +81,10 @@ describe("LiquidatorStrategy", () => {
     let result = strat.utils.calculateTokensToLiquidate({
       syntheticTokenBalance: 100,
       positionTokens: 10,
-      maxTokensToLiquidateWei: "1000"
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: true
     });
-    // should respsect position size
+    // should respect position size
     assert.equal(result.toString(), "10");
 
     strat = Strategy(
@@ -97,10 +98,22 @@ describe("LiquidatorStrategy", () => {
       syntheticTokenBalance: 100,
       positionTokens: 10,
       whaleDefenseFundWei: 95,
-      maxTokensToLiquidateWei: "1000"
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: true
     });
-    // should respsect emp min sponsor size
+    // should respect emp min sponsor size
     assert.equal(result.toString(), "0");
+
+    // If you set `withdrawRequestPending` to false, then the `whaleDefenseFundWei` is ignored
+    // and the max balance is used (taking into consideration min sponsor size)
+    result = strat.utils.calculateTokensToLiquidate({
+      syntheticTokenBalance: 100,
+      positionTokens: 10,
+      whaleDefenseFundWei: 95,
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: false
+    });
+    assert.equal(result.toString(), "10");
 
     strat = Strategy(
       {
@@ -114,7 +127,8 @@ describe("LiquidatorStrategy", () => {
       syntheticTokenBalance: 100,
       positionTokens: 50,
       whaleDefenseFundWei: 60,
-      maxTokensToLiquidateWei: "1000"
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: true
     });
     // should respsect wdf reserve value
     assert.equal(result.toString(), "40");
@@ -122,7 +136,8 @@ describe("LiquidatorStrategy", () => {
     result = strat.utils.calculateTokensToLiquidate({
       syntheticTokenBalance: 8,
       positionTokens: 10,
-      maxTokensToLiquidateWei: "1000"
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: true
     });
     // should respsect emp min sponsor size
     assert.equal(result.toString(), "0");
@@ -139,7 +154,8 @@ describe("LiquidatorStrategy", () => {
     result = strat.utils.calculateTokensToLiquidate({
       syntheticTokenBalance: 100,
       positionTokens: 1000,
-      maxTokensToLiquidateWei: "1000"
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: true
     });
     // should respect our balance and whale defense fund
     assert.equal(result.toString(), "5");
@@ -156,7 +172,8 @@ describe("LiquidatorStrategy", () => {
     result = strat.utils.calculateTokensToLiquidate({
       syntheticTokenBalance: 100,
       positionTokens: 101,
-      maxTokensToLiquidateWei: "1000"
+      maxTokensToLiquidateWei: "1000",
+      withdrawRequestPending: true
     });
     // should respsect empminsponsor size
     assert.equal(result.toString(), "1");
@@ -164,7 +181,8 @@ describe("LiquidatorStrategy", () => {
     result = strat.utils.calculateTokensToLiquidate({
       syntheticTokenBalance: 1000,
       positionTokens: 10000,
-      maxTokensToLiquidateWei: "100"
+      maxTokensToLiquidateWei: "100",
+      withdrawRequestPending: true
     });
     // should respect max to liquidate
     assert.equal(result.toString(), "100");

--- a/packages/liquidator/src/liquidationStrategy.js
+++ b/packages/liquidator/src/liquidationStrategy.js
@@ -142,9 +142,8 @@ module.exports = (
     assert(currentBlockTime >= 0, "requires currentBlockTime");
     assert(position, "requires position");
 
-    // whale fund enabled AND withdrawal request is still live and therefore can be extended
-    let withdrawRequestPending = hasWithdrawRequestPending({ position, currentBlockTime });
-    if (whaleDefenseFundWei && toBN(whaleDefenseFundWei).gt(toBN("0")) && withdrawRequestPending) {
+    // whale fund enabled, check if withdraw liveness can be extended with a min liquidation
+    if (whaleDefenseFundWei && toBN(whaleDefenseFundWei).gt(toBN("0"))) {
       // we should only liquidate the minimum here to extend withdraw
       if (
         shouldLiquidateMinimum({
@@ -176,12 +175,12 @@ module.exports = (
       }
     }
 
-    // calculate tokens to liquidate respecting all constraints
+    // WDF strategy not activated, calculate tokens to liquidate respecting all constraints
     const tokensToLiquidate = calculateTokensToLiquidate({
       syntheticTokenBalance,
       positionTokens: position.numTokens,
       maxTokensToLiquidateWei,
-      withdrawRequestPending
+      withdrawRequestPending: hasWithdrawRequestPending({ position, currentBlockTime })
     });
 
     // check if we should try to liquidate this position

--- a/packages/liquidator/src/liquidationStrategy.js
+++ b/packages/liquidator/src/liquidationStrategy.js
@@ -105,12 +105,6 @@ module.exports = (
     // Available capital calculates the max we can currently spend.
     // If there is NO withdrawal request pending (or the request has expired liveness), then
     // we'll ignore the WDF constraint and just liquidate with max funds.
-    // let availableCapital;
-    if (withdrawRequestPending) {
-      //   availableCapital = BN.max(toBN(0), syntheticTokenBalance.sub(toBN(whaleDefenseFundWei)))
-    } else {
-      //   availableCapital = syntheticTokenBalance
-    }
     let availableCapital = withdrawRequestPending
       ? BN.max(toBN(0), syntheticTokenBalance.sub(toBN(whaleDefenseFundWei)))
       : syntheticTokenBalance;

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -298,7 +298,8 @@ class Liquidator {
       // has not passed the WDF's activation threshold.
       // This gets logged as an event, see constructor
       if (!liquidationArgs) {
-        // If WDF is active but liveness hasn't passed activation %, then send customized log:
+        // If WDF is active, withdrawal request is active but has NOT expired yet,
+        // and liveness hasn't passed activation % then send customized log:
         if (
           this.defenseActivationPercent &&
           !this.liquidationStrategy.utils.passedDefenseActivationPercent({ position, currentBlockTime })
@@ -328,12 +329,11 @@ class Liquidator {
           });
           continue;
         }
-        // the bot cannot liquidate the full position size, but the full position size is at the minimum sponsor threshold. Therefore, the
-        // bot can liquidate 0 tokens. The smart contracts should disallow this, but a/o June 2020 this behavior is allowed so we should block it
-        // client-side.
+        // the bot has 0 balance.
         this.logger.error({
           at: "Liquidator",
-          message: "Position size is equal to the minimum: not enough synthetic to initiate full liquidation✋",
+          message:
+            "Zero liquidation balance. If bot has balance, then it likely does not have enough balance to fully liquidate the position, which is equal to the minimum sponsor size✋",
           sponsor: position.sponsor,
           inputPrice: scaledPrice.toString(),
           position: position,

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1576,13 +1576,15 @@ contract("Liquidator.js", function(accounts) {
               // show a third liquidation has been added
               assert.equal(sponsor2Liquidations.length, 3);
 
-              // finally allow full liquidation by adding more tokens to bot
-              await emp.create(
-                { rawValue: convertCollateral("1000") },
-                { rawValue: convertSynthetic("200") },
-                { from: liquidatorBot }
-              );
-
+              // Now, advance time past the withdrawal liveness and test that the bot
+              // uses the remainder of its balance to send a liquidation, even if it wouldn't normally be able to send
+              // a liquidation because of the WDF constraints. Once the withdrawal passes and the liveness
+              // can no longer be reset, we should liquidate with as many funds as possible.
+              // At this point, sponsor has 40 tokens left and the WDF is 50, so if the withdrawal
+              // request had not passed liveness yet, the liquidator would only liquidate 5 tokens.
+              // However, now that the liveness has passed, the liquidator should use the remainder of its
+              // balance since the WDF no longer applies.
+              await emp.setCurrentTime(sponsor2Positions.withdrawalRequestPassTimestamp);
               await liquidator.update();
               await liquidator.liquidatePositions();
 
@@ -1593,6 +1595,63 @@ contract("Liquidator.js", function(accounts) {
               assert.equal(sponsor2Liquidations.length, 4);
               // show position has been fully liquidated
               assert.equal(sponsor2Positions.tokensOutstanding, "0");
+            }
+          );
+          versionedIt([{ contractType: "any", contractVersion: "any" }])(
+            "if no withdrawal request, then ignore WDF constraints",
+            async () => {
+              // If there is no withdrawal liveness that can be extended, either because its absent
+              // or it has expired already, then ignore the WDF constraint and liquidate using as many
+              // funds as the bot owns. We test the second case (where the withdrawal request has already expired)
+              // in the previous test.
+              liquidatorConfig = {
+                ...liquidatorConfig,
+                // entire fund dedicated to strategy
+                whaleDefenseFundWei: convertSynthetic("90"),
+                // will extend even if withdraw progress is 0% (typically this would be set to 50% +)
+                defenseActivationPercent: 0
+              };
+              const liquidator = new Liquidator({
+                logger: spyLogger,
+                expiringMultiPartyClient: empClient,
+                gasEstimator,
+                votingContract: mockOracle.contract,
+                syntheticToken: syntheticToken.contract,
+                priceFeed: priceFeedMock,
+                account: accounts[0],
+                empProps,
+                liquidatorConfig
+              });
+              // sponsor1 creates a position with 120 units of collateral, creating 100 synthetic tokens.
+              await emp.create(
+                { rawValue: convertCollateral("120") },
+                { rawValue: convertSynthetic("100") },
+                { from: sponsor1 }
+              );
+
+              // liquidatorBot creates a position to have synthetic tokens to pay off debt upon liquidation.
+              // does not have enough to liquidate entire position
+              await emp.create(
+                { rawValue: convertCollateral("1000") },
+                { rawValue: convertSynthetic("90") },
+                { from: liquidatorBot }
+              );
+
+              // Start with a mocked price of 5 usd per token.
+              // This makes the sponsor under collateralized even without a withdraw request
+              priceFeedMock.setCurrentPrice(convertPrice("5"));
+              await liquidator.update();
+              await liquidator.liquidatePositions();
+
+              // There should be exactly one liquidation in sponsor1's account that used the entire
+              // liquidator bot's balance of 90 tokens.
+              let liquidationObject = (await emp.getLiquidations(sponsor1))[0];
+              assert.equal(liquidationObject.sponsor, sponsor1);
+              assert.equal(liquidationObject.liquidator, liquidatorBot);
+              assert.equal(liquidationObject.state, LiquidationStatesEnum.PRE_DISPUTE);
+              // 90/100 tokens were liquidated, equivalent to 0.9 * 120 = 108 collateral.
+              assert.equal(liquidationObject.liquidatedCollateral, convertCollateral("108"));
+              assert.equal(liquidationObject.lockedCollateral, convertCollateral("108"));
             }
           );
         });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2510 

Related to #2508


**Summary**

Adds check to `liquidationStrategy` to ignore WDF threshold if no withdrawal request to extend. The WDF is typically used to maintain a balance of funds with which to extend withdrawal timers, but this should be ignored if there are no withdrawals to process.

**However, this is a controversial PR because merging it would mean that we can no longer guarantee that a bot will always have >= WDF in token balance.**

Something to consider if we merge this PR: Does this render the `whaleDefenseFundWei` parameter irrelevant? I.e. can we merge this PR AND subsequently remove that param?

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2510

