### PR TITLE
fix(financial-templates-lib): Change Basis configs to use median

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -419,8 +419,8 @@ const defaultConfigs = {
   "ETH-BASIS-6M/USDC": {
     type: "expression",
     expression: `
-      SPOT = mean(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
-      FUTURES = mean(FUT_BINANCE, FUT_OKEX, FUT_FTX);
+      SPOT = median(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
+      FUTURES = median(FUT_BINANCE, FUT_OKEX, FUT_FTX);
       min(1.25, max(0.75, 1.0 + ((FUTURES - SPOT) / SPOT))) * 100
       `,
     lookback: 7200,
@@ -437,8 +437,8 @@ const defaultConfigs = {
   "ETH-BASIS-3M/USDC": {
     type: "expression",
     expression: `
-      SPOT = mean(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
-      FUTURES = mean(FUT_BINANCE, FUT_OKEX, FUT_FTX);
+      SPOT = median(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
+      FUTURES = median(FUT_BINANCE, FUT_OKEX, FUT_FTX);
       min(1.25, max(0.75, 1.0 + ((FUTURES - SPOT) / SPOT))) * 100
       `,
     lookback: 7200,
@@ -455,8 +455,8 @@ const defaultConfigs = {
   "BTC-BASIS-6M/USDC": {
     type: "expression",
     expression: `
-      SPOT = mean(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
-      FUTURES = mean(FUT_BINANCE, FUT_OKEX, FUT_FTX);
+      SPOT = median(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
+      FUTURES = median(FUT_BINANCE, FUT_OKEX, FUT_FTX);
       min(1.25, max(0.75, 1.0 + ((FUTURES - SPOT) / SPOT))) * 100
       `,
     lookback: 7200,
@@ -473,8 +473,8 @@ const defaultConfigs = {
   "BTC-BASIS-3M/USDC": {
     type: "expression",
     expression: `
-      SPOT = mean(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
-      FUTURES = mean(FUT_BINANCE, FUT_OKEX, FUT_FTX);
+      SPOT = median(SPOT_BINANCE, SPOT_OKEX, SPOT_FTX);
+      FUTURES = median(FUT_BINANCE, FUT_OKEX, FUT_FTX);
       min(1.25, max(0.75, 1.0 + ((FUTURES - SPOT) / SPOT))) * 100
       `,
     lookback: 7200,


### PR DESCRIPTION
**Motivation**

The Basis price feed configs should use a median rather than a mean. This follows the guidelines of the [umip-40](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-40.md). 

**Summary**

Change mean to median within the price feed expressions.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested

Ran monitor bot.

**Issue(s)**
NA
