### PR TITLE
patch(disputer): Cast liquidation price BN --> String before logging

### DIFF
--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -153,7 +153,7 @@ class Disputer {
               liquidation: JSON.stringify(liquidation)
             });
 
-            return { ...liquidation, price };
+            return { ...liquidation, price: price.toString() };
           }
 
           return null;
@@ -205,7 +205,6 @@ class Disputer {
         at: "Disputer",
         message: "Disputing liquidation",
         liquidation: disputeableLiquidation,
-        inputPrice,
         txnConfig
       });
 

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -199,8 +199,6 @@ class Disputer {
         gasPrice: this.gasEstimator.getCurrentFastPrice()
       };
 
-      const inputPrice = disputeableLiquidation.price;
-
       this.logger.debug({
         at: "Disputer",
         message: "Disputing liquidation",
@@ -232,7 +230,6 @@ class Disputer {
         at: "Disputer",
         message: "Position has been disputed!👮‍♂️",
         liquidation: disputeableLiquidation,
-        inputPrice,
         txnConfig,
         disputeResult: logResult
       });


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

After dispute is sent, DIsputer logs details about the transaction receipt including the historical price it used to submit the dispute. The price is not correctly cast to a String before sending to the logger, which causes the Slack Transport to error.

Notice in the logs below how the `price` looks strange, because the `price` is actually a BN object.
![Screen Shot 2021-02-28 at 16 03 19](https://user-images.githubusercontent.com/9457025/109433479-7b1b0100-79de-11eb-91a0-6a09dd7f8b1f.png)

**Testing**

Tested on Kovan

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
