### PR TITLE
feat(financial-templates-lib): add Multiline support to ExpressionPriceFeed

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -133,8 +133,13 @@ class ExpressionPriceFeed extends PriceFeedInterface {
     return math.bignumber(price.toString()).div(decimalsMultiplier);
   }
 
-  // Takes a math.bignumber number and converts it to a fixed point number that's expected outside this library.
+  // Takes a math.bignumber OR math.ResultSet of math.bignumbers and converts it to a fixed point number that's
+  // expected outside this library. Note: if the price is a ResultSet, the last value is converted and returned.
   _convertToFixed(price, outputDecimals) {
+    // If the price is a ResultSet with multiple entires, extract the last one and make that the price.
+    if (price.entries) {
+      price = price.entries[price.entries.length - 1];
+    }
     const decimals = math.bignumber(outputDecimals);
     const decimalsMultiplier = math.bignumber(10).pow(decimals);
     return Web3.utils.toBN(math.format(price.mul(decimalsMultiplier).round(), { notation: "fixed" }));


### PR DESCRIPTION
**Motivation**

ExpressionPriceFeed should support expressions that are multi-line.


**Summary**

When multiline expressions are passed in, mathjs returns `ResultSet`, which can return multiple results at once. In that case, the ExpressionPriceFeed returns the last line's result.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
