### PR TITLE
feat(find-contract-verion): add back perpetual hash

### DIFF
--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -69,6 +69,11 @@ const versionMap = {
     // latest Perpetual deployed from hardhat tests.
     contractType: "Perpetual",
     contractVersion: "latest"
+  },
+  "0x238569485842107d2e938ff59c78841860b4dcd00d37be9859699f2c4ddbb3a0": {
+    // Latest Mainnet Perpetual contract
+    contractType: "Perpetual",
+    contractVersion: "latest"
   }
 };
 

--- a/packages/common/src/FindContractVersion.js
+++ b/packages/common/src/FindContractVersion.js
@@ -71,7 +71,7 @@ const versionMap = {
     contractVersion: "latest"
   },
   "0x238569485842107d2e938ff59c78841860b4dcd00d37be9859699f2c4ddbb3a0": {
-    // Latest Mainnet Perpetual contract
+    // Latest Mainnet Perpetual contract.
     contractType: "Perpetual",
     contractVersion: "latest"
   }


### PR DESCRIPTION
**Motivation**

This PR adds back a missing contract hash for the perpetual.