### PR TITLE
Add default price feed configs for OCEANUSD and USDOCEAN

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -697,6 +697,25 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "binance", pair: "uniusdt" },
       { type: "cryptowatch", exchange: "okex", pair: "uniusdt" }
     ]
+  },
+  USDOCEAN: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "binance", pair: "oceanusdt" },
+      { type: "cryptowatch", exchange: "bittrex", pair: "oceanusdt" },
+      { type: "cryptowatch", exchange: "bitz", pair: "oceanusdt" }
+    ]
+  },
+  OCEANUSD: {
+    type: "medianizer",
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "binance", pair: "oceanusdt" },
+      { type: "cryptowatch", exchange: "bittrex", pair: "oceanusdt" },
+      { type: "cryptowatch", exchange: "bitz", pair: "oceanusdt" }
+    ]
   }
 };
 


### PR DESCRIPTION

**Motivation**

To support the OCEANUSD and USDOCEAN price identifiers added in [UMIP-46](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-46.md), default price feed configs need to be added.

OCEANUSD and USDOCEAN price identifiers use Binance, Bittrex and BitZ and are all available on Cryptowatch.


**Summary**

Added medianizer configs for OCEANUSD and USDOCEAN price identifiers.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested

Ran OCEANUSD and USDOCEAN price feeds in a monitor bot locally.

**Issue(s)**

NA
