### PR TITLE
fix(liquidator): update DSProxy to deal with reserve currency matching collateral currency

### DIFF
--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -364,7 +364,7 @@ class Liquidator {
     }
 
     // In legacy versions of the EMP, withdrawing needs to be done by a party involved in the liquidation (i.e liquidator,
-    // sponsor or disputer).As the liquidator is the DSProxy, we would require the ability to send the withdrawal tx
+    // sponsor or disputer). As the liquidator is the DSProxy, we would require the ability to send the withdrawal tx
     // directly from the DSProxy to facilitate this.This functionality is not implemented as almost all legacy EMPs expired.
     if (
       this.proxyTransactionWrapper?.useDsProxyToLiquidate &&

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -342,6 +342,17 @@ class Liquidator {
       message: "Checking for expired and disputed liquidations to withdraw rewards from"
     });
 
+    // In legacy versions of the EMP, withdrawing needs to be done by a party involved in the liquidation (i.e liquidator,
+    // sponsor or disputer).As the liquidator is the DSProxy, we would require the ability to send the withdrawal tx
+    // directly from the DSProxy to facilitate this.This functionality is not implemented as almost all legacy EMPs expired.
+    if (this.proxyTransactionWrapper?.useDsProxyToLiquidate && this.isLegacyEmpVersion) {
+      this.logger.warn({
+        at: "Liquidator",
+        message: "Attempting to withdraw liquidation from a legacy EMP🙈",
+        details: "This is not supported on legacy with a DSProxy! Please manually withdraw the liquidation"
+      });
+      return;
+    }
     // All of the liquidations that we could withdraw rewards from are drawn from the pool of
     // expired and disputed liquidations.
     const expiredLiquidations = this.financialContractClient.getExpiredLiquidations();
@@ -359,22 +370,6 @@ class Liquidator {
       this.logger.debug({
         at: "Liquidator",
         message: "No withdrawable liquidations"
-      });
-      return;
-    }
-
-    // In legacy versions of the EMP, withdrawing needs to be done by a party involved in the liquidation (i.e liquidator,
-    // sponsor or disputer). As the liquidator is the DSProxy, we would require the ability to send the withdrawal tx
-    // directly from the DSProxy to facilitate this.This functionality is not implemented as almost all legacy EMPs expired.
-    if (
-      this.proxyTransactionWrapper?.useDsProxyToLiquidate &&
-      this.isLegacyEmpVersion &&
-      potentialWithdrawableLiquidations.length > 0
-    ) {
-      this.logger.warn({
-        at: "Liquidator",
-        message: "Attempting to withdraw liquidation from a legacy EMP🙈",
-        details: "This is not supported on legacy with a DSProxy! Please manually withdraw the liquidation"
       });
       return;
     }

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -342,17 +342,6 @@ class Liquidator {
       message: "Checking for expired and disputed liquidations to withdraw rewards from"
     });
 
-    // In legacy versions of the EMP, withdrawing needs to be done by a party involved in the liquidation (i.e liquidator,
-    // sponsor or disputer).As the liquidator is the DSProxy, we would require the ability to send the withdrawal tx
-    // directly from the DSProxy to facilitate this.This functionality is not implemented as almost all legacy EMPs expired.
-    if (this.proxyTransactionWrapper?.useDsProxyToLiquidate && this.isLegacyEmpVersion) {
-      this.logger.warn({
-        at: "Liquidator",
-        message: "Attempting to withdraw liquidation from a legacy EMP🙈",
-        details: "This is not supported on legacy with a DSProxy! Please manually withdraw the liquidation"
-      });
-      return;
-    }
     // All of the liquidations that we could withdraw rewards from are drawn from the pool of
     // expired and disputed liquidations.
     const expiredLiquidations = this.financialContractClient.getExpiredLiquidations();
