### PR TITLE
feat(scripts): log identifiers being verified

### DIFF
--- a/packages/core/scripts/identifier-umip/3_Verify.js
+++ b/packages/core/scripts/identifier-umip/3_Verify.js
@@ -28,9 +28,11 @@ async function runExport() {
     identifiers = [argv.identifier];
   }
 
+  console.log("Testing identifiers:", identifiers);
   const identifierWhitelist = await IdentifierWhitelist.deployed();
 
   for (const identifier of identifiers) {
+    console.log(identifier, "verified.");
     assert.equal(await identifierWhitelist.isIdentifierSupported(web3.utils.utf8ToHex(identifier)), true);
   }
 

--- a/packages/core/scripts/identifier-umip/3_Verify.js
+++ b/packages/core/scripts/identifier-umip/3_Verify.js
@@ -32,8 +32,8 @@ async function runExport() {
   const identifierWhitelist = await IdentifierWhitelist.deployed();
 
   for (const identifier of identifiers) {
-    console.log(identifier, "verified.");
     assert.equal(await identifierWhitelist.isIdentifierSupported(web3.utils.utf8ToHex(identifier)), true);
+    console.log(identifier, "verified.");
   }
 
   console.log("Upgrade Verified!");


### PR DESCRIPTION
Signed-off-by: John Shutt <john.d.shutt@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Adds console logs showing the price identifiers being verified in the UMIP verification script. This is helpful when you're adding a bunch of identifiers at once, especially for troubleshooting failed verifications.


**Summary**

Just added some logs.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
n/a
