### PR TITLE
fix(networker): throw on error rather than logging an error

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/Networker.js
+++ b/packages/financial-templates-lib/src/price-feed/Networker.js
@@ -16,6 +16,7 @@ class Networker {
     const response = await fetch(url);
     const json = await response.json();
     if (!json) {
+      // Throw if no error. Will result in a retry upstream.
       throw new Error(`Networker failed to get json response. Response: ${response}`);
     }
     return json;

--- a/packages/financial-templates-lib/src/price-feed/Networker.js
+++ b/packages/financial-templates-lib/src/price-feed/Networker.js
@@ -16,12 +16,7 @@ class Networker {
     const response = await fetch(url);
     const json = await response.json();
     if (!json) {
-      this.logger.error({
-        at: "Networker",
-        message: "Failed to get json response🚨",
-        url: url,
-        error: new Error(response)
-      });
+      throw new Error(`Networker failed to get json response. Response: ${response}`);
     }
     return json;
   }


### PR DESCRIPTION

**Motivation**
The networker has a error log that should be changed to throw an error. When the Networker fails to complete a request it will produce an error even though it correctly fetched pricing information in the subsequent execution.

An example of the error produced can be seen below:
![image](https://user-images.githubusercontent.com/12886084/111023517-2b770500-83e2-11eb-9581-b0f9079663a2.png)

However, the bot _did_ correctly finish its execution cycle, after the retry logic re-initiated the price request. see screenshot below:
![image](https://user-images.githubusercontent.com/12886084/111023534-4cd7f100-83e2-11eb-8dea-3478e2d45026.png)

As a result, This PR updates the networker to rather throw an error such that the error can be bubbled up to the price feed using it, enabling the bot to re-run its execution and optimistically return a value price on the next retry loop.