### PR TITLE
improve(tradermade-pricefeed): Fall back to hourly OHLC interval when minute interval fails

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -386,7 +386,8 @@ const defaultConfigs = {
     pair: "CNYUSD",
     minuteLookback: 7200, // interval=minute allowed lookback up to 2 days
     hourlyLookback: 604800, // interval=hour allowed lookback up to 2 months
-    minTimeBetweenUpdates: 600
+    minTimeBetweenUpdates: 600,
+    ohlcPeriod: 10 // CNYUSD only available at 10 minute granularity
   },
   PHPDAI: {
     type: "medianizer",

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -384,8 +384,6 @@ const defaultConfigs = {
   CNYUSD: {
     type: "tradermade",
     pair: "CNYUSD",
-    minuteLookback: 7200, // interval=minute allowed lookback up to 2 days
-    hourlyLookback: 604800, // interval=hour allowed lookback up to 2 months
     minTimeBetweenUpdates: 600,
     ohlcPeriod: 10 // CNYUSD only available at 10 minute granularity
   },
@@ -475,9 +473,7 @@ const defaultConfigs = {
   XAUUSD: {
     type: "tradermade",
     pair: "XAUUSD",
-    minTimeBetweenUpdates: 60,
-    minuteLookback: 7200,
-    hourlyLookback: 604800
+    minTimeBetweenUpdates: 60
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this
   // default price feed config.

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -385,6 +385,13 @@ const defaultConfigs = {
     type: "tradermade",
     pair: "CNYUSD",
     minTimeBetweenUpdates: 600,
+    minuteLookback: 172800,
+    // Set minute lookback to maximum of 2 days allowed by minute-interval endpoint. This is longer
+    // than the expected liquidationLiveness of 2 hours because we might need to get the last price
+    // before the tradermade API stopped serving prices for the weekend.
+    hourlyLookback: 604800,
+    // Hourly interval data will be used as fallback if minute data is empty, so
+    // set conservatively to 1 week.
     ohlcPeriod: 10 // CNYUSD only available at 10 minute granularity
   },
   PHPDAI: {
@@ -473,6 +480,13 @@ const defaultConfigs = {
   XAUUSD: {
     type: "tradermade",
     pair: "XAUUSD",
+    minuteLookback: 172800,
+    // Set minute lookback to maximum of 2 days allowed by minute-interval endpoint. This is longer
+    // than the expected liquidationLiveness of 2 hours because we might need to get the last price
+    // before the tradermade API stopped serving prices for the weekend.
+    hourlyLookback: 604800,
+    // Hourly interval data will be used as fallback if minute data is empty, so
+    // set conservatively to 1 week.
     minTimeBetweenUpdates: 60
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -385,17 +385,15 @@ const defaultConfigs = {
     type: "tradermade",
     pair: "CNYUSD",
     minTimeBetweenUpdates: 600,
-    // Since TradeMadeAPI timeseries data is unavailable over the weekend,
-    // set either the `minuteLookback` or the `hourlyLookback` to be longer than 3 days (259200 seconds)
-    // so that we can fetch the last known price prior to the weekend start.
-    // For example, if `minuteLookback = 7200`, then 2 hours after the weekend has "begun",
-    // `TraderMadePriceFeed.updateMinute()` will fail to find any prices. Simultaneously
-    // setting `hourLookback = 604800` ensures that if `updateMinute()` fails then `updateHourly()`
-    // will return the last hourly price. Alternatively, you can set `minuteLookback = 172800`, or
-    // 2 days (the maximum minute interval lookback) which will allow `updateMinute()` to fetch
-    // data for longer into the off-market period. We set `minuteLookback` to 7200 and `hourlyLookback`
-    // to 604800 so that we can both reduce the amount of data to parse from the minute-interval
-    // and ensure that we can always find a price when weekend prices are not available.
+// Since TradeMadeAPI timeseries data is unavailable over the weekend, set either the `minuteLookback` or the
+// `hourlyLookback` to be longer than 3 days (259200 seconds) so that we can fetch the last known price prior to the
+// weekend start. For example, if `minuteLookback = 7200`, then 2 hours after the weekend has "begun",
+// `TraderMadePriceFeed.updateMinute()` will fail to find any prices. Simultaneously setting `hourLookback = 604800`
+// ensures that if `updateMinute()` fails then `updateHourly()` will return the last hourly price. Alternatively, you
+// can set `minuteLookback = 172800`, or 2 days (the maximum minute interval lookback) which will allow `updateMinute()`
+// to fetch data for longer into the off-market period. We set `minuteLookback` to 7200 and `hourlyLookback` to 604800 so
+// that we can both reduce the amount of data to parse from the minute-interval and ensure that we can always find a price when 
+// weekend prices are not available.
     minuteLookback: 7200,
     hourlyLookback: 604800,
     ohlcPeriod: 10 // CNYUSD only available at 10 minute granularity

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -385,13 +385,19 @@ const defaultConfigs = {
     type: "tradermade",
     pair: "CNYUSD",
     minTimeBetweenUpdates: 600,
-    minuteLookback: 172800,
-    // Set minute lookback to maximum of 2 days allowed by minute-interval endpoint. This is longer
-    // than the expected liquidationLiveness of 2 hours because we might need to get the last price
-    // before the tradermade API stopped serving prices for the weekend.
+    // Since TradeMadeAPI timeseries data is unavailable over the weekend,
+    // set either the `minuteLookback` or the `hourlyLookback` to be longer than 3 days (259200 seconds)
+    // so that we can fetch the last known price prior to the weekend start.
+    // For example, if `minuteLookback = 7200`, then 2 hours after the weekend has "begun",
+    // `TraderMadePriceFeed.updateMinute()` will fail to find any prices. Simultaneously
+    // setting `hourLookback = 604800` ensures that if `updateMinute()` fails then `updateHourly()`
+    // will return the last hourly price. Alternatively, you can set `minuteLookback = 172800`, or
+    // 2 days (the maximum minute interval lookback) which will allow `updateMinute()` to fetch
+    // data for longer into the off-market period. We set `minuteLookback` to 7200 and `hourlyLookback`
+    // to 604800 so that we can both reduce the amount of data to parse from the minute-interval
+    // and ensure that we can always find a price when weekend prices are not available.
+    minuteLookback: 7200,
     hourlyLookback: 604800,
-    // Hourly interval data will be used as fallback if minute data is empty, so
-    // set conservatively to 1 week.
     ohlcPeriod: 10 // CNYUSD only available at 10 minute granularity
   },
   PHPDAI: {
@@ -480,13 +486,19 @@ const defaultConfigs = {
   XAUUSD: {
     type: "tradermade",
     pair: "XAUUSD",
-    minuteLookback: 172800,
-    // Set minute lookback to maximum of 2 days allowed by minute-interval endpoint. This is longer
-    // than the expected liquidationLiveness of 2 hours because we might need to get the last price
-    // before the tradermade API stopped serving prices for the weekend.
+    // Since TradeMadeAPI timeseries data is unavailable over the weekend,
+    // set either the `minuteLookback` or the `hourlyLookback` to be longer than 3 days (259200 seconds)
+    // so that we can fetch the last known price prior to the weekend start.
+    // For example, if `minuteLookback = 7200`, then 2 hours after the weekend has "begun",
+    // `TraderMadePriceFeed.updateMinute()` will fail to find any prices. Simultaneously
+    // setting `hourLookback = 604800` ensures that if `updateMinute()` fails then `updateHourly()`
+    // will return the last hourly price. Alternatively, you can set `minuteLookback = 172800`, or
+    // 2 days (the maximum minute interval lookback) which will allow `updateMinute()` to fetch
+    // data for longer into the off-market period. We set `minuteLookback` to 7200 and `hourlyLookback`
+    // to 604800 so that we can both reduce the amount of data to parse from the minute-interval
+    // and ensure that we can always find a price when weekend prices are not available.
+    minuteLookback: 7200,
     hourlyLookback: 604800,
-    // Hourly interval data will be used as fallback if minute data is empty, so
-    // set conservatively to 1 week.
     minTimeBetweenUpdates: 60
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -385,15 +385,6 @@ const defaultConfigs = {
     type: "tradermade",
     pair: "CNYUSD",
     minTimeBetweenUpdates: 600,
-// Since TradeMadeAPI timeseries data is unavailable over the weekend, set either the `minuteLookback` or the
-// `hourlyLookback` to be longer than 3 days (259200 seconds) so that we can fetch the last known price prior to the
-// weekend start. For example, if `minuteLookback = 7200`, then 2 hours after the weekend has "begun",
-// `TraderMadePriceFeed.updateMinute()` will fail to find any prices. Simultaneously setting `hourLookback = 604800`
-// ensures that if `updateMinute()` fails then `updateHourly()` will return the last hourly price. Alternatively, you
-// can set `minuteLookback = 172800`, or 2 days (the maximum minute interval lookback) which will allow `updateMinute()`
-// to fetch data for longer into the off-market period. We set `minuteLookback` to 7200 and `hourlyLookback` to 604800 so
-// that we can both reduce the amount of data to parse from the minute-interval and ensure that we can always find a price when 
-// weekend prices are not available.
     minuteLookback: 7200,
     hourlyLookback: 604800,
     ohlcPeriod: 10 // CNYUSD only available at 10 minute granularity
@@ -484,17 +475,6 @@ const defaultConfigs = {
   XAUUSD: {
     type: "tradermade",
     pair: "XAUUSD",
-    // Since TradeMadeAPI timeseries data is unavailable over the weekend,
-    // set either the `minuteLookback` or the `hourlyLookback` to be longer than 3 days (259200 seconds)
-    // so that we can fetch the last known price prior to the weekend start.
-    // For example, if `minuteLookback = 7200`, then 2 hours after the weekend has "begun",
-    // `TraderMadePriceFeed.updateMinute()` will fail to find any prices. Simultaneously
-    // setting `hourLookback = 604800` ensures that if `updateMinute()` fails then `updateHourly()`
-    // will return the last hourly price. Alternatively, you can set `minuteLookback = 172800`, or
-    // 2 days (the maximum minute interval lookback) which will allow `updateMinute()` to fetch
-    // data for longer into the off-market period. We set `minuteLookback` to 7200 and `hourlyLookback`
-    // to 604800 so that we can both reduce the amount of data to parse from the minute-interval
-    // and ensure that we can always find a price when weekend prices are not available.
     minuteLookback: 7200,
     hourlyLookback: 604800,
     minTimeBetweenUpdates: 60

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -24,8 +24,8 @@ class TraderMadePriceFeed extends PriceFeedInterface {
     web3,
     apiKey,
     pair,
-    minuteLookback = 172800, // Max lookback for minute interval is 2 days
-    hourlyLookback = 604800, // Max lookback for hourly interval is 2 months, but 1 week is a reasonable default.
+    minuteLookback,
+    hourlyLookback,
     networker,
     getTime,
     minTimeBetweenUpdates,

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -397,7 +397,9 @@ class TraderMadePriceFeed extends PriceFeedInterface {
 
     // If `minuteLookback` is not specified but `hourlyLookback` is, then we'll
     // just update the hourly timeseries and throw an error if that fails.
-    if (this.hourlyLookback) {
+    // Skip this update if hourlyPrices were already updated following an updateMinute
+    // failure.
+    if (!this.historicalPricesHourly && this.hourlyLookback) {
       await this.updateHourly(lastUpdateTime);
     }
   }

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -71,13 +71,10 @@ class TraderMadePriceFeed extends PriceFeedInterface {
     // Set first price time in `historicalPrices` to first non-null price.
     let firstPriceTime;
 
-    // If no minute-interval prices are available, try the hourly-interval:
-    // Note: The TraderMade API does not update /timeseries data over the weekend,
-    // so to handle this case we can fall back on the longer lookback window of the
-    // hourly timeseries. (The lookback limit for the minute inverval is 2 days, while the limit
-    // for the hourly interval is 2 months). This fall back logic will only work
-    // if `this.hourlyLookback` is configured long enough such that there is an hourly price
-    // available.
+// Note: The TraderMade API does not update /timeseries data over the weekend, so to handle this case we can fall back
+// on the longer lookback window of the hourly timeseries. (The lookback limit for the minute inverval is 2 days, while
+// the limit for the hourly interval is 2 months). This fall back logic will only work if `this.hourlyLookback` is
+// configured long enough such that there is an hourly price available.
     let historicalPricesToCheck = this.historicalPricesMinute
       ? this.historicalPricesMinute
       : this.historicalPricesHourly;

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -30,7 +30,7 @@ class TraderMadePriceFeed extends PriceFeedInterface {
     getTime,
     minTimeBetweenUpdates,
     priceFeedDecimals = 18,
-    ohlcPeriod = 10 // Only 5, 10, 15 minutes is supported by TraderMade.
+    ohlcPeriod = 1 // Some pairs like CNYUSD are only available at higher granularities like 10
   ) {
     super();
     this.logger = logger;

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -309,7 +309,6 @@ class TraderMadePriceFeed extends PriceFeedInterface {
     const ohlcHourlyUrl = `https://marketdata.tradermade.com/api/v1/timeseries?currency=${this.pair}&api_key=${this.apiKey}&start_date=${startHourlyDate}&end_date=${endDate}&format=records&interval=hourly`;
 
     // 2. Send requests.
-    console.log(this.networker.getJsonReturns);
     const ohlcHourlyResponse = await this.networker.getJson(ohlcHourlyUrl);
 
     // 3. Check responses.

--- a/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/TraderMadePriceFeed.js
@@ -24,8 +24,8 @@ class TraderMadePriceFeed extends PriceFeedInterface {
     web3,
     apiKey,
     pair,
-    minuteLookback,
-    hourlyLookback,
+    minuteLookback = 172800, // Max lookback for minute interval is 2 days
+    hourlyLookback = 604800, // Max lookback for hourly interval is 2 months, but 1 week is a reasonable default.
     networker,
     getTime,
     minTimeBetweenUpdates,

--- a/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
@@ -104,10 +104,6 @@ contract("TraderMadePriceFeed.js", function() {
 
     await traderMadePriceFeed.update();
 
-    // TODO: These tests might fail if they are not being run in the GMT-0 timezone as the UNIX
-    // timestamps are hardcoded to the GMT-0 times corresponding to the `date` objects in
-    // the validResponses array.
-
     // Before period 1 should fail.
     assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1611607700 - timezeoneOffsetSeconds).catch(() => true));
 

--- a/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
@@ -1,11 +1,15 @@
 const { TraderMadePriceFeed } = require("../../src/price-feed/TraderMadePriceFeed");
 const { NetworkerMock } = require("../../src/price-feed/NetworkerMock");
+const { spyLogIncludes, SpyTransport } = require("../../src/logger/SpyTransport");
 const winston = require("winston");
+const sinon = require("sinon");
+const moment = require("moment");
 
 contract("TraderMadePriceFeed.js", function() {
   let traderMadePriceFeed;
   let mockTime = 1614314000;
   let networker;
+  let spy;
 
   const apiKey = "test-api-key";
   const pair = "test-pair";
@@ -13,6 +17,14 @@ contract("TraderMadePriceFeed.js", function() {
   const hourlyLookback = 172800; // 2 days
   const getTime = () => mockTime;
   const minTimeBetweenUpdates = 600;
+
+  // TraderMadePriceFeed converts "date" strings (YYYY-MM-DD HH:mm:ss) into unix timestamps,
+  // therefore to test that timestamps are set/fetched correctly we need to adjust for how `moment`
+  // will convert date-strings into UNIX time for the local machine.
+  // For example: `moment().utcOffset()` will return -300 if you are in GMT-5, so we
+  // can use this value to make sure tests pass on all machines regardless of zone.
+  const timezoneOffsetMinutes = moment().utcOffset();
+  const timezeoneOffsetSeconds = timezoneOffsetMinutes * 60;
 
   const { toWei } = web3.utils;
 
@@ -92,20 +104,36 @@ contract("TraderMadePriceFeed.js", function() {
 
     await traderMadePriceFeed.update();
 
+    // TODO: These tests might fail if they are not being run in the GMT-0 timezone as the UNIX
+    // timestamps are hardcoded to the GMT-0 times corresponding to the `date` objects in
+    // the validResponses array.
+
     // Before period 1 should fail.
-    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1611607700).catch(() => true));
+    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1611607700 - timezeoneOffsetSeconds).catch(() => true));
 
     // During period 1.
-    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611608300)).toString(), toWei("0.1543"));
+    assert.equal(
+      (await traderMadePriceFeed.getHistoricalPrice(1611608300 - timezeoneOffsetSeconds)).toString(),
+      toWei("0.1543")
+    );
 
     // During period 2.
-    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611608900)).toString(), toWei("0.1533"));
+    assert.equal(
+      (await traderMadePriceFeed.getHistoricalPrice(1611608900 - timezeoneOffsetSeconds)).toString(),
+      toWei("0.1533")
+    );
 
     // During period 3.
-    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611609500)).toString(), toWei("0.1523"));
+    assert.equal(
+      (await traderMadePriceFeed.getHistoricalPrice(1611609500 - timezeoneOffsetSeconds)).toString(),
+      toWei("0.1523")
+    );
 
     // After period 3 should return the most recent price.
-    assert.equal((await traderMadePriceFeed.getHistoricalPrice(1611610100)).toString(), toWei("0.1553"));
+    assert.equal(
+      (await traderMadePriceFeed.getHistoricalPrice(1611610100 - timezeoneOffsetSeconds)).toString(),
+      toWei("0.1553")
+    );
 
     const expectOhlcHourlyPrices = [
       {
@@ -123,8 +151,8 @@ contract("TraderMadePriceFeed.js", function() {
     ];
     const actualOhlcHourlyPrices = traderMadePriceFeed.getHistoricalPricePeriods();
     for (let i = 0; i < expectOhlcHourlyPrices.length; i++) {
-      assert.equal(expectOhlcHourlyPrices[i].closeTime, actualOhlcHourlyPrices[i].closeTime);
-      assert.equal(expectOhlcHourlyPrices[i].openTime, actualOhlcHourlyPrices[i].openTime);
+      assert.equal(expectOhlcHourlyPrices[i].closeTime - timezeoneOffsetSeconds, actualOhlcHourlyPrices[i].closeTime);
+      assert.equal(expectOhlcHourlyPrices[i].openTime - timezeoneOffsetSeconds, actualOhlcHourlyPrices[i].openTime);
     }
   });
 
@@ -148,87 +176,303 @@ contract("TraderMadePriceFeed.js", function() {
     assert.equal(traderMadePriceFeed.getLastUpdateTime(), mockTime);
   });
 
-  it("No or bad response", async function() {
-    // Bad price response.
-    networker.getJsonReturns = [
-      {
-        quotes: [
-          {
-            error: "test"
-          }
-        ]
-      },
-      {
-        quotes: [
-          {
-            close: 0.1543,
-            date: "2021-01-26 00:00:00"
-          },
-          {
-            close: 0.1533,
-            date: "2021-01-26 00:00:00"
-          },
-          {
-            close: 0.1523,
-            date: "2021-01-26 00:00:00"
-          }
-        ]
-      },
-      {
-        quotes: [
-          {
-            close: 0.1543,
-            date: "2021-01-26 00:00:00"
-          },
-          {
-            close: 0.1533,
-            date: "2021-01-26 00:00:00"
-          },
-          {
-            close: 0.1523,
-            date: "2021-01-26 00:00:00"
-          }
-        ]
-      }
-    ];
+  describe("Hourly interval can act as historical price fallback for minute interval", function() {
+    it("Fallback to hourly interval ENABLED, failure to fetch minute interval successfully fetches hourly data", async function() {
+      // Missing minute interval historical ohlc response. Fallback to hourly interval succeeds,
+      // so historical price is available.
+      networker.getJsonReturns = [
+        {
+          quotes: [
+            {
+              ask: 0.1553
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              error: "test"
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              close: 0.1543,
+              date: "2021-01-25 21:00:00"
+            },
+            {
+              close: 0.1533,
+              date: "2021-01-25 22:00:00"
+            },
+            {
+              close: 0.1523,
+              date: "2021-01-25 23:00:00"
+            }
+          ]
+        }
+      ];
 
-    // Update should throw errors in both cases.
-    assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+      // Create spy to listen for debug level events to catch fallback log.
+      spy = sinon.spy();
+      traderMadePriceFeed = new TraderMadePriceFeed(
+        winston.createLogger({
+          level: "info",
+          transports: [new SpyTransport({ level: "debug" }, { spy: spy })]
+        }),
+        web3,
+        apiKey,
+        pair,
+        minuteLookback,
+        hourlyLookback,
+        networker,
+        getTime,
+        minTimeBetweenUpdates,
+        18
+      );
+      // Update should not throw and the historical price should correspond to hourly interval data.
+      await traderMadePriceFeed.update();
 
-    assert.equal(traderMadePriceFeed.getCurrentPrice(), undefined);
-    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1614319100).catch(() => true));
-    assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+      // Second to last log should be about falling back to hourly interval:
+      assert.isTrue(spyLogIncludes(spy, -2, "updateMinute failed, falling back to updateHourly"));
 
-    // Bad historical ohlc response.
-    networker.getJsonReturns = [
-      {
-        quotes: [
-          {
-            ask: 0.1553
-          }
-        ]
-      },
-      {
-        quotes: [
-          {
-            error: "test"
-          }
-        ]
-      },
-      {
-        quotes: [
-          {
-            error: "test"
-          }
-        ]
-      }
-    ];
+      assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+      assert.equal(
+        (await traderMadePriceFeed.getHistoricalPrice(1611608300 - timezeoneOffsetSeconds)).toString(),
+        toWei("0.1543")
+      );
+      assert.equal(traderMadePriceFeed.getHistoricalPricePeriods().length, 3);
+    });
+    it("Fallback to hourly interval DISABLED, failure to fetch minute interval fails", async function() {
+      // Missing minute interval historical ohlc response.
+      networker.getJsonReturns = [
+        {
+          quotes: [
+            {
+              ask: 0.1553
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              error: "test"
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              close: 0.1543,
+              date: "2021-01-25 21:00:00"
+            },
+            {
+              close: 0.1533,
+              date: "2021-01-25 22:00:00"
+            },
+            {
+              close: 0.1523,
+              date: "2021-01-25 23:00:00"
+            }
+          ]
+        }
+      ];
 
-    assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+      // Create spy to make sure no "fallback" logs are emitted
+      spy = sinon.spy();
+      traderMadePriceFeed = new TraderMadePriceFeed(
+        winston.createLogger({
+          level: "info",
+          transports: [new SpyTransport({ level: "debug" }, { spy: spy })]
+        }),
+        web3,
+        apiKey,
+        pair,
+        minuteLookback,
+        0, // hourly lookback disabled!
+        networker,
+        getTime,
+        minTimeBetweenUpdates,
+        18
+      );
 
-    assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
-    assert.isTrue(await traderMadePriceFeed.getHistoricalPrice(1614319100).catch(() => true));
-    assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+      // Update should throw since no hourly fallback is specified and there is no minute data.
+      assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+      // Last log should be about updating minute interval.
+      assert.isTrue(spyLogIncludes(spy, -1, "Updating Minute Price"));
+
+      assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+      assert.isTrue(
+        await traderMadePriceFeed.getHistoricalPrice(1611608300 - timezeoneOffsetSeconds).catch(() => true)
+      );
+      assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+    });
+    it("Fallback to hourly interval ENABLED, latest, minute and hourly intervals all fail to respond", async function() {
+      // Bad current price response causes update() to throw regardless of historical data.
+      networker.getJsonReturns = [
+        {
+          quotes: [
+            {
+              error: "test"
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              close: 0.1543,
+              date: "2021-01-26 00:00:00"
+            },
+            {
+              close: 0.1533,
+              date: "2021-01-26 00:00:00"
+            },
+            {
+              close: 0.1523,
+              date: "2021-01-26 00:00:00"
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              close: 0.1543,
+              date: "2021-01-26 00:00:00"
+            },
+            {
+              close: 0.1533,
+              date: "2021-01-26 00:00:00"
+            },
+            {
+              close: 0.1523,
+              date: "2021-01-26 00:00:00"
+            }
+          ]
+        }
+      ];
+
+      // Update should throw errors in both cases because the `updateLatest` method throws.
+      assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+
+      assert.equal(traderMadePriceFeed.getCurrentPrice(), undefined);
+      assert.isTrue(
+        await traderMadePriceFeed.getHistoricalPrice(1614319100 - timezeoneOffsetSeconds).catch(() => true)
+      );
+      assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+
+      // Missing minute and hourly interval historical ohlc response. Minute interval and subsequent
+      // fallback to hourly interval fail.
+      networker.getJsonReturns = [
+        {
+          quotes: [
+            {
+              ask: 0.1553
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              error: "test"
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              error: "test"
+            }
+          ]
+        }
+      ];
+
+      // Create spy to listen for fallback failure
+      spy = sinon.spy();
+      traderMadePriceFeed = new TraderMadePriceFeed(
+        winston.createLogger({
+          level: "info",
+          transports: [new SpyTransport({ level: "debug" }, { spy: spy })]
+        }),
+        web3,
+        apiKey,
+        pair,
+        minuteLookback,
+        hourlyLookback,
+        networker,
+        getTime,
+        minTimeBetweenUpdates,
+        18
+      );
+
+      assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+      // Last log should be fallback to hourly failing.
+      assert.isTrue(spyLogIncludes(spy, -1, "fallback to updateHourly also failed"));
+
+      assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+      assert.isTrue(
+        await traderMadePriceFeed.getHistoricalPrice(1614319100 - timezeoneOffsetSeconds).catch(() => true)
+      );
+      assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+    });
+    it("minuteLookback is undefined, only need to fetch hourly interval data", async function() {
+      // Missing minute interval historical ohlc response is not a problem if minuteLookback is not set.
+      networker.getJsonReturns = [
+        {
+          quotes: [
+            {
+              ask: 0.1553
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              error: "test"
+            }
+          ]
+        },
+        {
+          quotes: [
+            {
+              close: 0.1543,
+              date: "2021-01-25 21:00:00"
+            },
+            {
+              close: 0.1533,
+              date: "2021-01-25 22:00:00"
+            },
+            {
+              close: 0.1523,
+              date: "2021-01-25 23:00:00"
+            }
+          ]
+        }
+      ];
+      traderMadePriceFeed = new TraderMadePriceFeed(
+        winston.createLogger({
+          level: "info",
+          transports: [new winston.transports.Console()]
+        }),
+        web3,
+        apiKey,
+        pair,
+        0, // minute lookback disabled!
+        hourlyLookback,
+        networker,
+        getTime,
+        minTimeBetweenUpdates,
+        18
+      );
+
+      // Update should not throw and the historical price should correspond to hourly interval data.
+      assert.isTrue(await traderMadePriceFeed.update().catch(() => true), "Update didn't throw");
+
+      assert.equal(traderMadePriceFeed.getCurrentPrice().toString(), toWei("0.1553"));
+      assert.isTrue(
+        await traderMadePriceFeed.getHistoricalPrice(1611608300 - timezeoneOffsetSeconds).catch(() => true)
+      );
+      assert.equal(traderMadePriceFeed.getHistoricalPricePeriods(), undefined);
+    });
   });
 
   it("Update frequency", async function() {
@@ -253,6 +497,7 @@ contract("TraderMadePriceFeed.js", function() {
     networker.getJsonReturns = [...validResponses];
     await traderMadePriceFeed.update();
 
+    // TODO: The `start_date` and `end_date` need to be adjusted for machine timezone.
     assert.deepStrictEqual(networker.getJsonInputs, [
       "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=test-api-key&start_date=2021-02-24-04:00&end_date=2021-02-26-04:43&format=records&interval=hourly",
       "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=test-api-key&start_date=2021-02-26-04:30&end_date=2021-02-26-04:43&format=records&interval=minute&period=10",
@@ -265,6 +510,7 @@ contract("TraderMadePriceFeed.js", function() {
     networker.getJsonReturns = [...validResponses];
     await traderMadePriceFeed.update();
 
+    // TODO: The `start_date` and `end_date` need to be adjusted for machine timezone.
     assert.deepStrictEqual(networker.getJsonInputs, [
       "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=undefined&start_date=2021-02-24-04:00&end_date=2021-02-26-04:43&format=records&interval=hourly",
       "https://marketdata.tradermade.com/api/v1/timeseries?currency=test-pair&api_key=undefined&start_date=2021-02-26-04:30&end_date=2021-02-26-04:43&format=records&interval=minute&period=10",

--- a/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/TraderMadePriceFeed.js
@@ -14,6 +14,7 @@ contract("TraderMadePriceFeed.js", function() {
   const apiKey = "test-api-key";
   const pair = "test-pair";
   const minuteLookback = 600; // 10 minutes
+  const ohlcPeriod = 10;
   const hourlyLookback = 172800; // 2 days
   const getTime = () => mockTime;
   const minTimeBetweenUpdates = 600;
@@ -88,7 +89,8 @@ contract("TraderMadePriceFeed.js", function() {
       networker,
       getTime,
       minTimeBetweenUpdates,
-      18
+      18,
+      ohlcPeriod
     );
   });
 


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

TraderMade API expectedly returns no timeseries data over the weekend, but the price identifier UMIPs that suggest using the TraderMade API request that pricefeeds fall back to the last known price, see [UMIP-32](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-32.md#weekend-price) for an example of this recommendation.

[The PR that implemented the TraderMadePriceFeed originally was supposed to implement this fallback](https://github.com/UMAprotocol/protocol/pull/2479#issuecomment-771237776) but the feature got lost to no individual fault. This PR therefore adds the fallback functionality to both the `update()` and `getHistoricalPrice` methods:

- `update` fetches historical price data from the `minute` timeseries but also should fallback to the `hourly` timeseries if the `minute` update fails.
- `getHistoricalPrices` should use `historicalPricesHourly` if `historicalPricesMinute` was not constructed properly during `update`.

Note: Another TraderMade UMIP for XAUUSD should add in language that addresses weekend-price, [UMIP-26](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-26.md).


**Summary**

TODO: add unit tests for the following cases:
- `minuteLookback` and `hourlyLookback` are specified, `minute` timeseries is empty and `hourly` timeseries is OK, error should NOT be thrown on `update()`
- `minuteLookback` is specified, `hourlyLookback` is NOT specified, `minute` timeseries is empty and `hourly` timeseries is OK, error should  be thrown on `update()` because fallback to `hourly` should be skipped.
- `minuteLookback` is NOT specified, `hourlyLookback` is specified, `minute` timeseries is empty and `hourly` timeseries is OK, error should  NOT be thrown on `update()` because `updateMinute` should be skipped.

Current unit tests test the following case:
- `minuteLookback` and `hourlyLookback` are specified, but `minute` and `hourly` timeseries are empty, error should be thrown on `update()`

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
