### PR TITLE
feat(proposal-scripts): add gas price estimation to reusable proposal scripts

### DIFF
--- a/packages/core/scripts/collateral-umip/1_Propose.js
+++ b/packages/core/scripts/collateral-umip/1_Propose.js
@@ -110,7 +110,6 @@ async function runExport() {
   await gasEstimator.update();
   const txn = await governor.propose(transactionList, {
     from: proposerWallet,
-    gas: 2000000,
     gasPrice: gasEstimator.getCurrentFastPrice()
   });
   console.log("Transaction: ", txn?.tx);

--- a/packages/core/scripts/collateral-umip/1_Propose.js
+++ b/packages/core/scripts/collateral-umip/1_Propose.js
@@ -14,11 +14,13 @@ const ERC20 = artifacts.require("ERC20");
 const Voting = artifacts.require("Voting");
 
 const { interfaceName } = require("@uma/common");
+const { GasEstimator } = require("@uma/financial-templates-lib");
 
 const { parseUnits } = require("@ethersproject/units");
 const { getDecimals } = require("./utils");
 
 const _ = require("lodash");
+const winston = require("winston");
 
 const argv = require("minimist")(process.argv.slice(), { string: ["collateral", "fee", "decimals"] });
 
@@ -27,6 +29,14 @@ const proposerWallet = "0x2bAaA41d155ad8a4126184950B31F50A1513cE25";
 async function runExport() {
   console.log("Running Upgrade🔥");
   console.log("Connected to network id", await web3.eth.net.getId());
+
+  const gasEstimator = new GasEstimator(
+    winston.createLogger({
+      silent: true
+    }),
+    60, // Time between updates.
+    100 // Default gas price.
+  );
 
   if (!argv.collateral || !argv.fee) {
     throw new Error("Must provide --fee and --collateral");
@@ -97,7 +107,12 @@ async function runExport() {
   console.log(`Sending to governor @ ${governor.address}`);
 
   // Send the proposal
-  const txn = await governor.propose(transactionList, { from: proposerWallet, gas: 2000000 });
+  await gasEstimator.update();
+  const txn = await governor.propose(transactionList, {
+    from: proposerWallet,
+    gas: 2000000,
+    gasPrice: gasEstimator.getCurrentFastPrice()
+  });
   console.log("Transaction: ", txn?.tx);
 
   const finder = await Finder.deployed();

--- a/packages/core/scripts/creator-umip/1_Propose.js
+++ b/packages/core/scripts/creator-umip/1_Propose.js
@@ -46,7 +46,7 @@ async function runExport() {
         data: addCreatorToRegistryTx
       }
     ],
-    { from: proposerWallet, gas: 2000000, gasPrice: gasEstimator.getCurrentFastPrice() }
+    { from: proposerWallet, gasPrice: gasEstimator.getCurrentFastPrice() }
   );
 
   console.log(`

--- a/packages/core/scripts/creator-umip/1_Propose.js
+++ b/packages/core/scripts/creator-umip/1_Propose.js
@@ -9,12 +9,23 @@ const Governor = artifacts.require("Governor");
 
 const argv = require("minimist")(process.argv.slice(), { string: ["creator"] });
 const { RegistryRolesEnum } = require("@uma/common");
+const { GasEstimator } = require("@uma/financial-templates-lib");
+
+const winston = require("winston");
 
 const proposerWallet = "0x2bAaA41d155ad8a4126184950B31F50A1513cE25";
 
 async function runExport() {
   console.log("Running Upgrade🔥");
   console.log("Connected to network id", await web3.eth.net.getId());
+
+  const gasEstimator = new GasEstimator(
+    winston.createLogger({
+      silent: true
+    }),
+    60, // Time between updates.
+    100 // Default gas price.
+  );
 
   // The proposal will add this new contract creator to the Registry.
   const registry = await Registry.deployed();
@@ -26,6 +37,7 @@ async function runExport() {
 
   // Send the proposal
   const governor = await Governor.deployed();
+  await gasEstimator.update();
   await governor.propose(
     [
       {
@@ -34,7 +46,7 @@ async function runExport() {
         data: addCreatorToRegistryTx
       }
     ],
-    { from: proposerWallet, gas: 2000000 }
+    { from: proposerWallet, gas: 2000000, gasPrice: gasEstimator.getCurrentFastPrice() }
   );
 
   console.log(`


### PR DESCRIPTION
**Motivation**

Proposal scripts that are used often should use embedded gas price estimation.

**Summary**

Added the gas estimator class to these scripts to estimate the gas price.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
