### PR TITLE
fix(voter-dapp): Change subgraph URL and query

### DIFF
--- a/packages/voter-dapp/src/apollo/client.js
+++ b/packages/voter-dapp/src/apollo/client.js
@@ -1,6 +1,6 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
 export const client = new ApolloClient({
-  uri: "https://api.thegraph.com/subgraphs/name/nicholaspai/mainnet-voting-staging",
+  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/mainnet-voting",
   cache: new InMemoryCache()
 });

--- a/packages/voter-dapp/src/apollo/client.js
+++ b/packages/voter-dapp/src/apollo/client.js
@@ -1,6 +1,6 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
 export const client = new ApolloClient({
-  uri: "https://api.thegraph.com/subgraphs/name/umaprotocol/uma",
+  uri: "https://api.thegraph.com/subgraphs/name/nicholaspai/mainnet-voting-staging",
   cache: new InMemoryCache()
 });

--- a/packages/voter-dapp/src/apollo/queries.js
+++ b/packages/voter-dapp/src/apollo/queries.js
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const PRICE_REQUEST_VOTING_DATA = gql`
   query priceRequestRounds {
-    priceRequestRounds {
+    priceRequestRounds(first: 1000) {
       id
       identifier {
         id


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Old subgraph has now been replaced by two separate subgraphs ([repo](https://github.com/UMAprotocol/subgraphs)) that sync faster and better separate concerns, including one dedicated to DVM events. We still need to decide how we automate deployments to a `staging` and a `production` subgraph and we also should add these under the `umaprotocol` subgraph account instead of `nicholaspai` but TBD how we solve that. This fix enables the "vote stats" button to display again.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested