### PR TITLE
fix(common): duplicate key causing lint to fail

### DIFF
--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -64,11 +64,6 @@ const versionMap = {
     // latest Perpetual deployed from hardhat tests.
     contractType: "Perpetual",
     contractVersion: "latest"
-  },
-  "0x1f75b3ae77a4a3b91fefd81264ec94751dcceafb02d42d2250a209385cdee39a": {
-    // Latest Mainnet ExpiringMultiParty.
-    contractType: "ExpiringMultiParty",
-    contractVersion: "latest"
   }
 };
 


### PR DESCRIPTION
**Motivation**

ci is broken due to a merge issue I believe.


**Summary**

Removed the duplicate key in the object that ci is complaining about.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
