### PR TITLE
feat(voter-dapp): fetch users 2key contract state, and show migration banner if required

### DIFF
--- a/packages/core/contracts/oracle/test/VotingAncillaryInterfaceTest.sol
+++ b/packages/core/contracts/oracle/test/VotingAncillaryInterfaceTest.sol
@@ -44,6 +44,7 @@ abstract contract VotingAncillaryInterfaceTesting is OracleAncillaryInterface, V
         uint256 indexed roundId,
         bytes32 indexed identifier,
         uint256 time,
+        bytes ancillaryData,
         uint256 numTokens
     );
 

--- a/packages/voter-dapp/src/Dashboard.js
+++ b/packages/voter-dapp/src/Dashboard.js
@@ -8,12 +8,14 @@ import DesignatedVotingTransfer from "./DesignatedVotingTransfer.js";
 import DesignatedVoting from "@uma/core/build/contracts/DesignatedVoting.json";
 import RetrieveRewards from "./RetrieveRewards.js";
 import { drizzleReactHooks } from "@umaprotocol/react-plugin";
+import { formatWithMaxDecimals, formatWei } from "@uma/common";
 
 function Dashboard() {
   const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
   const { account } = drizzleReactHooks.useDrizzleState(drizzleState => ({
     account: drizzleState.accounts[0]
   }));
+  const { web3 } = drizzle;
 
   const addressZero = "0x0000000000000000000000000000000000000000";
 
@@ -21,6 +23,23 @@ function Dashboard() {
   const { designatedVoting } = drizzleReactHooks.useDrizzleState(drizzleState => ({
     designatedVoting: drizzleState.contracts[deployedDesignatedVotingAddress]
   }));
+
+  const { shouldShowBanner, oldDesignatedVotingAddress, balance } = useCacheCall(
+    ["OldDesignatedVotingFactory", "VotingToken"],
+    call => {
+      if (!account) return {};
+      const oldDesignatedVotingAddress = call("OldDesignatedVotingFactory", "designatedVotingContracts", account);
+      if (!oldDesignatedVotingAddress) return {};
+      const balance = call("VotingToken", "balanceOf", oldDesignatedVotingAddress);
+      if (!oldDesignatedVotingBalance) return {};
+
+      const balanceBN = web3.utils.toBN(oldDesignatedVotingBalance.toString());
+      const shouldShowBanner = !balanceBN.isZero();
+      const formattedBalance = formatWithMaxDecimals(formatWei(balance, web3), 2, 4, false);
+
+      return { shouldShowBanner, oldDesignatedVotingAddress, oldDesignatedVotingBalance: formattedbalance };
+    }
+  );
 
   // We only want to run `drizzle.addContract` once, even if a change deep inside the `drizzle` object retriggers this
   // `useEffect`.

--- a/packages/voter-dapp/src/Dashboard.js
+++ b/packages/voter-dapp/src/Dashboard.js
@@ -24,7 +24,7 @@ function Dashboard() {
     designatedVoting: drizzleState.contracts[deployedDesignatedVotingAddress]
   }));
 
