### PR TITLE
feat(financial-templates-lib): add uSTONKS default price feed

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -479,6 +479,12 @@ const defaultConfigs = {
     hourlyLookback: 604800,
     minTimeBetweenUpdates: 60
   },
+  uSTONKS_APR21: {
+    type: "uniswap",
+    uniswapAddress: "0x683ea972ffa19b7bad6d6be0440e0a8465dba71c",
+    twapLength: 7200,
+    poolDecimals: 6
+  },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this
   // default price feed config.
   TEST8DECIMALS: {

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -481,7 +481,7 @@ const defaultConfigs = {
   },
   uSTONKS_APR21: {
     type: "uniswap",
-    uniswapAddress: "0x683ea972ffa19b7bad6d6be0440e0a8465dba71c",
+    uniswapAddress: "0xedf187890af846bd59f560827ebd2091c49b75df",
     twapLength: 7200,
     poolDecimals: 6
   },

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -483,7 +483,6 @@ const defaultConfigs = {
     type: "uniswap",
     uniswapAddress: "0xedf187890af846bd59f560827ebd2091c49b75df",
     twapLength: 7200,
-    poolDecimals: 6,
     invertPrice: true
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -483,7 +483,8 @@ const defaultConfigs = {
     type: "uniswap",
     uniswapAddress: "0xedf187890af846bd59f560827ebd2091c49b75df",
     twapLength: 7200,
-    poolDecimals: 6
+    poolDecimals: 6,
+    invertPrice: true
   },
   // The following identifiers can be used to test how `CreatePriceFeed` interacts with this
   // default price feed config.


### PR DESCRIPTION
**Motivation**

The uSTONKS_APR21 price [identifier](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-47.md) needs a default price feed config.


**Summary**

Adds the default price feed config.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
