### PR TITLE
fix(find-contract-version): Add EMP and perp contract hashes

### DIFF
--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -74,6 +74,11 @@ const versionMap = {
     // latest Perpetual deployed from hardhat tests.
     contractType: "Perpetual",
     contractVersion: "latest"
+  },
+  "0x8540e80983690e561f3546c311935a494196854f0994a8aaaa5f771073699ea2": {
+    // latest Perpetual deployed from hardhat tests.
+    contractType: "Perpetual",
+    contractVersion: "latest"
   }
 };
 

--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -55,6 +55,11 @@ const versionMap = {
     contractType: "ExpiringMultiParty",
     contractVersion: "latest"
   },
+  "0x1f75b3ae77a4a3b91fefd81264ec94751dcceafb02d42d2250a209385cdee39a": {
+    // Latest Mainnet ExpiringMultiParty.
+    contractType: "ExpiringMultiParty",
+    contractVersion: "latest"
+  },
   "0xc0d00c5690d02e8efbb151d8d8f6a85f8c81bdc977fd1cc9cf3fc43d9d96281c": {
     // latest ExpiringMultiParty deployed on Kovan from EMPCreator, which was deployed with Truffle using Hardhat bytecode.
     contractType: "ExpiringMultiParty",


### PR DESCRIPTION
**Motivation**

EMP and Perp contract code hashes needs to be added back to `FindContractVersion.js`.

**Summary**

Adds mainnet latest EMP and Perp hashes to `FindContractVersion.js`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**

NA
