### PR TITLE
improve(optimistic-oracle-monitor): Change default log level for PriceRequests and PriceSettlements to "debug" from "info"

### DIFF
--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -95,9 +95,9 @@ class OptimisticOracleContractMonitor {
         )} and the final fee is ${this.formatDecimalString(convertCollateralDecimals(event.finalFee))}. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      // The default log level should be reduced to "info" for funding rate identifiers:
+      // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
-        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error")
+        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "error")
       ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Request Alert 👮🏻!",
@@ -198,7 +198,10 @@ class OptimisticOracleContractMonitor {
         `The ancillary data field is ${event.ancillaryData}. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      this.logger[this.logOverrides.settledPrice || "info"]({
+      // The default log level should be reduced to "debug" for funding rate identifiers:
+      this.logger[
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Settlement Alert 🏧!",
         mrkdwn: mrkdwn


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Some of these alerts are redundant, by default only the OO Monitor's `PriceProposed` event should be "info" level. The `PriceSettlement` is captured by the funding rate monitor's `FundingRateUpdated` log and the `PriceRequest` is redundant with `PriceProposed` for funding rates specifically:
![Screen Shot 2021-04-07 at 09 21 18](https://user-images.githubusercontent.com/9457025/113873361-bf8a8100-9782-11eb-8972-04e48f8a6b96.png)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested