### PR TITLE
improve(admin-scripts): Use SignedInt for salt

### DIFF
--- a/packages/core/scripts/umip-3/2_VoteSimulate.js
+++ b/packages/core/scripts/umip-3/2_VoteSimulate.js
@@ -7,7 +7,7 @@
 const assert = require("assert").strict;
 
 const {
-  getRandomUnsignedInt,
+  getRandomSignedInt,
   advanceBlockAndSetTime,
   takeSnapshot,
   revertToSnapshot,
@@ -114,7 +114,7 @@ async function runExport() {
     const time = pendingRequests[pendingIndex].time.toString();
     const price = web3.utils.toWei("1"); // a "yes" vote
 
-    const salt = getRandomUnsignedInt();
+    const salt = getRandomSignedInt();
     // Main net DVM uses the old commit reveal scheme of hashed concatenation of price and salt
     let voteHash;
     const request = pendingRequests[pendingIndex];


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Known error when passing large unsigned uints as function arguments where an int is expected. Newer web3 doesn't seem to cast between uints and ints like it used to:

```
Error: value out-of-bounds (argument="salt", value="93598013133266225946634221140404577226246205875115240595869719382411854555386", code=INVALID_ARGUMENT, version=abi/5.0.0-beta.153)
    at runExport (/Users/nicholaspai/UMA/protocol/packages/core/scripts/identifier-umip/2_VoteSimulate.js:195:44)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at run (/Users/nicholaspai/UMA/protocol/packages/core/scripts/identifier-umip/2_VoteSimulate.js:255:5) {
  reason: 'value out-of-bounds',
  code: 'INVALID_ARGUMENT',
  argument: 'salt',
  value: '93598013133266225946634221140404577226246205875115240595869719382411854555386',
  hijackedStack: 'Error: value out-of-bounds (argument="salt", value="93598013133266225946634221140404577226246205875115240595869719382411854555386", code=INVALID_ARGUMENT, version=abi/5.0.0-beta.153)\n' +
    '    at Logger.makeError (/Users/nicholaspai/UMA/protocol/node_modules/@ethersproject/logger/src.ts/index.ts:205:28)\n' +
    '    at Logger.throwError (/Users/nicholaspai/UMA/protocol/node_modules/@ethersproject/logger/src.ts/index.ts:217:20)\n' +
    '    at Logger.throwArgumentError (/Users/nicholaspai/UMA/protocol/node_modules/@ethersproject/logger/src.ts/index.ts:221:21)\n' +
    '    at NumberCoder.Coder._throwError (/Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/node_modules/@ethersproject/abi/lib/coders/abstract-coder.js:40:16)\n' +
    '    at NumberCoder.encode (/Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/node_modules/@ethersproject/abi/lib/coders/number.js:36:22)\n' +
    '    at /Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/node_modules/@ethersproject/abi/lib/coders/array.js:55:19\n' +
    '    at Array.forEach (<anonymous>)\n' +
    '    at Object.pack (/Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/node_modules/@ethersproject/abi/lib/coders/array.js:41:12)\n' +
    '    at TupleCoder.encode (/Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/node_modules/@ethersproject/abi/lib/coders/tuple.js:36:24)\n' +
    '    at AbiCoder.encode (/Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/node_modules/@ethersproject/abi/lib/abi-coder.js:86:15)\n' +
    '    at ABICoder.encodeParameters (/Users/nicholaspai/UMA/protocol/node_modules/web3-eth-abi/src/index.js:145:27)\n' +
    '    at /Users/nicholaspai/UMA/protocol/node_modules/@truffle/interface-adapter/node_modules/web3-eth-contract/src/index.js:531:24\n' +
    '    at Array.map (<anonymous>)\n' +
    '    at Object._encodeMethodABI (/Users/nicholaspai/UMA/protocol/node_modules/@truffle/interface-adapter/node_modules/web3-eth-contract/src/index.js:530:12)\n' +
    '    at /Users/nicholaspai/UMA/protocol/node_modules/@truffle/contract/lib/execute.js:181:42\n' +
    '    at processTicksAndRejections (internal/process/task_queues.js:93:5)'
}
```
