### PR TITLE
fix(FallBackPriceFeed): implement missing method that broke in production

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/FallBackPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/FallBackPriceFeed.js
@@ -68,6 +68,11 @@ class FallBackPriceFeed extends PriceFeedInterface {
     }
   }
 
+  // return the longest lookback within all the fallback feeds.
+  getLookback() {
+    return Math.max(this.priceFeeds.map(feed => feed.historicalLookback));
+  }
+
   // Errors out if any price feed had a different number of decimals.
   getPriceFeedDecimals() {
     const priceFeedDecimals = this.priceFeeds.map(priceFeed => priceFeed.getPriceFeedDecimals());

--- a/packages/financial-templates-lib/src/price-feed/FallBackPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/FallBackPriceFeed.js
@@ -68,7 +68,7 @@ class FallBackPriceFeed extends PriceFeedInterface {
     }
   }
 
-  // return the longest lookback within all the fallback feeds.
+  // Return the longest lookback within all the fallback feeds.
   getLookback() {
     return Math.max(this.priceFeeds.map(feed => feed.historicalLookback));
   }


### PR DESCRIPTION
The Expression price feed does not fully implement the `PriceFeedInterface` resulting in errors in production. An example error is shown below:

![image](https://user-images.githubusercontent.com/12886084/115134308-5b33b100-a00f-11eb-852a-d48e48569a2c.png)


This PR addresses this issue.