### PR TITLE
feat(optimistic-oracle-proposer): Add dispute logic

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -93,7 +93,8 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         uint256 timestamp,
         bytes ancillaryData,
         int256 proposedPrice,
-        uint256 expirationTimestamp
+        uint256 expirationTimestamp,
+        address currency
     );
     event DisputePrice(
         address indexed requester,
@@ -101,7 +102,8 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         address indexed disputer,
         bytes32 identifier,
         uint256 timestamp,
-        bytes ancillaryData
+        bytes ancillaryData,
+        int256 proposedPrice
     );
     event Settle(
         address indexed requester,
@@ -300,7 +302,8 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
             timestamp,
             ancillaryData,
             proposedPrice,
-            request.expirationTime
+            request.expirationTime,
+            address(request.currency)
         );
 
         // Callback.
@@ -390,7 +393,15 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
             request.currency.safeTransfer(requester, refund);
         }
 
-        emit DisputePrice(requester, request.proposer, disputer, identifier, timestamp, ancillaryData);
+        emit DisputePrice(
+            requester,
+            request.proposer,
+            disputer,
+            identifier,
+            timestamp,
+            ancillaryData,
+            request.proposedPrice
+        );
 
         // Callback.
         if (address(requester).isContract())

--- a/packages/financial-templates-lib/src/clients/OptimisticOracleClient.js
+++ b/packages/financial-templates-lib/src/clients/OptimisticOracleClient.js
@@ -66,19 +66,11 @@ class OptimisticOracleClient {
     });
   }
 
-  // Returns disputes that can be settled and that involved the caler as the disputer
+  // Returns disputes that can be settled and that involved the caller as the disputer
   getSettleableDisputes(caller) {
     return this.settleableDisputes.filter(event => {
       return event.disputer === caller;
     });
-  }
-
-  // Returns an array of Price Request objects for each position that someone has proposed a price for and whose
-  // proposal can be disputed. The proposal can be disputed because the proposed price deviates from the `inputPrice` by
-  // more than the `errorThreshold`.
-  getDisputablePriceProposals() {
-    // TODO
-    return;
   }
 
   // Returns the last update timestamp.
@@ -140,7 +132,8 @@ class OptimisticOracleClient {
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
           timestamp: event.returnValues.timestamp,
           proposedPrice: event.returnValues.proposedPrice,
-          expirationTimestamp: event.returnValues.expirationTimestamp
+          expirationTimestamp: event.returnValues.expirationTimestamp,
+          currency: event.returnValues.currency
         };
       });
 
@@ -210,10 +203,7 @@ class OptimisticOracleClient {
     ).filter(event => event !== undefined);
     this.settleableDisputes = unsettledResolvedDisputeEvents;
 
