### PR TITLE
fix(merkle-distributor-injestor): fix a small bug and typo

### DIFF
--- a/packages/merkle-distributor/scripts/0_MerklePayoutIngestor.ts
+++ b/packages/merkle-distributor/scripts/0_MerklePayoutIngestor.ts
@@ -7,8 +7,8 @@
 // the `-i` flag. See the example execution for the KPI options token-distribution below.
 
 // ts-node ./scripts/0_MerklePayoutIngestor.ts --input ../../outputs/governance_recipients.json ../../outputs/uma_holder_recipients.json \
-// ../../outputs/uma_user_recipients.json -- key null null null -- d 18 18 18 -- reason "KPI Options drop 1: Governance Recipient" \
-// "KPI Options drop1: UMA Token Holder" "KPI Options drop1: UMA User" -- rewardToken 0x47B1EE6d02af0AA5082C90Ea1c2c14c70399186c -- chainId 42 -- windowIndex 0
+// ../../outputs/uma_user_recipients.json --key null null null --decimals 18 18 18 --reason "KPI Options drop 1: Governance Recipient" \
+// "KPI Options drop1: UMA Token Holder" "KPI Options drop1: UMA User" --rewardToken 0x47B1EE6d02af0AA5082C90Ea1c2c14c70399186c --chainId 42 --windowIndex 0
 
 import assert from "assert";
 import path from "path";
@@ -62,7 +62,7 @@ async function main() {
 
     // Fetch the recipients from the input file. The key donates the identifier within the input file. if this is null
     // then the input file has no nested structures and only contains the recipients.
-    const recipients = o.key == "null" ? inputFile[o.key] : inputFile;
+    const recipients = o.key[i] == "null" ? inputFile : inputFile[o.key[i]];
     Object.keys(recipients).forEach((recipientAddress: string) => {
       const checkSumRecipientAddress = toChecksumAddress(recipientAddress); // Ensure consistent address case
 

--- a/packages/merkle-distributor/scripts/0_MerklePayoutIngestor.ts
+++ b/packages/merkle-distributor/scripts/0_MerklePayoutIngestor.ts
@@ -60,7 +60,7 @@ async function main() {
   for (let i = 0; i < o.input.length; i++) {
     const inputFile = JSON.parse(fs.readFileSync(o.input[i], { encoding: "utf8" }));
 
-    // Fetch the recipients from the input file. The key donates the identifier within the input file. if this is null
+    // Fetch the recipients from the input file. The key donates the identifier within the input file. If this is null
     // then the input file has no nested structures and only contains the recipients.
     const recipients = o.key[i] == "null" ? inputFile : inputFile[o.key[i]];
     Object.keys(recipients).forEach((recipientAddress: string) => {


### PR DESCRIPTION
**Motivation**

The injestor has a small bug when dealing with only 1 payout file. This PR Addresses this. Additionally, the comments are slightly changed.
