### PR TITLE
feat(call): allow anyone to set strike price in covered call library

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/CoveredCallFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/CoveredCallFinancialProductLibrary.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import "./FinancialProductLibrary.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "../../../common/implementation/Lockable.sol";
 
 /**
@@ -15,7 +14,7 @@ import "../../../common/implementation/Lockable.sol";
  * If ETHUSD = $800 at expiry, the call is $400 in the money, and the contract pays out 0.5 WETH (worth $400).
  * If ETHUSD =< $400 at expiry, the call is out of the money, and the contract pays out 0 WETH.
  */
-contract CoveredCallFinancialProductLibrary is FinancialProductLibrary, Ownable, Lockable {
+contract CoveredCallFinancialProductLibrary is FinancialProductLibrary, Lockable {
     mapping(address => FixedPoint.Unsigned) private financialProductStrikes;
 
     /**
@@ -28,7 +27,6 @@ contract CoveredCallFinancialProductLibrary is FinancialProductLibrary, Ownable,
      */
     function setFinancialProductStrike(address financialProduct, FixedPoint.Unsigned memory strikePrice)
         public
-        onlyOwner
         nonReentrant()
     {
         require(strikePrice.isGreaterThan(0), "Cant set 0 strike");

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/CoveredCallFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/CoveredCallFinancialProductLibrary.sol
@@ -18,12 +18,13 @@ contract CoveredCallFinancialProductLibrary is FinancialProductLibrary, Lockable
     mapping(address => FixedPoint.Unsigned) private financialProductStrikes;
 
     /**
-     * @notice Enables the deployer of the library to set the strike price for an associated financial product.
+     * @notice Enables any address to set the strike price for an associated financial product.
      * @param financialProduct address of the financial product.
      * @param strikePrice the strike price for the covered call to be applied to the financial product.
-     * @dev Note: a) Only the owner (deployer) of this library can set new strike prices b) A strike price cannot be 0.
+     * @dev Note: a) Any address can set the initial strike price b) A strike price cannot be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
-     * d)  financialProduct must exposes an expirationTimestamp method.
+     * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
+     * e) financialProduct must expose an expirationTimestamp method.
      */
     function setFinancialProductStrike(address financialProduct, FixedPoint.Unsigned memory strikePrice)
         public


### PR DESCRIPTION
Signed-off-by: John Shutt <john.d.shutt@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Updates financial product library to allow anyone to set the strike price for a newly deployed covered call. Previously, only the deployer of the _library_ contract can set the strike price for a covered call contract using the library, which limits the reusability of the library, as each deployer would need to deploy their own library.

There is a limited risk of an uneconomical griefing attack, where someone (for some reason) sets the strike price of a covered call contract before the deployer sets the strike price. There is no incentive to do so, but if it became a problem for some reason, deployment of the covered call and setting of the strike price could be done via an atomic transaction.

A different risk would be an improper deployment order of operations, where the deployer mints call options and uses them to seed an AMM pool before setting a strike price in the contract. That could create an economic incentive for someone else to set an incorrect strike price. (This risk is similar, conceptually, to the risk of misconfiguration of EMP parameters, like a too-low collateralization ratio.)

Documentation for covered call deployment should emphasize that the strike price should be set after deploying the covered call contract and before minting any options.


**Summary**

Removes `Ownable` and the `onlyOwner` modifier in the set strike price method.


**Details**

n/a


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
