### PR TITLE
feat(networks): Add DSProxyFactory

### DIFF
--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -70,5 +70,9 @@
   {
     "contractName": "PerpetualCreator",
     "address": "0xE9f67235C1B0EE401e5F5e119fB9DFc9753F10F9"
+  },
+  {
+    "contractName": "DSProxyFactory",
+    "address": "0xAB75727d4e89A7f7F04f57C00234a35950527115"
   }
 ]


### PR DESCRIPTION
**Motivation**

As part of the UMA move to use DSProxys in liquidations and the roll out of the range trader, we require a main net DSProxy deployment. This PR adds this address to the networks file.

Note I have already verified this source code on etherscan as well as a deployed child DSProxy. all future DSProxies should auto-verify as a result. 

