### PR TITLE
improve(trader): add hardhat test setup

### DIFF
--- a/packages/trader/hardhat.config.ts
+++ b/packages/trader/hardhat.config.ts
@@ -1,6 +1,9 @@
-const { getHardhatConfig } = require("@uma/common");
+import "@nomiclabs/hardhat-web3";
+import "@nomiclabs/hardhat-truffle5";
 
-const path = require("path");
+import { getHardhatConfig } from "@uma/common";
+import path from "path";
+
 const coreWkdir = path.dirname(require.resolve("@uma/core/package.json"));
 const packageWkdir = path.dirname(require.resolve("@uma/optimistic-oracle/package.json"));
 
@@ -10,7 +13,7 @@ const configOverride = {
     sources: `${coreWkdir}/contracts`,
     artifacts: `${coreWkdir}/artifacts`,
     cache: `${coreWkdir}/cache`,
-    tests: `${packageWkdir}/dist/build/test`
+    tests: `${packageWkdir}/test`
   }
 };
 

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -29,7 +29,7 @@
     "url": "git+https://github.com/UMAprotocol/protocol.git"
   },
   "files": [
-    "/src/**/*.js"
+    "/dist/**/*.js"
   ],
   "bin": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -9,9 +9,14 @@
     "dotenv": "^8.2.0"
   },
   "devDependencies": {
-    "typescript": "^4.1.3",
     "@tsconfig/node14": "^1.0.0",
-    "@types/async-retry": "^1.4.2"
+    "@types/async-retry": "^1.4.2",
+    "@types/chai": "^4.2.14",
+    "@types/mocha": "^8.2.0",
+    "@types/node": "^14.14.25",
+    "chai": "^4.3.0",
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.3"
   },
   "homepage": "https://umaproject.org",
   "license": "AGPL-3.0-or-later",
@@ -30,9 +35,8 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc && tsc -p tsconfig-build.json",
-    "test": "echo \"No tests configured!\"",
-    "test-log": "truffle test ./test/*.js --network=test logInTest"
+    "build": "tsc -b",
+    "test": "hardhat test"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -9,6 +9,8 @@
     "dotenv": "^8.2.0"
   },
   "devDependencies": {
+    "@nomiclabs/hardhat-truffle5": "^2.0.0",
+    "@nomiclabs/hardhat-web3": "^2.0.0",
     "@tsconfig/node14": "^1.0.0",
     "@types/async-retry": "^1.4.2",
     "@types/chai": "^4.2.14",

--- a/packages/trader/src/index.ts
+++ b/packages/trader/src/index.ts
@@ -8,7 +8,7 @@ export async function run(): Promise<void> {
   const config = new TraderConfig(process.env);
   await retry(
     async () => {
-      console.log(config.empAddress);
+      // Trading logic here.
     },
     {
       retries: 3,

--- a/packages/trader/src/tsconfig.json
+++ b/packages/trader/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "include": ["./**/*.ts"],
+  "compilerOptions": {
+    "outDir": "../dist",
+    "rootDir": "../",
+    "composite": true
+  }
+}

--- a/packages/trader/test/index.ts
+++ b/packages/trader/test/index.ts
@@ -1,0 +1,23 @@
+import { run } from "../src/index";
+import { web3, assert } from "hardhat";
+
+describe("index.js", function() {
+  let accounts: string[];
+
+  before(async function() {
+    accounts = await web3.eth.getAccounts();
+  });
+
+  it("Runs with no errors", async function() {
+    const originalEnv = process.env;
+    process.env.EMP_ADDRESS = web3.utils.randomHex(20);
+
+    // Nonsensical check just to use assert.
+    assert.isAbove(accounts.length, 0);
+
+    // Must not throw.
+    await run();
+
+    process.env = originalEnv;
+  });
+});

--- a/packages/trader/tsconfig-build.json
+++ b/packages/trader/tsconfig-build.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "dist"
-  }
-}

--- a/packages/trader/tsconfig.json
+++ b/packages/trader/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
-  "include": ["src/**/*.ts"],
+  "include": ["test/**/*.ts", "hardhat.config.ts"],
   "compilerOptions": {
-    "outDir": "build",
-    "declaration": true
-  }
+    "outDir": "build"
+  },
+  "references": [
+    { "path": "./src/" }
+]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,52 +3419,52 @@
   integrity sha512-EL3SiX43m9poFSnhDx4d4fn9SSaqyO2rHsCNhETi9bWPmjXK3uPJ0QpPFtx39FEdHcz1vJmsiW41kqc0AgvtzQ==
 
 "@node-rs/crc32-android-arm64@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.0.0.tgz#721dd3c711ffc1d6d1a54d1c69110d2e37966fc7"
