### PR TITLE
feat(price-feeds): add twap to cryptowatch

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -57,7 +57,8 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.minTimeBetweenUpdates,
       config.invertPrice, // Not checked in config because this parameter just defaults to false.
       config.priceFeedDecimals, // Defaults to 18 unless supplied. Informs how the feed should be scaled to match a DVM response.
-      config.ohlcPeriod // Defaults to 60 unless supplied.
+      config.ohlcPeriod, // Defaults to 60 unless supplied.
+      config.twapLength
     );
   } else if (config.type === "quandl") {
     const requiredFields = ["datasetCode", "databaseCode", "lookback", "quandlApiKey"];

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -1,5 +1,7 @@
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 const { parseFixed } = require("@uma/common");
+const { computeTWAP } = require("./utils");
+const lodash = require("lodash");
 
 // An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
 class CryptoWatchPriceFeed extends PriceFeedInterface {
@@ -33,7 +35,8 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     minTimeBetweenUpdates,
     invertPrice,
     priceFeedDecimals = 18,
-    ohlcPeriod = 60 // One minute is CryptoWatch's most granular option.
+    ohlcPeriod = 60, // One minute is CryptoWatch's most granular option.
+    twapLength = 0 // No TWAP by default.
   ) {
     super();
     this.logger = logger;
@@ -43,6 +46,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     this.exchange = exchange;
     this.pair = pair;
     this.lookback = lookback;
+    this.twapLength = twapLength;
     this.uuid = `CryptoWatch-${exchange}-${pair}`;
     this.networker = networker;
     this.getTime = getTime;
@@ -71,6 +75,15 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       throw new Error(`${this.uuid}: undefined lastUpdateTime`);
     }
 
+    // Return early if computing a TWAP.
+    if (this.twapLength) {
+      const twapPrice = this._computeTwap(time, this.historicalPricePeriods);
+      if (!twapPrice) {
+        throw new Error(`${this.uuid}: historical TWAP computation failed due to no data in the TWAP range`);
+      }
+      return twapPrice;
+    }
+
     // Set first price period in `historicalPricePeriods` to first non-null price.
     let firstPricePeriod;
     for (let p in this.historicalPricePeriods) {
@@ -80,7 +93,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       }
     }
 
-    // If there are no valid price periods, return null.
+    // If there are no valid price periods, throw.
     if (!firstPricePeriod) {
       throw new Error(`${this.uuid}: no valid price periods`);
     }
@@ -181,46 +194,56 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     // Round down to the nearest ohlc period so the queries captures the OHLC of the period *before* this earliest
     // timestamp (because the close of that OHLC may be relevant).
-    const earliestHistoricalTimestamp = Math.floor((currentTime - this.lookback) / this.ohlcPeriod) * this.ohlcPeriod;
+    const earliestHistoricalTimestamp =
+      Math.floor((currentTime - (this.lookback + this.twapLength)) / this.ohlcPeriod) * this.ohlcPeriod;
 
