### PR TITLE
patch(disputer,liquidator): Handle changed LiquidationWithdrawn event params

### DIFF
--- a/packages/common/src/MultiVersionTestHelpers.js
+++ b/packages/common/src/MultiVersionTestHelpers.js
@@ -14,7 +14,7 @@ const SUPPORTED_CONTRACT_VERSIONS = [
 ];
 
 // Versions that unit tests will test against. Note that there is no need to re-test anything less than 1.2.2 as
-// functionally therese versions are identical to 1.2.2.
+// functionally these versions are identical to 1.2.2.
 const TESTED_CONTRACT_VERSIONS = [
   { contractType: "ExpiringMultiParty", contractVersion: "1.2.2" },
   { contractType: "ExpiringMultiParty", contractVersion: "latest" },

--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -19,7 +19,7 @@ const {
 } = require("@uma/financial-templates-lib");
 
 // Truffle contracts.
-const { getAbi, getAddress } = require("@uma/core");
+const { getAbi } = require("@uma/core");
 const { getWeb3 } = require("@uma/common");
 
 /**
@@ -63,10 +63,9 @@ async function run({
     });
 
     // Load unlocked web3 accounts and get the networkId.
-    const [detectedContract, accounts, networkId] = await Promise.all([
+    const [detectedContract, accounts] = await Promise.all([
       findContractVersion(financialContractAddress, web3),
-      web3.eth.getAccounts(),
-      web3.eth.net.getId()
+      web3.eth.getAccounts()
     ]);
 
     // Append the contract version and type to the disputerConfig, if the disputerConfig does not already contain one.
@@ -89,7 +88,6 @@ async function run({
       );
 
     // Setup contract instances.
-    const voting = new web3.eth.Contract(getAbi("Voting", "1.2.2"), getAddress("Voting", networkId));
     const financialContract = new web3.eth.Contract(
       getAbi(disputerConfig.contractType, disputerConfig.contractVersion),
       financialContractAddress
@@ -144,7 +142,6 @@ async function run({
     const disputer = new Disputer({
       logger,
       financialContractClient,
-      votingContract: voting,
       gasEstimator,
       priceFeed,
       account: accounts[0],

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -9,7 +9,6 @@ class Disputer {
    * @notice Constructs new Disputer bot.
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} financialContractClient Module used to query Financial Contract information on-chain.
-   * @param {Object} votingContract DVM to query price requests.
    * @param {Object} gasEstimator Module used to estimate optimal gas price with which to send txns.
    * @param {Object} priceFeed Module used to get the current or historical token price.
    * @param {String} account Ethereum account from which to send txns.
@@ -20,7 +19,6 @@ class Disputer {
   constructor({
     logger,
     financialContractClient,
-    votingContract,
     gasEstimator,
     priceFeed,
     account,
@@ -42,7 +40,6 @@ class Disputer {
 
     // Instance of the expiring multiparty to perform on-chain disputes
     this.financialContract = this.financialContractClient.financialContract;
-    this.votingContract = votingContract;
 
     this.financialContractIdentifier = financialContractProps.priceIdentifier;
 
@@ -89,6 +86,11 @@ class Disputer {
 
     // Validate and set config settings to class state.
     Object.assign(this, createObjectFromDefaultProps(disputerConfig, defaultConfig));
+
+    // These EMP versions have different "LiquidationWithdrawn" event parameters that we need to handle.
+    this.isLegacyEmpVersion = Boolean(
+      this.contractVersion === "1.2.0" || this.contractVersion === "1.2.1" || this.contractVersion === "1.2.2"
+    );
   }
 
   // Update the client and gasEstimator clients.
@@ -230,7 +232,6 @@ class Disputer {
         at: "Disputer",
         message: "Position has been disputed!👮‍♂️",
         liquidation: disputeableLiquidation,
-        txnConfig,
         disputeResult: logResult
       });
     }
@@ -278,10 +279,9 @@ class Disputer {
 
         // In contract version 1.2.2 and below this function returns one value: the amount withdrawn by the function caller.
         // In later versions it returns an object containing all payouts.
-        paidToDisputer =
-          this.contractVersion === "1.2.0" || this.contractVersion === "1.2.0" || this.contractVersion === "1.2.2"
-            ? withdrawalCallResponse.rawValue.toString()
-            : withdrawalCallResponse.paidToDisputer.rawValue.toString();
+        paidToDisputer = this.isLegacyEmpVersion
+          ? withdrawalCallResponse.rawValue.toString()
+          : withdrawalCallResponse.paidToDisputer.rawValue.toString();
 
         // If the call would revert OR the disputer would get nothing for withdrawing then throw and continue.
         if (revertWrapper(withdrawalCallResponse) === null || paidToDisputer === "0") {
@@ -291,8 +291,7 @@ class Disputer {
         this.logger.debug({
           at: "Disputer",
           message: "No rewards to withdraw",
-          liquidation: liquidation,
-          error
+          liquidation: liquidation
         });
         continue;
       }
@@ -310,11 +309,6 @@ class Disputer {
         txnConfig
       });
 
-      // Before submitting transaction, store liquidation timestamp before it is potentially deleted if this is the final reward to be withdrawn.
-      // We can be confident that `liquidationTime` property is available and accurate because the liquidation has not been deleted yet if we `withdrawLiquidation()`
-      // is callable.
-      const requestTimestamp = liquidation.liquidationTime;
-
       // Send the transaction or report failure.
       let receipt;
       try {
@@ -328,31 +322,30 @@ class Disputer {
         continue;
       }
 
-      // Get resolved price request for dispute. `getPrice()` should not fail since the dispute price request must have settled in order for `withdrawLiquidation()`
-      // to be callable.
-      let resolvedPrice = await this.votingContract.methods
-        .getPrice(this.financialContractIdentifier, requestTimestamp)
-        .call({
-          from: this.financialContract.options.address
-        });
-
-      const logResult = {
+      let logResult = {
         tx: receipt.transactionHash,
         caller: receipt.events.LiquidationWithdrawn.returnValues.caller,
-        withdrawalAmount: receipt.events.LiquidationWithdrawn.returnValues.withdrawalAmount,
+        settlementPrice: receipt.events.LiquidationWithdrawn.returnValues.settlementPrice,
         liquidationStatus:
           PostWithdrawLiquidationRewardsStatusTranslations[
             receipt.events.LiquidationWithdrawn.returnValues.liquidationStatus
-          ],
-        resolvedPrice: resolvedPrice.toString()
+          ]
       };
+
+      // In contract version 1.2.2 and below this event returns one value, `withdrawalAmount`: the amount withdrawn by the function caller.
+      // In later versions it returns an object containing all payouts.
+      if (this.isLegacyEmpVersion) {
+        logResult.withdrawalAmount = receipt.events.LiquidationWithdrawn.returnValues.withdrawalAmount;
+      } else {
+        logResult.paidToLiquidator = receipt.events.LiquidationWithdrawn.returnValues.paidToLiquidator;
+        logResult.paidToDisputer = receipt.events.LiquidationWithdrawn.returnValues.paidToDisputer;
+        logResult.paidToSponsor = receipt.events.LiquidationWithdrawn.returnValues.paidToSponsor;
+      }
 
       this.logger.info({
         at: "Disputer",
         message: "Dispute withdrawn🤑",
         liquidation: liquidation,
-        paidToDisputer,
-        txnConfig,
         liquidationResult: logResult
       });
     }

--- a/packages/disputer/test/Disputer.js
+++ b/packages/disputer/test/Disputer.js
@@ -272,7 +272,6 @@ contract("Disputer.js", function(accounts) {
           disputer = new Disputer({
             logger: spyLogger,
             financialContractClient: financialContractClient,
-            votingContract: mockOracle.contract,
             gasEstimator,
             priceFeed: priceFeedMock,
             account: accounts[0],
@@ -570,7 +569,16 @@ contract("Disputer.js", function(accounts) {
               spy.getCall(-1).lastArg.liquidationResult.liquidationStatus,
               PostWithdrawLiquidationRewardsStatusTranslations[LiquidationStatesEnum.DISPUTE_SUCCEEDED]
             );
-            assert.equal(spy.getCall(-1).lastArg.liquidationResult.resolvedPrice, convertPrice("1.3"));
+            assert.equal(spy.getCall(-1).lastArg.liquidationResult.settlementPrice, convertPrice("1.3"));
+
+            // Check that the log contains the dispute rewards:
+            if (disputer.isLegacyEmpVersion) {
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.withdrawalAmount).gt(0));
+            } else {
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToLiquidator).gt(0));
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToSponsor).gt(0));
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToDisputer).gt(0));
+            }
 
             // After the dispute is resolved, the liquidation should still exist but the disputer should no longer be able to withdraw any rewards.
             await disputer.update();
@@ -660,7 +668,6 @@ contract("Disputer.js", function(accounts) {
                 disputer = new Disputer({
                   logger: spyLogger,
                   financialContractClient: financialContractClient,
-                  votingContract: mockOracle.contract,
                   gasEstimator,
                   priceFeed: priceFeedMock,
                   account: accounts[0],
@@ -682,7 +689,6 @@ contract("Disputer.js", function(accounts) {
               disputer = new Disputer({
                 logger: spyLogger,
                 financialContractClient: financialContractClient,
-                votingContract: mockOracle.contract,
                 gasEstimator,
                 priceFeed: priceFeedMock,
                 account: accounts[0],

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -18,7 +18,7 @@ const {
 } = require("@uma/financial-templates-lib");
 
 // Contract ABIs and network Addresses.
-const { getAbi, getAddress } = require("@uma/core");
+const { getAbi } = require("@uma/core");
 
 /**
  * @notice Continuously attempts to liquidate positions in the Financial Contract contract.
@@ -70,10 +70,9 @@ async function run({
     });
 
     // Load unlocked web3 accounts and get the networkId.
-    const [detectedContract, accounts, networkId] = await Promise.all([
+    const [detectedContract, accounts] = await Promise.all([
       findContractVersion(financialContractAddress, web3),
-      web3.eth.getAccounts(),
-      web3.eth.net.getId()
+      web3.eth.getAccounts()
     ]);
     // Append the contract version and type to the liquidatorConfig, if the liquidatorConfig does not already contain one.
     if (!liquidatorConfig) liquidatorConfig = {};
@@ -95,7 +94,6 @@ async function run({
       );
 
     // Setup contract instances. This uses the contract version pulled in from previous step. Voting is hardcoded to latest main net version.
-    const voting = new web3.eth.Contract(getAbi("Voting", "1.2.2"), getAddress("Voting", networkId));
     const financialContract = new web3.eth.Contract(
       getAbi(liquidatorConfig.contractType, liquidatorConfig.contractVersion),
       financialContractAddress
@@ -215,7 +213,6 @@ async function run({
       logger,
       financialContractClient,
       gasEstimator,
-      votingContract: voting,
       syntheticToken,
       priceFeed,
       account: accounts[0],

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -283,7 +283,6 @@ contract("Liquidator.js", function(accounts) {
             logger: spyLogger,
             financialContractClient: financialContractClient,
             gasEstimator,
-            votingContract: mockOracle.contract,
             syntheticToken: syntheticToken.contract,
             priceFeed: priceFeedMock,
             account: accounts[0],
@@ -608,7 +607,16 @@ contract("Liquidator.js", function(accounts) {
                   : LiquidationStatesEnum.DISPUTE_FAILED
               ]
             );
-            assert.equal(spy.getCall(-1).lastArg.liquidationResult.resolvedPrice, convertPrice("1.3"));
+            assert.equal(spy.getCall(-1).lastArg.liquidationResult.settlementPrice, convertPrice("1.3"));
+
+            // Check that the log contains the dispute rewards:
+            if (liquidator.isLegacyEmpVersion) {
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.withdrawalAmount).gt(0));
+            } else {
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToLiquidator).gt(0));
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToSponsor).gt(0));
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToDisputer).gt(0));
+            }
 
             // After the dispute is resolved, the liquidation should no longer exist and there should be no disputes to withdraw rewards from.
             await liquidator.update();
@@ -678,7 +686,16 @@ contract("Liquidator.js", function(accounts) {
               spy.getCall(-1).lastArg.liquidationResult.liquidationStatus,
               PostWithdrawLiquidationRewardsStatusTranslations[LiquidationStatesEnum.DISPUTE_SUCCEEDED]
             );
-            assert.equal(spy.getCall(-1).lastArg.liquidationResult.resolvedPrice, convertPrice("1"));
+            assert.equal(spy.getCall(-1).lastArg.liquidationResult.settlementPrice, convertPrice("1"));
+
+            // Check that the log contains the dispute rewards:
+            if (liquidator.isLegacyEmpVersion) {
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.withdrawalAmount).gt(0));
+            } else {
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToLiquidator).gt(0));
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToSponsor).gt(0));
+              assert.isTrue(toBN(spy.getCall(-1).lastArg.liquidationResult.paidToDisputer).gt(0));
+            }
 
             // After the dispute is resolved, the liquidation should still exist but the liquidator should no longer be able to withdraw any rewards.
             await liquidator.update();
@@ -743,7 +760,6 @@ contract("Liquidator.js", function(accounts) {
                   logger: spyLogger,
                   financialContractClient: financialContractClient,
                   gasEstimator,
-                  votingContract: mockOracle.contract,
                   syntheticToken: syntheticToken.contract,
                   priceFeed: priceFeedMock,
                   account: accounts[0],
@@ -783,7 +799,6 @@ contract("Liquidator.js", function(accounts) {
               logger: spyLogger,
               financialContractClient: financialContractClient,
               gasEstimator,
-              votingContract: mockOracle.contract,
               syntheticToken: syntheticToken.contract,
               priceFeed: priceFeedMock,
               account: accounts[0],
@@ -857,7 +872,6 @@ contract("Liquidator.js", function(accounts) {
                   logger: spyLogger,
                   financialContractClient: financialContractClient,
                   gasEstimator,
-                  votingContract: mockOracle.contract,
                   syntheticToken: syntheticToken.contract,
                   priceFeed: priceFeedMock,
                   account: accounts[0],
@@ -1187,7 +1201,6 @@ contract("Liquidator.js", function(accounts) {
                   logger: spyLogger,
                   financialContractClient: financialContractClient,
                   gasEstimator,
-                  votingContract: mockOracle.contract,
                   syntheticToken: syntheticToken.contract,
                   priceFeed: priceFeedMock,
                   account: accounts[0],
@@ -1290,7 +1303,6 @@ contract("Liquidator.js", function(accounts) {
               logger: spyLogger,
               financialContractClient: financialContractClient,
               gasEstimator,
-              votingContract: mockOracle.contract,
               syntheticToken: syntheticToken.contract,
               priceFeed: priceFeedMock,
               account: accounts[0],
@@ -1312,7 +1324,6 @@ contract("Liquidator.js", function(accounts) {
                 logger: spyLogger,
                 financialContractClient: financialContractClient,
                 gasEstimator,
-                votingContract: mockOracle.contract,
                 syntheticToken: syntheticToken.contract,
                 priceFeed: priceFeedMock,
                 account: accounts[0],
@@ -1431,7 +1442,6 @@ contract("Liquidator.js", function(accounts) {
                 logger: spyLogger,
                 financialContractClient,
                 gasEstimator,
-                votingContract: mockOracle.contract,
                 syntheticToken: syntheticToken.contract,
                 priceFeed: priceFeedMock,
                 account: accounts[0],

--- a/packages/liquidator/test/index.js
+++ b/packages/liquidator/test/index.js
@@ -353,7 +353,12 @@ contract("index.js", function(accounts) {
         if (contractVersion.contractType == "ExpiringMultiParty") assert.isTrue(spyLogIncludes(spy, 2, "expired"));
         if (contractVersion.contractType == "Perpetual") assert.isTrue(spyLogIncludes(spy, 2, "shutdown"));
         assert.isTrue(spyLogIncludes(spy, -1, "Liquidation withdrawn"));
-        assert.equal(spy.getCall(-1).lastArg.amountWithdrawn, toWei("80")); // Amount withdrawn by liquidator minus dispute rewards.
+        assert.equal(
+          contractVersion.contractVersion === "1.2.2"
+            ? spy.getCall(-1).lastArg.liquidationResult.withdrawalAmount
+            : spy.getCall(-1).lastArg.liquidationResult.paidToLiquidator,
+          toWei("80")
+        ); // Amount withdrawn by liquidator minus dispute rewards.
       });
 
       it("Allowances are set", async function() {


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Resolved disputes are withdrawn successfully but event log parsing is mishandled if EMP version is not a legacy (<=1.2.2) one.

Additionally, we can query `settlementPrice` from the event logs instead of making a call to the VotingContract.getPrice(), which removes the need for the bots to construct the Voting contract.

Tested log output to Slack successfully on Kovan.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
