### PR TITLE
feat(financial-templates-lib): add BlockFinder

### DIFF
--- a/packages/common/src/TimeUtils.js
+++ b/packages/common/src/TimeUtils.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 /**
  * @notice Return average block-time for a period.
  */
-const averageBlockTimeSeconds = async (/* lookbackSeconds */) => {
+async function averageBlockTimeSeconds(/* lookbackSeconds */) {
   // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
   // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
   // since April 2016, although this value seems to spike periodically for a relatively short period of time.
@@ -15,7 +15,7 @@ const averageBlockTimeSeconds = async (/* lookbackSeconds */) => {
   } else {
     return defaultBlockTimeSeconds;
   }
-};
+}
 
 // Sets fromBlock to the value of an environment variable if one is set. This can be set to 0 to make tests work with Ganache, or any other value needed for a production script or bot.
 async function getFromBlock(web3) {
@@ -29,7 +29,19 @@ async function getFromBlock(web3) {
   }
 }
 
+/**
+ * @notice Estimates the blocks elapsed over a certain number of seconds.
+ * @param seconds the number of seconds.
+ * @param cushionPercentage the percentage to add to the number as a cushion.
+ */
+async function estimateBlocksElapsed(seconds, cushionPercentage = 0.0) {
+  const cushionMultiplier = cushionPercentage + 1.0;
+  const averageBlockTime = await averageBlockTimeSeconds();
+  return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
+}
+
 module.exports = {
   averageBlockTimeSeconds,
-  getFromBlock
+  getFromBlock,
+  estimateBlocksElapsed
 };

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -192,8 +192,11 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
     return block;
   }
 
