### PR TITLE
feat(pricefeeds): Add COMPUSDC-APR-MAR28/USDC

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -343,7 +343,8 @@ const defaultConfigs = {
   "COMPUSDC-APR-MAR28/USDC": {
     type: "uniswap",
     uniswapAddress: "0xd8ecab1d50c3335d01885c17b1ce498105238f24",
-    twapLength: 7200
+    twapLength: 7200,
+    poolDecimals: 6
   },
   BTCDOM: {
     type: "domfi",

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -340,6 +340,11 @@ const defaultConfigs = {
     uniswapAddress: "0x683ea972ffa19b7bad6d6be0440e0a8465dba71c",
     twapLength: 7200
   },
+  "COMPUSDC-APR-MAR28/USDC": {
+    type: "uniswap",
+    uniswapAddress: "0xd8ecab1d50c3335d01885c17b1ce498105238f24",
+    twapLength: 7200
+  },
   BTCDOM: {
     type: "domfi",
     pair: "BTCDOM",


### PR DESCRIPTION
**Motivation**

This price identifier is self referential. It tracks the price of the synthetic that uses it.
UMIP-38 for price identifier spec: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-38.md

**Summary**

Added config for tracking the Uniswap pool for new synthetic.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested