### PR TITLE
improve(pricefeed): Add default config for CNYUSD to TraderMade

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -378,6 +378,13 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "bitfinex", pair: "amplusd" }
     ]
   },
+  CNYUSD: {
+    type: "tradermade",
+    pair: "CNYUSD",
+    minuteLookback: 7200,
+    hourlyLookback: 604800,
+    minTimeBetweenUpdates: 600
+  },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this
   // default price feed config.
   TEST8DECIMALS: {

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -381,7 +381,7 @@ const defaultConfigs = {
   CNYUSD: {
     type: "tradermade",
     pair: "CNYUSD",
-    minuteLookback: 7200, // minuteLookback up to 2 days
+    minuteLookback: 7200, // interval=minute allowed lookback up to 2 days
     hourlyLookback: 604800, // interval=hour allowed lookback up to 2 months
     minTimeBetweenUpdates: 600
   },

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -381,8 +381,8 @@ const defaultConfigs = {
   CNYUSD: {
     type: "tradermade",
     pair: "CNYUSD",
-    minuteLookback: 7200,
-    hourlyLookback: 604800,
+    minuteLookback: 7200, // minuteLookback up to 2 days
+    hourlyLookback: 604800, // hourlyLookback up to 2 months
     minTimeBetweenUpdates: 600
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -382,7 +382,7 @@ const defaultConfigs = {
     type: "tradermade",
     pair: "CNYUSD",
     minuteLookback: 7200, // minuteLookback up to 2 days
-    hourlyLookback: 604800, // hourlyLookback up to 2 months
+    hourlyLookback: 604800, // interval=hour allowed lookback up to 2 months
     minTimeBetweenUpdates: 600
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this


### PR DESCRIPTION
Signed-off-by: FreshmanQ <xunand@quarkchain.org>

**Motivation**

Part of #2479 

**Summary**

Add CNYUSD price identifier default configuration 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [✅ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
