### PR TITLE
feat(financial-templates-lib): add a new price feed config for XAUPERL

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -408,6 +408,17 @@ const defaultConfigs = {
       }
     ]
   },
+  XAUPERL: {
+    type: "expression",
+    expression: "XAUUSD * USDPERL"
+  },
+  XAUUSD: {
+    type: "tradermade",
+    pair: "XAUUSD",
+    minTimeBetweenUpdates: 300,
+    minuteLookback: 7200,
+    hourlyLookback: 7200
+  },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this
   // default price feed config.
   TEST8DECIMALS: {

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -415,9 +415,9 @@ const defaultConfigs = {
   XAUUSD: {
     type: "tradermade",
     pair: "XAUUSD",
-    minTimeBetweenUpdates: 300,
+    minTimeBetweenUpdates: 60,
     minuteLookback: 7200,
-    hourlyLookback: 7200
+    hourlyLookback: 604800
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this
   // default price feed config.


### PR DESCRIPTION
**Motivation**

To support [UMIP-26](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-26.md), default price feeds for XAUPERL and XAUUSD need to be added. Merging this PR should allow #2534 to be closed.

**Summary**

These price feeds follow the specifications in UMIP-26.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

**Issue(s)**

NA
