### PR TITLE
refactor(create-price-feeds)!: Each PriceFeed renames apiKey config param

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -41,7 +41,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new CryptoWatchPriceFeed(
       logger,
       web3,
-      config.apiKey,
+      config.cryptowatchApiKey,
       config.exchange,
       config.pair,
       config.lookback,
@@ -103,7 +103,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.priceFeedDecimals // This defaults to 18 unless supplied by user
     );
   } else if (config.type === "defipulsetvl") {
-    const requiredFields = ["lookback", "minTimeBetweenUpdates", "apiKey"];
+    const requiredFields = ["lookback", "minTimeBetweenUpdates", "defipulseApiKey"];
 
     if (isMissingField(config, requiredFields, logger)) {
       return null;
@@ -118,7 +118,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new DefiPulseTotalPriceFeed(
       logger,
       web3,
-      config.apiKey,
+      config.defipulseApiKey,
       config.lookback,
       networker,
       getTime,
@@ -198,7 +198,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new BasketSpreadPriceFeed(web3, logger, baselinePriceFeeds, experimentalPriceFeeds, denominatorPriceFeed);
   } else if (config.type === "coinmarketcap") {
-    const requiredFields = ["apiKey", "symbol", "quoteCurrency", "lookback", "minTimeBetweenUpdates"];
+    const requiredFields = ["cmcApiKey", "symbol", "quoteCurrency", "lookback", "minTimeBetweenUpdates"];
 
     if (isMissingField(config, requiredFields, logger)) {
       return null;
@@ -213,7 +213,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new CoinMarketCapPriceFeed(
       logger,
       web3,
-      config.apiKey,
+      config.cmcApiKey,
       config.symbol,
       config.quoteCurrency,
       config.lookback,
@@ -249,7 +249,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.priceFeedDecimals // Defaults to 18 unless supplied. Informs how the feed should be scaled to match a DVM response.
     );
   } else if (config.type === "tradermade") {
-    const requiredFields = ["pair", "apiKey", "minTimeBetweenUpdates"];
+    const requiredFields = ["pair", "tradermadeApiKey", "minTimeBetweenUpdates"];
 
     if (isMissingField(config, requiredFields, logger)) {
       return null;
@@ -264,7 +264,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new TraderMadePriceFeed(
       logger,
       web3,
-      config.apiKey,
+      config.tradermadeApiKey,
       config.pair,
       config.minuteLookback,
       config.hourlyLookback,

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -323,7 +323,7 @@ contract("CreatePriceFeed.js", function(accounts) {
   it("Valid CryptoWatch config", async function() {
     const config = {
       type: "cryptowatch",
-      apiKey,
+      cryptowatchApiKey: apiKey,
       exchange,
       pair,
       lookback,
@@ -359,7 +359,7 @@ contract("CreatePriceFeed.js", function(accounts) {
   it("Invalid CryptoWatch config", async function() {
     const validConfig = {
       type: "cryptowatch",
-      apiKey,
+      cryptowatchApiKey: apiKey,
       exchange,
       pair,
       lookback,
@@ -788,7 +788,7 @@ contract("CreatePriceFeed.js", function(accounts) {
       customFeeds: {
         mysymbol: {
           type: "cryptowatch",
-          apiKey,
+          cryptowatchApiKey: apiKey,
           exchange,
           pair,
           lookback,
@@ -1128,7 +1128,7 @@ contract("CreatePriceFeed.js", function(accounts) {
   it("Valid CoinMarketCap config", async function() {
     const config = {
       type: "coinmarketcap",
-      apiKey,
+      cmcApiKey: apiKey,
       symbol,
       quoteCurrency,
       lookback,
@@ -1149,14 +1149,17 @@ contract("CreatePriceFeed.js", function(accounts) {
   it("Invalid CoinMarketCap config", async function() {
     const validConfig = {
       type: "coinmarketcap",
-      apiKey,
+      cmcApiKey: apiKey,
       symbol,
       quoteCurrency,
       lookback,
       minTimeBetweenUpdates
     };
 
-    assert.equal(await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, apiKey: undefined }), null);
+    assert.equal(
+      await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, cmcApiKey: undefined }),
+      null
+    );
     assert.equal(await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, symbol: undefined }), null);
     assert.equal(
       await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, quoteCurrency: undefined }),


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2588


**Summary**

When this PR is merged, bot configs need to be changed that are using `apiKey` as a config param.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2588