-  integrity sha512-pIODecKEcJQo0WJiz1CSct7lQ9eBSwCjIv51V1GTny1AvutMz4CN0WWVPwPXxsE/k4QWxAaseYNMdUqO36w40g==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.1.0.tgz#869f5f4414d145e00e6b12d1841eda0d70188db2"
+  integrity sha512-DXcsyCmTXEHr+aCocDtrSTBkIghvQ87rZNxQrThpNU3RgCAvCtNCPJw4F8/Il5MXN3c+xzl/ZglN03USqSPmAA==
 
 "@node-rs/crc32-darwin-arm64@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.0.0.tgz#47840b75ebf39c876cb91d186d9fdade8f647957"
-  integrity sha512-5uiAPAWZairY43SspVE2THkqtbdCAxKRDuXMIpYBKRpPAsV8osZGPkko76EdB8q7l82scGU/AszU9XTScQcYkA==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.1.0.tgz#b6f41c931f992f8fff93a5c086eb1c7f0b393fa5"
+  integrity sha512-dE04JL+w4+V0YBw+nrnzw7U0c5yTtAWg1jelNuZl+4BWCFrkHpAmUR+dHiz2OhZvbKV7RApwDNmYbvG+ppYK0Q==
 
 "@node-rs/crc32-darwin-x64@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.0.0.tgz#18ed061f65012f4328c14c522f89b0000a2b9bd1"
-  integrity sha512-qhjYz1e9HaOZpr1kmqbefAbENHLkNcBCU7MQ5dbdFo6QKnmA377UQ/A7La4Oheuc+nB9u5VkJYa3sb1LtB7kww==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.1.0.tgz#291f4b4b0a562c220537bdf69bd72b19bf7a19be"
+  integrity sha512-/nfj8EixjXc3iuyR5CybB2vOzQ23xjv/MrQiWtozcS2mLNsbMG/Ue0C9QLq4FQbL6HXEnhbrVbAQnByNurP4Ew==
 
 "@node-rs/crc32-linux-arm-gnueabihf@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.0.0.tgz#4717f8e8c8f9bf7390cfe8fd0805108834e3fb37"
-  integrity sha512-lQH//XOTvmq+OK+vVFtm8dEWgvTDaiuCpmgBbi+yKlVbjp2Vi/VXuPUf8OariH3UwG8odN/qaP3NGEdaC9+Caw==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.1.0.tgz#b54c7f12661f8c2ef0d1200716dce67811beb2ea"
+  integrity sha512-RX7VTEKfM/KMLeRMw89vJdsdvxZafoHQrwUvR290vuHE2Zfqc10YQQMJvq0iU7IaKmgDAnYZtUPhSAv1FdbtFQ==
 
 "@node-rs/crc32-linux-arm64-gnu@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.0.0.tgz#fec59b25415093d454316ebc4d2bb9cd9a6e420f"
-  integrity sha512-cEnFZYSuOwv7yUAxr205ffdJfwFlb7KG4BBoUXjz1vileVFXW5cjgxUeC3lqAFZkU1n4or444Dwwr4L9bPfhhg==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.1.0.tgz#736f745a16fd4c8be448646a957d3115cea9d18f"
+  integrity sha512-Age/YDyYhQEMSBZgHx4RhHXx6xcWNSGA3jDBu5NcBXo5dZZ2b3HAOjosdhfHqTGIrOdd+CAx3BqO5O46UiLU2Q==
 
 "@node-rs/crc32-linux-x64-gnu@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.0.0.tgz#4084795fe115c1436e2c1a23f384cfbd28eea732"
-  integrity sha512-faNmgDV3CSMVlMlNBxc9llDdQqYDdg6+0+EyhaaZBYoWRfuLTAuqg+gt0L6uyv0OM7IM/EXdNSVe9Wot9ERsUQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.1.0.tgz#9eca53c5ec185c838fa9ce4344efef7fb020dc3e"
+  integrity sha512-QUB3hkejwnziEyOT4zo51/qHEAW6YMs3eogQxOyB/IIkji8SwC1dgx94PC6MypBWSnjs2eAi0UiiZh6iK5+7kw==
 
 "@node-rs/crc32-linux-x64-musl@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.0.0.tgz#09c5c1f545a649ba0e6a5a8eea762e93df6970f4"
