### PR TITLE
fix(blockfinder): Explicitly cast timestamp to Number

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/ExpressionPriceFeed.js
@@ -63,7 +63,7 @@ class ExpressionPriceFeed extends PriceFeedInterface {
     const errors = [];
     await Promise.all(
       Object.entries(this.priceFeedMap).map(async ([name, pf]) => {
-        const price = await pf.getHistoricalPrice(time, verbose).catch(err => errors.push(err));
+        const price = await pf.getHistoricalPrice(Number(time), verbose).catch(err => errors.push(err));
         historicalPrices[name] = this._convertToDecimal(price, pf.getPriceFeedDecimals());
       })
     );

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -199,7 +199,6 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
   async function findBlock(startBlock, endBlock, timestamp) {
     // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
     // timestamp.
-    timestamp = Number(timestamp);
     if (endBlock.timestamp === timestamp) return endBlock;
 
     // If there's no equality, but the blocks are adjacent, return the startBlock, since we want the returned block's

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -199,6 +199,7 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
   async function findBlock(startBlock, endBlock, timestamp) {
     // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
     // timestamp.
+    timestamp = Number(timestamp);
     if (endBlock.timestamp === timestamp) return endBlock;
 
     // If there's no equality, but the blocks are adjacent, return the startBlock, since we want the returned block's

--- a/packages/financial-templates-lib/src/price-feed/utils.js
+++ b/packages/financial-templates-lib/src/price-feed/utils.js
@@ -234,6 +234,7 @@ exports.BlockFinder = (requestBlock, blocks = []) => {
    * @param {number} timestamp timestamp to search.
    */
   async function getBlockForTimestamp(timestamp) {
+    timestamp = Number(timestamp);
     assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
     // If the last block we have stored is too early, grab the latest block.
     if (blocks.length === 0 || blocks[blocks.length - 1].timestamp < timestamp) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Sometimes `timestamp` is passed in as a String via an upstream `getHistoricalPrice()` call, such as [here](https://github.com/UMAprotocol/protocol/blob/master/packages/core/scripts/local/getHistoricalPrice.js#L94) in the script that's designed to aid UMA voters. This bug currently causes the script to return a slightly different price than one that would be returned by the `optimistic-oracle-proposer` bot, which correctly inputs `timestamp` as a Number [here](https://github.com/UMAprotocol/protocol/blob/master/packages/optimistic-oracle/src/proposer.js#L265).

There might be other instances in the repo where a String `timestamp` is unexpectedly passed into this Blockfinder utility method expecting a number.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
