### PR TITLE
feat(price-feeds): add ExpressionPriceFeed

### DIFF
--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -11,6 +11,7 @@
     "@uniswap/sdk": "^2.0.5",
     "bluebird": "^3.7.2",
     "dotenv": "^6.2.0",
+    "mathjs": "^9.2.0",
     "minimist": "^1.2.0",
     "node-fetch": "^2.6.0",
     "node-pagerduty": "^1.2.0",

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -192,8 +192,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
   // Returns an ExpressionPriceFeed.
   async function _createExpressionPriceFeed(expressionConfig) {
     // Build list of configs that could be used in the expression including default price feed configs and customFeeds
-    // that the user has provided inside the ExpressionPriceFeed config. Tranform keys by stripping "/" since that
-    // would be interpreted as division.
+    // that the user has provided inside the ExpressionPriceFeed config. Note: default configs are overriden by
+    // customFeeds with the same name. Tranform keys by stripping "/" since that would be interpreted as division.
     const allConfigs = Object.fromEntries(
       Object.entries({ ...defaultConfigs, ...expressionConfig.customFeeds }).map(([key, value]) => {
         return [key.replace("/", ""), value];
@@ -201,8 +201,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     );
 
     // This call chain:
-    // 1. Parses the expression tree into "nodes"
-    // 2. Filters for "symbol" nodes, which would be price feed identifiers in our case.
+    // 1. Parses the expression into an expression tree of nodes.
+    // 2. Filters for "symbol" nodes, which would be price feed identifiers in this case.
     // 3. Extract the name property for each of these symbol nodes
     // 4. Puts it all in a set to dedupe repeated symbols.
     const symbols = new Set(

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 const { ChainId, Token, Pair, TokenAmount } = require("@uniswap/sdk");
+const { parse } = require("mathjs");
 const { MedianizerPriceFeed } = require("./MedianizerPriceFeed");
 const { CryptoWatchPriceFeed } = require("./CryptoWatchPriceFeed");
 const { UniswapPriceFeed } = require("./UniswapPriceFeed");
@@ -8,6 +9,7 @@ const { DominationFinancePriceFeed } = require("./DominationFinancePriceFeed");
 const { BasketSpreadPriceFeed } = require("./BasketSpreadPriceFeed");
 const { defaultConfigs } = require("./DefaultPriceFeedConfigs");
 const { getTruffleContract } = require("@uma/core");
+const { ExpressionPriceFeed } = require("./ExpressionPriceFeed");
 
 async function createPriceFeed(logger, web3, networker, getTime, config) {
   const Uniswap = getTruffleContract("Uniswap", web3, "latest");
@@ -162,6 +164,19 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.denominatorPriceFeed && (await _createMedianizerPriceFeed(config.denominatorPriceFeed));
 
     return new BasketSpreadPriceFeed(web3, logger, baselinePriceFeeds, experimentalPriceFeeds, denominatorPriceFeed);
+  } else if (config.type === "expression") {
+    const requiredFields = ["expression"];
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating ExpressionPriceFeed",
+      config
+    });
+
+    return await _createExpressionPriceFeed(config);
   }
 
   logger.error({
@@ -173,6 +188,63 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
   return null;
 
   // Internal helper methods:
+
+  // Returns an ExpressionPriceFeed.
+  async function _createExpressionPriceFeed(expressionConfig) {
+    // Build list of configs that could be used in the expression including default price feed configs and customFeeds
+    // that the user has provided inside the ExpressionPriceFeed config. Tranform keys by stripping "/" since that
+    // would be interpreted as division.
+    const allConfigs = Object.fromEntries(
+      Object.entries({ ...defaultConfigs, ...expressionConfig.customFeeds }).map(([key, value]) => {
+        return [key.replace("/", ""), value];
+      })
+    );
+
+    // This call chain:
+    // 1. Parses the expression tree into "nodes"
+    // 2. Filters for "symbol" nodes, which would be price feed identifiers in our case.
+    // 3. Extract the name property for each of these symbol nodes
+    // 4. Puts it all in a set to dedupe repeated symbols.
+    const symbols = new Set(
+      parse(expressionConfig.expression)
+        .filter(node => node.isSymbolNode)
+        .map(node => node.name)
+    );
+
+    // This is a complicated looking map that maps each symbol into an entry in an object with its value the price
+    // feed created from the mapped config in allConfigs.
+    const priceFeedMap = Object.fromEntries(
+      await Promise.all(
+        symbols.values().map(async symbol => {
+          const config = allConfigs[symbol];
+
+          // If there is no config for this symbol, insert null and send an error.
+          if (!config) {
+            logger.error({
+              at: "_createExpressionPriceFeed",
+              message: `No price feed config found for symbol: ${symbol} 🚨`,
+              expressionConfig
+            });
+            return [symbol, null];
+          }
+
+          // These configs will inherit the expression config values (except type), but prefer the individual config's
+          // value when present.
+          const combinedConfig = { ...expressionConfig, type: undefined, ...config };
+
+          // If this returns null, just return upstream since the error has already been logged and the null will be
+          // detected upstream.
+          const priceFeed = await createPriceFeed(logger, web3, networker, getTime, combinedConfig);
+          return [symbol, priceFeed];
+        })
+      )
+    );
+
+    // Return null if any of the price feeds in the map are null (meaning there was an error).
+    if (Object.values(priceFeedMap).some(priceFeed => priceFeed === null)) return null;
+
+    return new ExpressionPriceFeed(priceFeedMap, expressionConfig.expression);
+  }
 
   // Returns a MedianizerPriceFeed
   async function _createMedianizerPriceFeed(medianizerConfig) {
@@ -196,6 +268,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     }
     return new MedianizerPriceFeed(priceFeedsToMedianize, medianizerConfig.computeMean);
   }
+
   // Returns an array or "basket" of MedianizerPriceFeeds
   async function _createBasketOfMedianizerPriceFeeds(medianizerConfigs) {
     return await Promise.all(medianizerConfigs.map(config => _createMedianizerPriceFeed(config)));

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -245,7 +245,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     // Return null if any of the price feeds in the map are null (meaning there was an error).
     if (Object.values(priceFeedMap).some(priceFeed => priceFeed === null)) return null;
 
-    return new ExpressionPriceFeed(priceFeedMap, expressionConfig.expression);
+    return new ExpressionPriceFeed(priceFeedMap, expressionConfig.expression, expressionConfig.priceFeedDecimals);
   }
 
   // Returns a MedianizerPriceFeed

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -204,18 +204,20 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     // 1. Parses the expression into an expression tree of nodes.
     // 2. Filters for "symbol" nodes, which would be price feed identifiers in this case.
     // 3. Extract the name property for each of these symbol nodes
-    // 4. Puts it all in a set to dedupe repeated symbols.
-    const symbols = new Set(
-      parse(expressionConfig.expression)
-        .filter(node => node.isSymbolNode)
-        .map(node => node.name)
+    // 4. Puts it all in a set and converts back to an array to dedupe any repeated values.
+    const symbols = Array.from(
+      new Set(
+        parse(expressionConfig.expression)
+          .filter(node => node.isSymbolNode)
+          .map(node => node.name)
+      )
     );
 
     // This is a complicated looking map that maps each symbol into an entry in an object with its value the price
     // feed created from the mapped config in allConfigs.
     const priceFeedMap = Object.fromEntries(
       await Promise.all(
-        symbols.values().map(async symbol => {
+        symbols.map(async symbol => {
           const config = allConfigs[symbol];
 
           // If there is no config for this symbol, insert null and send an error.

--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -1,0 +1,117 @@
+const assert = require("assert");
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+const Web3 = require("web3");
+const { create, all } = require("mathjs");
+const math = create(all, {
+  number: "BigNumber",
+  precision: 100
+});
+
+// Gets balancer spot and historical prices. This price feed assumes that it is returning
+// prices as 18 decimals of precision, so it will scale up the pool's price as reported by Balancer contracts
+// if the user specifies that the Balancer contract is returning non-18 decimal precision prices.
+class ExpressionPriceFeed extends PriceFeedInterface {
+  constructor(priceFeedMap, expression) {
+    super();
+    this.expressionCode = math.parse(expression).compile();
+    this.priceFeedMap = priceFeedMap;
+  }
+
+  async getHistoricalPrice(time) {
+    const historicalPrices = {};
+    const errors = [];
+    await Promise.all(
+      Object.entries(this.priceFeedMap).map(async ([name, pf]) => {
+        const price = await pf.getHistoricalPrice(time).catch(err => errors.push(err));
+        historicalPrices[name] = this._convertToDecimal(price);
+      })
+    );
+
+    if (errors.length > 0) {
+      throw errors;
+    }
+
+    return this._convertToFixed(this.expressionCode.evaluate(historicalPrices));
+  }
+
+  getLastUpdateTime() {
+    const lastUpdateTimes = Object.values(this.priceFeedMap).map(pf => pf.getLastUpdateTime());
+
+    // If any constituents returned an invalid value, bubble it up.
+    if (lastUpdateTimes.some(time => time === null || time === undefined)) {
+      return null;
+    }
+
+    // Take the max.
+    return Math.max(...lastUpdateTimes);
+  }
+
+  getLookback() {
+    const lookbacks = Object.values(this.priceFeedMap).map(priceFeed => priceFeed.getLookback());
+
+    // If any constituents returned an invalid value, bubble it up.
+    if (lookbacks.some(lookback => lookback === undefined || lookback === null)) {
+      return null;
+    }
+
+    // Take the min since the overall lookback will be the min.
+    return Math.min(...lookbacks);
+  }
+
+  getCurrentPrice() {
+    const prices = {};
+    const errors = [];
+    Object.entries(this.priceFeedMap).map(async ([name, pf]) => {
+      try {
+        const price = pf.getCurrentPrice();
+        assert(price !== undefined && price !== null, "Valid price must be returned");
+        prices[name] = this._convertToDecimal(price);
+      } catch (err) {
+        errors.push(err);
+      }
+    });
+
+    if (errors.length > 0) return null;
+
+    return this._convertToFixed(this.expressionCode.evaluate(prices));
+  }
+
+  getPriceFeedDecimals() {
+    const decimalArray = Object.values(this.priceFeedMap).map(pf => pf.getPriceFeedDecimals());
+    const decimalsValue = decimalArray[0];
+    assert(decimalsValue, "Invalid decimals value");
+    assert(
+      decimalArray.every(decimals => decimals === decimalArray[0]),
+      "Constituent price feeds do not have matching decimals"
+    );
+    return decimalsValue;
+  }
+
+  async update() {
+    // Update all constituent price feeds.
+    await Promise.all(Object.values(this.priceFeedMap).map(pf => pf.update()));
+  }
+
+  // Takes a BN fixed point number and converts it to a math.bignumber decimal number that the math library can handle.
+  _convertToDecimal(price) {
+    const decimals = math.bignumber(this.getPriceFeedDecimals());
+    const decimalsMultiplier = math.bignumber(10).pow(decimals);
+    return math.bignumber(price.toString()).div(decimalsMultiplier);
+  }
+
+  // Takes a math.bignumber number and converts it to a fixed point number that's expected outside this library.
+  _convertToFixed(price) {
+    const decimals = math.bignumber(this.getPriceFeedDecimals());
+    const decimalsMultiplier = math.bignumber(10).pow(decimals);
+    return Web3.utils.toBN(
+      price
+        .mul(decimalsMultiplier)
+        .round()
+        .toString()
+    );
+  }
+}
+
+module.exports = {
+  ExpressionPriceFeed
+};

--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -81,7 +81,7 @@ class ExpressionPriceFeed extends PriceFeedInterface {
     const decimalsValue = decimalArray[0];
     assert(decimalsValue, "Invalid decimals value");
     assert(
-      decimalArray.every(decimals => decimals === decimalArray[0]),
+      decimalArray.every(decimals => decimals === decimalsValue),
       "Constituent price feeds do not have matching decimals"
     );
     return decimalsValue;

--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -2,10 +2,7 @@ const assert = require("assert");
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 const Web3 = require("web3");
 const { create, all } = require("mathjs");
-const math = create(all, {
-  number: "BigNumber",
-  precision: 100
-});
+const math = create(all, { number: "BigNumber", precision: 100 });
 
 // Gets balancer spot and historical prices. This price feed assumes that it is returning
 // prices as 18 decimals of precision, so it will scale up the pool's price as reported by Balancer contracts

--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -7,6 +7,8 @@ const { create, all } = require("mathjs");
 const math = create(all, { number: "BigNumber", precision: 100 });
 const nativeIsAlpha = math.parse.isAlpha;
 const allowedSpecialCharacters = Array.from("[]/ -");
+
+// Modifies math.js's function to determine whether a character is allowed in a symbol name.
 math.parse.isAlpha = function(c, cPrev, cNext) {
   // This character is the escape and the next is the special character.
   const isValidEscapeChar = c === "\\" && allowedSpecialCharacters.includes(cNext);
@@ -17,6 +19,9 @@ math.parse.isAlpha = function(c, cPrev, cNext) {
   return nativeIsAlpha(c, cPrev, cNext) || isValidEscapeChar || isSpecialChar;
 };
 
+// This escapes all the special characters (defined in the allowedSpecialCharacters array) in a string.
+// For example (note that "\\" is the js representation for a single literal backslash)
+// "ab/c d [e]" -> "ab\\/c\\ d\\[e\\]"
 function escapeSpecialCharacters(input) {
   return Array.from(input)
     .map((char, index, array) => {
@@ -29,9 +34,9 @@ function escapeSpecialCharacters(input) {
     .join("");
 }
 
-// Gets balancer spot and historical prices. This price feed assumes that it is returning
-// prices as 18 decimals of precision, so it will scale up the pool's price as reported by Balancer contracts
-// if the user specifies that the Balancer contract is returning non-18 decimal precision prices.
+// Allows users to combine other price feeds using "expressions" with the price feed identifiers being the symbols
+// in these expressions. Ex: "USDETH * COMPUSD". Users can also comfigure custom price feeds in their configuration
+// with custom symbols. Ex: "USDETH * COMPUSD * MY_CUSTOM_FEED".
 class ExpressionPriceFeed extends PriceFeedInterface {
   constructor(priceFeedMap, expression) {
     super();

--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -72,7 +72,7 @@ class ExpressionPriceFeed extends PriceFeedInterface {
       throw errors;
     }
 
-    return this._convertToFixed(this.expressionCode.evaluate(historicalPrices));
+    return this._convertToFixed(this.expressionCode.evaluate(historicalPrices), this.getPriceFeedDecimals());
   }
 
   getLastUpdateTime() {
@@ -114,7 +114,7 @@ class ExpressionPriceFeed extends PriceFeedInterface {
 
     if (errors.length > 0) return null;
 
-    return this._convertToFixed(this.expressionCode.evaluate(prices));
+    return this._convertToFixed(this.expressionCode.evaluate(prices), this.getPriceFeedDecimals());
   }
 
   getPriceFeedDecimals() {
@@ -137,12 +137,7 @@ class ExpressionPriceFeed extends PriceFeedInterface {
   _convertToFixed(price, outputDecimals) {
     const decimals = math.bignumber(outputDecimals);
     const decimalsMultiplier = math.bignumber(10).pow(decimals);
-    return Web3.utils.toBN(
-      price
-        .mul(decimalsMultiplier)
-        .round()
-        .toString()
-    );
+    return Web3.utils.toBN(math.format(price.mul(decimalsMultiplier).round(), { notation: "fixed" }));
   }
 }
 

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -793,7 +793,7 @@ contract("CreatePriceFeed.js", function(accounts) {
     const config = {
       type: "expression",
       lookback,
-      expression: "USDETH + ETHBTC"
+      expression: "USDETH + ETH\\/BTC"
     };
 
     const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -713,6 +713,119 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(medianizerFeed, null);
   });
 
+  it("ExpressionPriceFeed: invalid config, no expression", async function() {
+    const config = {
+      type: "expression"
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNull(expressionPriceFeed);
+  });
+
+  it("ExpressionPriceFeed: invalid config, symbol not found", async function() {
+    const config = {
+      type: "expression",
+      expression: "mysymbol * 2"
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNull(expressionPriceFeed);
+  });
+
+  it("ExpressionPriceFeed: customFeeds", async function() {
+    const config = {
+      type: "expression",
+      expression: "mysymbol * 2",
+      customFeeds: {
+        mysymbol: {
+          type: "cryptowatch",
+          apiKey,
+          exchange,
+          pair,
+          lookback,
+          minTimeBetweenUpdates
+        }
+      }
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNotNull(expressionPriceFeed);
+    assert.exists(expressionPriceFeed.priceFeedMap["mysymbol"]);
+  });
+
+  it("ExpressionPriceFeed: inherited config", async function() {
+    const config = {
+      type: "expression",
+      expression: "mysymbol * 2",
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      minTimeBetweenUpdates,
+      customFeeds: {
+        mysymbol: {
+          type: "cryptowatch"
+        }
+      }
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNotNull(expressionPriceFeed);
+    assert.exists(expressionPriceFeed.priceFeedMap["mysymbol"]);
+    assert.equal(expressionPriceFeed.priceFeedMap["mysymbol"].lookback, lookback);
+  });
+
+  it("ExpressionPriceFeed: invalid config, no expression", async function() {
+    const config = {
+      type: "expression"
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNull(expressionPriceFeed);
+  });
+
+  it("ExpressionPriceFeed: can find default price feeds", async function() {
+    const config = {
+      type: "expression",
+      lookback,
+      expression: "USDETH + ETHBTC"
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNotNull(expressionPriceFeed);
+  });
+
+  it("ExpressionPriceFeed: invalid config in customFeeds is ignored if unused", async function() {
+    const config = {
+      type: "expression",
+      expression: "2 + 5",
+      customFeeds: {
+        ETHBTC: {} // Invalid because it has no type.
+      }
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNotNull(expressionPriceFeed);
+  });
+
+  it("ExpressionPriceFeed: constant expression", async function() {
+    const config = {
+      type: "expression",
+      expression: "1 + 2"
+    };
+
+    const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNotNull(expressionPriceFeed);
+  });
+
   it("Default reference price feed", async function() {
     const collateralToken = await Token.new("Wrapped Ether", "WETH", 18, { from: accounts[0] });
     const syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18, { from: accounts[0] });

--- a/packages/financial-templates-lib/test/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/ExpressionPriceFeed.js
@@ -1,0 +1,141 @@
+const { toWei, toBN } = web3.utils;
+
+const { ExpressionPriceFeed } = require("../../src/price-feed/ExpressionPriceFeed");
+const { PriceFeedMock } = require("../../src/price-feed/PriceFeedMock");
+
+contract("ExpressionPriceFeed.js", function() {
+  it("Update", async function() {
+    const priceFeedMap = {
+      ETHUSD: new PriceFeedMock(),
+      BTCUSD: new PriceFeedMock()
+    };
+
+    const expressionPriceFeed = new ExpressionPriceFeed(priceFeedMap, "ETHUSD + BTCUSD");
+    await expressionPriceFeed.update();
+    await expressionPriceFeed.update();
+
+    assert.equal(priceFeedMap.ETHUSD.updateCalled, 2);
+    assert.equal(priceFeedMap.BTCUSD.updateCalled, 2);
+  });
+
+  it("Basic expression", async function() {
+    const priceFeedMap = {
+      //                        currentPrice      historicalPrice    lastUpdatedTime   decimals   lookback
+      ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100, 18, 500),
+      BTCUSD: new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000, 18, 4000),
+      COMPUSD: new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25, 18, 50000)
+    };
+
+    const expressionPriceFeed = new ExpressionPriceFeed(priceFeedMap, "ETHUSD + BTCUSD + COMPUSD");
+
+    // Should return the sum of the current prices.
+    assert.equal(expressionPriceFeed.getCurrentPrice(), toWei("12"));
+
+    // Should return the summed historical price (because we're using mocks, the timestamp doesn't matter).
+    const arbitraryHistoricalTimestamp = 1000;
+    assert.equal(await expressionPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp), toWei("92"));
+
+    // Should return the *maximum* lastUpdatedTime.
+    assert.equal(expressionPriceFeed.getLastUpdateTime(), 50000);
+
+    // Should return the min lookback.
+    assert.equal(expressionPriceFeed.getLookback(), 500);
+  });
+
+  it("Complex expression", async function() {
+    const priceFeedMap = {
+      //                        currentPrice      historicalPrice    lastUpdatedTime   decimals
+      ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100, 18),
+      BTCUSD: new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000, 18),
+      COMPUSD: new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25, 18)
+    };
+
+    const expressionPriceFeed = new ExpressionPriceFeed(
+      priceFeedMap,
+      "(ETHUSD + COMPUSD) * (BTCUSD + COMPUSD) / 7.321"
+    );
+
+    // Should return the sum of the current prices.
+    // (1 + 9) * (2 + 9) / 7.321 = 15.025269771889086190 (rounded to 18 decimals).
+    assert.equal(expressionPriceFeed.getCurrentPrice(), toWei("15.025269771889086190"));
+
+    // Should return the summed historical price (because we're using mocks, the timestamp doesn't matter).
+    const arbitraryHistoricalTimestamp = 1000;
+    // (25 + 10) * (57 + 10) / 7.321 = 320.311432864362791968 (rounded to 18 decimals).
+    assert.equal(
+      await expressionPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp),
+      toWei("320.311432864362791968")
+    );
+  });
+
+  it("sub-pricefeeds fail to return price", async function() {
+    const priceFeeds = {
+      //                currentPrice      historicalPrice    lastUpdatedTime
+      ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("17")), 100),
+      BTCUSD: new PriceFeedMock(null, null, null),
+      COMPUSD: new PriceFeedMock(null, null, null)
+    };
+
+    const expressionPriceFeed = new ExpressionPriceFeed(priceFeeds, "ETHUSD * BTCUSD * COMPUSD");
+
+    // Should return null since there was a null price output.
+    assert.equal(expressionPriceFeed.getCurrentPrice(), null);
+
+    // Should throw an error for each null price output.
+    const arbitraryHistoricalTimestamp = 1000;
+    await expressionPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).then(
+      () => assert.fail(),
+      err => {
+        assert.equal(err[0].message, "PriceFeedMock expected error thrown");
+        assert.equal(err[1].message, "PriceFeedMock expected error thrown");
+        assert.equal(err.length, 2);
+      }
+    );
+
+    // Should return null since there was a null input.
+    assert.equal(expressionPriceFeed.getLastUpdateTime(), null);
+  });
+
+  it("undefined inputs", async function() {
+    const priceFeeds = {
+      //                currentPrice      historicalPrice    lastUpdatedTime
+      ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("17")), 100),
+      BTCUSD: new PriceFeedMock(undefined, undefined, undefined)
+    };
+
+    const expressionPriceFeed = new ExpressionPriceFeed(priceFeeds, "ETHUSD * BTCUSD * COMPUSD");
+
+    // Should return null since there was an undefined price output.
+    assert.equal(expressionPriceFeed.getCurrentPrice(), null);
+
+    // Should throw since there was an undefined price output.
+    const arbitraryHistoricalTimestamp = 1000;
+    assert.isTrue(await expressionPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).catch(() => true));
+
+    // Should return null since there was an undefined output.
+    assert.equal(expressionPriceFeed.getLastUpdateTime(), null);
+  });
+
+  it("Validates feeds decimals correctly", async function() {
+    const validDecimalsPriceFeeds = {
+      //                        currentPrice      historicalPrice    lastUpdatedTime   decimals
+      ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100, 18),
+      BTCUSD: new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000, 18, 4000),
+      COMPUSD: new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25, 18, 50000)
+    };
+
+    const validExpressionPriceFeed = new ExpressionPriceFeed(validDecimalsPriceFeeds, "ETHUSD * BTCUSD * COMPUSD");
+    assert.equal(validExpressionPriceFeed.getPriceFeedDecimals(), 18);
+
+    // Create three feeds, one with a diffrent number of decimals. Medianizer should reject this when checking the decimals.
+    const inValidDecimalsPriceFeeds = {
+      //                        currentPrice      historicalPrice    lastUpdatedTime   decimals
+      ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100, 18),
+      BTCUSD: new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000, 18),
+      COMPUSD: new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25, 17)
+    };
+
+    const invalidExpressionPriceFeed = new ExpressionPriceFeed(inValidDecimalsPriceFeeds, "ETHUSD * BTCUSD * COMPUSD");
+    assert.throws(() => invalidExpressionPriceFeed.getPriceFeedDecimals());
+  });
+});

--- a/packages/financial-templates-lib/test/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/ExpressionPriceFeed.js
@@ -18,14 +18,19 @@ contract("ExpressionPriceFeed.js", function() {
   });
 
   it("Basic expression", async function() {
+    // Note: the third price feed's name is meant to be a complex name with many special characters to demonstrate
+    // that it works.
     const priceFeedMap = {
       //                        currentPrice      historicalPrice    lastUpdatedTime   decimals   lookback
       ETHUSD: new PriceFeedMock(toBN(toWei("1")), toBN(toWei("25")), 100, 18, 500),
       BTCUSD: new PriceFeedMock(toBN(toWei("2")), toBN(toWei("57")), 50000, 18, 4000),
-      COMPUSD: new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25, 18, 50000)
+      "USD\\-\\[bwBTC\\/ETH\\ SLP\\]": new PriceFeedMock(toBN(toWei("9")), toBN(toWei("10")), 25, 18, 50000)
     };
 
-    const expressionPriceFeed = new ExpressionPriceFeed(priceFeedMap, "ETHUSD + BTCUSD + COMPUSD");
+    const expressionPriceFeed = new ExpressionPriceFeed(
+      priceFeedMap,
+      "ETHUSD + BTCUSD + USD\\-\\[bwBTC\\/ETH\\ SLP\\]"
+    );
 
     // Should return the sum of the current prices.
     assert.equal(expressionPriceFeed.getCurrentPrice(), toWei("12"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -7891,6 +7891,11 @@ compare-versions@^3.6.0:
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
   integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
+complex.js@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.11.tgz#09a873fbf15ffd8c18c9c2201ccef425c32b8bf1"
+  integrity sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw==
+
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -8738,6 +8743,11 @@ decimal.js-light@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.0.tgz#ca7faf504c799326df94b0ab920424fdfc125348"
   integrity sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg==
+
+decimal.js@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -9631,6 +9641,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
+escape-latex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/escape-latex/-/escape-latex-1.2.0.tgz#07c03818cf7dac250cce517f4fda1b001ef2bca1"
+  integrity sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -11302,6 +11317,11 @@ fp-ts@^1.0.0:
   version "1.19.5"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
+
+fraction.js@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.13.tgz#3c1c315fa16b35c85fffa95725a36fa729c69dfe"
+  integrity sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -13843,6 +13863,11 @@ iterate-value@^1.0.0:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
+javascript-natural-sort@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
+
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
@@ -15631,6 +15656,20 @@ matcher@~2.1:
   integrity sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+mathjs@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-9.2.0.tgz#247f204c6d0151ee01d1a2696b90d30e25f82a7e"
+  integrity sha512-R2fQxaOmyifxgP4+c59dnfLwpKI1KYHdnT5lLwDuHIZvgyGb71M8ay6kTJTEv9rG04pduqvX4tbBUoG5ypTF8A==
+  dependencies:
+    complex.js "^2.0.11"
+    decimal.js "^10.2.1"
+    escape-latex "^1.2.0"
+    fraction.js "^4.0.13"
+    javascript-natural-sort "^0.7.1"
+    seedrandom "^3.0.5"
+    tiny-emitter "^2.1.0"
+    typed-function "^2.0.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -20225,6 +20264,11 @@ secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
 seek-bzip@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.6.tgz#35c4171f55a680916b52a07859ecf3b5857f21c4"
@@ -21863,6 +21907,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tiny-invariant@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
@@ -22249,6 +22298,11 @@ type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+
+typed-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-2.0.0.tgz#15ab3825845138a8b1113bd89e60cd6a435739e8"
+  integrity sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
**Motivation**

To support more arbitrary types of price feeds, it is becoming clear that it would be useful to be able to define arbitrary expressions that combine existing price feeds. This is a proposal for a price feed that takes expressions of the form:

```
"BTCUSD * 100 / ETHUSD"
```

Note: the library can actually handle _far more_ complex expressions, even multiline ones. But, for now, we should encourage users to keep them fairly simple.

**Summary**

This is a _proposal_ for a type of expression-parsing price feed to add more generality to the price feed creation process. This would move much of the simple math to the config and leave only the data-acquisition to the price feeds themselves.

I haven't added the configuration and construction portions of this price feed, as I want to ensure the team agrees with this rough direction. However, it's important to note that I think this price feed will be constructed by searching for known strings in the expression and including price feeds associated with each of those known strings. The user would basically be able to use existing default price feed identifiers _and_ they would be able to include a custom mapping in their config for additional price feed names that they'd like to map.

Ultimately, this expression parser could make the medianizer price feed unnecessary, as the library used would allow us to inject a custom medianizer function.

This will also facilitate the badger price feed.

Other notes:
- The `mathjs` library used for expression parsing is quite powerful and large. It has some very convenient scoping mechanisms that allow us to replace "symbols" with values. This sort of functionality could potentially be replaced with a call to `eval` but that's generally considered bad practice due to security and performance concerns. However, it would shrink the size of the dependencies considerably.
- To make _all_ of our default price identifiers work with this sort of strategy, we'll need to strip them of `/` characters (which could be confused with a division operator by the parser) when ingesting them here. That's not a huge concern, but it is a slight added complexity.
- The decimal strategy in this class is quite different from others. In this case, I use a high-precision BigNumber class that comes with the mathjs library to convert all values to decimal before being processed by the library. This allows the library to use its default arithmetic operators, which is far far simpler than trying to make it operate on fixed point values. To ensure this BigNumber can handle our high-precision fixed point numbers, I customized the config to give them 100 decimals of precision, which should be plenty for our use. After the operations, it rounds off the result to drop any precision that's larger than our fixed point numbers allow.

This is how you configure an expression price feed:
```js
{
  type: "expression",
  expression: "ETHBTC + MYCUSTOMFEED",
  customFeeds: {
    MYCUSTOMFEED: {
      type: "cryptowatch",
      exchange: "coinbase-pro",
      pair: "ethusd"
    }
  }
}
```

In this example, the parser would find that the two "symbols" in the expression are `ETHBTC` (notice that we have stripped the `/` character) and `MYCUSTOMFEED`. Preferring customFeeds in the resolution, we would look through customFeeds _and_ the default feeds in the repo searching for each of these symbols. If any resolution fails, the construction fails. In this case, however, it would construct both feeds and use them to evaluate the expression. The nice thing about the early resolution is that any symbols that aren't in the expression are pruned, so there should never be any unnecessary feeds being constructed and/or evaluated.

Note: for feed names that contain special characters that are allowed in identifiers: `/`, ` `, `[`, `]`, they will need to be escaped, like `"\\/"` in the configuration.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
