### PR TITLE
fix(merkle-distributor-scripts): add option to print a table of output params rather than sending a tx

### DIFF
--- a/packages/merkle-distributor/scripts/1_CreateClaimsForWindow.ts
+++ b/packages/merkle-distributor/scripts/1_CreateClaimsForWindow.ts
@@ -15,7 +15,7 @@
 //   }... for all recipients
 // }
 
-// example execution: ts-node ./scripts/1_CreateClaimsForWindow.ts -i ./scripts/example.json
+// example execution: ts-node ./scripts/1_CreateClaimsForWindow.ts --input ./scripts/example.json
 
 import assert from "assert";
 import path from "path";

--- a/packages/merkle-distributor/scripts/2_PublishClaimsForWindow.ts
+++ b/packages/merkle-distributor/scripts/2_PublishClaimsForWindow.ts
@@ -76,7 +76,6 @@ async function main() {
   // Do some basic sanity checks.
   console.log("0. Running some basic sanity checks on the payout file 🔎");
   assert(web3.utils.isAddress(options.merkleDistributorAddress), "Invalid merkleDistributorAddress");
-  console.log({ options });
   console.log("Boolean(options.sendTransaction)", Boolean(options.sendTransaction));
   if (options.sendTransaction == "true")
     assert((await merkleDistributor.methods.owner().call()) == account, "Account is not the owner of the contract");

--- a/packages/merkle-distributor/scripts/2_PublishClaimsForWindow.ts
+++ b/packages/merkle-distributor/scripts/2_PublishClaimsForWindow.ts
@@ -76,7 +76,6 @@ async function main() {
   // Do some basic sanity checks.
   console.log("0. Running some basic sanity checks on the payout file 🔎");
   assert(web3.utils.isAddress(options.merkleDistributorAddress), "Invalid merkleDistributorAddress");
-  console.log("Boolean(options.sendTransaction)", Boolean(options.sendTransaction));
   if (options.sendTransaction == "true")
     assert((await merkleDistributor.methods.owner().call()) == account, "Account is not the owner of the contract");
   assert((await web3.eth.net.getId()) == claimsObject.chainId, "The connected network not match your  JSON chainId");


### PR DESCRIPTION
**Motivation**

The scripts in their current form  assume the runner wants to send a tx in while running the script. this makes them incompatible with multisigs and other implementations. 

This PR modifies the scripts to enable the tx to be done separately, by a multis or directly on etherscan.
