### PR TITLE
fix(price-feeds): correct PHPDAI default price feed config

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -397,13 +397,13 @@ const defaultConfigs = {
       {
         type: "coinmarketcap",
         symbol: "DAI",
-        convert: "PHP",
+        quoteCurrency: "PHP",
         invertPrice: true
       },
       {
         type: "coingecko",
         contractAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
-        currency: "php",
+        quoteCurrency: "php",
         invertPrice: true
       }
     ]


### PR DESCRIPTION
**Motivation**

After applying the variable renames on https://github.com/UMAprotocol/protocol/pull/2480 last iteration, we missed updating `DefaultPriceFeedConfig.js`, thus this new PR.

**Summary**

Renamed `convert` & `currency` to `quoteCurrency`.

**Details**

This fixes a potential liquidator bot error should the `PRICE_FEED_CONFIG` won't include `quoteCurrency` parameter for `coinmarketcap` & `coingecko` price feeds.

This is the liquidation bot error if the value is `PRICE_FEED_CONFIG={ "apiKey": "<cmc-api-key>" }`

```
[error]: {
  "at": "Liquidator#index",
  "message": "Liquidator execution error🚨"
}
Error: Price feed config is invalid
```


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
