### PR TITLE
improve(core): update voting upgrade script to pass proposer wallet as migrated address

### DIFF
--- a/packages/core/scripts/voting-upgrade-umip/1_Propose.js
+++ b/packages/core/scripts/voting-upgrade-umip/1_Propose.js
@@ -79,6 +79,7 @@ async function runExport() {
     existingVoting.address,
     newVoting.address,
     finder.address,
+    proposerWallet, // Pass proposer wallet as the "migrated" address.
     {
       from: proposerWallet
     }

--- a/packages/core/scripts/voting-upgrade-umip/3_Verify.js
+++ b/packages/core/scripts/voting-upgrade-umip/3_Verify.js
@@ -28,6 +28,7 @@ async function runExport() {
 
   // The finder should correctly match the addresses of new contracts
   const finder = await Finder.deployed();
+  const governor = await Governor.deployed();
   const interfaceNameBytes32 = web3.utils.utf8ToHex(interfaceName.Oracle);
   const finderSetAddress = await finder.getImplementationAddress(interfaceNameBytes32);
   assert.equal(web3.utils.toChecksumAddress(finderSetAddress), web3.utils.toChecksumAddress(votingAddress));
@@ -37,7 +38,7 @@ async function runExport() {
 
   const newVotingContract = await Voting.at(votingAddress);
   const currentOwner = await newVotingContract.owner();
-  assert.equal(web3.utils.toChecksumAddress(currentOwner), web3.utils.toChecksumAddress(Governor.address));
+  assert.equal(web3.utils.toChecksumAddress(currentOwner), web3.utils.toChecksumAddress(governor.address));
 
   console.log("✅ New Voting correctly transferred ownership!");
 
@@ -51,8 +52,8 @@ async function runExport() {
 
   console.log(" 4. Validating old voting contract and finder is owned by governor...");
 
-  assert.equal(await oldVotingContract.owner(), Governor.address);
-  assert.equal(await finder.owner(), Governor.address);
+  assert.equal(await oldVotingContract.owner(), governor.address);
+  assert.equal(await finder.owner(), governor.address);
 
   console.log("✅ Old Voting & finder correctly transferred ownership back to governor!");
 }


### PR DESCRIPTION
**Motivation**

To allow the foundation hot wallet to claim rewards on behalf of voters in the old voting contract, we need to set it as the migrated address.


**Summary**

Added a parameter to the upgrader contract and passed the foundation hot wallet to the constructor in the upgrade script.

Note: the migrated address has the following abilities:
- Migrated address can request a price to "start a vote"
- Nobody can cast votes (so any incomplete votes cannot be finalized and, therefore generate rewards).
- Migrated address can call claim rewards.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
