### PR TITLE
fix: call update on gas estimator before sending transactions

### DIFF
--- a/packages/financial-templates-lib/src/proxy-transaction-handler/DSProxyManager.js
+++ b/packages/financial-templates-lib/src/proxy-transaction-handler/DSProxyManager.js
@@ -90,6 +90,7 @@ class DSProxyManager {
         message: "No DSProxy found for EOA. Deploying new DSProxy",
         account: this.account
       });
+      await this.gasEstimator.update();
       const dsProxyCreateTx = await this.dsProxyFactory.methods.build().send({
         from: this.account,
         gasPrice: this.gasEstimator.getCurrentFastPrice()
@@ -118,6 +119,7 @@ class DSProxyManager {
       callData
     });
 
+    await this.gasEstimator.update();
     const executeTransaction = await this.dsProxy.methods["execute(address,bytes)"](libraryAddress, callData).send({
       from: this.account,
       gasPrice: this.gasEstimator.getCurrentFastPrice()
@@ -144,6 +146,7 @@ class DSProxyManager {
       callCode
     });
 
+    await this.gasEstimator.update();
     const executeTransaction = await this.dsProxy.methods["execute(bytes,bytes)"](callCode, callData).send({
       from: this.account,
       gasPrice: this.gasEstimator.getCurrentFastPrice()


### PR DESCRIPTION
**Motivation**

Minor trader fix to ensure the gas price estimation is updated before sending transactions.

**Summary**

Just added a few update calls.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
