### PR TITLE
fix(lerna): add yarn network timeout to help slow build processes

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 300000


### PR DESCRIPTION
**Motivation**

Docker hub has been failing with some builds due to timeouts. See screenshot below:
![image](https://user-images.githubusercontent.com/12886084/115508996-37c26d80-a27e-11eb-8d20-11db6acb21d4.png)


This PR adds a 5 min timeout delay to the yarn process which should hopefully help with this issue. It's not a guaranteed fix though. Curious to hear from @UMAprotocol/eng if you see any better solutions.