### PR TITLE
patch(expression-pricefeed): Throw errors not errors.map(err => err.stack)

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -69,7 +69,7 @@ class ExpressionPriceFeed extends PriceFeedInterface {
     );
 
     if (errors.length > 0) {
-      throw errors.map(error => error.stack);
+      throw errors;
     }
 
     return this._convertToFixed(this.expressionCode.evaluate(historicalPrices), this.getPriceFeedDecimals());

--- a/packages/financial-templates-lib/test/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/ExpressionPriceFeed.js
@@ -90,8 +90,8 @@ contract("ExpressionPriceFeed.js", function() {
     await expressionPriceFeed.getHistoricalPrice(arbitraryHistoricalTimestamp).then(
       () => assert.fail(),
       err => {
-        assert.isTrue(err[0].includes("PriceFeedMock"));
-        assert.isTrue(err[1].includes("PriceFeedMock"));
+        assert.isTrue(err[0].message.includes("PriceFeedMock"));
+        assert.isTrue(err[1].message.includes("PriceFeedMock"));
         assert.equal(err.length, 2);
       }
     );


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Matching `BasketSpreadPriceFeed` which also aggregates component pricefeed errors, the Expression pricefeed should be throwing the full Error objects not just their `.stack` parameters.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested