### PR TITLE
fix(docker): point docker build to use commands in package.json rather than hardcoded commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get install -y libudev-dev libusb-1.0-0-dev jq yarn
 RUN npx lerna bootstrap
 
 # Clean and run all package build steps, but exclude dapps (to save time).
-RUN yarn lerna run clean --ignore '*/*dapp*'
+RUN yarn clean
 RUN yarn qbuild
 
 # Command to run any command provided by the COMMAND env variable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npx lerna bootstrap
 
 # Clean and run all package build steps, but exclude dapps (to save time).
 RUN yarn lerna run clean --ignore '*/*dapp*'
-RUN yarn lerna run build --ignore '*/*dapp*'
+RUN yarn qbuild
 
 # Command to run any command provided by the COMMAND env variable.
 ENTRYPOINT ["/bin/bash", "scripts/runCommand.sh"]


### PR DESCRIPTION
**Motivation**

The docker build process was previously using commands that are repeated in the package.json. This PR updates this to have one source of truth.
