### PR TITLE
feat(financial-templates-lib): add LPPriceFeed

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -16,6 +16,7 @@ const { defaultConfigs } = require("./DefaultPriceFeedConfigs");
 const { getTruffleContract, getAbi } = require("@uma/core");
 const { ExpressionPriceFeed, math, escapeSpecialCharacters } = require("./ExpressionPriceFeed");
 const { VaultPriceFeed } = require("./VaultPriceFeed");
+const { LPPriceFeed } = require("./LPPriceFeed");
 const { BlockFinder } = require("./utils");
 
 async function createPriceFeed(logger, web3, networker, getTime, config) {
@@ -327,9 +328,30 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       ...config,
       logger,
       web3,
+      getTime,
       vaultAbi: getAbi("VaultInterface", "latest"),
       erc20Abi: getAbi("IERC20Standard", "latest"),
       vaultAddress: config.address,
+      blockFinder: getSharedBlockFinder(web3)
+    });
+  } else if (config.type === "lp") {
+    const requiredFields = ["poolAddress", "tokenAddress"];
+    if (isMissingField(config, requiredFields, logger)) {
+      return null;
+    }
+
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating LPPriceFeed",
+      config
+    });
+
+    return new LPPriceFeed({
+      ...config,
+      logger,
+      web3,
+      getTime,
+      erc20Abi: getAbi("IERC20Standard", "latest"),
       blockFinder: getSharedBlockFinder(web3)
     });
   }

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -13,7 +13,7 @@ const { TraderMadePriceFeed } = require("./TraderMadePriceFeed");
 const { PriceFeedMockScaled } = require("./PriceFeedMockScaled");
 const { InvalidPriceFeedMock } = require("./InvalidPriceFeedMock");
 const { defaultConfigs } = require("./DefaultPriceFeedConfigs");
-const { getTruffleContract, getAbi } = require("@uma/core");
+const { getTruffleContract } = require("@uma/core");
 const { ExpressionPriceFeed, math, escapeSpecialCharacters } = require("./ExpressionPriceFeed");
 const { VaultPriceFeed } = require("./VaultPriceFeed");
 const { LPPriceFeed } = require("./LPPriceFeed");
@@ -23,6 +23,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
   const Uniswap = getTruffleContract("Uniswap", web3, "latest");
   const ERC20 = getTruffleContract("ExpandedERC20", web3, "latest");
   const Balancer = getTruffleContract("Balancer", web3, "latest");
+  const VaultInterface = getTruffleContract("VaultInterface", web3, "latest");
 
   if (config.type === "cryptowatch") {
     const requiredFields = ["exchange", "pair", "lookback", "minTimeBetweenUpdates"];
@@ -329,8 +330,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       logger,
       web3,
       getTime,
-      vaultAbi: getAbi("VaultInterface", "latest"),
-      erc20Abi: getAbi("IERC20Standard", "latest"),
+      vaultAbi: VaultInterface.abi,
+      erc20Abi: ERC20.abi,
       vaultAddress: config.address,
       blockFinder: getSharedBlockFinder(web3)
     });
@@ -351,7 +352,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       logger,
       web3,
       getTime,
-      erc20Abi: getAbi("IERC20Standard", "latest"),
+      erc20Abi: ERC20.abi,
       blockFinder: getSharedBlockFinder(web3)
     });
   }