+  // Return the latest block, between startBlock and endBlock, whose timestamp is <= timestamp.
   // Effectively, this is an interpolation search algorithm to minimize block requests.
   async function findBlock(startBlock, endBlock, timestamp) {
+    assert(endBlock.number !== startBlock.number, "startBlock cannot equal endBlock");
+
     // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
     // timestamp.
     if (endBlock.timestamp === timestamp) return endBlock;

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -197,8 +197,6 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
   // Effectively, this is an interpolation search algorithm to minimize block requests.
   // Note: startBlock and endBlock _must_ be different blocks.
   async function findBlock(startBlock, endBlock, timestamp) {
-    assert(endBlock.number !== startBlock.number, "startBlock cannot equal endBlock");
-
     // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
     // timestamp.
     if (endBlock.timestamp === timestamp) return endBlock;
@@ -207,6 +205,7 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
     // timestamp to be <= the requested timestamp.
     if (endBlock.number === startBlock.number + 1) return startBlock;
 
+    assert(endBlock.number !== startBlock.number, "startBlock cannot equal endBlock");
     assert(
       timestamp < endBlock.timestamp && timestamp > startBlock.timestamp,
       "timestamp not in between start and end blocks"

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -194,7 +194,12 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
 
   // Effectively, this is an interpolation search algorithm to minimize block requests.
   async function findBlock(startBlock, endBlock, timestamp) {
+    // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
+    // timestamp.
     if (endBlock.timestamp === timestamp) return endBlock;
+
+    // If there's no equality, but the blocks are adjacent, return the startBlock, since we want the returned block's
+    // timestamp to be <= the requested timestamp.
     if (endBlock.number === startBlock.number + 1) return startBlock;
 
     assert(

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -168,7 +168,12 @@ exports.PriceHistory = (getPrice, prices = {}) => {
   };
 };
 
-// A simple class-like structure to find blocks by timestamp, but keep a cache to optimize the search.
+/**
+ * @notice Constructs the BlockFinder, which is a simple class-like object to find blocks by timestamp, but keeps a
+ *      cache to optimize the search.
+ * @param {Function} requestBlock async function, like web3.eth.getBlock that returns a block for a particular block
+ *      number or returns the latest block if no argument is provided. Blocks returned must have a `number` and
+ */
 exports.BlockFinder = (requestBlock, blocks = []) => {
   // Grabs the most recent block and caches it.
   async function getLatestBlock() {
@@ -214,8 +219,10 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
     }
   }
 
-  // Gets the latest block with a timestamp <= the provided timestamp.
-  // Throws if the timestamp is after the latest block or before the 0th block.
+  /**
+   * @notice Gets the latest block whose timestamp is <= the provided timestamp.
+   * @param {number} timestamp timestamp to search.
+   */
   async function getBlockForTimestamp(timestamp) {
     // If the last block we have stored is too early, grab the latest block.
     if (blocks.length === 0 || blocks[blocks.length - 1].timestamp < timestamp) {

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -175,6 +175,7 @@ exports.PriceHistory = (getPrice, prices = {}) => {
  *      number or returns the latest block if no argument is provided. Blocks returned must have a `number` and
  */
 exports.BlockFinder = (requestBlock, blocks = []) => {
+  assert(requestBlock, "requestBlock function must be provided");
   // Grabs the most recent block and caches it.
   async function getLatestBlock() {
     const block = await requestBlock();
@@ -233,6 +234,7 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
    * @param {number} timestamp timestamp to search.
    */
   async function getBlockForTimestamp(timestamp) {
+    assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
     // If the last block we have stored is too early, grab the latest block.
     if (blocks.length === 0 || blocks[blocks.length - 1].timestamp < timestamp) {
       const block = await getLatestBlock();

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -194,6 +194,7 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
 
   // Return the latest block, between startBlock and endBlock, whose timestamp is <= timestamp.
   // Effectively, this is an interpolation search algorithm to minimize block requests.
+  // Note: startBlock and endBlock _must_ be different blocks.
   async function findBlock(startBlock, endBlock, timestamp) {
     assert(endBlock.number !== startBlock.number, "startBlock cannot equal endBlock");
 

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -1,6 +1,6 @@
 const lodash = require("lodash");
 const assert = require("assert");
-const { averageBlockTimeSeconds, MAX_SAFE_JS_INT } = require("@uma/common");
+const { averageBlockTimeSeconds, MAX_SAFE_JS_INT, estimateBlocksElapsed } = require("@uma/common");
 
 // Downloads blocks and caches them for certain time into the past.
 // Allows some in memory searches to go from timestamp to block number.
@@ -166,6 +166,85 @@ exports.PriceHistory = (getPrice, prices = {}) => {
     update,
     list
   };
+};
+
+// A simple class-like structure to find blocks by timestamp, but keep a cache to optimize the search.
+exports.BlockFinder = (requestBlock, blocks = []) => {
+  // Grabs the most recent block and caches it.
+  async function getLatestBlock() {
+    const block = await requestBlock();
+    const index = lodash.sortedIndexBy(blocks, block, "number");
+    if (blocks[index]?.number !== block.number) blocks.splice(index, 0, block);
+    return blocks[index];
+  }
+
+  // Grabs the block for a particular number and caches it.
+  async function getBlock(number) {
+    const index = lodash.sortedIndexBy(blocks, { number }, "number");
+    if (blocks[index]?.number === number) return blocks[index]; // Return early if block already exists.
+    const block = await requestBlock(number);
+    blocks.splice(index, 0, block); // A simple insert at index.
+    return block;
+  }
+
+  // Effectively, this is an interpolation search algorithm to minimize block requests.
+  async function findBlock(startBlock, endBlock, timestamp) {
+    if (endBlock.timestamp === timestamp) return endBlock;
+    if (endBlock.number === startBlock.number + 1) return startBlock;
+
+    assert(
+      timestamp < endBlock.timestamp && timestamp > startBlock.timestamp,
+      "timestamp not in between start and end blocks"
+    );
+
+    // Interpolating the timestamp we're searching for to block numbers.
+    const totalTimeDifference = endBlock.timestamp - startBlock.timestamp;
+    const totalBlockDistance = endBlock.number - startBlock.number;
+    const blockPercentile = (timestamp - startBlock.timestamp) / totalTimeDifference;
+    const estimatedBlock = startBlock.number + Math.round(blockPercentile * totalBlockDistance);
+
+    // Clamp is just ensures the estimated block is strictly greater than the start block and strictly less than the end block.
+    const newBlock = await getBlock(lodash.clamp(estimatedBlock, startBlock.number + 1, endBlock.number - 1));
+
+    // Depending on whether the new block is below or above the timestamp, narrow the search space accordingly.
+    if (newBlock.timestamp < timestamp) {
+      return findBlock(newBlock, endBlock, timestamp);
+    } else {
+      return findBlock(startBlock, newBlock, timestamp);
+    }
+  }
+
+  // Gets the latest block with a timestamp <= the provided timestamp.
+  // Throws if the timestamp is after the latest block or before the 0th block.
+  async function getBlockForTimestamp(timestamp) {
+    // If the last block we have stored is too early, grab the latest block.
+    if (blocks.length === 0 || blocks[blocks.length - 1].timestamp < timestamp) {
+      const block = await getLatestBlock();
+      assert(block.timestamp >= timestamp, "timestamp is in the future (after latest block)");
+    }
+
+    // Check the first block. If it's grater than our timestamp, we need to find an earlier block.
+    if (blocks[0].timestamp > timestamp) {
+      let initialBlock = blocks[0];
+      const cushion = 1.1;
+      const incrementDistance = await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion);
+
+      // Search backwards by a constant increment until we find a block before the timestamp or hit block 0.
+      for (let multiplier = 1; ; multiplier++) {
+        let distance = multiplier * incrementDistance;
+        let blockNumber = Math.max(0, initialBlock.number - distance);
+        let block = await getBlock(blockNumber);
+        if (block.timestamp <= timestamp) break; // Found an earlier block.
+        assert(blockNumber > 0, "timestamp is before block 0"); // Block 0 was not earlier than this timestamp. Throw.
+      }
+    }
+
+    // Find the index where the block would be inserted and use that as the end block (since it is >= the timestamp).
+    const index = lodash.sortedIndexBy(blocks, { timestamp }, "timestamp");
+    return findBlock(blocks[index - 1], blocks[index], timestamp);
+  }
+
+  return { getBlockForTimestamp };
 };
 
 // Given a list of price events in chronological order [timestamp, price] and a time window, returns the time-weighted

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -213,7 +213,7 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
     const blockPercentile = (timestamp - startBlock.timestamp) / totalTimeDifference;
     const estimatedBlock = startBlock.number + Math.round(blockPercentile * totalBlockDistance);
 
-    // Clamp is just ensures the estimated block is strictly greater than the start block and strictly less than the end block.
+    // Clamp ensures the estimated block is strictly greater than the start block and strictly less than the end block.
     const newBlock = await getBlock(lodash.clamp(estimatedBlock, startBlock.number + 1, endBlock.number - 1));
 
     // Depending on whether the new block is below or above the timestamp, narrow the search space accordingly.


### PR DESCRIPTION
**Motivation**

To build a price feeds that require past block queries at specific _times_, we need a way to find the exact block at or immediately preceding a particular timestamp. Our existing block querying utilities _can_ do this, but they query _all_ blocks over a certain range. This utility serves a slightly different purpose in that it uses a binary search (technically interpolation search) to find the block for a timestamp at any point in the blockchain's history without needing _all_ blocks since that point. Because it's a binary-style search, this can take slightly longer since all queries need to be done in series.

**Summary**

The BlockFinder follows the same style as the other block querying utilities. Its interface is a single function to get the block for a timestamp.

Note: the implementation may be convoluted in certain spots, so please point out where more comments or details are needed.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
