### PR TITLE
feat(core): general improvements to claim rewards script

### DIFF
--- a/packages/core/scripts/local/ClaimAllRewards.js
+++ b/packages/core/scripts/local/ClaimAllRewards.js
@@ -1,39 +1,98 @@
-// Usage: $(npm bin)/truffle exec ./scripts/ClaimAllRewards.js --round <round_id> --batcherAddress 0x82458d1C812D7c930Bb3229c9e159cbabD9AA8Cb --network mainnet_mnemonic
+// Usage: $(npm bin)/truffle exec ./scripts/ClaimAllRewards.js --batcherAddress 0x82458d1C812D7c930Bb3229c9e159cbabD9AA8Cb --network mainnet_mnemonic
+// Other optional args:
+// --round <round id> Example: `--round 9344 --round 9342`. This only considers rewards for rounds 9344 and 9342.
+// --claimAddress <address> Example: `--claimAddress 0x1234 --claimAddress 0x5678`. This only considers rewards for
+//   0x1234 and 0x5678. Defaults to claiming for _all_ addresses.
+// --excludeAddress <address> Example: `--excludeAddress 0x1234 --excludeAddress 0x5678`. This excludes addresses
+//   0x1234 and 0x5678. Defaults to excluding no addresses.
+// --onlyPrint. This flag takes no arguments. It tells the script to just print out the available rewards rather than
+//   trying to claim them. Default off.
+// --version <version string>. Example: `--version 1.2.2 --version latest` DVM versions to consider when claiming.
+//   Since a new Voting contract was deployed in version 2.0.0, that version will only claim for that contract, not
+//   older ones. Defaults to 1.2.2 and latest.
 
-const Voting = artifacts.require("Voting");
-const VotingInterfaceTesting = artifacts.require("VotingInterfaceTesting");
+const { getAbi, getAddress } = require("../../index");
 const TransactionBatcher = artifacts.require("TransactionBatcher");
+const lodash = require("lodash");
+const winston = require("winston");
+const { GasEstimator } = require("@uma/financial-templates-lib");
 
-const argv = require("minimist")(process.argv.slice(), { string: ["round", "batcherAddress"] });
+const argv = require("minimist")(process.argv.slice(), {
+  string: ["round", "batcherAddress", "claimAddress", "excludeAddress", "version"],
+  boolean: "onlyPrint"
+});
 
-const { toBN, toWei } = web3.utils;
+const { toBN, toWei, toChecksumAddress } = web3.utils;
 
 // This script claims all voter's rewards for the round provided.
 async function claimRewards() {
-  const voting = await VotingInterfaceTesting.at((await Voting.deployed()).address);
+  const rounds = argv.round ? lodash.castArray(argv.round) : [];
+  const excludeAddresses = argv.excludeAddress ? lodash.castArray(argv.excludeAddress) : [];
+  const claimAddresses = argv.claimAddress ? lodash.castArray(argv.claimAddress) : [];
+  const versions = argv.version ? lodash.castArray(argv.version) : ["latest", "1.2.2"];
 
-  const events = await voting.contract.getPastEvents("VoteRevealed", {
-    filter: { roundId: argv.round },
-    fromBlock: 0,
-    toBlock: "latest"
+  const account = (await web3.eth.getAccounts())[0];
+  const networkId = await web3.eth.net.getId();
+
+  const votingContracts = versions.map(version => {
+    if (version.startsWith("1")) {
+      return new web3.eth.Contract(getAbi("Voting", version), getAddress("Voting", networkId, version));
+    } else {
+      return new web3.eth.Contract(
+        getAbi("VotingAncillaryInterfaceTesting", "latest"),
+        getAddress("Voting", networkId, version)
+      );
+    }
   });
 
-  const votersToPriceRequests = {};
+  const events = lodash.flatten(
+    await Promise.all(
+      votingContracts.map(voting =>
+        voting.getPastEvents("VoteRevealed", {
+          filter: { roundId: rounds, voter: claimAddresses },
+          fromBlock: 0,
+          toBlock: "latest"
+        })
+      )
+    )
+  );
+
+  const priceRequestMap = {};
   for (const event of events) {
     const voter = event.returnValues.voter;
-    const newPriceRequest = { identifier: event.returnValues.identifier, time: event.returnValues.time };
-    if (votersToPriceRequests[voter]) {
-      votersToPriceRequests[voter].push(newPriceRequest);
+    const round = event.returnValues.roundId;
+    const contractAddress = event.address;
+    const key = [voter, round, contractAddress].join("|");
+    if (excludeAddresses.includes(toChecksumAddress(voter))) {
+      console.log("Found noclaim voter", voter);
+      continue;
+    }
+    const newPriceRequest = {
+      identifier: event.returnValues.identifier,
+      time: event.returnValues.time,
+      ancillaryData: event.returnValues.ancillaryData === null ? "0x" : event.returnValues.ancillaryData
+    };
+    if (priceRequestMap[key]) {
+      priceRequestMap[key].push(newPriceRequest);
     } else {
-      votersToPriceRequests[voter] = [newPriceRequest];
+      priceRequestMap[key] = [newPriceRequest];
     }
   }
 
   const retrievableRewards = (
     await Promise.all(
-      Object.entries(votersToPriceRequests).map(async ([voter, priceRequests]) => {
+      Object.entries(priceRequestMap).map(async ([key, priceRequests]) => {
+        const [voter, round, contractAddress] = key.split("|");
+        const voting = votingContracts.find(
+          contract => toChecksumAddress(contract.options.address) === toChecksumAddress(contractAddress)
+        );
+        if (!voting) throw `Couldn't find voting contract for ${contractAddress}`;
+        const fullVotingContract = new web3.eth.Contract(getAbi("Voting", "latest"), voting.options.address);
+        const migratedAddress = await fullVotingContract.methods.migratedAddress().call();
         try {
-          const output = await voting.retrieveRewards.call(voter, argv.round, priceRequests);
+          const output = await voting.methods
+            .retrieveRewards(voter, round, priceRequests)
+            .call({ from: migratedAddress });
           if (output.toString() === "0") {
             return null;
           } else if (toBN(output.toString()).gt(toBN(toWei("100000000")))) {
@@ -41,32 +100,91 @@ async function claimRewards() {
             return null;
           } else {
             console.log("Found Rewards for voter", voter);
-            return [voter, priceRequests];
+            return { voter, priceRequests, round, voting, rewards: toBN(output.toString()) };
           }
         } catch (error) {
+          console.error(error);
           return null;
         }
       })
     )
   ).filter(element => element !== null);
 
-  const dataArray = retrievableRewards.map(([voter, priceRequests]) => {
-    return voting.contract.methods.retrieveRewards(voter, argv.round, priceRequests).encodeABI();
-  });
-
-  const valuesArray = dataArray.map(() => "0");
-  const targetArray = dataArray.map(() => voting.address);
-
-  const transactionBatcher = await TransactionBatcher.at(argv.batcherAddress);
-  const txn = transactionBatcher.contract.methods.batchSend(targetArray, valuesArray, dataArray);
-  const account = (await web3.eth.getAccounts())[0];
-  const gasEstimate = await txn.estimateGas({ from: account });
-
-  if (gasEstimate > 9000000) {
-    throw "The transaction requires too much gas. Will need to be split up.";
+  if (argv.onlyCompute) {
+    const groupedByVoter = lodash.groupBy(retrievableRewards, el => el.voter);
+    Object.entries(groupedByVoter).forEach(([voter, rewardArray]) => {
+      console.group(`Reward details for voter ${voter}:`);
+      rewardArray.forEach(({ priceRequests, round, voting, rewards }) => {
+        console.group(`Reward from voting contract ${voting.options.address}:`);
+        console.log(`Round: ${round} has ${priceRequests.length} rewards to claim.`);
+        priceRequests.forEach(({ identifier, time, ancillaryData }, i) => {
+          console.group(`Price Request ${i}`);
+          console.log(`Identifier: ${identifier} (${web3.utils.hexToUtf8(identifier)})`);
+          console.log(`Time: ${time}`);
+          if (ancillaryData) console.log(`Ancillary data: ${ancillaryData}`);
+          console.groupEnd();
+        });
+        console.log(`Total Rewards: ${web3.utils.fromWei(rewards.toString())}`);
+        console.groupEnd();
+      });
+      console.groupEnd();
+    });
+    const rewardSummary = Object.fromEntries(
+      Object.entries(groupedByVoter).map(([voter, rewardArray]) => {
+        const totalRewards = rewardArray.reduce((sum, { rewards }) => sum.add(rewards), toBN("0"));
+        return [voter, web3.utils.fromWei(totalRewards.toString())];
+      })
+    );
+    console.group("Per-voter reward summary:");
+    console.log(rewardSummary);
+    console.groupEnd();
+    return;
   }
 
-  await transactionBatcher.batchSend(targetArray, valuesArray, dataArray);
+  const dataArray = retrievableRewards.map(({ voter, priceRequests, round, voting }) => {
+    return voting.methods.retrieveRewards(voter, round, priceRequests).encodeABI();
+  });
+
+  const valuesArray = retrievableRewards.map(() => "0");
+  const targetArray = retrievableRewards.map(({ voting }) => voting.options.address);
+
+  const transactionBatcher = await TransactionBatcher.at(argv.batcherAddress);
+
+  const gasEstimator = new GasEstimator(
+    winston.createLogger({
+      silent: true
+    }),
+    60, // Time between updates.
+    100 // Default gas price.
+  );
+
+  // These nested calls just chunk up the above arrays into 30 transaction chunks, then organize them in groups for
+  // sending on-chain.
+  await Promise.all(
+    lodash
+      .zip(...[targetArray, valuesArray, dataArray].map(arr => lodash.chunk(arr, 30)))
+      .map(async ([chunkedTargetArray, chunkedValueArray, chunkedDataArray]) => {
+        const txn = transactionBatcher.contract.methods.batchSend(
+          chunkedTargetArray,
+          chunkedValueArray,
+          chunkedDataArray
+        );
+        const gasEstimate = await txn.estimateGas({ from: account });
+
+        if (gasEstimate > 6000000) {
+          throw "The transaction requires too much gas. Will need to be split up.";
+        }
+        await gasEstimator.update();
+
+        const receipt = await txn.send({
+          gasPrice: gasEstimator.getCurrentFastPrice(),
+          gas: gasEstimate * 2,
+          from: account
+        });
+
+        console.log("Transaction hash", receipt.transactionHash);
+      })
+  );
 }
 
 async function wrapper(callback) {


### PR DESCRIPTION
**Motivation**

Over the past few weeks, I've had to modify the claim rewards script a few times as a part of our upgrade process. To make this process easier in the future, I thought it might be nice to publish these updates.


**Summary**

A few notable updates:
- The script can now exclude addresses.
- The script can now claim for all rounds if unspecified or user-specified round(s).
- The script can now be used to only claim for one or multiple addresses instead of all addresses.
- The script can talk to multiple Voting versions at once.
- The script now takes an option just to print a summary of unclaimed rewards rather than claiming.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