--- a/packages/financial-templates-lib/src/price-feed/LPPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/LPPriceFeed.js
@@ -1,0 +1,129 @@
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+const { BlockFinder } = require("./utils");
+const { ConvertDecimals } = require("@uma/common");
+const assert = require("assert");
+class LPPriceFeed extends PriceFeedInterface {
+  /**
+   * @notice Constructs new price feed object that tracks how much of a provided token a single LP share is redeemable
+   *         for.
+   * @dev Note: this can support most LP shares and may support other types of pool contracts.
+   * @param {Object} logger Winston module used to send logs.
+   * @param {Object} web3 Provider from Truffle instance to connect to Ethereum network.
+   * @param {Object} erc20Abi ERC20 abi object to create a contract instance.
+   * @param {String} poolAddress Ethereum address of the LP pool to monitor.
+   * @param {String} tokenAddress Ethereum address of the per-share token balance we're tracking within the pool.
+   * @param {Function} getTime Returns the current time.
+   * @param {Function} [blockFinder] Optionally pass in a shared blockFinder instance (to share the cache).
+   * @param {Integer} [minTimeBetweenUpdates] Minimum amount of time that must pass before update will actually run
+   *                                        again.
+   * @param {Integer} [priceFeedDecimals] Precision that the caller wants precision to be reported in.
+   * @return None or throws an Error.
+   */
+  constructor({
+    logger,
+    web3,
+    erc20Abi,
+    poolAddress,
+    tokenAddress,
+    getTime,
+    blockFinder,
+    minTimeBetweenUpdates = 60,
+    priceFeedDecimals = 18
+  }) {
+    super();
+
+    // Assert required arguments.
+    assert(logger, "logger required");
+    assert(web3, "web3 required");
+    assert(erc20Abi, "erc20Abi required");
+    assert(poolAddress, "poolAddress required");
+    assert(tokenAddress, "tokenAddress required");
+    assert(getTime, "getTime required");
+
+    this.logger = logger;
+    this.web3 = web3;
+    this.toBN = web3.utils.toBN;
+
+    this.pool = new web3.eth.Contract(erc20Abi, poolAddress);
+    this.token = new web3.eth.Contract(erc20Abi, tokenAddress);
+    this.uuid = `LP-${poolAddress}-${tokenAddress}`;
+    this.getTime = getTime;
+    this.priceFeedDecimals = priceFeedDecimals;
+    this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+    this.blockFinder = blockFinder || BlockFinder(web3.eth.getBlock);
+  }
+
+  getCurrentPrice() {
+    return this.price;
+  }
+
+  async getHistoricalPrice(time) {
+    const block = await this.blockFinder.getBlockForTimestamp(time);
+    return this._getPrice(block.number);
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  getLookback() {
+    // Return infinity since this price feed can technically look back as far as needed.
+    return Infinity;
+  }
+
+  getPriceFeedDecimals() {
+    return this.priceFeedDecimals;
+  }
+
+  async update() {
+    const currentTime = await this.getTime();
+    if (this.lastUpdateTime === undefined || currentTime >= this.lastUpdateTime + this.minTimeBetweenUpdates) {
+      this.price = await this._getPrice();
+      this.lastUpdateTime = currentTime;
+    }
+  }
+
+  async _getDecimals() {
+    if (this.tokenDecimals === undefined) {
+      this.tokenDecimals = parseInt(await this.token.methods.decimals().call());
+    }
+
+    if (this.poolDecimals === undefined) {
+      this.poolDecimals = parseInt(await this.pool.methods.decimals().call());
+    }
+
+    return { poolDecimals: this.poolDecimals, tokenDecimals: this.tokenDecimals };
+  }
+
+  async _getPrice(blockNumber = "latest") {
+    const lpTotalSupply = this.toBN(await this.pool.methods.totalSupply().call(undefined, blockNumber));
+    const tokensInPool = this.toBN(
+      await this.token.methods.balanceOf(this.pool.options.address).call(undefined, blockNumber)
+    );
+
+    // 10^decimals is the fixed point multiplier for the pool.
+    const { poolDecimals } = await this._getDecimals();
+    const poolDecimalMultiplier = this.toBN("10").pow(this.toBN(poolDecimals));
+
+    // To get the price, we divide the total tokens in the pool by the number of LP shares.
+    // Note: this produces a rawPrice that is in terms of the token's decimals, not the pool's.
+    // Note: if the total supply is zero, then we just set the price to 0 since no LP tokens exist.
+    const rawPrice = lpTotalSupply.isZero()
+      ? web3.utils.toBN("0")
+      : tokensInPool.mul(poolDecimalMultiplier).divRound(lpTotalSupply);
+
+    // _convertDecimals takes a price with the token's decimals and returns it in terms of priceFeedDecimals.
+    return await this._convertDecimals(rawPrice);
+  }
+
+  // Converts decimals from the token decimals to the configured output decimals.
+  async _convertDecimals(value) {
+    const { tokenDecimals } = await this._getDecimals();
+    const convertDecimals = ConvertDecimals(tokenDecimals, this.priceFeedDecimals, this.web3);
+    return convertDecimals(value);
+  }
+}
+
+module.exports = {
+  LPPriceFeed
+};

--- a/packages/financial-templates-lib/src/price-feed/VaultPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/VaultPriceFeed.js
@@ -29,6 +29,15 @@ class VaultPriceFeed extends PriceFeedInterface {
     priceFeedDecimals = 18
   }) {
     super();
+
+    // Assert required inputs.
+    assert(logger, "logger required");
+    assert(vaultAbi, "vaultAbi required");
+    assert(erc20Abi, "erc20Abi required");
+    assert(web3, "web3 required");
+    assert(vaultAddress, "vaultAddress required");
+    assert(getTime, "getTime required");
+
     this.logger = logger;
     this.web3 = web3;
 

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -923,6 +923,74 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(vaultPriceFeed.vault.options.address, web3.utils.toChecksumAddress(address));
   });
 