-  integrity sha512-mpudloSc0QgKUztnEOUhwzy8FQ0fQJtlo4pogObhtq/9akZBuRb0we7phXJT3z4Uy0cw5L7uCcH6jVnHfHcfww==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.1.0.tgz#28c5433ac1b5c30cb8b083a02c12ec302b97bb10"
+  integrity sha512-avmN8ZU69+U1kUZ9CKjhpBcwL4LD29pg+sRJ4+zQSbqbAqOaMfWsvEemKymfOENrQJLR80azwKWfgxldP7/X3A==
 
 "@node-rs/crc32-win32-x64-msvc@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.0.0.tgz#d63e8ac1409ad1e0dcbccde36fcdc36cee8c03cb"
-  integrity sha512-HOdm5jCzJmW8r3LMuz9wVtpuXoz8Np2+/Jkwu7DBW5OmZ5oFZ1W5NGgbBxOWAgig3KP5ochwnVZFIWH2dsCfPQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.1.0.tgz#e47d43161bec61c2c9f61bf577bdaa4c2887bc16"
+  integrity sha512-dqEQP+PxidHalhaEdat/54pGKx/aVIt7FDgWho5AEp2Wfc90aUdH4o1UX/sE4azDejo7eXc+kUHrTn3ZZWrRfw==
 
 "@node-rs/helper@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-rs/helper/-/helper-1.0.0.tgz#9fcd3f38b84af599e42c0aec272b308da55583e9"
-  integrity sha512-B4CSMHCuYPqai3LMsRTXyvBEP24YRnCZUUsDPYkgFD6tFA+q43rLkaEzsnTJTKJq5ZnJ4n5YJpJwEz7Xn8+0vg==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/helper/-/helper-1.1.0.tgz#4fcbbebae3b81932d1ff3e431c7cd3886b504742"
+  integrity sha512-r43YnnrY5JNzDuXJdW3sBJrKzvejvFmFWbiItUEoBJsaPzOIWFMhXB7i5j4c9EMXcFfxveF4l7hT+rLmwtjrVQ==
   dependencies:
     "@napi-rs/triples" "^1.0.2"
-    tslib "^2.0.3"
+    tslib "^2.1.0"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -4458,6 +4458,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.12.tgz#6160ae454cd89dae05adc3bb97997f488b608201"
   integrity sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==
 
+"@types/chai@^4.2.14":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
+  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -4572,6 +4577,11 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
+"@types/mocha@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.0.tgz#3eb56d13a1de1d347ecb1957c6860c911704bc44"
+  integrity sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==
+
 "@types/node@*", "@types/node@>= 8":
   version "14.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
@@ -4601,6 +4611,11 @@
   version "13.13.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.15.tgz#fe1cc3aa465a3ea6858b793fd380b66c39919766"
   integrity sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==
+
+"@types/node@^14.14.25":
+  version "14.14.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.25.tgz#15967a7b577ff81383f9b888aa6705d43fbbae93"
+  integrity sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
 
 "@types/node@^8.0.0":
   version "8.10.65"
@@ -5542,6 +5557,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -7302,6 +7322,18 @@ chai@^4.2.0:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
+chai@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.0.tgz#5523a5faf7f819c8a92480d70a8cccbadacfc25f"
+  integrity sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chalk-pipe@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk-pipe/-/chalk-pipe-3.0.0.tgz#57dfd9b9dae6615d32a2dd611ac691f8aff47504"
@@ -8291,6 +8323,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
@@ -9060,7 +9097,7 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
-diff@4.0.2, diff@^4.0.2:
+diff@4.0.2, diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -15552,6 +15589,11 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 make-fetch-happen@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz#aa8387104f2687edca01c8687ee45013d02d19bd"
@@ -20867,7 +20909,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.13, source-map-support@^0.5.16, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
+source-map-support@^0.5.13, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -22097,6 +22139,18 @@ ts-invariant@^0.4.4:
   dependencies:
     tslib "^1.9.3"
 
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
@@ -22127,7 +22181,7 @@ tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^2.0.3:
+tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
@@ -24682,6 +24736,11 @@ yazl@^2.2.1:
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zen-observable@^0.8.14:
   version "0.8.15"


### PR DESCRIPTION
**Motivation**

The trader package doesn't currently have a test setup.

**Summary**

It was a little tricky to get typescript tests set up in hardhat using truffle5 and web3, but it's doable. This PR adds a sample test and shuffles the package configuration to make it so `hardhat test` works as one would expect. I suspect there may be other issues down the road, but this should be a good place to start and has the basics.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
