### PR TITLE
feat(funding-rate-proposer): Call applyFundingRate if it hasn't been called recently

### DIFF
--- a/packages/funding-rate-proposer/index.js
+++ b/packages/funding-rate-proposer/index.js
@@ -84,6 +84,7 @@ async function run({
       await retry(
         async () => {
           await fundingRateProposer.update();
+          await fundingRateProposer.applyFundingRates();
           await fundingRateProposer.updateFundingRates(isTest);
           return;
         },

--- a/packages/funding-rate-proposer/src/proposer.js
+++ b/packages/funding-rate-proposer/src/proposer.js
@@ -129,7 +129,7 @@ class FundingRateProposer {
 
   // Publishes a pending funding rate if the current funding rate was last updated
   // more than some threshold of time ago.
-  async applyFundingRate() {
+  async applyFundingRates() {
     await Promise.map(Object.keys(this.contractCache), contractAddress => {
       return this._applyFundingRate(contractAddress);
     });
@@ -150,7 +150,7 @@ class FundingRateProposer {
     const fundingRateIdentifier = this.hexToUtf8(currentFundingRateData.identifier);
     const hasPendingProposal = this.toBN(currentFundingRateData.proposalTime.toString());
     const lastApplicationTime = this.toBN(currentFundingRateData.applicationTime.toString());
-    const currentContractTime = await cachedContract.methods.getCurrenTime().call();
+    const currentContractTime = await cachedContract.contract.methods.getCurrentTime().call();
 
     if (
       hasPendingProposal.gt(this.toBN(0)) &&
@@ -164,6 +164,7 @@ class FundingRateProposer {
         message: "Applying new funding rate",
         fundingRateIdentifier,
         lastApplicationTime: lastApplicationTime.toString(),
+        currentContractTime: currentContractTime.toString(),
         pendingProposalTime: hasPendingProposal.toString()
       });
       try {
@@ -182,6 +183,7 @@ class FundingRateProposer {
           caller: this.account,
           fundingRateIdentifier,
           lastApplicationTime: lastApplicationTime.toString(),
+          currentContractTime: currentContractTime.toString(),
           pendingProposalTime: hasPendingProposal.toString()
         };
         this.logger.info({
@@ -205,6 +207,7 @@ class FundingRateProposer {
         message: "Skipping because there is either no pending funding rate or last application time was too recent",
         fundingRateIdentifier,
         lastApplicationTime: lastApplicationTime.toString(),
+        currentContractTime: currentContractTime.toString(),
         pendingProposalTime: hasPendingProposal.toString()
       });
     }

--- a/packages/funding-rate-proposer/test/index.js
+++ b/packages/funding-rate-proposer/test/index.js
@@ -150,6 +150,8 @@ contract("index.js", function(accounts) {
 
     for (let i = 0; i < spy.callCount; i++) {
       assert.notStrictEqual(spyLogLevel(spy, i), "error");
+      // `applyFundingRate()` should not have been called on startup:
+      assert.isFalse(spyLogIncludes(spy, i, "Applied new funding rate"));
     }
 
     // The first log should indicate that the Proposer runner started successfully,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `FinancialContractClient` is in charge of determining position collateralization ratios. It performs the calculation: `(collateral value / token value * cumulativeFundingRateMultiplier (CFRM))`
- The CFRM is read on-chain directly from the Perpetual contract: `(await perpetual.fundingRate()).cumulativeFundingRateMultiplier()`
- The CFRM is only updated on chain when an` applyFundingRate()` method is called (this is called as a modifier on every single contract transaction).
- Therefore, it is possible that the CFRM doesn’t update for some time, even though it will update correctly on the next contract interaction. Therefore, it is possible that the liquidator bot can be delayed in liquidating until the CFRM is updated.
- This is potentially exploitable by a malicious sponsor who knows that the pending CFRM will cause their position to go undercollateralized, but the CFRM just doesn’t get updated because this contract doesn’t have a lot of users for example.

This adds a new feature to the funding rate proposer bot whereby it sets an upper bound on the amount of time that a pending proposal can sit unpublished for before the bot will call `applyFundingRate()`. Setting the update threshold time is a subjective task, and I'm also currently investigating simulating calling `applyFundingRate().call()` and `cumulativeFundingRateMultiplier()` atomically to get the to-be-published funding rate without having to broadcast a transaction.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested