### PR TITLE
fix(optimistic-oracle-monitor): Reduce default log level for funding rate price requests

### DIFF
--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -95,7 +95,10 @@ class OptimisticOracleContractMonitor {
         )} and the final fee is ${this.formatDecimalString(convertCollateralDecimals(event.finalFee))}. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      this.logger[this.logOverrides.requestedPrice || "error"]({
+      // The default log level should be reduced to "info" for funding rate identifiers:
+      this.logger[
+        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error")
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Request Alert 👮🏻!",
         mrkdwn: mrkdwn
@@ -128,7 +131,10 @@ class OptimisticOracleContractMonitor {
         `Collateral currency address is ${event.currency}. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      this.logger[this.logOverrides.proposedPrice || "error"]({
+      // The default log level should be reduced to "info" for funding rate identifiers:
+      this.logger[
+        this.logOverrides.proposedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error")
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Proposal Alert 🧞‍♂️!",
         mrkdwn: mrkdwn
@@ -158,7 +164,9 @@ class OptimisticOracleContractMonitor {
         `The ancillary data field is ${event.ancillaryData}. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      this.logger[this.logOverrides.disputedPrice || "error"]({
+      this.logger[
+        this._isFundingRateIdentifier(event.identifier) ? "info" : this.logOverrides.disputedPrice || "error"
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Dispute Alert ⛔️!",
         mrkdwn: mrkdwn
@@ -215,6 +223,12 @@ class OptimisticOracleContractMonitor {
       return 0;
     }
     return eventArray[eventArray.length - 1].blockNumber;
+  }
+
+  // We make the assumption that identifiers that end with "_fr" like "ethbtc_fr" are funding rate identifiers,
+  // and we should lower the alert levels for such price requests because we expect them to appear often.
+  _isFundingRateIdentifier(identifier) {
+    return identifier.toLowerCase().endsWith("_fr");
   }
 }
 

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -164,9 +164,7 @@ class OptimisticOracleContractMonitor {
         `The ancillary data field is ${event.ancillaryData}. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      this.logger[
-        this._isFundingRateIdentifier(event.identifier) ? "info" : this.logOverrides.disputedPrice || "error"
-      ]({
+      this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Dispute Alert ⛔️!",
         mrkdwn: mrkdwn


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Typically we want to be alerted loudly when OO proposals and requests are made. However, funding rate proposals are expected to be sent often, possibly every liveness period during times of extended volatility. Therefore we should detect which identifiers are funding rate ones and lower the default log level.

This PR makes the possibly erroneous assumption that identifiers that end with "_FR" are funding rate identifiers. Currently this is true but we should either refactor this bot or codify this rule off chain going forwards.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested