### PR TITLE
improve(pricefeed-script): Pass verbose flag down from meta pricefeeds

### DIFF
--- a/packages/core/scripts/local/getHistoricalPrice.js
+++ b/packages/core/scripts/local/getHistoricalPrice.js
@@ -1,11 +1,16 @@
 /**
- * @notice This is an example script demonstrating how to get a historical median price at a specific timestamp.
+ * @notice This is an example script demonstrating how to get a historical price at a specific timestamp.
  * It could be used for example to query a price before committing a vote for a DVM price request.
  * We provide default configurations for querying median prices on specific markets across some exchanges and markets.
  * This script should serve as a template for constructing other historical median queries.
  *
- * @notice This script will fail if the `--time` is not within a 4 day lookback window and one of the medianized pricefeeds is a cryptowatch price feed.
- * @dev How to run: yarn truffle exec ./packages/core/scripts/local/getMedianHistoricalPrice.js --network mainnet_mnemonic --identifier USDBTC --time 1601503200
+ * @notice This script will fail if the `--time` is not within a the caller's configured lookback window. The caller
+ * set this via the PRICEFEED_CONFIG={"lookback":x} environment variable.
+ * @dev How to run:
+ *     yarn truffle exec ./packages/core/scripts/local/getHistoricalPrice.js
+ *         --network mainnet_mnemonic
+ *         --identifier USDBTC
+ *         --time 1601503200
  */
 const { fromWei } = web3.utils;
 const { createReferencePriceFeedForFinancialContract, Networker } = require("@uma/financial-templates-lib");
@@ -29,7 +34,7 @@ const UMIP_PRECISION = {
 };
 const DEFAULT_PRECISION = 5;
 
-async function getMedianHistoricalPrice(callback) {
+async function getHistoricalPrice(callback) {
   try {
     // If user did not specify an identifier, provide a default value.
     let queryIdentifier;
@@ -56,12 +61,13 @@ async function getMedianHistoricalPrice(callback) {
     console.log(`⏰ Fetching nearest prices for the timestamp: ${new Date(queryTime * 1000).toUTCString()}`);
     const lookback = Math.round(Math.max(getTime() - queryTime, 1800));
 
-    // Create and update a new Medianizer price feed.
+    // Create and update a new default price feed.
     let dummyLogger = winston.createLogger({
       silent: true
     });
     let priceFeedConfig = {
-      // Empirically, Cryptowatch API only returns data up to ~4 days back.
+      // Empirically, Cryptowatch API only returns data up to ~4 days back so that's why we default the lookback
+      // 1800.
       lookback,
       priceFeedDecimals: 18, // Ensure all prices come out as 18-decimal denominated so the fromWei conversion works at the end.
       // Append price feed config params from environment such as "apiKey" for CryptoWatch price feeds.
@@ -99,4 +105,4 @@ async function getMedianHistoricalPrice(callback) {
   callback();
 }
 
-module.exports = getMedianHistoricalPrice;
+module.exports = getHistoricalPrice;

--- a/packages/core/scripts/local/getMedianHistoricalPrice.js
+++ b/packages/core/scripts/local/getMedianHistoricalPrice.js
@@ -67,7 +67,7 @@ async function getMedianHistoricalPrice(callback) {
       // Append price feed config params from environment such as "apiKey" for CryptoWatch price feeds.
       ...(process.env.PRICE_FEED_CONFIG ? JSON.parse(process.env.PRICE_FEED_CONFIG) : {})
     };
-    const medianizerPriceFeed = await createReferencePriceFeedForFinancialContract(
+    const defaultPriceFeed = await createReferencePriceFeedForFinancialContract(
       dummyLogger,
       web3,
       new Networker(dummyLogger),
@@ -76,15 +76,15 @@ async function getMedianHistoricalPrice(callback) {
       priceFeedConfig,
       queryIdentifier
     );
-    if (!medianizerPriceFeed) {
-      throw new Error(`Failed to construct medianizer price feed for the ${queryIdentifier} identifier`);
+    if (!defaultPriceFeed) {
+      throw new Error(`Failed to construct default price feed for the ${queryIdentifier} identifier`);
     }
 
-    await medianizerPriceFeed.update();
+    await defaultPriceFeed.update();
 
     // The default exchanges to fetch prices for (and from which the median is derived) are based on UMIP's and can be found in:
     // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
-    const queryPrice = await medianizerPriceFeed.getHistoricalPrice(queryTime, true);
+    const queryPrice = await defaultPriceFeed.getHistoricalPrice(queryTime, true);
     const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
     console.log(`\n⚠️ Truncating price to ${precisionToUse} decimals`);
     console.log(

--- a/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/BasketSpreadPriceFeed.js
@@ -110,23 +110,25 @@ class BasketSpreadPriceFeed extends PriceFeedInterface {
     }
   }
 
-  async getHistoricalPrice(time) {
+  async getHistoricalPrice(time, verbose = false) {
     // If failure to fetch any constituent historical prices, then throw
     // array of errors.
     const errors = [];
     const experimentalPrices = await Promise.all(
       this.experimentalPriceFeeds.map(priceFeed => {
-        return priceFeed.getHistoricalPrice(time).catch(err => errors.push(err));
+        return priceFeed.getHistoricalPrice(time, verbose).catch(err => errors.push(err));
       })
     );
     const baselinePrices = await Promise.all(
       this.baselinePriceFeeds.map(priceFeed => {
-        return priceFeed.getHistoricalPrice(time).catch(err => errors.push(err));
+        return priceFeed.getHistoricalPrice(time, verbose).catch(err => errors.push(err));
       })
     );
     let denominatorPrice;
     if (this.denominatorPriceFeed) {
-      denominatorPrice = await this.denominatorPriceFeed.getHistoricalPrice(time).catch(err => errors.push(err));
+      denominatorPrice = await this.denominatorPriceFeed
+        .getHistoricalPrice(time, verbose)
+        .catch(err => errors.push(err));
     }
 
     if (errors.length > 0) {

--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -58,12 +58,12 @@ class ExpressionPriceFeed extends PriceFeedInterface {
     this.decimals = decimals;
   }
 
-  async getHistoricalPrice(time) {
+  async getHistoricalPrice(time, verbose = false) {
     const historicalPrices = {};
     const errors = [];
     await Promise.all(
       Object.entries(this.priceFeedMap).map(async ([name, pf]) => {
-        const price = await pf.getHistoricalPrice(time).catch(err => errors.push(err));
+        const price = await pf.getHistoricalPrice(time, verbose).catch(err => errors.push(err));
         historicalPrices[name] = this._convertToDecimal(price, pf.getPriceFeedDecimals());
       })
     );


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Recent price requests for `STABLESPREAD` identifiers have highlighted that the `BasketSpreadPriceFeed` does not pass down a `verbose` flag to children pricefeeds, which may or may not implement additional logging useful for running the `getHistoricalPrice` script. Also removes any mentions of "medianizer" because this script is being used for al pricefeed now, not just medianizers.


**Summary**

Example run: `yarn truffle exec ./packages/core/scripts/local/getHistoricalPrice.js --network mainnet_mnemonic --identifier STABLESPREAD/USDC --time 1616936400`

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