-    // Determine which undisputed proposals SHOULD be disputed based on current prices:
-    // TODO: This would involve having a pricefeed for each identifier. This logic might be
-    // better placed in the OO Keeper instead of the client.
-
+    // Update timestamp and end update.
     this.lastUpdateTimestamp = currentTime;
     this.logger.debug({
       at: "OptimisticOracleClient",

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
@@ -161,6 +161,7 @@ contract("OptimisticOracleClient.js", function(accounts) {
         proposer: proposer,
         identifier: hexToUtf8(identifier),
         ancillaryData: "0x",
+        currency: collateral.address,
         timestamp: requestTime.toString(),
         proposedPrice: correctPrice,
         expirationTimestamp: (Number(currentContractTime) + liveness).toString()
@@ -188,6 +189,7 @@ contract("OptimisticOracleClient.js", function(accounts) {
         proposer: proposer,
         identifier: hexToUtf8(identifier),
         ancillaryData: "0x",
+        currency: collateral.address,
         timestamp: requestTime.toString(),
         proposedPrice: correctPrice,
         expirationTimestamp: (Number(currentContractTime) + liveness).toString()

--- a/packages/optimistic-oracle/src/proposer.js
+++ b/packages/optimistic-oracle/src/proposer.js
@@ -214,8 +214,7 @@ class OptimisticOracleProposer {
         continue;
       }
 
-      // If proposal price is not equal to the dispute price, then
-      // prepare dispute.
+      // If proposal price is not equal to the dispute price, then prepare dispute
       // TODO: Implement dispute buffer feature to only dispute if proposal and dispute price
       // differ using some margin of error. For example, we could define a variable `proposalErrorPrecision`
       // and set it to 5, to only send disputes if prices differ after rounding to 5 decimals of precision.

--- a/packages/optimistic-oracle/src/proposer.js
+++ b/packages/optimistic-oracle/src/proposer.js
@@ -68,7 +68,7 @@ class OptimisticOracleProposer {
   // Submit proposals to unproposed price requests.
   async sendProposals() {
     this.logger.debug({
-      at: "OptimisticOracleProposer",
+      at: "OptimisticOracleProposer#sendProposals",
       message: "Checking for unproposed price requests to send proposals for"
     });
 
@@ -78,7 +78,7 @@ class OptimisticOracleProposer {
       // Pricefeed is either constructed correctly or is null.
       if (!priceFeed) {
         this.logger.error({
-          at: "OptimisticOracleProposer",
+          at: "OptimisticOracleProposer#sendProposals",
           message: "Failed to construct a PriceFeed for price request",
           priceRequest
         });
@@ -92,7 +92,7 @@ class OptimisticOracleProposer {
         proposalPrice = (await priceFeed.getHistoricalPrice(priceRequest.timestamp)).toString();
       } catch (error) {
         this.logger.error({
-          at: "OptimisticOracleProposer",
+          at: "OptimisticOracleProposer#sendProposals",
           message: "Failed to query historical price for price request",
           priceRequest,
           error
@@ -119,7 +119,7 @@ class OptimisticOracleProposer {
         ]);
       } catch (error) {
         this.logger.error({
-          at: "OptimisticOracle#Proposer",
+          at: "OptimisticOracleProposer#sendProposals",
           message: "Cannot propose price: not enough collateral (or large enough approval)✋",
           proposer: this.account,
           proposalBond,
@@ -135,7 +135,7 @@ class OptimisticOracleProposer {
       };
 
       this.logger.debug({
-        at: "OptimisticOracle#Proposer",
+        at: "OptimisticOracleProposer#sendProposals",
         message: "Proposing new price",
         priceRequest,
         proposalPrice,
@@ -148,7 +148,7 @@ class OptimisticOracleProposer {
         receipt = await proposal.send(txnConfig);
       } catch (error) {
         this.logger.error({
-          at: "OptimisticOracle#Proposer",
+          at: "OptimisticOracleProposer#sendProposals",
           message: "Failed to propose price🚨",
           error
         });
@@ -165,7 +165,7 @@ class OptimisticOracleProposer {
         expirationTimestamp: receipt.events.ProposePrice.returnValues.expirationTimestamp
       };
       this.logger.info({
-        at: "OptimisticOracle#Proposer",
+        at: "OptimisticOracleProposer#sendProposals",
         message: "Proposed price!💍",
         priceRequest,
         proposalPrice,
@@ -175,8 +175,126 @@ class OptimisticOracleProposer {
     }
   }
 
+  // Submit disputes to proposed price requests
   async sendDisputes() {
-    // TODO
+    this.logger.debug({
+      at: "OptimisticOracleProposer#sendDisputes",
+      message: "Checking for undisputed price requests to dispute"
+    });
+
+    for (let priceRequest of this.optimisticOracleClient.getUndisputedProposals()) {
+      // Get proposal price
+      let proposalPrice = priceRequest.proposedPrice;
+
+      // Create pricefeed for identifier
+      const priceFeed = await this._createOrGetCachedPriceFeed(priceRequest.identifier);
+
+      // Pricefeed is either constructed correctly or is null.
+      if (!priceFeed) {
+        this.logger.error({
+          at: "OptimisticOracleProposer#sendDisputes",
+          message: "Failed to construct a PriceFeed for price request",
+          priceRequest
+        });
+        continue;
+      }
+
+      // With pricefeed successfully constructed, confirm the proposal price
+      await priceFeed.update();
+      let disputePrice;
+      try {
+        disputePrice = (await priceFeed.getHistoricalPrice(priceRequest.timestamp)).toString();
+      } catch (error) {
+        this.logger.error({
+          at: "OptimisticOracleProposer#sendDisputes",
+          message: "Failed to query historical price for price request",
+          disputePrice,
+          error
+        });
+        continue;
+      }
+
+      // If proposal price is not equal to the dispute price, then
+      // prepare dispute.
+      // TODO: Implement dispute buffer feature to only dispute if proposal and dispute price
+      // differ using some margin of error. For example, we could define a variable `proposalErrorPrecision`
+      // and set it to 5, to only send disputes if prices differ after rounding to 5 decimals of precision.
+      let isPriceDisputable = !this.toBN(disputePrice).eq(this.toBN(proposalPrice));
+      if (isPriceDisputable) {
+        // Create the transaction.
+        const dispute = this.ooContract.methods.disputePrice(
+          priceRequest.requester,
+          this.utf8ToHex(priceRequest.identifier),
+          priceRequest.timestamp,
+          priceRequest.ancillaryData
+        );
+
+        // Simple version of inventory management: simulate the transaction and assume that if it fails,
+        // the caller didn't have enough collateral.
+        let disputeBond, gasEstimation;
+        try {
+          [disputeBond, gasEstimation] = await Promise.all([
+            dispute.call({ from: this.account }),
+            dispute.estimateGas({ from: this.account })
+          ]);
+        } catch (error) {
+          this.logger.error({
+            at: "OptimisticOracleProposer#sendDisputes",
+            message: "Cannot dispute price: not enough collateral (or large enough approval)✋",
+            proposer: this.account,
+            disputeBond,
+            priceRequest,
+            error
+          });
+          continue;
+        }
+        const txnConfig = {
+          from: this.account,
+          gas: Math.min(Math.floor(gasEstimation * this.GAS_LIMIT_BUFFER), this.txnGasLimit),
+          gasPrice: this.gasEstimator.getCurrentFastPrice()
+        };
+
+        this.logger.debug({
+          at: "OptimisticOracleProposer#sendDisputes",
+          message: "Disputing proposal",
+          priceRequest,
+          proposalPrice,
+          disputePrice,
+          txnConfig
+        });
+
+        // Send the transaction or report failure.
+        let receipt;
+        try {
+          receipt = await dispute.send(txnConfig);
+        } catch (error) {
+          this.logger.error({
+            at: "OptimisticOracleProposer#sendDisputes",
+            message: "Failed to dispute proposal🚨",
+            error
+          });
+          continue;
+        }
+        const logResult = {
+          tx: receipt.transactionHash,
+          requester: receipt.events.DisputePrice.returnValues.requester,
+          proposer: receipt.events.DisputePrice.returnValues.proposer,
+          disputer: receipt.events.DisputePrice.returnValues.disputer,
+          identifier: this.hexToUtf8(receipt.events.DisputePrice.returnValues.identifier),
+          ancillaryData: receipt.events.DisputePrice.returnValues.ancillaryData,
+          timestamp: receipt.events.DisputePrice.returnValues.timestamp,
+          proposedPrice: receipt.events.DisputePrice.returnValues.proposedPrice
+        };
+        this.logger.info({
+          at: "OptimisticOracleProposer#sendDisputes",
+          message: "Disputed proposal!⛑",
+          priceRequest,
+          disputePrice,
+          txnConfig,
+          disputeResult: logResult
+        });
+      }
+    }
   }
 
   async settleRequests() {
@@ -191,29 +309,45 @@ class OptimisticOracleProposer {
 
   // Sets allowances for all collateral currencies used in unproposed price requests
   async _setAllowances() {
-    // TODO: Should we do this also for currencies from undisputedProposals?
-    for (let priceRequest of this.optimisticOracleClient.getUnproposedPriceRequests()) {
-      // The OO requires approval to transfer the proposed price request's collateral currency in order to post a bond.
-      // We'll set this once to the max value and top up whenever the bot's allowance drops below MAX_INT / 2.
+    const approvalPromises = [];
+
+    // Increase allowance to MAX for the `priceRequest.currency`
+    const _approveCollateralCurrencyForPriceRequest = async priceRequest => {
       const collateralToken = new this.web3.eth.Contract(getAbi("ExpandedERC20"), priceRequest.currency);
-      const [currentCollateralAllowance] = await Promise.all([
-        collateralToken.methods.allowance(this.account, this.ooContract.options.address).call()
-      ]);
+      const currentCollateralAllowance = await collateralToken.methods
+        .allowance(this.account, this.ooContract.options.address)
+        .call();
       if (this.toBN(currentCollateralAllowance).lt(this.toBN(MAX_UINT_VAL).div(this.toBN("2")))) {
-        const collateralApprovalTx = await collateralToken.methods
+        const collateralApprovalPromise = collateralToken.methods
           .approve(this.ooContract.options.address, MAX_UINT_VAL)
           .send({
             from: this.account,
             gasPrice: this.gasEstimator.getCurrentFastPrice()
+          })
+          .then(tx => {
+            this.logger.info({
+              at: "OptimisticOracle#Proposer",
+              message: "Approved OO to transfer unlimited collateral tokens 💰",
+              currency: collateralToken.options.address,
+              collateralApprovalTx: tx.transactionHash
+            });
           });
-        this.logger.info({
-          at: "OptimisticOracle#Proposer",
-          message: "Approved OO to transfer unlimited collateral tokens 💰",
-          currency: collateralToken.options.address,
-          collateralApprovalTx: collateralApprovalTx.transactionHash
-        });
+        approvalPromises.push(collateralApprovalPromise);
       }
+    };
+
+    // The OO requires approval to transfer the proposed price request's collateral currency in order to post a bond.
+    // We'll set this once to the max value and top up whenever the bot's allowance drops below MAX_INT / 2.
+    for (let priceRequest of this.optimisticOracleClient.getUnproposedPriceRequests()) {
+      await _approveCollateralCurrencyForPriceRequest(priceRequest);
     }
+
+    // We also approve currencies stored in disputes if for some reason they were not approved already.
+    for (let priceRequest of this.optimisticOracleClient.getUndisputedProposals()) {
+      await _approveCollateralCurrencyForPriceRequest(priceRequest);
+    }
+
+    await Promise.all(approvalPromises);
   }
 
   // Create the pricefeed for a specific identifier and save it to the state, or


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Part of #2411

Adds dispute logic to Optimistic Oracle proposer bot.

**Summary**

- Added event parameters to `OptimisticOracle.sol` to simplify bot logic. See comments for more details.
- Implemented `sendDisputes` in the `packages/OptimisticOracle: proposer.js` bot which checks proposed prices for `undisputed proposals` and sends disputes where `disputePrice != proposePrice`

Future work:
- Add a disputePrice buffer configuration variable to the OO bot which allows `disputePrice` and `proposePrice` to diverge beyond a certain precision, (e.g. 5 decimals of precision), without having to send a dispute.
- Add settlePrice feature


**Details**

- Adding event parameters to `OptimisticOracle.sol` should be harmless but its important to note that this would change Contract bytecode from that in the latest OpenZeppelin audit.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
