### PR TITLE
fix(liquidator): address issue in log produced resulting in Winston slack transport error

### DIFF
--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -187,7 +187,6 @@ class ProxyTransactionWrapper {
 
     // Send the transaction or report failure.
     let receipt;
-    let txnConfig;
     try {
       const txResponse = await runTransaction({
         transaction: liquidation,
@@ -211,7 +210,10 @@ class ProxyTransactionWrapper {
       tokensOutstanding: receipt.events.LiquidationCreated.returnValues.tokensOutstanding,
       lockedCollateral: receipt.events.LiquidationCreated.returnValues.lockedCollateral,
       liquidatedCollateral: receipt.events.LiquidationCreated.returnValues.liquidatedCollateral,
-      txnConfig
+      txnConfig: {
+        gasPrice: this.gasEstimator.getCurrentFastPrice(),
+        from: this.account
+      }
     };
   }
 


### PR DESCRIPTION

**Motivation**

There is a small error in the log produced that is sent to Winston resulting in an error slack message. This PR should address this.


Faulty slack log:

![image](https://user-images.githubusercontent.com/12886084/115115187-4285b580-9f93-11eb-92e9-851c6c2ee46c.png)


The error produced is `Error:TypeError: Cannot read property 'length' of undefined`. The `undefined` in reference here is the `txnConfig`. This was not correctly set previously and is addressed in this PR.