### PR TITLE
feat(financial-templates-lib): Add various altcoin price feed configs

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -563,6 +563,102 @@ const defaultConfigs = {
     uniswapAddress: "0xedf187890af846bd59f560827ebd2091c49b75df",
     twapLength: 7200,
     invertPrice: true
+  },
+  USDAAVE: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "aaveusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "aaveusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "aaveusdt" }
+    ]
+  },
+  AAVEUSD: {
+    type: "medianizer",
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "aaveusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "aaveusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "aaveusdt" }
+    ]
+  },
+  USDLINK: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "linkusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "linkusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "linkusdt" }
+    ]
+  },
+  LINKUSD: {
+    type: "medianizer",
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "linkusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "linkusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "linkusdt" }
+    ]
+  },
+  USDSNX: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "snxusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "snxusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "snxusdt" }
+    ]
+  },
+  SNXUSD: {
+    type: "medianizer",
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "snxusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "snxusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "snxusdt" }
+    ]
+  },
+  USDUMA: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "umausd" },
+      { type: "cryptowatch", exchange: "binance", pair: "umausdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "umausdt" }
+    ]
+  },
+  UMAUSD: {
+    type: "medianizer",
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "umausd" },
+      { type: "cryptowatch", exchange: "binance", pair: "umausdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "umausdt" }
+    ]
+  },
+  USDUNI: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "uniusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "uniusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "uniusdt" }
+    ]
+  },
+  UNIUSD: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "uniusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "uniusdt" },
+      { type: "cryptowatch", exchange: "okex", pair: "uniusdt" }
+    ]
   }
 };
 

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -652,7 +652,6 @@ const defaultConfigs = {
   },
   UNIUSD: {
     type: "medianizer",
-    invertPrice: true,
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [
       { type: "cryptowatch", exchange: "coinbase-pro", pair: "uniusd" },


### PR DESCRIPTION
**Motivation**

To support the AAVEUSD, USDAAVE, UMAUSD, USDUMA, SNXUSD, USDSNX, LINKUSD, USDLINK, UNIUSD and USDUNI price identifiers added in [UMIP-57](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-57.md), default price feed configs need to be added.

All of these price identifiers use Coinbase Pro, Binance and OKEx and are all available on Cryptowatch. 

**Summary**

Added medianizer configs for each price identifier listed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested

Ran USD/XYZ price feeds in a monitor bot locally.
 
**Issue(s)**

NA
