### PR TITLE
fix(serverless-hub): Address dropped spoke logs and mismatch timedout spokes

### DIFF
--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -178,6 +178,7 @@ async function run({
           message: "End of serverless execution loop - terminating process"
         });
         await waitForLogger(logger);
+        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
         break;
       }
       logger.debug({
@@ -207,10 +208,10 @@ async function Poll(callback) {
       empAddress: process.env.EMP_ADDRESS,
       // Default to 1 minute delay. If set to 0 in env variables then the script will exit after full execution.
       pollingDelay: process.env.POLLING_DELAY ? Number(process.env.POLLING_DELAY) : 60,
-      // Default to 5 re-tries on error within the execution loop.
-      errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 5,
-      // Default to 10 seconds in between error re-tries.
-      errorRetriesTimeout: process.env.ERROR_RETRIES__TIMEOUT ? Number(process.env.ERROR_RETRIES__TIMEOUT) : 10,
+      // Default to 3 re-tries on error within the execution loop.
+      errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 3,
+      // Default to 1 seconds in between error re-tries.
+      errorRetriesTimeout: process.env.ERROR_RETRIES__TIMEOUT ? Number(process.env.ERROR_RETRIES__TIMEOUT) : 1,
       // Read price feed configuration from an environment variable. This can be a crypto watch, medianizer or uniswap
       // price feed Config defines the exchanges to use. If not provided then the bot will try and infer a price feed
       // from the EMP_ADDRESS. EG with medianizer: {"type":"medianizer","pair":"ethbtc",

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -300,6 +300,7 @@ async function run({
           message: "End of serverless execution loop - terminating process"
         });
         await waitForLogger(logger);
+        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
         break;
       }
       logger.debug({
@@ -333,9 +334,9 @@ async function Poll(callback) {
       // Default to 1 minute delay. If set to 0 in env variables then the script will exit after full execution.
       pollingDelay: process.env.POLLING_DELAY ? Number(process.env.POLLING_DELAY) : 60,
       // Default to 3 re-tries on error within the execution loop.
-      errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 5,
+      errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 3,
       // Default to 10 seconds in between error re-tries.
-      errorRetriesTimeout: process.env.ERROR_RETRIES_TIMEOUT ? Number(process.env.ERROR_RETRIES_TIMEOUT) : 10,
+      errorRetriesTimeout: process.env.ERROR_RETRIES_TIMEOUT ? Number(process.env.ERROR_RETRIES_TIMEOUT) : 1,
       // Read price feed configuration from an environment variable. This can be a crypto watch, medianizer or uniswap
       // price feed Config defines the exchanges to use. If not provided then the bot will try and infer a price feed
       // from the EMP_ADDRESS. EG with medianizer: {"type":"medianizer","pair":"ethbtc",

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -335,7 +335,7 @@ async function Poll(callback) {
       pollingDelay: process.env.POLLING_DELAY ? Number(process.env.POLLING_DELAY) : 60,
       // Default to 3 re-tries on error within the execution loop.
       errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 3,
-      // Default to 10 seconds in between error re-tries.
+      // Default to 1 seconds in between error re-tries.
       errorRetriesTimeout: process.env.ERROR_RETRIES_TIMEOUT ? Number(process.env.ERROR_RETRIES_TIMEOUT) : 1,
       // Read price feed configuration from an environment variable. This can be a crypto watch, medianizer or uniswap
       // price feed Config defines the exchanges to use. If not provided then the bot will try and infer a price feed

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -274,6 +274,7 @@ async function run({
           message: "End of serverless execution loop - terminating process"
         });
         await waitForLogger(logger);
+        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
         break;
       }
       logger.debug({
@@ -306,10 +307,10 @@ async function Poll(callback) {
       empAddress: process.env.EMP_ADDRESS,
       // Default to 1 minute delay. If set to 0 in env variables then the script will exit after full execution.
       pollingDelay: process.env.POLLING_DELAY ? Number(process.env.POLLING_DELAY) : 60,
-      // Default to 5 re-tries on error within the execution loop.
-      errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 5,
-      // Default to 10 seconds in between error re-tries.
-      errorRetriesTimeout: process.env.ERROR_RETRIES__TIMEOUT ? Number(process.env.ERROR_RETRIES__TIMEOUT) : 10,
+      // Default to 3 re-tries on error within the execution loop.
+      errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 3,
+      // Default to 1 seconds in between error re-tries.
+      errorRetriesTimeout: process.env.ERROR_RETRIES_TIMEOUT ? Number(process.env.ERROR_RETRIES_TIMEOUT) : 1,
       // Block number to search for events from. If set, acts to offset the search to ignore events in the past. If not
       // set then default to null which indicates that the bot should start at the current block number.
       startingBlock: process.env.STARTING_BLOCK_NUMBER,

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -46,7 +46,7 @@ const defaultHubConfig = {
   configRetrieval: "localStorage",
   saveQueriedBlock: "localStorage",
   spokeRunner: "localStorage",
-  rejectSpokeDelay: 120 // 2 min.
+  rejectSpokeDelay: 60 // 2 min.
 };
 
 hub.post("/", async (req, res) => {
@@ -186,7 +186,7 @@ hub.post("/", async (req, res) => {
               spokeName: spokeName,
               errorReported: errorOutput.errorOutputs[spokeName].execResponse
                 ? errorOutput.errorOutputs[spokeName].execResponse.stderr
-                : JSON.stringify(errorOutput.errorOutputs[spokeName])
+                : errorOutput.errorOutputs[spokeName]
             };
           } catch (err) {
             // `errorMessages` is in an unexpected JSON shape.

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -46,7 +46,7 @@ const defaultHubConfig = {
   configRetrieval: "localStorage",
   saveQueriedBlock: "localStorage",
   spokeRunner: "localStorage",
-  rejectSpokeDelay: 60 // 2 min.
+  rejectSpokeDelay: 120 // 2 min.
 };
 
 hub.post("/", async (req, res) => {

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -142,7 +142,7 @@ hub.post("/", async (req, res) => {
       });
       const rejectedRetryResults = await Promise.allSettled(rejectedRetryPromiseArray);
       rejectedRetryResults.forEach((result, index) => {
-        _processSpokeResponse(Object.keys(configObject)[index], result, validOutputs, errorOutputs);
+        _processSpokeResponse(retriedOutputs[index], result, validOutputs, errorOutputs);
       });
     }
     // If there are any error outputs(from the original loop or from re-tried calls) then throw.

--- a/packages/serverless-orchestration/test-helpers/TimeoutSpokeProcess.js
+++ b/packages/serverless-orchestration/test-helpers/TimeoutSpokeProcess.js
@@ -1,0 +1,9 @@
+const { delay } = require("@uma/financial-templates-lib");
+
+async function Run() {
+  console.log("Running timeoutsimulatedSpoke");
+  await delay(70);
+  console.log("Done & closing");
+}
+
+Run().then(() => {}); // Use the default winston logger & env port.

--- a/packages/serverless-orchestration/test-helpers/TimeoutSpokeProcess.js
+++ b/packages/serverless-orchestration/test-helpers/TimeoutSpokeProcess.js
@@ -1,3 +1,4 @@
+// script the sleeps for a defined duration then closes. Can be used to debug hub/spoke interactions.
 const { delay } = require("@uma/financial-templates-lib");
 
 async function Run() {
@@ -6,4 +7,4 @@ async function Run() {
   console.log("Done & closing");
 }
 
-Run().then(() => {}); // Use the default winston logger & env port.
+Run().then(() => {});


### PR DESCRIPTION
**Motivation**
This PR addresses two issues identified within the serverless configuration:

- Often spoke logs are dropped at the end of a spoke execution and are not logged correctly.
- There was a mismatch between the timed out spokes and the error spokes reported in hub logs. 

**Details**

**Problem 1:**
When debugging hub/spoke interactions, you can sometimes find that the bottom-most set of logs can get lost. The screenshot below shows the logs within a spoke for a given bot. This bot executed correctly and all logs were produced. however, some did not show up within GCP correctly. 
![image](https://user-images.githubusercontent.com/12886084/107238079-1a785400-6a30-11eb-9dd7-303bab9c68fd.png)

To deal with this issue, each bot's `index.js` file was updated to accommodate a 2-second timeout before the process terminates. This is a pretty shitty patch but it solves the issue and for now it'll be a bandaid until we can better deal with terminating transport issues.

**Problem 2:**
While working with the bots over last week it kept looking like the name of the bot reported in the `retriedSpokes` did not match the correct bot as the `retriedSpokes` always looked as if they completed their loops correctly. In particular, this log is nonsensical:
![image](https://user-images.githubusercontent.com/12886084/107238460-88bd1680-6a30-11eb-837c-654412f71949.png)

here you can see that the hub reported that the `retriedSpokes` is `stablespreadethmarch-mainnet-disputer` but the `errorOutputs` is `usdperl-mainnet-disputer` with this bot exceeding the timeout. This does not make sense as `usdperl-mainnet-disputer` shows up just fine within the `validOutputs`. This indicates that the `retriedSpokes` contains the wrong bot names.

After investigating locally I uncovered a small but meaningful error in how the hub logs are produced that mismatched these spokes. After this change, the re-tried spokes are correctly logged within the slack & GCP messages.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


Note that this does not yet solve the underlying timeout issues but it should help a bit in getting to the resolution.