### PR TITLE
feat(optimistic-oracle-proposer): Blacklist identifiers to skip post-expiry

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -25,8 +25,21 @@ const getPrecisionForIdentifier = identifier => {
   return IDENTIFIER_NON_18_PRECISION[identifier] ? IDENTIFIER_NON_18_PRECISION[identifier] : 18;
 };
 
+// The optimistic oracle proposer should skip proposing prices for these identifiers, for expired EMP contracts,
+// because they map to self-referential pricefeeds pre-expiry, but have different price resolution ogic post-expiry.
+// For example, please see [UMIP47](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-47.md):
+// - "The type of price that the DVM will return is dependent on the timestamp the price request is made at. This
+//   timestamp is the expiry timestamp of the contract that is intended to use this price identifier, so the TWAP
+//   calculation is used pre-expiry and the closing index value of uSTONKS calculation is used at expiry.""
+const OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY = [
+  "TESTBLACKLIST", // Used for testing this list, assumed by tests to be at index 0.
+  "uSTONKS_APR21",
+  "GASETH-TWAP-1Mx1M"
+];
+
 module.exports = {
   IDENTIFIER_BLACKLIST,
   IDENTIFIER_NON_18_PRECISION,
-  getPrecisionForIdentifier
+  getPrecisionForIdentifier,
+  OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY
 };

--- a/packages/core/contracts/oracle/implementation/test/OptimisticRequesterTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/OptimisticRequesterTest.sol
@@ -21,6 +21,9 @@ contract OptimisticRequesterTest is OptimisticRequester {
     // token can be fetched by off-chain clients.
     IERC20 public collateralCurrency;
 
+    // Manually set an expiration timestamp to simulate expiry price requests
+    uint256 public expirationTimestamp;
+
     constructor(OptimisticOracle _optimisticOracle) public {
         optimisticOracle = _optimisticOracle;
     }
@@ -75,6 +78,10 @@ contract OptimisticRequesterTest is OptimisticRequester {
 
     function setRevert(bool _shouldRevert) external {
         shouldRevert = _shouldRevert;
+    }
+
+    function setExpirationTimestamp(uint256 _expirationTimestamp) external {
+        expirationTimestamp = _expirationTimestamp;
     }
 
     function clearState() external {

--- a/packages/optimistic-oracle/src/proposer.js
+++ b/packages/optimistic-oracle/src/proposer.js
@@ -4,7 +4,8 @@ const {
   setAllowance,
   isDeviationOutsideErrorMargin
 } = require("@uma/financial-templates-lib");
-const { createObjectFromDefaultProps, runTransaction } = require("@uma/common");
+const { createObjectFromDefaultProps, runTransaction, OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY } = require("@uma/common");
+const { getAbi } = require("@uma/core");
 
 class OptimisticOracleProposer {
   /**
@@ -32,6 +33,10 @@ class OptimisticOracleProposer {
 
     // Gas Estimator to calculate the current Fast gas rate.
     this.gasEstimator = gasEstimator;
+
+    this.createEmpContract = empAddress => {
+      return new this.web3.eth.Contract(getAbi("ExpiringMultiParty"), empAddress);
+    };
 
     this.optimisticOracleContract = this.optimisticOracleClient.oracle;
 
@@ -88,6 +93,29 @@ class OptimisticOracleProposer {
     // TODO: Should allow user to filter out price requests with rewards below a threshold,
     // allowing the bot to prevent itself from being induced to unprofitably propose.
     for (let priceRequest of this.optimisticOracleClient.getUnproposedPriceRequests()) {
+      // If the price request is an expiry price request for a specific type of EMP
+      // whose price resolution is self-referential pre-expiry and diferent post-expiry,
+      // then skip the price request:
+      if (OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY.includes(priceRequest.identifier)) {
+        // Check if (1) contract is an EMP and (2) EMP has expired:
+        try {
+          // The requester should be an EMP contract if this is an expiry price request.
+          const empContract = this.createEmpContract(priceRequest.requester);
+          const expirationTimestamp = await empContract.methods.expirationTimestamp().call();
+          if (Number(priceRequest.timestamp) >= Number(expirationTimestamp)) {
+            this.logger.debug({
+              at: "OptimisticOracleProposer#sendProposals",
+              message: "EMP contract has expired and identifier's price resolution logic transforms post-expiry",
+              identifier: priceRequest.identifier,
+              expirationTimestamp: expirationTimestamp.toString()
+            });
+            continue;
+          }
+        } catch (err) {
+          console.error(err);
+          // Do nothing, contract is probably not an EMP
+        }
+      }
       await this._sendProposal(priceRequest);
     }
   }

--- a/packages/optimistic-oracle/test/proposer.js
+++ b/packages/optimistic-oracle/test/proposer.js
@@ -584,7 +584,7 @@ contract("OptimisticOracle: proposer.js", function(accounts) {
       optimisticOracleClient: client,
       gasEstimator,
       account: botRunner,
-      commonPriceFeedConfig: { currentPrice: "1.2" }
+      commonPriceFeedConfig: { currentPrice: "1", historicalPrice: "2" }
     });
 
     // Update the bot to read the new OO state.


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

`uSTONKS` expires at the end of April and `uGAS` expires at the end of May. They are self-referential contracts that are using the latest version of the EMP. The bots currently are going to provide a price at expiry of the 2-hour TWAP instead of the final closing index value of uSTONKS. We need the bots to blacklist these two contracts so they do not propose a price. We assume that a manual price will occur instead.

The price request alert should still be emitted by the `optimistic-oracle-monitor` (i.e. the blacklist resides in the proposer bot, not the client shared between bot and monitor).


**Summary**

To check if an identifier is coming from an EMP post-expiry, we attempt to construct an EMP using the price request's `requester` address, which is the expired EMP address if the price request was an expiry one.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
