### PR TITLE
Add USDBTC_18DEC price feed config

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -728,6 +728,16 @@ const defaultConfigs = {
       { type: "cryptowatch", exchange: "bittrex", pair: "oceanusdt" },
       { type: "cryptowatch", exchange: "bitz", pair: "oceanusdt" }
     ]
+  },
+  USDBTC_18DEC: {
+    type: "medianizer",
+    invertPrice: true,
+    minTimeBetweenUpdates: 60,
+    medianizedFeeds: [
+      { type: "cryptowatch", exchange: "coinbase-pro", pair: "btcusd" },
+      { type: "cryptowatch", exchange: "binance", pair: "btcusdt" },
+      { type: "cryptowatch", exchange: "bitstamp", pair: "btcusd" }
+    ]
   }
 };
 


### PR DESCRIPTION
**Summary**

Adds a price feed config to support the USDBTC_18DEC price identifier added in [UMIP-66](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-66.md). This follows the exact same pattern as the existing USDBTC price identifier.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

**Issue(s)**
NA
