### PR TITLE
feat(financial-product-library): Create a KPI Options financial product library

### DIFF
--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -60,7 +60,7 @@ const versionMap = {
     contractType: "ExpiringMultiParty",
     contractVersion: "latest"
   },
-  "0x238569485842107d2e938ff59c78841860b4dcd00d37be9859699f2c4ddbb3a0": {
+  "0x39dca3c82cfcba75d4355b45d546eedba21d3f9d6198324b8d951f33756a51c4": {
     // latest Perpetual deployed from hardhat tests.
     contractType: "Perpetual",
     contractVersion: "latest"

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -6,12 +6,35 @@ import "../../../common/implementation/Lockable.sol";
 
 /**
  * @title KPI Options Financial Product Library
- * @notice Returns a transformed collateral requirement. The collateralization requirement should
- * always be equivalent to being collateralized by 2 tokens, no matter what the price or expiration status is.
+ * @notice Adds custom tranformation logic to modify the price and collateral requirement behavior of the expiring multi party contract.
+ * If a price request is made pre-expiry, the price should always be set to 2 and the collateral requirement should be set to 1.
+ * Post-expiry, the collateral requirement is left as 1 and the price is left unchanged.
  */
 contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Ownable, Lockable {
     /**
-     * @notice Returns a transformed collateral requirement that is always set to 2 tokens.
+     * @notice Returns a transformed price for pre-expiry price requests.
+     * @param oraclePrice price from the oracle to be transformed.
+     * @param requestTime timestamp the oraclePrice was requested at.
+     * @return transformedPrice the input oracle price with the price transformation logic applied to it.
+     */
+    function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
+        public
+        view
+        override
+        nonReentrantView()
+        returns (FixedPoint.Unsigned memory)
+    {
+        // If price request is made before expiry, return 2. Thus we can keep the contract 100% collateralized with
+        // each token backed 1:2 by collateral currency. Post-expiry, leave unchanged.
+        if (requestTime < ExpiringContractInterface(msg.sender).expirationTimestamp()) {
+            return FixedPoint.fromUnscaledUint(2);
+        } else {
+            return oraclePrice;
+        }
+    }
+
+    /**
+     * @notice Returns a transformed collateral requirement that is set to be equivalent to 2 tokens pre-expiry.
      * @param oraclePrice price from the oracle to transform the collateral requirement.
      * @param collateralRequirement financial products collateral requirement to be scaled to a flat rate.
      * @return transformedCollateralRequirement the input collateral requirement with the transformation logic applied to it.
@@ -20,7 +43,7 @@ contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Ownable, 
         FixedPoint.Unsigned memory oraclePrice,
         FixedPoint.Unsigned memory collateralRequirement
     ) public view override nonReentrantView() returns (FixedPoint.Unsigned memory) {
-        // Always return 2 because the option must be collateralized by 2 tokens.
-        return FixedPoint.fromUnscaledUint(2);
+        // Always return 1.
+        return FixedPoint.fromUnscaledUint(1);
     }
 }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+import "./FinancialProductLibrary.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../../../common/implementation/Lockable.sol";
+
+/**
+ * @title KPI Options Financial Product Library
+ * @notice Returns a transformed collateral requirement. The collateralization requirement should
+ * always be equivalent to being collateralized by 2 tokens, no matter what the price or expiration status is.
+ */
+contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Ownable, Lockable {
+    /**
+     * @notice Returns a transformed collateral requirement that is always set to 2 tokens.
+     * @param oraclePrice price from the oracle to transform the collateral requirement.
+     * @param collateralRequirement financial products collateral requirement to be scaled to a flat rate.
+     * @return transformedCollateralRequirement the input collateral requirement with the transformation logic applied to it.
+     */
+    function transformCollateralRequirement(
+        FixedPoint.Unsigned memory oraclePrice,
+        FixedPoint.Unsigned memory collateralRequirement
+    ) public view override nonReentrantView() returns (FixedPoint.Unsigned memory) {
+        // Always return 2 because the option must be collateralized by 2 tokens.
+        return FixedPoint.fromUnscaledUint(2);
+    }
+}

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import "./FinancialProductLibrary.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "../../../common/implementation/Lockable.sol";
 
 /**
@@ -10,7 +9,7 @@ import "../../../common/implementation/Lockable.sol";
  * If a price request is made pre-expiry, the price should always be set to 2 and the collateral requirement should be set to 1.
  * Post-expiry, the collateral requirement is left as 1 and the price is left unchanged.
  */
-contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Ownable, Lockable {
+contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Lockable {
     /**
      * @notice Returns a transformed price for pre-expiry price requests.
      * @param oraclePrice price from the oracle to be transformed.

--- a/packages/core/test/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.js
@@ -67,7 +67,7 @@ contract("KpiOptionsFinancialProductLibrary", function() {
             (await expiringMultiParty.getCurrentTime()).toString()
           )
         ).toString(),
-        "0.2"
+        toWei("0.2")
       );
     });
   });

--- a/packages/core/test/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.js
@@ -41,7 +41,7 @@ contract("KpiOptionsFinancialProductLibrary", function() {
         toWei("2")
       );
 
-      // advance the timer after expiration and ensure the CR is still 1.
+      // advance the timer after expiration and ensure the CR is still 2.
       await timer.setCurrentTime(expirationTime + 1);
 
       // Check post-expiration

--- a/packages/core/test/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.js
@@ -30,24 +30,65 @@ contract("KpiOptionsFinancialProductLibrary", function() {
       timer.address
     );
   });
+  describe("price transformation", () => {
+    it("Library returns 2 price if before expiration", async () => {
+      // Calling the transformation function through the emp mock.
+      assert.equal(
+        (
+          await expiringMultiParty.transformPrice(
+            { rawValue: toWei("1") },
+            (await expiringMultiParty.getCurrentTime()).toString()
+          )
+        ).toString(),
+        toWei("2")
+      );
+
+      // Calling the transformation function as a mocked emp caller should also work.
+      assert.equal(
+        (
+          await expiringMultiParty.transformPrice.call(
+            { rawValue: toWei("1") },
+            (await expiringMultiParty.getCurrentTime()).toString(),
+            { from: expiringMultiParty.address }
+          )
+        ).toString(),
+        toWei("2")
+      );
+    });
+
+    it("Library returns correctly transformed price after expiration", async () => {
+      await timer.setCurrentTime(expirationTime + 1);
+
+      // If transformPrice is called after expiration, no transformation should occur.
+      assert.equal(
+        (
+          await expiringMultiParty.transformPrice(
+            { rawValue: toWei("0.2") },
+            (await expiringMultiParty.getCurrentTime()).toString()
+          )
+        ).toString(),
+        "0.2"
+      );
+    });
+  });
 
   describe("Collateralization ratio transformation", () => {
     it("Library returns correctly transformed collateralization ratio", async () => {
-      // Under all scenarios, the collateral requirement of the contract should be 2.
+      // Under all scenarios, the collateral requirement of the contract should be 1.
 
       // Check pre-expiration
       assert.equal(
         (await expiringMultiParty.transformCollateralRequirement({ rawValue: toWei("0.1") })).toString(),
-        toWei("2")
+        toWei("1")
       );
 
-      // advance the timer after expiration and ensure the CR is still 2.
+      // advance the timer after expiration and ensure the CR is still 1.
       await timer.setCurrentTime(expirationTime + 1);
 
       // Check post-expiration
       assert.equal(
         (await expiringMultiParty.transformCollateralRequirement({ rawValue: toWei("0.2") })).toString(),
-        toWei("2")
+        toWei("1")
       );
     });
   });


### PR DESCRIPTION
**Motivation**

To create KPI options, we require a simple library to transform the collateral requirement and price of an EMP. 

Behavior:
- Pre-expiry the price is always set to 2.
- Post-expiry the price is not transformed
- The collateral requirement is always set to 1

The price identifier that will be used with this library is the `uTVL_KPI_UMA` price identifier, defined in [UMIP-65](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-65.md). `uTVL_KPI_UMA` sets a price ceiling of 2, so enforcement a pre-expiry collateralization requirement of 2 tokens will ensure that positions cannot become under collateralized by means of an increase in the token price.

**Summary**

`KpiOptionsFinancialProductLibrary.sol` added with associated unit tests.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
