### PR TITLE
improve(financial-templates-lib): updates GASETH-TWAP-1Mx1M default config

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -335,7 +335,7 @@ const defaultConfigs = {
   },
   "GASETH-TWAP-1Mx1M": {
     type: "uniswap",
-    uniswapAddress: "0x25fb29D865C1356F9e95D621F21366d3a5DB6BB0",
+    uniswapAddress: "0x2b5dfb7874f685bea30b7d8426c9643a4bcf5873",
     twapLength: 7200
   },
   "GASETH-FEB21": {


### PR DESCRIPTION
**Motivation**

The contract originally using the `GASETH-TWAP-1Mx1M` price identifier has expired. The default `GASETH-TWAP-1Mx1M` is being updated to support another contract and is accompanied by this UMIP [edit](https://github.com/UMAprotocol/UMIPs/pull/203).

**Summary**

Reference pool address has been updated to new uGAS Uniswap pool.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested

Ran monitor bot.

**Issue(s)**

NA