@@ -370,6 +359,22 @@ class Liquidator {
       this.logger.debug({
         at: "Liquidator",
         message: "No withdrawable liquidations"
+      });
+      return;
+    }
+
+    // In legacy versions of the EMP, withdrawing needs to be done by a party involved in the liquidation (i.e liquidator,
+    // sponsor or disputer).As the liquidator is the DSProxy, we would require the ability to send the withdrawal tx
+    // directly from the DSProxy to facilitate this.This functionality is not implemented as almost all legacy EMPs expired.
+    if (
+      this.proxyTransactionWrapper?.useDsProxyToLiquidate &&
+      this.isLegacyEmpVersion &&
+      potentialWithdrawableLiquidations.length > 0
+    ) {
+      this.logger.warn({
+        at: "Liquidator",
+        message: "Attempting to withdraw liquidation from a legacy EMP🙈",
+        details: "This is not supported on legacy with a DSProxy! Please manually withdraw the liquidation"
       });
       return;
     }

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -47,6 +47,7 @@ class ProxyTransactionWrapper {
     // Helper functions from web3.
     this.toBN = this.web3.utils.toBN;
     this.toWei = this.web3.utils.toWei;
+    this.toChecksumAddress = this.web3.utils.toChecksumAddress;
 
     this.useDsProxyToLiquidate = useDsProxyToLiquidate;
 
@@ -117,43 +118,45 @@ class ProxyTransactionWrapper {
   // then consider the synthetics could be minted, + any synthetics the DSProxy already has.
   async getEffectiveSyntheticTokenBalance() {
     const syntheticTokenBalance = await this.syntheticToken.methods.balanceOf(this.account).call();
+    // If using the DSProxy to liquidate then return the current synthetic token balance.
     if (!this.useDsProxyToLiquidate) return syntheticTokenBalance;
     else {
-      // Instantiate uniswap factory to fetch the pair address.
-      const uniswapFactory = await this.createContractObjectFromJson(UniswapV2Factory).at(this.uniswapFactoryAddress);
-
-      const pairAddress = await uniswapFactory.getPair(this.reserveToken._address, this.collateralToken._address);
-      const uniswapPair = await this.createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
-
-      // We can now fetch the reserves. At the same time, we can batch a few other required async calls.
-      const [
-        reserves,
-        token0,
-        contractPFC,
-        contractTokensOutstanding,
-        reserveTokenBalance,
-        collateralTokenBalance
-      ] = await Promise.all([
-        uniswapPair.getReserves(),
-        uniswapPair.token0(),
+      // Else, if using the DSProxy to liquidate we need to work out the effective balance.
+      const [contractPFC, contractTokensOutstanding, reserveTokenBalance, collateralTokenBalance] = await Promise.all([
         this.financialContract.methods.pfc().call(),
         this.financialContract.methods.totalTokensOutstanding().call(),
         this.reserveToken.methods.balanceOf(this.dsProxyManager.getDSProxyAddress()).call(),
         this.collateralToken.methods.balanceOf(this.dsProxyManager.getDSProxyAddress()).call()
       ]);
+      let maxPurchasableCollateral; // set to the reserve token balance ( if reserve==collateral) or the max purchasable.
 
-      // Detect if the reserve currency is token0 or 1. This informs the order in the following computation.
-      const reserveToken0 = token0 == this.reserveToken._address;
+      // If the reserve currency is the collateral currency then there is no trading needed.
+      if (this.toChecksumAddress(this.reserveToken._address) === this.toChecksumAddress(this.collateralToken._address))
+        maxPurchasableCollateral = reserveTokenBalance;
+      // Else, work out how much collateral could be purchased using all the reserve currency.
+      else {
+        // Instantiate uniswap factory to fetch the pair address.
+        const uniswapFactory = await this.createContractObjectFromJson(UniswapV2Factory).at(this.uniswapFactoryAddress);
 
-      const reserveIn = reserveToken0 ? reserves.reserve0 : reserves.reserve1;
-      const reserveOut = !reserveToken0 ? reserves.reserve0 : reserves.reserve1;
+        const pairAddress = await uniswapFactory.getPair(this.reserveToken._address, this.collateralToken._address);
+        const uniswapPair = await this.createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
 
-      // Compute the maximum amount of collateral that can be purchased with all reserve currency.
-      const amountInWithFee = this.toBN(reserveTokenBalance).muln(997);
-      const numerator = amountInWithFee.mul(reserveOut);
-      const denominator = reserveIn.muln(1000).add(amountInWithFee);
+        // We can now fetch the reserves. At the same time, we can batch a few other required async calls.
+        const [reserves, token0] = await Promise.all([uniswapPair.getReserves(), uniswapPair.token0()]);
 
-      const maxPurchasableCollateral = numerator.div(denominator);
+        // Detect if the reserve currency is token0 or 1. This informs the order in the following computation.
+        const reserveToken0 = token0 == this.reserveToken._address;
+
+        const reserveIn = reserveToken0 ? reserves.reserve0 : reserves.reserve1;
+        const reserveOut = !reserveToken0 ? reserves.reserve0 : reserves.reserve1;
+
+        // Compute the maximum amount of collateral that can be purchased with all reserve currency.
+        const amountInWithFee = this.toBN(reserveTokenBalance).muln(997);
+        const numerator = amountInWithFee.mul(reserveOut);
+        const denominator = reserveIn.muln(1000).add(amountInWithFee);
+
+        maxPurchasableCollateral = numerator.div(denominator);
+      }
 
       // Compute how many synthetics could be minted, given the collateral we can buy with the reserve currency.
       const gcr = this.toBN(contractPFC.rawValue)

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -35,9 +35,9 @@ const { assert } = require("chai");
 // 2) non-matching 8 collateral & 18 synthetic for legacy UMA synthetics.
 // 3) matching 8 collateral & 8 synthetic for current UMA synthetics.
 const configs = [
-  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 }
-  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
-  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
+  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 },
+  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
+  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
 ];
 
 let iterationTestVersion; // store the test version between tests that is currently being tested.

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -35,9 +35,9 @@ const { assert } = require("chai");
 // 2) non-matching 8 collateral & 18 synthetic for legacy UMA synthetics.
 // 3) matching 8 collateral & 8 synthetic for current UMA synthetics.
 const configs = [
-  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 },
-  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
-  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
+  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 }
+  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
+  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
 ];
 
 let iterationTestVersion; // store the test version between tests that is currently being tested.
@@ -2004,7 +2004,6 @@ contract("Liquidator.js", function(accounts) {
 
                 // Liquidator should have their collateral increased by Sponsor1 + sponsor2 collateral.
                 const collateralPostWithdraw = await collateralToken.balanceOf(dsProxy.address);
-                console.log("collateralPostWithdraw", collateralPostWithdraw.toString());
                 assert.equal(
                   toBN(collateralPreWithdraw)
                     .add(toBN(convertCollateral("125")))
@@ -2025,7 +2024,88 @@ contract("Liquidator.js", function(accounts) {
               }
             }
           );
+          versionedIt([{ contractType: "any", contractVersion: "any" }])(
+            "Correctly deals with reserve being the same as collateral currency using DSProxy",
+            async function() {
+              // create a new liquidator and set the reserve currency to the collateral currency.
+              const liquidator = new Liquidator({
+                logger: spyLogger,
+                financialContractClient: financialContractClient,
+                proxyTransactionWrapper,
+                gasEstimator,
+                syntheticToken: syntheticToken.contract,
+                priceFeed: priceFeedMock,
+                account: accounts[0],
+                financialContractProps,
+                liquidatorConfig: {
+                  ...liquidatorConfig,
+                  proxyTransactionWrapperConfig: {
+                    useDsProxyToLiquidate: true,
+                    uniswapRouterAddress: uniswapRouter.address,
+                    uniswapFactoryAddress: uniswapFactory.address,
+                    liquidatorReserveCurrencyAddress: collateralToken.address
+                  }
+                }
+              });
+              await financialContract.create(
+                { rawValue: convertCollateral("120") },
+                { rawValue: convertSynthetic("100") },
+                { from: sponsor1 }
+              );
+              await financialContract.create(
+                { rawValue: convertCollateral("175") },
+                { rawValue: convertSynthetic("100") },
+                { from: sponsor2 }
+              );
+              // Seed the DSProxy with some collateral tokens (this is the same as the reserve token).
+              await collateralToken.mint(dsProxy.address, convertCollateral("150"), { from: contractCreator });
 
+              // Liquidator should correctly liquidate both positions and have done no trades in the process as it
+              // used the reserve as collateral. Assume the price feed given to the liquidator has moved such one of the
+              // two positions are undercollateralized.
+              // Sponsor1: 100 * 1.3 * 1.2 > 125 [undercollateralized]
+              // Sponsor2: 100 * 1.3 * 1.2 < 175 [sufficiently collateralized]
+
+              priceFeedMock.setCurrentPrice(convertPrice("1.3"));
+              await liquidator.update();
+              await liquidator.liquidatePositions();
+              assert.equal(spy.callCount, 3); // 3 info level events should be sent at the conclusion of the 1 liquidations.
+              // 1 for the deployment of the DSProxy, 1 for the execution of the DSPRoxy ta and 1 for the liquidation.
+
+              // Sponsor1 should be in a liquidation state with the bot as the liquidator.
+              let liquidationObject = (await financialContract.getLiquidations(sponsor1))[0];
+              assert.equal(liquidationObject.sponsor, sponsor1);
+              assert.equal(liquidationObject.liquidator, dsProxy.address);
+              assert.equal(liquidationObject.state, LiquidationStatesEnum.PRE_DISPUTE);
+              assert.equal(liquidationObject.liquidatedCollateral, convertCollateral("120"));
+
+              // Sponsor1 should have zero collateral left in their position from the liquidation.
+              assert.equal((await financialContract.getCollateral(sponsor1)).rawValue, 0);
+
+              // Sponsor2 should not have any liquidations and should have all their collateral.
+              assert.deepStrictEqual(await financialContract.getLiquidations(sponsor2), []);
+              assert.equal((await financialContract.getCollateral(sponsor2)).rawValue, convertCollateral("175"));
+
+              // Next, try another liquidation. This time around the bot does not have enough collateral to mint enough
+              // to liquidate the min sponsor size. The bot should correctly report this without generating any errors
+              // or throwing any txs.
+
+              priceFeedMock.setCurrentPrice(convertPrice("2"));
+              await liquidator.update();
+              await liquidator.liquidatePositions();
+
+              liquidationObject = (await financialContract.getLiquidations(sponsor2))[0];
+              assert.equal(liquidationObject.sponsor, sponsor2);
+              assert.equal(liquidationObject.liquidator, dsProxy.address);
+              assert.equal(liquidationObject.state, LiquidationStatesEnum.PRE_DISPUTE);
+
+              assert.equal(spy.callCount, 7);
+              assert.isTrue(spyLogIncludes(spy, 3, "Submitting a partial liquidation"));
+              assert.isTrue(spyLogIncludes(spy, 4, "Executed function on a freshly deployed library"));
+              assert.isTrue(spyLogIncludes(spy, 5, "Position has been liquidated"));
+              assert.isTrue(spyLogIncludes(spy, 6, "Insufficient balance to liquidate the minimum sponsor size"));
+            }
+          );
           versionedIt([{ contractType: "any", contractVersion: "any" }])(
             "Correctly respects existing collateral balances when using DSProxy",
             async function() {
@@ -2185,7 +2265,6 @@ contract("Liquidator.js", function(accounts) {
               assert.equal(sponsor2Liquidations.length, 3);
               // The liquidator at this point should have spent all its DSProxy funds. Note we check that this is less
               // than 10 wei as there could be a tiny bit of dust left due to rounding.
-              console.log("B", (await reserveToken.balanceOf(dsProxy.address)).toString());
               assert.isTrue((await reserveToken.balanceOf(dsProxy.address)).lt(toBN(toWei("0.000001"))));
             }
           );


### PR DESCRIPTION
**Motivation**

Previously, if the liquidator's reserve currency was equal to the collateral currency an error was thrown that looked like this:

![image](https://user-images.githubusercontent.com/12886084/115420032-1cfae500-a1fb-11eb-886f-53eeec683fea.png)


This occurred within the `getEffectiveSyntheticTokenBalance` method in the `proxyTransactionWrapper` when trying to compute how much collateral could be purchased using the reserve currency.

This error occurred as there is no uniswap exchange between two tokens of the same type.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Details**

To address this, this PR adds a small bit of branching logic to skip the trading computation in the case of a collateral and reserve match. Tests were also added to verify this behavior, including the case when all collateral is spent.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
