### PR TITLE
feat(provider-utils): enable network parameterization 

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uma/common",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Common js utilities used by other UMA packages",
   "homepage": "http://umaproject.org",
   "license": "AGPL-3.0-or-later",

--- a/packages/common/src/ProviderUtils.js
+++ b/packages/common/src/ProviderUtils.js
@@ -57,14 +57,14 @@ function createBasicProvider(url) {
  * which load a hardcoded infura key. Default port is 9545.
  *
  */
-function getWeb3() {
+function getWeb3(parameterizedNetwork = "test") {
   // If a web3 instance has already been initialized, return it.
   if (web3) {
     return web3;
   }
 
   // Create basic web3 provider with no wallet connection based on the url alone.
-  const network = argv.network || "test"; // Default to the test network (local network).
+  const network = argv.network || parameterizedNetwork; // Default to the test network (local network).
   const basicProvider = createBasicProvider(getNodeUrl(network));
 
   // Use the basic provider to create a provider with an unlocked wallet. This piggybacks off the UMA common TruffleConfig

--- a/packages/common/src/ProviderUtils.js
+++ b/packages/common/src/ProviderUtils.js
@@ -48,13 +48,14 @@ function createBasicProvider(url) {
  * @notice Gets a web3 instance based on the network argument using the truffle config in this package.
  * Use this for compatibility for running with or without truffle.
  * @example
- *  If a node app uses getWeb3() and you want to load network 1 with a default wallet
- *  For full list of potential network names see common/src/TruffleConfig
- * node app --network=mainnet_mnemonic
+ *  If a node app uses getWeb3() and you want to load network 1 with a default wallet For full list of potential network
+ * names see common/src/TruffleConfig node app --network=mainnet_mnemonic
  *
- * @notice You can also specify environment variables
- * INFURA_API_KEY, CUSTOM_NODE_URL and CUSTOM_LOCAL_NODE_PORT. If not provided there are defaults
- * which load a hardcoded infura key. Default port is 9545.
+ * @notice You can also specify environment variables INFURA_API_KEY, CUSTOM_NODE_URL and CUSTOM_LOCAL_NODE_PORT.
+ * If not provided there are defaults which load a hardcoded infura key. Default port is 9545.
+ *
+ * @notice a parameterizedNetwork name can also be provided. This enables you to use the library without needing to define
+ * a `--network` argument. Useful in serverless or when running node scripts.
  *
  */
 function getWeb3(parameterizedNetwork = "test") {


### PR DESCRIPTION

**Motivation**

Right now the `getWeb3()` method is limited to pulling the network from the args used when running the node process. This is somewhat restrictive, especially when it comes to using this function in serverless. 

**Summary**

This PR enables the network to be parameterized when using this method.