+  it("LPPriceFeed: valid config", async function() {
+    const config = {
+      type: "lp",
+      poolAddress: web3.utils.randomHex(20),
+      tokenAddress: web3.utils.randomHex(20)
+    };
+
+    const lpPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNotNull(lpPriceFeed);
+  });
+
+  it("LPPriceFeed: invalid config, no token address", async function() {
+    let config = {
+      type: "lp",
+      poolAddress: web3.utils.randomHex(20)
+    };
+
+    const lpPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNull(lpPriceFeed);
+    assert.equal(spy.callCount, 1); // 1 error.
+  });
+
+  it("LPPriceFeed: invalid config, no pool address", async function() {
+    let config = {
+      type: "lp",
+      tokenAddress: web3.utils.randomHex(20)
+    };
+
+    const lpPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.isNull(lpPriceFeed);
+    assert.equal(spy.callCount, 1); // 1 error.
+  });
+
+  it("LPPriceFeed: shared BlockFinder", async function() {
+    const config = {
+      type: "lp",
+      poolAddress: web3.utils.randomHex(20),
+      tokenAddress: web3.utils.randomHex(20)
+    };
+
+    const lpPriceFeed1 = await createPriceFeed(logger, web3, networker, getTime, config);
+    const lpPriceFeed2 = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.strictEqual(lpPriceFeed2.blockFinder, lpPriceFeed1.blockFinder);
+  });
+
+  it("LPPriceFeed: optional parameters", async function() {
+    const tokenAddress = web3.utils.randomHex(20);
+    const poolAddress = web3.utils.randomHex(20);
+    const config = {
+      type: "lp",
+      tokenAddress,
+      poolAddress,
+      priceFeedDecimals: 6,
+      minTimeBetweenUpdates: 100
+    };
+
+    const lpPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
+
+    assert.equal(lpPriceFeed.minTimeBetweenUpdates, 100);
+    assert.equal(lpPriceFeed.priceFeedDecimals, 6);
+    assert.equal(lpPriceFeed.pool.options.address, web3.utils.toChecksumAddress(poolAddress));
+    assert.equal(lpPriceFeed.token.options.address, web3.utils.toChecksumAddress(tokenAddress));
+  });
+
   it("Default reference price feed", async function() {
     const collateralToken = await Token.new("Wrapped Ether", "WETH", 18, { from: accounts[0] });
     const syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18, { from: accounts[0] });

--- a/packages/financial-templates-lib/test/price-feed/LPPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/LPPriceFeed.js
@@ -1,0 +1,152 @@
+const winston = require("winston");
+
+const { LPPriceFeed } = require("../../src/price-feed/LPPriceFeed");
+const { advanceBlockAndSetTime, parseFixed } = require("@uma/common");
+const { BlockFinder } = require("../../src/price-feed/utils");
+const { getTruffleContract } = require("@uma/core");
+
+const CONTRACT_VERSION = "latest";
+
+const ERC20Interface = getTruffleContract("IERC20Standard", web3, CONTRACT_VERSION);
+const ERC20 = getTruffleContract("ExpandedERC20", web3, CONTRACT_VERSION);
+
+contract("LPPriceFeed.js", function(accounts) {
+  const owner = accounts[0];
+
+  let pool;
+  let token;
+  let lpPriceFeed;
+  let mockTime = 0;
+  let dummyLogger;
+  let poolDecimals = 18;
+  let tokenDecimals = 8;
+  let priceFeedDecimals = 12;
+
+  beforeEach(async function() {
+    pool = await ERC20.new("LP Pool", "LP", poolDecimals, { from: owner });
+    token = await ERC20.new("Test Token", "TT", tokenDecimals, { from: owner });
+    pool.addMinter(owner);
+    token.addMinter(owner);
+
+    dummyLogger = winston.createLogger({
+      level: "info",
+      transports: [new winston.transports.Console()]
+    });
+
+    lpPriceFeed = new LPPriceFeed({
+      logger: dummyLogger,
+      web3,
+      getTime: () => mockTime,
+      erc20Abi: ERC20Interface.abi,
+      tokenAddress: token.address,
+      poolAddress: pool.address,
+      priceFeedDecimals
+    });
+  });
+
+  it("Basic current price", async function() {
+    await pool.mint(owner, parseFixed("100", poolDecimals));
+    await token.mint(pool.address, parseFixed("25", tokenDecimals));
+    await lpPriceFeed.update();
+
+    assert.equal(lpPriceFeed.getCurrentPrice().toString(), parseFixed("0.25", priceFeedDecimals).toString());
+  });
+
+  it("Correctly selects most recent price", async function() {
+    await pool.mint(owner, parseFixed("100", poolDecimals));
+    await token.mint(pool.address, parseFixed("25", tokenDecimals));
+    await pool.mint(owner, parseFixed("100", poolDecimals));
+    await lpPriceFeed.update();
+
+    assert.equal(lpPriceFeed.getCurrentPrice().toString(), parseFixed("0.125", priceFeedDecimals).toString());
+  });
+
+  it("Historical Price", async function() {
+    await pool.mint(owner, parseFixed("100", poolDecimals));
+    await token.mint(pool.address, parseFixed("25", tokenDecimals));
+
+    await lpPriceFeed.update();
+
+    // Ensure that the next block is mined at a later time.
+    const { timestamp: firstPriceTimestamp } = await web3.eth.getBlock("latest");
+    await advanceBlockAndSetTime(web3, firstPriceTimestamp + 10);
+
+    await pool.mint(owner, parseFixed("100", poolDecimals));
+
+    const { timestamp: secondPriceTimestamp } = await web3.eth.getBlock("latest");
+
+    assert.equal(
+      (await lpPriceFeed.getHistoricalPrice(firstPriceTimestamp)).toString(),
+      parseFixed("0.25", priceFeedDecimals)
+    );
+    assert.equal(
+      (await lpPriceFeed.getHistoricalPrice(firstPriceTimestamp + 5)).toString(),
+      parseFixed("0.25", priceFeedDecimals)
+    );
+    assert.equal(
+      (await lpPriceFeed.getHistoricalPrice(secondPriceTimestamp - 1)).toString(),
+      parseFixed("0.25", priceFeedDecimals)
+    );
+    assert.equal(
+      (await lpPriceFeed.getHistoricalPrice(secondPriceTimestamp)).toString(),
+      parseFixed("0.125", priceFeedDecimals)
+    );
+  });
+
+  it("Zero LP shares", async function() {
+    await token.mint(pool.address, parseFixed("25", tokenDecimals));
+
+    await lpPriceFeed.update();
+
+    assert.equal(lpPriceFeed.getCurrentPrice().toString(), "0");
+  });
+
+  it("Update Frequency", async function() {
+    await pool.mint(owner, parseFixed("1", poolDecimals));
+    await token.mint(pool.address, parseFixed("50", tokenDecimals));
+    await lpPriceFeed.update();
+    assert.equal(lpPriceFeed.getCurrentPrice().toString(), parseFixed("50", priceFeedDecimals).toString());
+    const initialTime = mockTime;
+    assert.equal(lpPriceFeed.getLastUpdateTime(), initialTime);
+
+    // Increment time to just under the 1 minute default threshold and push a new price.
+    mockTime += 59;
+    await pool.mint(owner, parseFixed("4", poolDecimals));
+    await lpPriceFeed.update();
+    assert.equal(lpPriceFeed.getLastUpdateTime(), initialTime); // No change in update time.
+
+    // Price should not have changed.
+    assert.equal(lpPriceFeed.getCurrentPrice().toString(), parseFixed("50", priceFeedDecimals).toString());
+
+    // An increment of one more secont + update should trigger the feed to pull in the new price.
+    mockTime += 1;
+    await lpPriceFeed.update();
+    assert.equal(lpPriceFeed.getCurrentPrice().toString(), parseFixed("10", priceFeedDecimals).toString());
+    assert.equal(lpPriceFeed.getLastUpdateTime(), mockTime); // Update time should have no incremented.
+  });
+
+  it("PriceFeedDecimals", async function() {
+    assert.equal(lpPriceFeed.getPriceFeedDecimals(), priceFeedDecimals);
+  });
+
+  it("BlockFinder correctly passed in", async function() {
+    const blockFinder = BlockFinder(() => {
+      throw "err";
+    }); // BlockFinder should throw immediately.
+
+    lpPriceFeed = new LPPriceFeed({
+      logger: dummyLogger,
+      web3,
+      getTime: () => mockTime,
+      erc20Abi: ERC20Interface.abi,
+      tokenAddress: token.address,
+      poolAddress: pool.address,
+      priceFeedDecimals,
+      blockFinder
+    });
+
+    await lpPriceFeed.update();
+    // Blockfinder is used to grab a historical price. Should throw.
+    assert.isTrue(await lpPriceFeed.getHistoricalPrice(100).catch(() => true));
+  });
+});

--- a/packages/financial-templates-lib/test/price-feed/VaultPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/VaultPriceFeed.js
@@ -113,29 +113,6 @@ contract("VaultPriceFeed.js", function(accounts) {
     assert.equal(vaultPriceFeed.getLastUpdateTime(), mockTime); // Update time should have no incremented.
   });
 
-  it("Update Frequency", async function() {
-    await vaultMock.setPricePerFullShare(parseFixed("50", tokenDecimals));
-    await vaultPriceFeed.update();
-    assert.equal(vaultPriceFeed.getCurrentPrice().toString(), parseFixed("50", priceFeedDecimals).toString());
-    const initialTime = mockTime;
-    assert.equal(vaultPriceFeed.getLastUpdateTime(), initialTime);
-
-    // Increment time to just under the 1 minute default threshold and push a new price.
-    mockTime += 59;
-    await vaultMock.setPricePerFullShare(parseFixed("10", tokenDecimals));
-    await vaultPriceFeed.update();
-    assert.equal(vaultPriceFeed.getLastUpdateTime(), initialTime); // No change in update time.
-
-    // Price should not have changed.
-    assert.equal(vaultPriceFeed.getCurrentPrice().toString(), parseFixed("50", priceFeedDecimals).toString());
-
-    // An increment of one more secont + update should trigger the feed to pull in the new price.
-    mockTime += 1;
-    await vaultPriceFeed.update();
-    assert.equal(vaultPriceFeed.getCurrentPrice().toString(), parseFixed("10", priceFeedDecimals).toString());
-    assert.equal(vaultPriceFeed.getLastUpdateTime(), mockTime); // Update time should have no incremented.
-  });
-
   it("PriceFeedDecimals", async function() {
     assert.equal(vaultPriceFeed.getPriceFeedDecimals(), priceFeedDecimals);
   });


### PR DESCRIPTION
**Motivation**

We'd like to be able to price LP tokens. This LPPriceFeed can basically be used wherever there's a pool of tokens (one or more) and you'd like to know how much of a particular token is redeemable for a single LP share.

For instance, in a Uniswap pool with 50 WETH, 1 WBTC, and 25 LP shares, you could configure this feed to tell you how much WETH you'd get back for an LP share. The "price" that it would return would be 2 since the 50 WETH is spread over 25 shares. You could configure another instance of this feed to tell you how many WBTC each share is redeemable for. The "price" for that feed would be 0.04.

**Summary**

The LPPriceFeed was implemented very similarly to the VaultPriceFeed given that they do very similar things: make a smart contract call or two, do some math, and return the result in the right decimals.

Note: this PR also makes a few minor fixes to the VaultPriceFeed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
