### PR TITLE
feat(financial-templates-lib): Add default price feed configs for XSUSHIUSD, BALUSD and uSTONKS_JUN21

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -34,7 +34,8 @@ const getPrecisionForIdentifier = identifier => {
 const OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY = [
   "TESTBLACKLIST", // Used for testing this list, assumed by tests to be at index 0.
   "uSTONKS_APR21",
-  "GASETH-TWAP-1Mx1M"
+  "GASETH-TWAP-1Mx1M",
+  "uSTONKS_JUN21"
 ];
 
 module.exports = {

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -932,6 +932,12 @@ const defaultConfigs = {
         tokenAddress: "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2"
       }
     }
+  },
+  uSTONKS_JUN21: {
+    type: "uniswap",
+    uniswapAddress: "0x360acfeb5c1548bad3583c559a646d803077236d",
+    twapLength: 7200,
+    invertPrice: false
   }
 };
 

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -868,6 +868,72 @@ const defaultConfigs = {
       ETHBTC_PERP: { type: "uniswap", invertPrice: true, uniswapAddress: "0x899a45ee5a03d8cc57447157a17ce4ea4745b199" },
       PERP_FRM: { type: "frm", perpetualAddress: "0x32f0405834c4b50be53199628c45603cea3a28aa" }
     }
+  },
+  BALUSD: {
+    type: "expression",
+    expression: `
+      BALANCER_ETH_INVERTED = 1 / SPOT_BALANCER_ETH;
+      SPOT_BALANCER = BALANCER_ETH_INVERTED * ETHUSD;
+      median(SPOT_BINANCE, SPOT_COINBASE_PRO, SPOT_BALANCER)
+    `,
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    customFeeds: {
+      SPOT_BALANCER_ETH: {
+        type: "balancer",
+        twapLength: 2,
+        lookback: 3600,
+        invertPrice: false,
+        balancerAddress: "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
+        balancerTokenIn: "0xba100000625a3754423978a60c9317c58a424e3D",
+        balancerTokenOut: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        poolDecimals: 18
+      },
+      SPOT_BINANCE: { type: "cryptowatch", exchange: "binance", pair: "balusdt" },
+      SPOT_COINBASE_PRO: { type: "cryptowatch", exchange: "coinbase-pro", pair: "balusd" },
+      ETHUSD: {
+        type: "medianizer",
+        minTimeBetweenUpdates: 60,
+        medianizedFeeds: [
+          { type: "cryptowatch", exchange: "coinbase-pro", pair: "ethusd" },
+          { type: "cryptowatch", exchange: "binance", pair: "ethusdt" },
+          { type: "cryptowatch", exchange: "kraken", pair: "ethusd" }
+        ]
+      }
+    }
+  },
+  XSUSHIUSD: {
+    type: "expression",
+    expression: `
+        SPOT_SUSHISWAP = SPOT_SUSHISWAP_ETH * ETHUSD;
+        SUSHIUSD = median(SPOT_BINANCE, SPOT_HUOBI, SPOT_SUSHISWAP);
+        SUSHIUSD * SUSHI_PER_SHARE
+    `,
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    customFeeds: {
+      SPOT_BINANCE: { type: "cryptowatch", exchange: "binance", pair: "sushiusdt" },
+      SPOT_HUOBI: { type: "cryptowatch", exchange: "huobi", pair: "sushiusdt" },
+      SPOT_SUSHISWAP_ETH: {
+        type: "uniswap",
+        uniswapAddress: "0x795065dCc9f64b5614C407a6EFDC400DA6221FB0",
+        twapLength: 2
+      },
+      ETHUSD: {
+        type: "medianizer",
+        minTimeBetweenUpdates: 60,
+        medianizedFeeds: [
+          { type: "cryptowatch", exchange: "coinbase-pro", pair: "ethusd" },
+          { type: "cryptowatch", exchange: "binance", pair: "ethusdt" },
+          { type: "cryptowatch", exchange: "kraken", pair: "ethusd" }
+        ]
+      },
+      SUSHI_PER_SHARE: {
+        type: "lp",
+        poolAddress: "0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272",
+        tokenAddress: "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2"
+      }
+    }
   }
 };
 

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -872,8 +872,7 @@ const defaultConfigs = {
   BALUSD: {
     type: "expression",
     expression: `
-      BALANCER_ETH_INVERTED = 1 / SPOT_BALANCER_ETH;
-      SPOT_BALANCER = BALANCER_ETH_INVERTED * ETHUSD;
+      SPOT_BALANCER = SPOT_BALANCER_ETH * ETHUSD;
       median(SPOT_BINANCE, SPOT_COINBASE_PRO, SPOT_BALANCER)
     `,
     lookback: 7200,
@@ -883,10 +882,9 @@ const defaultConfigs = {
         type: "balancer",
         twapLength: 2,
         lookback: 3600,
-        invertPrice: false,
         balancerAddress: "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
-        balancerTokenIn: "0xba100000625a3754423978a60c9317c58a424e3D",
-        balancerTokenOut: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        balancerTokenIn: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        balancerTokenOut: "0xba100000625a3754423978a60c9317c58a424e3D",
         poolDecimals: 18
       },
       SPOT_BINANCE: { type: "cryptowatch", exchange: "binance", pair: "balusdt" },


### PR DESCRIPTION
**Motivation**

Default price feed configs for XSUSHIUSD, BALUSD and uSTONKS_JUN21 are needed. 

**Summary**

These price feeds follow the methodologies determined in:
- [UMIP-68](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-68.md) for XSUSHIUSD
- [UMIP-73](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-73.md) for BALUSD
- [UMIP-79](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-79.md) for uSTONKS_JUN21

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested

Ran monitor bots locally.

**Issue(s)**

NA