-  const { shouldShowBanner, oldDesignatedVotingAddress, balance } = useCacheCall(
+  const { shouldShowBanner, oldDesignatedVotingAddress, oldDesignatedVotingBalance } = useCacheCall(
     ["OldDesignatedVotingFactory", "VotingToken"],
     call => {
       if (!account) return {};

--- a/packages/voter-dapp/src/Dashboard.js
+++ b/packages/voter-dapp/src/Dashboard.js
@@ -30,7 +30,16 @@ function Dashboard() {
     call => {
       if (!account) return {};
       const oldDesignatedVotingAddress = call("OldDesignatedVotingFactory", "designatedVotingContracts", account);
-      if (!oldDesignatedVotingAddress) return {};
+      if (!oldDesignatedVotingAddress || oldDesignatedVotingAddress === addressZero) return {};
+
+      // Handle special case where there is no old designated voting factory so it is set to the new one.
+      const { toChecksumAddress } = web3.utils;
+      if (
+        deployedDesignatedVotingAddress &&
+        toChecksumAddress(oldDesignatedVotingAddress) === toChecksumAddress(deployedDesignatedVotingAddress)
+      )
+        return {};
+
       const balance = call("VotingToken", "balanceOf", oldDesignatedVotingAddress);
       if (!balance) return {};
 
@@ -100,7 +109,9 @@ function Dashboard() {
         <Header votingAccount={votingAccount} />
       </AppBar>
 
-      {shouldShowBanner && <MigrationBanner oldDesignatedVotingAddress={oldDesignatedVotingAddress} balance={oldDesignatedVotingBalance}/>}
+      {shouldShowBanner && (
+        <MigrationBanner oldDesignatedVotingAddress={oldDesignatedVotingAddress} balance={oldDesignatedVotingBalance} />
+      )}
       {designatedVotingHelpers}
       <RetrieveRewards votingAccount={votingAccount} />
       <ActiveRequests votingGateway={votingGateway} votingAccount={votingAccount} snapshotContract="Voting" />

--- a/packages/voter-dapp/src/Dashboard.js
+++ b/packages/voter-dapp/src/Dashboard.js
@@ -31,13 +31,13 @@ function Dashboard() {
       const oldDesignatedVotingAddress = call("OldDesignatedVotingFactory", "designatedVotingContracts", account);
       if (!oldDesignatedVotingAddress) return {};
       const balance = call("VotingToken", "balanceOf", oldDesignatedVotingAddress);
-      if (!oldDesignatedVotingBalance) return {};
+      if (!balance) return {};
 
-      const balanceBN = web3.utils.toBN(oldDesignatedVotingBalance.toString());
+      const balanceBN = web3.utils.toBN(balance.toString());
       const shouldShowBanner = !balanceBN.isZero();
       const formattedBalance = formatWithMaxDecimals(formatWei(balance, web3), 2, 4, false);
 
-      return { shouldShowBanner, oldDesignatedVotingAddress, oldDesignatedVotingBalance: formattedbalance };
+      return { shouldShowBanner, oldDesignatedVotingAddress, oldDesignatedVotingBalance: formattedBalance };
     }
   );
 

--- a/packages/voter-dapp/src/Dashboard.js
+++ b/packages/voter-dapp/src/Dashboard.js
@@ -9,6 +9,7 @@ import DesignatedVoting from "@uma/core/build/contracts/DesignatedVoting.json";
 import RetrieveRewards from "./RetrieveRewards.js";
 import { drizzleReactHooks } from "@umaprotocol/react-plugin";
 import { formatWithMaxDecimals, formatWei } from "@uma/common";
+import MigrationBanner from "./MigrationBanner";
 
 function Dashboard() {
   const { drizzle, useCacheCall } = drizzleReactHooks.useDrizzle();
@@ -98,6 +99,8 @@ function Dashboard() {
       <AppBar color="secondary" position="static">
         <Header votingAccount={votingAccount} />
       </AppBar>
+
+      {shouldShowBanner && <MigrationBanner oldDesignatedVotingAddress={oldDesignatedVotingAddress} balance={oldDesignatedVotingBalance}/>}
       {designatedVotingHelpers}
       <RetrieveRewards votingAccount={votingAccount} />
       <ActiveRequests votingGateway={votingGateway} votingAccount={votingAccount} snapshotContract="Voting" />

--- a/packages/voter-dapp/src/MigrationBanner.js
+++ b/packages/voter-dapp/src/MigrationBanner.js
@@ -1,0 +1,33 @@
+import React from "react";
+import NotificationBanner from "./NotificationBanner";
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+
+function eslink(addr) {
+  return `https://etherscan.io/address/${addr}`;
+}
+
+const OpenNewTab = link => () => window.open(link, "_blank");
+// This is ok to hard code for now
+const migrationLink = "https://docs.google.com/document/d/1dVQuMwiVsSEtlPFFl7AsCDe02-njgfLCLZr7a7zGUNo";
+
+// passing in balance is optional.
+function MigrationBanner({ oldDesignatedVotingAddress, balance }) {
+  return (
+    <NotificationBanner>
+      <Typography>
+        Warning: You have an old 2 Key contract&nbsp;
+        <a href={eslink(oldDesignatedVotingAddress)} rel="noopener noreferrer" target="_blank">
+          here
+        </a>
+        &nbsp;which holds {balance} <strong>UMA</strong> tokens. These tokens will not count towards a vote until you
+        migrate them to a new contract. Follow the migration guide to update your 2 Key contract.
+      </Typography>
+      <Button color="secondary" onClick={OpenNewTab(migrationLink)}>
+        <strong> Migration Guide</strong>
+      </Button>
+    </NotificationBanner>
+  );
+}
+
+export default MigrationBanner;

--- a/packages/voter-dapp/src/MigrationBanner.js
+++ b/packages/voter-dapp/src/MigrationBanner.js
@@ -7,7 +7,6 @@ function eslink(addr) {
   return `https://etherscan.io/address/${addr}`;
 }
 
-const OpenNewTab = link => () => window.open(link, "_blank");
 // This is ok to hard code for now
 const migrationLink = "https://docs.google.com/document/d/1dVQuMwiVsSEtlPFFl7AsCDe02-njgfLCLZr7a7zGUNo";
 
@@ -21,11 +20,14 @@ function MigrationBanner({ oldDesignatedVotingAddress, balance }) {
           here
         </a>
         &nbsp;which holds {balance} <strong>UMA</strong> tokens. These tokens will not count towards a vote until you
-        migrate them to a new contract. Follow the migration guide to update your 2 Key contract.
+        migrate them to a new contract. Follow the&nbsp;
+        <strong>
+          <a href={migrationLink} rel="noopener noreferrer" target="_blank">
+            migration guide
+          </a>
+        </strong>
+        &nbsp;to update your 2 Key contract.
       </Typography>
-      <Button color="secondary" onClick={OpenNewTab(migrationLink)}>
-        <strong> Migration Guide</strong>
-      </Button>
     </NotificationBanner>
   );
 }

--- a/packages/voter-dapp/src/NotificationBanner.js
+++ b/packages/voter-dapp/src/NotificationBanner.js
@@ -1,0 +1,12 @@
+import React from "react";
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+function NotificationBanner({ text = "Add your text", children }) {
+  return (
+    <AppBar color="primary" position="static">
+      <Toolbar>{children}</Toolbar>
+    </AppBar>
+  );
+}
+
+export default NotificationBanner;

--- a/packages/voter-dapp/src/RetrieveRewards.js
+++ b/packages/voter-dapp/src/RetrieveRewards.js
@@ -44,7 +44,6 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, reveals, votingAccount) {
 
     // Each of the following loops adds the relevant portions of the event state to the corresponding voteState data
     // structure.
-    console.log(retrievedRewardsEvents);
     for (const event of retrievedRewardsEvents) {
       const voteState = getVoteState(
         event.returnValues.identifier,

--- a/packages/voter-dapp/src/RetrieveRewards.js
+++ b/packages/voter-dapp/src/RetrieveRewards.js
@@ -44,11 +44,12 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, reveals, votingAccount) {
 
     // Each of the following loops adds the relevant portions of the event state to the corresponding voteState data
     // structure.
+    console.log(retrievedRewardsEvents);
     for (const event of retrievedRewardsEvents) {
       const voteState = getVoteState(
         event.returnValues.identifier,
         event.returnValues.time,
-        event.returnValues.ancillaryData
+        event.returnValues.ancillaryData || DEFAULT_ANCILLARY_DATA
       );
 
       voteState.retrievedRewards = true;
@@ -59,7 +60,7 @@ function useRetrieveRewardsTxn(retrievedRewardsEvents, reveals, votingAccount) {
     // should query (since only one can be chosen).
     let oldestUnclaimedRound = MAX_SAFE_JS_INT;
     for (const reveal of reveals) {
-      const voteState = getVoteState(reveal.identifier, reveal.time, reveal.ancillaryData);
+      const voteState = getVoteState(reveal.identifier, reveal.time, reveal.ancillaryData || DEFAULT_ANCILLARY_DATA);
       const revealRound = reveal.revealRound.toString();
       const revealPrice = reveal.revealPrice.toString();
       const lastVotingRound = reveal.lastVotingRound.toString();

--- a/packages/voter-dapp/src/drizzleOptions.js
+++ b/packages/voter-dapp/src/drizzleOptions.js
@@ -6,9 +6,22 @@ import VotingAncillaryTest from "@uma/core/build/contracts/VotingAncillaryInterf
 
 // Doing this to force using only the ancillary interface. Drizzle was getting confused when calling overloads.
 Voting.abi = [...VotingAncillaryTest.abi];
+const OldDesignatedVotingFactory = {
+  abi: DesignatedVotingFactory.abi,
+  networks: {
+    ...DesignatedVotingFactory.networks, // Unless overridden, this will make the "old" voting contract == new voting contract.
+    1: {
+      address: "0xE81EeE5Da165fA6863bBc82dF66E62d18625d592"
+    },
+    42: {
+      address: "0xF988f9f62f355966a758c5936C9080183C176585"
+    }
+  },
+  contractName: "OldDesignatedVotingFactory"
+};
 
 const options = {
-  contracts: [DesignatedVotingFactory, Governor, Voting, VotingToken],
+  contracts: [DesignatedVotingFactory, Governor, Voting, VotingToken, OldDesignatedVotingFactory],
   polls: {
     accounts: 1000,
     blocks: 3000


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Contract upgrades have required a 2key upgrade as well, and we will need to warn users who have not migrated to the newest 2key, to do so. 

**Summary**

The dashboard now has logic which looks up if a user has UMA tokens at the old 2key contract, if so, a banner component has been added which directs the user to the migration guide.


**Details**

This is an example of what it looks like, in production it will not show if a user has 0 uma at address
![image](https://user-images.githubusercontent.com/4429761/109872118-f9271400-7c39-11eb-8898-dfd7b775e52f.png)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested



