### PR TITLE
fix(trader): pass along range trader config from env variables

### DIFF
--- a/packages/trader/src/RangeTrader.ts
+++ b/packages/trader/src/RangeTrader.ts
@@ -34,8 +34,8 @@ export class RangeTrader {
     readonly referencePriceFeed: any,
     readonly exchangeAdapter: typeof ExchangeAdapterInterface,
     readonly rangeTraderConfig: {
-      tradeExecutionThreshold: number;
-      targetPriceSpread: number;
+      tradeExecutionThreshold?: number;
+      targetPriceSpread?: number;
     }
   ) {
     assert(tokenPriceFeed.getPriceFeedDecimals() === referencePriceFeed.getPriceFeedDecimals(), "decimals must match");

--- a/packages/trader/src/TraderConfig.ts
+++ b/packages/trader/src/TraderConfig.ts
@@ -16,6 +16,7 @@ export class TraderConfig {
   readonly tokenPriceFeedConfig: any;
   readonly referencePriceFeedConfig: any;
   readonly exchangeAdapterConfig: any;
+  readonly rangeTraderConfig: any;
 
   constructor(env: ProcessEnv) {
     const {
@@ -26,7 +27,8 @@ export class TraderConfig {
       ERROR_RETRIES_TIMEOUT,
       DS_PROXY_FACTORY_ADDRESS,
       REFERENCE_PRICE_FEED_CONFIG,
-      EXCHANGE_ADAPTER_CONFIG
+      EXCHANGE_ADAPTER_CONFIG,
+      RANGE_TRADER_CONFIG
     } = env;
     assert(EMP_ADDRESS, "EMP_ADDRESS required");
     this.financialContractAddress = Web3.utils.toChecksumAddress(EMP_ADDRESS);
@@ -39,5 +41,6 @@ export class TraderConfig {
     this.tokenPriceFeedConfig = TOKEN_PRICE_FEED_CONFIG ? JSON.parse(TOKEN_PRICE_FEED_CONFIG) : null;
     this.referencePriceFeedConfig = REFERENCE_PRICE_FEED_CONFIG ? JSON.parse(REFERENCE_PRICE_FEED_CONFIG) : null;
     this.exchangeAdapterConfig = EXCHANGE_ADAPTER_CONFIG ? JSON.parse(EXCHANGE_ADAPTER_CONFIG) : null;
+    this.rangeTraderConfig = RANGE_TRADER_CONFIG ? JSON.parse(RANGE_TRADER_CONFIG) : {};
   }
 }

--- a/packages/trader/src/index.ts
+++ b/packages/trader/src/index.ts
@@ -39,7 +39,8 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
       dsProxyFactoryAddress: config.dsProxyFactoryAddress,
       tokenPriceFeedConfig: config.tokenPriceFeedConfig,
       referencePriceFeedConfig: config.referencePriceFeedConfig,
-      exchangeAdapterConfig: config.exchangeAdapterConfig
+      exchangeAdapterConfig: config.exchangeAdapterConfig,
+      rangeTraderConfig: config.rangeTraderConfig
     });
 
     // Load unlocked web3 accounts, get the networkId and set up price feed.
@@ -79,7 +80,14 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
       ),
       createExchangeAdapter(logger, web3, dsProxyManager, config.exchangeAdapterConfig, networkId)
     ]);
-    const rangeTrader = new RangeTrader(logger, web3, tokenPriceFeed, referencePriceFeed, exchangeAdapter);
+    const rangeTrader = new RangeTrader(
+      logger,
+      web3,
+      tokenPriceFeed,
+      referencePriceFeed,
+      exchangeAdapter,
+      config.rangeTraderConfig
+    );
     for (;;) {
       await retry(
         async () => {


### PR DESCRIPTION
**Motivation**

There is no way to provide the range trader config via env variables.

**Summary**

Adds the range trader config to the index.ts file and passes it along.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A