### PR TITLE
fix(Merkle-distributor): bump package versions of core and update package to match npm

### DIFF
--- a/packages/merkle-distributor/package.json
+++ b/packages/merkle-distributor/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@uma/merkle-distributor",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "Simple script for dealing with Merkle distribution contracts and proofs hosted on IPFS",
   "dependencies": {
     "@types/commander": "^2.12.2",
     "@types/node-fetch": "^2.5.8",
-    "@uma/core": "^2.0.1",
+    "@uma/core": "^2.1.0",
     "chai": "^4.3.0",
     "commander": "^7.1.0",
     "ethers": "^5.0.31",


### PR DESCRIPTION
**Motivation**

We recently added a new package version of core to support the latest contract artefacts. This PR updates the Merkle-distributor package.json to match what is published in npm which uses these new releases.