-    // 1. Construct URLs.
+    const newHistoricalPricePeriods = await this._getOhlcPricePeriods(earliestHistoricalTimestamp, currentTime);
+    const newPrice = this.twapLength
+      ? this._computeTwap(currentTime, newHistoricalPricePeriods)
+      : await this._getImmediatePrice();
+
+    // 5. Store results.
+    this.currentPrice = newPrice;
+    this.historicalPricePeriods = newHistoricalPricePeriods;
+    this.lastUpdateTime = currentTime;
+  }
+
+  async _getImmediatePrice() {
     // See https://docs.cryptowat.ch/rest-api/markets/price for how this url is constructed.
     const priceUrl =
       `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/price` +
       (this.apiKey ? `?apikey=${this.apiKey}` : "");
 
-    // See https://docs.cryptowat.ch/rest-api/markets/ohlc for how this url is constructed.
-    const ohlcUrl = [
-      `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc`,
-      `?before=${currentTime}`,
-      `&after=${earliestHistoricalTimestamp}`,
-      `&periods=${this.ohlcPeriod}`,
-      this.apiKey ? `&apikey=${this.apiKey}` : ""
-    ].join("");
+    const priceResponse = await this.networker.getJson(priceUrl);
 
-    // 2. Send requests.
-    const [ohlcResponse, priceResponse] = await Promise.all([
-      this.networker.getJson(ohlcUrl),
-      this.networker.getJson(priceUrl)
-    ]);
-
-    // 3. Check responses.
     if (!priceResponse || !priceResponse.result || !priceResponse.result.price) {
       throw new Error(`🚨Could not parse price result from url ${priceUrl}: ${JSON.stringify(priceResponse)}`);
     }
 
-    if (!ohlcResponse || !ohlcResponse.result || !ohlcResponse.result[this.ohlcPeriod]) {
-      throw new Error(`🚨Could not parse ohlc result from url ${ohlcUrl}: ${JSON.stringify(ohlcResponse)}`);
-    }
-
-    // 4. Parse results.
     // Return data structure:
     // {
     //   "result": {
     //     "price": priceValue
     //   }
     // }
-    const newPrice = this.convertPriceFeedDecimals(priceResponse.result.price);
+    return this.convertPriceFeedDecimals(priceResponse.result.price);
+  }
+
+  async _getOhlcPricePeriods(fromTimestamp, toTimestamp) {
+    // See https://docs.cryptowat.ch/rest-api/markets/ohlc for how this url is constructed.
+    const ohlcUrl = [
+      `https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc`,
+      `?before=${toTimestamp}`,
+      `&after=${fromTimestamp}`,
+      `&periods=${this.ohlcPeriod}`,
+      this.apiKey ? `&apikey=${this.apiKey}` : ""
+    ].join("");
+
+    const ohlcResponse = await this.networker.getJson(ohlcUrl);
+
+    if (!ohlcResponse || !ohlcResponse.result || !ohlcResponse.result[this.ohlcPeriod]) {
+      throw new Error(`🚨Could not parse ohlc result from url ${ohlcUrl}: ${JSON.stringify(ohlcResponse)}`);
+    }
 
     // Return data structure:
     // {
@@ -240,7 +263,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     //   }
     // }
     // For more info, see: https://docs.cryptowat.ch/rest-api/markets/ohlc
-    const newHistoricalPricePeriods = ohlcResponse.result[this.ohlcPeriod.toString()]
+    return ohlcResponse.result[this.ohlcPeriod.toString()]
       .map(ohlc => ({
         // Output data should be a list of objects with only the open and close times and prices.
         openTime: ohlc[0] - this.ohlcPeriod,
@@ -252,11 +275,20 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
         // Sorts the data such that the oldest elements come first.
         return a.openTime - b.openTime;
       });
+  }
 
-    // 5. Store results.
-    this.currentPrice = newPrice;
-    this.historicalPricePeriods = newHistoricalPricePeriods;
-    this.lastUpdateTime = currentTime;
+  _computeTwap(endTime, ohlcs) {
+    const priceTimes = lodash.flatten(
+      ohlcs.map(pricePeriod => {
+        return [
+          [pricePeriod.openTime, pricePeriod.openPrice],
+          [pricePeriod.closeTime, pricePeriod.closePrice]
+        ];
+      })
+    );
+    const startTime = endTime - this.twapLength;
+
+    return computeTWAP(priceTimes, startTime, endTime, web3.utils.toBN("0"));
   }
 
   _invertPriceSafely(priceBN) {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -1,7 +1,6 @@
 const { PriceFeedInterface } = require("./PriceFeedInterface");
 const { parseFixed } = require("@uma/common");
 const { computeTWAP } = require("./utils");
-const lodash = require("lodash");
 
 // An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
 class CryptoWatchPriceFeed extends PriceFeedInterface {
@@ -279,14 +278,14 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
 
   _computeTwap(endTime, ohlcs) {
     // Combine open and close to get more data fidelity at the edges of the range.
-    const priceTimes = lodash.flatten(
-      ohlcs.map(pricePeriod => {
+    const priceTimes = ohlcs
+      .map(pricePeriod => {
         return [
           [pricePeriod.openTime, pricePeriod.openPrice],
           [pricePeriod.closeTime, pricePeriod.closePrice]
         ];
       })
-    );
+      .flat();
     const startTime = endTime - this.twapLength;
 
     return computeTWAP(priceTimes, startTime, endTime, web3.utils.toBN("0"));

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -278,6 +278,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   }
 
   _computeTwap(endTime, ohlcs) {
+    // Combine open and close to get more data fidelity at the edges of the range.
     const priceTimes = lodash.flatten(
       ohlcs.map(pricePeriod => {
         return [

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -554,7 +554,7 @@ const defaultConfigs = {
         uniswapAddress: "0xcd7989894bc033581532d2cd88da5db0a4b12859",
         invertPrice: true
       },
-      BADGER_USD_HUOBI: { type: "cryptowatch", exchange: "huobi", pair: "badgerusdt" },
+      BADGER_USD_HUOBI: { type: "cryptowatch", exchange: "huobi", pair: "badgerusdt", twapLength: 0 },
       BBADGER_BADGER: { type: "vault", address: "0x19d97d8fa813ee2f51ad4b4e04ea08baf4dffc28" }
     }
   },

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -7,6 +7,7 @@ contract("CryptoWatchPriceFeed.js", function() {
   let invertedCryptoWatchPriceFeed;
   let mockTime = 1588376548;
   let networker;
+  let dummyLogger;
 
   const apiKey = "test-api-key";
   const exchange = "test-exchange";
@@ -47,7 +48,7 @@ contract("CryptoWatchPriceFeed.js", function() {
 
   beforeEach(async function() {
     networker = new NetworkerMock();
-    const dummyLogger = winston.createLogger({
+    dummyLogger = winston.createLogger({
       level: "info",
       transports: [new winston.transports.Console()]
     });
@@ -176,6 +177,87 @@ contract("CryptoWatchPriceFeed.js", function() {
 
     // After period 3 should return the most recent price.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.5"));
+  });
+
+  it("Basic TWAP price", async function() {
+    cryptoWatchPriceFeed = new CryptoWatchPriceFeed(
+      dummyLogger,
+      web3,
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      networker,
+      getTime,
+      minTimeBetweenUpdates,
+      false,
+      18, // Add arbitrary decimal conversion and prove this works.
+      undefined,
+      120
+    );
+
+    // Inject data.
+    networker.getJsonReturns = [...validResponses];
+
+    await cryptoWatchPriceFeed.update();
+
+    // ((12 * 32) + (13 * 60) + (14 * 28)) / 120
+    assert.equal(cryptoWatchPriceFeed.getCurrentPrice().toString(), "1296666666666666666");
+  });
+
+  it("Basic TWAP historical price", async function() {
+    cryptoWatchPriceFeed = new CryptoWatchPriceFeed(
+      dummyLogger,
+      web3,
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      networker,
+      getTime,
+      minTimeBetweenUpdates,
+      false,
+      18, // Add arbitrary decimal conversion and prove this works.
+      undefined,
+      120
+    );
+
+    // Inject data.
+    networker.getJsonReturns = [...validResponses];
+
+    await cryptoWatchPriceFeed.update();
+
+    // ((12 * 60) + (11 * 60)) / 120
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376460)).toString(), web3.utils.toWei("1.15"));
+  });
+
+  it("TWAP fails if period starts before data", async function() {
+    cryptoWatchPriceFeed = new CryptoWatchPriceFeed(
+      dummyLogger,
+      web3,
+      apiKey,
+      exchange,
+      pair,
+      lookback,
+      networker,
+      getTime,
+      minTimeBetweenUpdates,
+      false,
+      18, // Add arbitrary decimal conversion and prove this works.
+      undefined,
+      500
+    );
+
+    // Inject data.
+    networker.getJsonReturns = [...validResponses];
+    const backupMockTime = mockTime;
+    mockTime = 1588376339; // 1 second before first data point.
+
+    await cryptoWatchPriceFeed.update();
+
+    assert.isNull(cryptoWatchPriceFeed.getCurrentPrice());
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(mockTime).catch(() => true));
+    mockTime = backupMockTime;
   });
 
   it("Basic current price", async function() {


### PR DESCRIPTION
**Motivation**

CW price feeds need to be able to compute a TWAP to allow us to generate more stable prices for funding rate calculations.


**Summary**

Uses the TWAP utility function to compute the TWAP across the cryptowatch array of price periods.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
