### PR TITLE
improve(default-pricefeed): Swap UniswapPriceFeed for CryptoWatchPriceFeed for elastic basket

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -287,11 +287,17 @@ const defaultConfigs = {
     experimentalPriceFeeds: [
       {
         type: "medianizer",
-        medianizedFeeds: [{ type: "cryptowatch", exchange: "uniswap-v2", pair: "fraxusdc" }]
+        medianizedFeeds: [
+          // FRAX/USDC:
+          { type: "uniswap", uniswapAddress: "0x97c4adc5d28a86f9470c70dd91dc6cc2f20d2d4d", twapLength: 2 }
+        ]
       },
       {
         type: "medianizer",
-        medianizedFeeds: [{ type: "cryptowatch", exchange: "uniswap-v2", pair: "esdusdc" }]
+        medianizedFeeds: [
+          // ESD/USDC:
+          { type: "uniswap", uniswapAddress: "0x88ff79eb2bc5850f27315415da8685282c7610f9", twapLength: 2 }
+        ]
       },
       {
         type: "medianizer",


### PR DESCRIPTION

Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

CryptoWatch OHLC data is often empty for FRAX/USDC and ESD/USDC markets because they are relatively low volume on Uniswap. Replace with UniswapPriceFeed that better handles missing data within a TWAP window.
