### PR TITLE
improve(run-transactions): Add gas limit estimation buffer

### DIFF
--- a/packages/common/src/ContractUtils.js
+++ b/packages/common/src/ContractUtils.js
@@ -36,15 +36,15 @@ const revertWrapper = result => {
  */
 const runTransaction = async ({ transaction, config }) => {
   // Multiplier applied to Truffle's estimated gas limit for a transaction to send.
-  GAS_LIMIT_BUFFER = 1.25;
-  
+  const GAS_LIMIT_BUFFER = 1.25;
+
   // First try to simulate transaction and also extract return value if its
   // a state-modifying transaction. If the function is state modifying, then successfully
   // sending it will return the transaction receipt, not the return value, so we grab it here.
   let returnValue, estimatedGas;
   try {
     [returnValue, estimatedGas] = await Promise.all([
-      transaction.call({ from: config.from }), 
+      transaction.call({ from: config.from }),
       transaction.estimateGas({ from: config.from })
     ]);
   } catch (error) {


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Empirical testing has revealed that the `estimateGas()` method in `web3.eth.Contract` objects sometimes underestimates. This adds a similar buffer used in other bots like the [disputer](https://github.com/UMAprotocol/protocol/blob/master/packages/disputer/src/disputer.js#L200).


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
