### PR TITLE
improve(funding-rate-proposer): update funding rates sequentially in order to set nonce

### DIFF
--- a/packages/funding-rate-proposer/src/proposer.js
+++ b/packages/funding-rate-proposer/src/proposer.js
@@ -130,7 +130,7 @@ class FundingRateProposer {
     // transactions to the `ynatm` package. If these calls were submitted in parallel then we wouldn't be able to
     // hardcode the nonce, which could cause unintended reverts due to duplicate transactions. Once the `ynatm` package
     // can handle nonce management, then we should update this logic to run in parallel.
-    for (let contractAddress of Object.keys(this.contractCache)) {
+    for (const contractAddress of Object.keys(this.contractCache)) {
       await this._updateFundingRate(contractAddress, usePriceFeedTime);
     }
   }


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

`updateFundingRate` currently proposes funding rates to all Perpetuals in parallel, which means we cannot hardcode the `nonce` before passing transactions to the `ynatm` transaction manager. This leads `ynatm` to send ou transactions that bump gas but incorrectly increment the nonce, which causes unneccessary transaction reverts.

We need to update `ynatm` or implement an alternative transaction management feature that handles nonce management for parallel transactions. Until then, we need to submit transactions sequentially to `ynatm`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
