### PR TITLE
fix(funding-rate-proposer): Use historical-price to propose funding rates

### DIFF
--- a/packages/funding-rate-proposer/src/proposer.js
+++ b/packages/funding-rate-proposer/src/proposer.js
@@ -185,7 +185,8 @@ class FundingRateProposer {
         at: "PerpetualProposer",
         message: "Failed to query current price for funding rate identifier",
         fundingRateIdentifier,
-        requestTimestamp
+        requestTimestamp,
+        error
       });
       return;
     }

--- a/packages/funding-rate-proposer/test/proposer.js
+++ b/packages/funding-rate-proposer/test/proposer.js
@@ -282,19 +282,19 @@ contract("Perpetual: proposer.js", function(accounts) {
       await proposer._setAllowances();
       assert.equal(spyCount, spy.callCount);
     });
-    it("(_cacheAndUpdatePriceFeeds)", async function() {
-      // `update` should create a new pricefeed for each funding rate identifier.
+    it("(_createOrGetCachedPriceFeed)", async function() {
+      // should create a new pricefeed for each funding rate identifier.
       assert.equal(Object.keys(proposer.priceFeedCache).length, fundingRateIdentifiersToTest.length);
       for (let i = 0; i < fundingRateIdentifiersToTest.length; i++) {
         assert.isTrue(
           proposer.priceFeedCache[hexToUtf8(fundingRateIdentifiersToTest[i])] instanceof PriceFeedMockScaled
         );
       }
-      // Calling `_cacheAndUpdatePriceFeeds` usually emits DEBUG logs for
+      // Calling `_createOrGetCachedPriceFeed` usually emits DEBUG logs for
       // each newly cached object. Calling it again should do nothing since we've already
       // cached the price feeds.
       const spyCount = spy.callCount;
-      await proposer._cacheAndUpdatePriceFeeds();
+      await proposer._createOrGetCachedPriceFeed();
       assert.equal(spyCount, spy.callCount);
     });
     describe("(updateFundingRate)", function() {

--- a/packages/funding-rate-proposer/test/proposer.js
+++ b/packages/funding-rate-proposer/test/proposer.js
@@ -201,10 +201,10 @@ contract("Perpetual: proposer.js", function(accounts) {
     // not set in DefaultPriceFeedConfig
     latestProposalTime = startTime.toNumber() + 1;
     commonPriceFeedConfig = {
-      currentPrice: "0.000005",
-      // Mocked current price. This will be scaled to the identifier's precision. 1/2 of max funding rate
-      historicalPrice: "0.000001",
-      // Mocked historical price. This should be irrelevant for these tests.
+      historicalPrice: "0.000005",
+      // Mocked historical price. This will be scaled to the identifier's precision. 1/2 of max funding rate
+      currentPrice: "0.000001",
+      // Mocked current price. This should be irrelevant for these tests.
       lastUpdateTime: latestProposalTime
       // On funding rate updates, proposer requests a price for this time. This must be > than the Perpetual
       // contract's last update time, which is the `startTime` when it was deployed. So we start
@@ -356,7 +356,7 @@ contract("Perpetual: proposer.js", function(accounts) {
         let pricesToPropose = "0.000006";
         for (let i = 0; i < fundingRateIdentifiersToTest.length; i++) {
           const priceFeed = proposer.priceFeedCache[hexToUtf8(fundingRateIdentifiersToTest[i])];
-          priceFeed.setCurrentPrice(pricesToPropose);
+          priceFeed.setHistoricalPrice(pricesToPropose);
           priceFeed.setLastUpdateTime(latestProposalTime);
         }
         await proposer.updateFundingRates(true);
@@ -402,7 +402,7 @@ contract("Perpetual: proposer.js", function(accounts) {
           assert.equal(pricesToPropose.length, fundingRateIdentifiersToTest.length);
           for (let i = 0; i < fundingRateIdentifiersToTest.length; i++) {
             const priceFeed = proposer.priceFeedCache[hexToUtf8(fundingRateIdentifiersToTest[i])];
-            priceFeed.setCurrentPrice(pricesToPropose[i]);
+            priceFeed.setHistoricalPrice(pricesToPropose[i]);
             priceFeed.setLastUpdateTime(latestProposalTime);
           }
 
@@ -428,9 +428,9 @@ contract("Perpetual: proposer.js", function(accounts) {
           for (let i = 0; i < fundingRateIdentifiersToTest.length; i++) {
             const priceFeed = proposer.priceFeedCache[hexToUtf8(fundingRateIdentifiersToTest[i])];
             if (i % 2 === 0) {
-              priceFeed.setCurrentPrice("1");
+              priceFeed.setHistoricalPrice("1");
             } else {
-              priceFeed.setCurrentPrice("-1");
+              priceFeed.setHistoricalPrice("-1");
             }
             priceFeed.setLastUpdateTime(latestProposalTime);
           }
@@ -476,10 +476,10 @@ contract("Perpetual: proposer.js", function(accounts) {
     // Update once to load priceFeedCache.
     await proposer.update();
 
-    // Force `getCurrentPrice()` to return null so that bot fails to fetch prices.
+    // Force `getHistoricalPrice(x)` to return null so that bot fails to fetch prices.
     for (let i = 0; i < fundingRateIdentifiersToTest.length; i++) {
       const priceFeed = proposer.priceFeedCache[hexToUtf8(fundingRateIdentifiersToTest[i])];
-      priceFeed.setCurrentPrice(null);
+      priceFeed.setHistoricalPrice(null);
     }
 
     // Update again


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Funding Rate Proposer bot uses the latest block timestamp as the request timestamp. Any disputes will reference this same timestamp, therefore the proposed price should be the historical price for this timestamp. Currently, the current price is used, but the current price can be off from the historical price at the request timestamp because of the lag between the last block time and the current (off-chain) system time.

The latest block timestamp is used as the request time instead of the current system time because the Optimistic Oracle prevents request timestamps from being >= the latest block time. See [this PR](https://github.com/UMAprotocol/protocol/pull/2687) for more details.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
