### PR TITLE
feat(price-feed): Proposed dVIX Price Feed Interface

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -8,6 +8,7 @@ const { QuandlPriceFeed } = require("./QuandlPriceFeed");
 const { DefiPulsePriceFeed } = require("./DefiPulsePriceFeed");
 const { UniswapPriceFeed } = require("./UniswapPriceFeed");
 const { BalancerPriceFeed } = require("./BalancerPriceFeed");
+const { ETHVIXPriceFeed } = require("./EthVixPriceFeed");
 const { DominationFinancePriceFeed } = require("./DominationFinancePriceFeed");
 const { BasketSpreadPriceFeed } = require("./BasketSpreadPriceFeed");
 const { CoinMarketCapPriceFeed } = require("./CoinMarketCapPriceFeed");
@@ -375,6 +376,22 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       config.lastUpdateTime,
       config.priceFeedDecimals, // Defaults to 18 unless supplied. Informs how the feed should be scaled to match a DVM response.
       config.lookback
+    );
+  } else if (config.type === "ethvix") {
+    logger.debug({
+      at: "createPriceFeed",
+      message: "Creating EthVixPriceFeed",
+      config
+    });
+
+    return new ETHVIXPriceFeed(
+      logger,
+      web3,
+      config.inverse,
+      networker,
+      getTime,
+      config.minTimeBetweenUpdates,
+      config.priceFeedDecimals
     );
   } else if (config.type === "invalid") {
     logger.debug({

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -1,30 +1,32 @@
 const assert = require("assert");
 const { ChainId, Token, Pair, TokenAmount } = require("@uniswap/sdk");
-const { MedianizerPriceFeed } = require("./MedianizerPriceFeed");
-const { FallBackPriceFeed } = require("./FallBackPriceFeed");
-const { CryptoWatchPriceFeed } = require("./CryptoWatchPriceFeed");
-const { ForexDailyPriceFeed } = require("./ForexDailyPriceFeed");
-const { QuandlPriceFeed } = require("./QuandlPriceFeed");
-const { DefiPulsePriceFeed } = require("./DefiPulsePriceFeed");
-const { UniswapPriceFeed } = require("./UniswapPriceFeed");
-const { BalancerPriceFeed } = require("./BalancerPriceFeed");
-const { ETHVIXPriceFeed } = require("./EthVixPriceFeed");
-const { DominationFinancePriceFeed } = require("./DominationFinancePriceFeed");
-const { BasketSpreadPriceFeed } = require("./BasketSpreadPriceFeed");
-const { CoinMarketCapPriceFeed } = require("./CoinMarketCapPriceFeed");
-const { CoinGeckoPriceFeed } = require("./CoinGeckoPriceFeed");
-const { TraderMadePriceFeed } = require("./TraderMadePriceFeed");
-const { PriceFeedMockScaled } = require("./PriceFeedMockScaled");
-const { InvalidPriceFeedMock } = require("./InvalidPriceFeedMock");
 const { defaultConfigs } = require("./DefaultPriceFeedConfigs");
 const { getTruffleContract } = require("@uma/core");
-const { ExpressionPriceFeed, math, escapeSpecialCharacters } = require("./ExpressionPriceFeed");
-const { VaultPriceFeed } = require("./VaultPriceFeed");
-const { LPPriceFeed } = require("./LPPriceFeed");
 const { BlockFinder } = require("./utils");
 const { getPrecisionForIdentifier, PublicNetworks } = require("@uma/common");
-const { FundingRateMultiplierPriceFeed } = require("./FundingRateMultiplierPriceFeed");
 const { multicallAddressMap } = require("../helpers/multicall");
+
+// Price feed interfaces (sorted alphabetically)
+const { BalancerPriceFeed } = require("./BalancerPriceFeed");
+const { BasketSpreadPriceFeed } = require("./BasketSpreadPriceFeed");
+const { CoinGeckoPriceFeed } = require("./CoinGeckoPriceFeed");
+const { CoinMarketCapPriceFeed } = require("./CoinMarketCapPriceFeed");
+const { CryptoWatchPriceFeed } = require("./CryptoWatchPriceFeed");
+const { DefiPulsePriceFeed } = require("./DefiPulsePriceFeed");
+const { DominationFinancePriceFeed } = require("./DominationFinancePriceFeed");
+const { ETHVIXPriceFeed } = require("./EthVixPriceFeed");
+const { ExpressionPriceFeed, math, escapeSpecialCharacters } = require("./ExpressionPriceFeed");
+const { FallBackPriceFeed } = require("./FallBackPriceFeed");
+const { ForexDailyPriceFeed } = require("./ForexDailyPriceFeed");
+const { FundingRateMultiplierPriceFeed } = require("./FundingRateMultiplierPriceFeed");
+const { InvalidPriceFeedMock } = require("./InvalidPriceFeedMock");
+const { LPPriceFeed } = require("./LPPriceFeed");
+const { MedianizerPriceFeed } = require("./MedianizerPriceFeed");
+const { PriceFeedMockScaled } = require("./PriceFeedMockScaled");
+const { QuandlPriceFeed } = require("./QuandlPriceFeed");
+const { TraderMadePriceFeed } = require("./TraderMadePriceFeed");
+const { UniswapPriceFeed } = require("./UniswapPriceFeed");
+const { VaultPriceFeed } = require("./VaultPriceFeed");
 
 // Global cache for block (promises) used by uniswap price feeds.
 const uniswapBlockCache = {};

--- a/packages/financial-templates-lib/src/price-feed/EthVixPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/EthVixPriceFeed.js
@@ -8,27 +8,39 @@ class ETHVIXPriceFeed extends PriceFeedInterface {
   /**
    * @notice Constructs price feeds for indexes listed on dVIX.io.
    * @param {Object} logger Winston module used to send logs.
+   * @param {Object} web3 Provider from truffle instance to connect to Ethereum network.
    * @param {Boolean} inverse Whether to return the short/inverse result.
    * @param {Object} networker Used to send the API requests.
    * @param {Function} getTime Returns the current time.
    * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
    *      this number of seconds has passed, it will be a no-op.
+   * @param {Number} priceFeedDecimals Number of priceFeedDecimals to use to convert price to wei.
    */
-  constructor(logger, inverse, networker, getTime, minTimeBetweenUpdates = 60) {
+  constructor(logger, web3, inverse, networker, getTime, minTimeBetweenUpdates = 60, priceFeedDecimals = 18) {
     super();
     this.logger = logger;
+    this.web3 = web3;
     this.inverse = inverse;
     this.networker = networker;
     this.getTime = getTime;
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+    this.priceFeedDecimals = priceFeedDecimals;
 
     this.uuid = `dVIX.${inverse ? "iethVIX" : "ethVIX"}`;
     this.historicalPrices = [];
+
+    this.toBN = this.web3.utils.toBN;
+
+    this.convertPriceFeedDecimals = number => {
+      // Converts the decimal price result to a BigNumber integer scaled to wei units.
+      // Note: Must ensure that `number` has no more decimal places than `priceFeedDecimals`.
+      return this.toBN(parseFixed(number.toString().substring(0, priceFeedDecimals), priceFeedDecimals).toString());
+    };
   }
 
   getCurrentPrice() {
     assert(this.lastUpdateTime, `${this.uuid}: undefined lastUpdateTime. Update required.`);
-    return this.currentPrice;
+    return this.convertPriceFeedDecimals(this.currentPrice);
   }
 
   async getHistoricalPrice(time) {
@@ -48,7 +60,7 @@ class ETHVIXPriceFeed extends PriceFeedInterface {
     const result = this.historicalPrices.find(price => roundedTime.isSame(price.timestamp));
     assert(result, `${this.uuid}: No cached result found for timestamp: ${roundedTime.toISOString()}`);
 
-    return parseFixed(result.vix, 6);
+    return this.convertPriceFeedDecimals(result.vix);
   }
 
   getLastUpdateTime() {
@@ -92,8 +104,8 @@ class ETHVIXPriceFeed extends PriceFeedInterface {
     // [
     //   {
     //     "timestamp": "2021-03-24T15:00:00.000Z",
-    //     "iVix": 142.4470728085134,
-    //     "vix": 70.20151276427174,
+    //     "iVix": "142.44",
+    //     "vix": "70.20",
     //     ...
     //   },
     //   ...
@@ -105,7 +117,7 @@ class ETHVIXPriceFeed extends PriceFeedInterface {
     // 4. Store results.
     this.lastUpdateTime = currentTime;
     this.historicalPrices = [...this.historicalPrices, ...response];
-    this.currentPrice = parseFixed(this.inverse ? mostRecent.iVix : mostRecent.vix, 6);
+    this.currentPrice = this.inverse ? mostRecent.iVix : mostRecent.vix;
   }
 }
 

--- a/packages/financial-templates-lib/src/price-feed/EthVixPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/EthVixPriceFeed.js
@@ -111,10 +111,13 @@ class ETHVIXPriceFeed extends PriceFeedInterface {
     //   ...
     // ]
 
-    // 3. Get last result in the stack.
+    // 3. Sort the results in case the data source didn't already.
+    response.sort((a, b) => moment(a.timestamp).valueOf() - moment(b.timestamp).valueOf());
+
+    // 4. Get last result in the stack.
     const mostRecent = response[response.length - 1];
 
-    // 4. Store results.
+    // 5. Store results.
     this.lastUpdateTime = currentTime;
     this.historicalPrices = [...this.historicalPrices, ...response];
     this.currentPrice = this.inverse ? mostRecent.iVix : mostRecent.vix;

--- a/packages/financial-templates-lib/src/price-feed/EthVixPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/EthVixPriceFeed.js
@@ -1,0 +1,114 @@
+const assert = require("assert");
+const moment = require("moment");
+const { parseFixed } = require("@uma/common");
+const { PriceFeedInterface } = require("./PriceFeedInterface");
+
+// An implementation of PriceFeedInterface that uses the dVIX API to retrieve ethVIX prices.
+class ETHVIXPriceFeed extends PriceFeedInterface {
+  /**
+   * @notice Constructs price feeds for indexes listed on dVIX.io.
+   * @param {Object} logger Winston module used to send logs.
+   * @param {Boolean} inverse Whether to return the short/inverse result.
+   * @param {Object} networker Used to send the API requests.
+   * @param {Function} getTime Returns the current time.
+   * @param {Integer} minTimeBetweenUpdates Min number of seconds between updates. If update() is called again before
+   *      this number of seconds has passed, it will be a no-op.
+   */
+  constructor(logger, inverse, networker, getTime, minTimeBetweenUpdates = 60) {
+    super();
+    this.logger = logger;
+    this.inverse = inverse;
+    this.networker = networker;
+    this.getTime = getTime;
+    this.minTimeBetweenUpdates = minTimeBetweenUpdates;
+
+    this.uuid = `dVIX.${inverse ? "iethVIX" : "ethVIX"}`;
+    this.historicalPrices = [];
+  }
+
+  getCurrentPrice() {
+    assert(this.lastUpdateTime, `${this.uuid}: undefined lastUpdateTime. Update required.`);
+    return this.currentPrice;
+  }
+
+  async getHistoricalPrice(time) {
+    assert(this.lastUpdateTime, `${this.uuid}: undefined lastUpdateTime. Update required.`);
+
+    assert(
+      moment.utc(time).isAfter(this.historicalPrices[0].timestamp),
+      `${this.uuid}: The requested time precedes available data.`
+    );
+
+    // Rounds timestamp down to the nearest 15m, the minimum index update frequency
+    let roundedTime = moment.utc(time).startOf("minute");
+    if (roundedTime.minutes() % 15) {
+      roundedTime = roundedTime.subtract(roundedTime.minutes() % 15, "minutes");
+    }
+
+    const result = this.historicalPrices.find(price => roundedTime.isSame(price.timestamp));
+    assert(result, `${this.uuid}: No cached result found for timestamp: ${roundedTime.toISOString()}`);
+
+    return parseFixed(result.vix, 6);
+  }
+
+  getLastUpdateTime() {
+    return this.lastUpdateTime;
+  }
+
+  async update() {
+    const currentTime = this.getTime();
+    const earliestAllowableUpdateTime = currentTime + moment.duration(this.minTimeBetweenUpdates, "seconds");
+
+    // Return early if the last call was too recent.
+    if (this.lastUpdateTime !== undefined && moment(currentTime).isSameOrAfter(earliestAllowableUpdateTime)) {
+      console.log({
+        at: "ETHVIXPriceFeed",
+        message: "Update skipped because the last one was too recent",
+        currentTime: currentTime,
+        lastUpdateTimestamp: this.lastUpdateTime,
+        timeRemainingUntilUpdate: earliestAllowableUpdateTime - currentTime
+      });
+      return;
+    }
+
+    this.logger.debug({
+      at: "ETHVIXPriceFeed",
+      message: "Updating",
+      currentTime: currentTime,
+      lastUpdateTimestamp: this.lastUpdateTime
+    });
+
+    // 1. Request the data.
+    const priceUrl = "https://dvix.io/api/historicalData?currency=ETH";
+    const response = await this.networker.getJson(priceUrl);
+
+    // 2. Check the response.
+    assert(
+      Array.isArray(response) && response.length,
+      `🚨 Could not fetch historical prices from url ${priceUrl}: ${JSON.stringify(response)}`
+    );
+
+    // Expected response data structure:
+    // [
+    //   {
+    //     "timestamp": "2021-03-24T15:00:00.000Z",
+    //     "iVix": 142.4470728085134,
+    //     "vix": 70.20151276427174,
+    //     ...
+    //   },
+    //   ...
+    // ]
+
+    // 3. Get last result in the stack.
+    const mostRecent = response[response.length - 1];
+
+    // 4. Store results.
+    this.lastUpdateTime = currentTime;
+    this.historicalPrices = [...this.historicalPrices, ...response];
+    this.currentPrice = parseFixed(this.inverse ? mostRecent.iVix : mostRecent.vix, 6);
+  }
+}
+
+module.exports = {
+  ETHVIXPriceFeed
+};

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -31,6 +31,7 @@ const { CoinMarketCapPriceFeed } = require("../../src/price-feed/CoinMarketCapPr
 const { CoinGeckoPriceFeed } = require("../../src/price-feed/CoinGeckoPriceFeed");
 const { NetworkerMock } = require("../../src/price-feed/NetworkerMock");
 const { DefiPulsePriceFeed } = require("../../src/price-feed/DefiPulsePriceFeed");
+const { ETHVIXPriceFeed } = require("../../src/price-feed/EthVixPriceFeed");
 const { ForexDailyPriceFeed } = require("../../src/price-feed/ForexDailyPriceFeed");
 const { QuandlPriceFeed } = require("../../src/price-feed/QuandlPriceFeed");
 const { SpyTransport } = require("../../src/logger/SpyTransport");
@@ -1480,6 +1481,22 @@ contract("CreatePriceFeed.js", function(accounts) {
     assert.equal(
       await createPriceFeed(logger, web3, networker, getTime, { ...validConfig, minTimeBetweenUpdates: undefined }),
       null
+    );
+  });
+
+  it("Default ethVIX Config", async function() {
+    assert.isTrue(
+      (await createPriceFeed(logger, web3, networker, getTime, { type: "ethvix" })) instanceof ETHVIXPriceFeed
+    );
+  });
+
+  it("Valid ethVIX Config", async function() {
+    assert.isTrue(
+      (await createPriceFeed(logger, web3, networker, getTime, {
+        inverse: true,
+        randomUnknownParam: Math.random(),
+        type: "ethvix"
+      })) instanceof ETHVIXPriceFeed
     );
   });
 });

--- a/packages/financial-templates-lib/test/price-feed/EthVixPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/EthVixPriceFeed.js
@@ -1,0 +1,174 @@
+const { ETHVIXPriceFeed } = require("../../src/price-feed/EthVixPriceFeed");
+const { NetworkerMock } = require("../../src/price-feed/NetworkerMock");
+const { parseFixed } = require("@uma/common");
+const moment = require("moment");
+const winston = require("winston");
+const { assert } = require("hardhat");
+
+describe("EthVixPriceFeed.js", () => {
+  let networker;
+  let priceFeed;
+  let inversePriceFeed;
+  let mockTime = 1616598000000;
+
+  const getTime = () => mockTime;
+  const minTimeBetweenUpdates = 60;
+
+  const historicalResponse = [
+    {
+      currency: "ETH",
+      timestamp: "2021-03-24T14:30:00.000Z",
+      spotPrice: "1737.04",
+      vix: "88.47",
+      iVix: "113.04"
+    },
+    {
+      currency: "ETH",
+      timestamp: "2021-03-24T14:45:00.000Z",
+      spotPrice: "1738.36",
+      vix: "88.78",
+      iVix: "112.62"
+    },
+    {
+      currency: "ETH",
+      timestamp: "2021-03-24T15:00:00.000Z",
+      spotPrice: "1740.26",
+      vix: "70.2",
+      iVix: "142.44"
+    }
+  ];
+
+  beforeEach(() => {
+    const logger = winston.createLogger({
+      level: "info",
+      transports: [new winston.transports.Console()]
+    });
+    networker = new NetworkerMock();
+    priceFeed = new ETHVIXPriceFeed(logger, false, networker, getTime, minTimeBetweenUpdates);
+    inversePriceFeed = new ETHVIXPriceFeed(logger, true, networker, getTime, minTimeBetweenUpdates);
+  });
+
+  describe("After an initial update has been performed", () => {
+    beforeEach(async () => {
+      networker.getJsonReturns = new Array(3).fill(historicalResponse);
+    });
+
+    describe("Price discovery", () => {
+      it("can return the latest ethVIX price", async () => {
+        await priceFeed.update();
+        assert.equal(priceFeed.getCurrentPrice().toString(), "70200000");
+      });
+
+      it("can return the latest iethVIX price", async () => {
+        await inversePriceFeed.update();
+        assert.equal(inversePriceFeed.getCurrentPrice().toString(), "142440000");
+      });
+    });
+
+    describe("Historical price discovery", () => {
+      it("can return the historical ethVIX price at a specific time", async () => {
+        const { timestamp, vix } = historicalResponse[1];
+        await priceFeed.update();
+        const historicalPrice = await priceFeed.getHistoricalPrice(moment.utc(timestamp).valueOf());
+        assert.equal(historicalPrice.toString(), parseFixed(vix, 6).toString());
+      });
+
+      it("can return the most recent historical ethVIX price within 15m of a given time", async () => {
+        await priceFeed.update();
+        const historicalPrice = await priceFeed.getHistoricalPrice(
+          moment
+            .utc(historicalResponse[1].timestamp)
+            .add(1, "minute")
+            .valueOf()
+        );
+        assert.equal(historicalPrice.toString(), parseFixed(historicalResponse[1].vix, 6).toString());
+
+        const justBeforeNextPrice = await priceFeed.getHistoricalPrice(
+          moment
+            .utc(historicalResponse[1].timestamp)
+            .add(15, "minutes")
+            .subtract(1, "ms")
+            .valueOf()
+        );
+        assert.equal(justBeforeNextPrice.toString(), parseFixed(historicalResponse[1].vix, 6).toString());
+
+        const nextPrice = await priceFeed.getHistoricalPrice(
+          moment
+            .utc(historicalResponse[1].timestamp)
+            .add(15, "minutes")
+            .valueOf()
+        );
+        assert.equal(nextPrice.toString(), parseFixed(historicalResponse[2].vix, 6).toString());
+      });
+    });
+
+    describe("Updating the cache", () => {
+      it("will process updates as frequently as configured", async () => {
+        await priceFeed.update();
+        const initialUpdateTime = priceFeed.getLastUpdateTime();
+
+        mockTime += moment.duration(minTimeBetweenUpdates, "seconds");
+        await priceFeed.update();
+        const subsequentUpdateTime = priceFeed.getLastUpdateTime();
+
+        assert.notEqual(subsequentUpdateTime, initialUpdateTime);
+      });
+
+      it("will not process updates too frequently", async () => {
+        await priceFeed.update();
+        const initialUpdateTime = priceFeed.getLastUpdateTime();
+
+        await priceFeed.update();
+        const skippedUpdateTime = priceFeed.getLastUpdateTime();
+        assert.equal(skippedUpdateTime, initialUpdateTime);
+
+        mockTime += moment.duration(minTimeBetweenUpdates, "seconds");
+        await priceFeed.update();
+        const finalUpdateTime = priceFeed.getLastUpdateTime();
+        assert.notEqual(finalUpdateTime, initialUpdateTime);
+      });
+    });
+  });
+
+  describe("Before an initial update has been performed", () => {
+    it("does not have a last update time", () => {
+      assert.isUndefined(priceFeed.getLastUpdateTime());
+    });
+
+    it("throws when the ethVIX price is requested", () => {
+      assert.throws(() => priceFeed.getCurrentPrice());
+    });
+
+    it("throws when the iethVIX price is requested", () => {
+      assert.throws(() => inversePriceFeed.getCurrentPrice());
+    });
+
+    it("throws when the historical ethVIX price is requested", async () => {
+      let result;
+      let errorMessage;
+
+      try {
+        result = await priceFeed.getHistoricalPrice(mockTime);
+      } catch (error) {
+        errorMessage = error.message;
+      }
+
+      assert.equal(errorMessage, "dVIX.ethVIX: undefined lastUpdateTime. Update required.");
+      assert.isUndefined(result);
+    });
+
+    it("throws when the historical iethVIX price is requested", async () => {
+      let result;
+      let errorMessage;
+
+      try {
+        result = await inversePriceFeed.getHistoricalPrice(mockTime);
+      } catch (error) {
+        errorMessage = error.message;
+      }
+
+      assert.equal(errorMessage, "dVIX.iethVIX: undefined lastUpdateTime. Update required.");
+      assert.isUndefined(result);
+    });
+  });
+});

--- a/packages/financial-templates-lib/test/price-feed/EthVixPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/EthVixPriceFeed.js
@@ -56,12 +56,12 @@ describe("EthVixPriceFeed.js", () => {
     describe("Price discovery", () => {
       it("can return the latest ethVIX price", async () => {
         await priceFeed.update();
-        assert.equal(priceFeed.getCurrentPrice().toString(), "70200000000000000000");
+        assert.equal(priceFeed.getCurrentPrice().toString(), web3.utils.toWei("70.2"));
       });
 
       it("can return the latest iethVIX price", async () => {
         await inversePriceFeed.update();
-        assert.equal(inversePriceFeed.getCurrentPrice().toString(), "142440000000000000000");
+        assert.equal(inversePriceFeed.getCurrentPrice().toString(), web3.utils.toWei("142.44"));
       });
 
       it("can properly scale results per the DVM requirement (wei units)", async () => {

--- a/packages/financial-templates-lib/test/price-feed/EthVixPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/EthVixPriceFeed.js
@@ -68,6 +68,12 @@ describe("EthVixPriceFeed.js", () => {
         await priceFeed.update();
         assert.equal(web3.utils.fromWei(priceFeed.getCurrentPrice()), "70.2");
       });
+
+      it("can properly handle unordered response data", async () => {
+        networker.getJsonReturns = [[...historicalResponse].reverse()];
+        await priceFeed.update();
+        assert.equal(web3.utils.fromWei(priceFeed.getCurrentPrice()), "70.2");
+      });
     });
 
     describe("Historical price discovery", () => {


### PR DESCRIPTION
**Motivation**

ethVIX and iethVIX allow for the trading of model-free expected volatility of ETH. ethVIX is best understood as a long volatility position while iethVIX is a short volatility position. The ethVIX index is very similar to the Cboe VIX which tracks the expected volatility of the S&P 500. By trading ethVIX or iethVIX traders can take long or short positions against volatility, either as a speculative trading instrument itself or a hedge for other speculative trades.

Here are some examples of how traders might use ethVIX and iethVIX:

- In early March of 2020, 0xAlice believes that the global pandemic will greatly affect the price of ETH but she’s not sure if it will drop like the stock market or go up as a safe haven asset. She buys ethVIX for roughly 80 USDC per token. On Black Thursday (March 12th, 2020), the price of ETH drops significantly and the price of ethVIX moves to around 280 USDC. At expiration, 0xAlice redeems her ethVIX tokens while the price feed is still over 200 USDC. 

- In March of 2021, the price of ETH goes up quickly in a bull market. This volatility causes ethVIX to rise to roughly 120 USDC. iethVIX drops inversely to 80 USDC. 0xCarol believes that the price of ETH will soon stabilize. She buys iethVIX at roughly 90 USDC on March 12. At expiry on March 19 the price feed has moved to 97.50 USDC and she redeems her tokens for that price. 


**Summary**

We've implemented a price feed compatible with UMA's `PriceFeedInterface` as per the UMIP price feed submission guidelines.


**Details**

There are no dependency changes or implementation decisions in this PR.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


