### PR TITLE
fix(ReserveCurrencyLiquidator): improve how the contract handles reserve OR collateral currency shortfall

### DIFF
--- a/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
+++ b/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
@@ -28,7 +28,7 @@ contract ReserveCurrencyLiquidator {
      * @dev Any synthetics & collateral that the DSProxy already has are considered in the amount swapped and minted.
      * These existing tokens will be used first before any swaps or mints are done.
      * @dev If there is a token shortfall (either from not enough reserve to buy sufficient collateral or not enough
-     * collateral to begins with or due to slippage) the script will liquidate as much as posable given the reserves.
+     * collateral to begins with or due to slippage) the script will liquidate as much as possible given the reserves.
      * @param uniswapRouter address of the uniswap router used to facilitate trades.
      * @param financialContract address of the financial contract on which the liquidation is occurring.
      * @param reserveCurrency address of the token to swap for collateral. THis is the common currency held by the DSProxy.

--- a/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
+++ b/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
@@ -27,6 +27,8 @@ contract ReserveCurrencyLiquidator {
      * passed liveness. At this point the position can be manually unwound.
      * @dev Any synthetics & collateral that the DSProxy already has are considered in the amount swapped and minted.
      * These existing tokens will be used first before any swaps or mints are done.
+     * @dev If there is a token shortfall (either from not enough reserve to buy sufficient collateral or not enough
+     * collateral to begins with or due to slippage) the script will liquidate as much as posable given the reserves.
      * @param uniswapRouter address of the uniswap router used to facilitate trades.
      * @param financialContract address of the financial contract on which the liquidation is occurring.
      * @param reserveCurrency address of the token to swap for collateral. THis is the common currency held by the DSProxy.

--- a/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
+++ b/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
@@ -54,8 +54,7 @@ contract ReserveCurrencyLiquidator {
 
         // 1. Calculate the token shortfall. This is the synthetics to liquidate minus any synthetics the DSProxy already
         // has. If this number is negative(balance large than synthetics to liquidate) the return 0 (no shortfall).
-        FixedPoint.Unsigned memory tokenShortfall =
-            subOrZero(maxTokensToLiquidate, FixedPoint.Unsigned(IERC20(fc.tokenCurrency()).balanceOf(address(this))));
+        FixedPoint.Unsigned memory tokenShortfall = subOrZero(maxTokensToLiquidate, getSyntheticBalance(fc));
 
         // 2. Calculate how much collateral is needed to make up the token shortfall from minting new synthetics.
         FixedPoint.Unsigned memory gcr = fc.pfc().divCeil(fc.totalTokensOutstanding());
@@ -63,18 +62,13 @@ contract ReserveCurrencyLiquidator {
 
         // 3. Calculate the total collateral required. This considers the final fee for the given collateral type + any
         // collateral needed to mint the token short fall.
-        FixedPoint.Unsigned memory totalCollateralRequired =
-            IStore(IFinder(fc.finder()).getImplementationAddress("Store")).computeFinalFee(fc.collateralCurrency()).add(
-                collateralToMintShortfall
-            );
+
+        FixedPoint.Unsigned memory totalCollateralRequired = getFinalFee(fc).add(collateralToMintShortfall);
 
         // 4.a. Calculate how much collateral needs to be purchased. If the DSProxy already has some collateral then this
         // will factor this in. If the DSProxy has more collateral than the total amount required the purchased = 0.
         FixedPoint.Unsigned memory collateralToBePurchased =
-            subOrZero(
-                totalCollateralRequired,
-                FixedPoint.Unsigned(IERC20(fc.collateralCurrency()).balanceOf(address(this)))
-            );
+            subOrZero(totalCollateralRequired, getCollateralBalance(fc));
 
         // 4.b. If there is some collateral to be purchased, execute a trade on uniswap to meet the shortfall.
         // Note the path assumes a direct route from the reserve currency to the collateral currency.
@@ -97,16 +91,10 @@ contract ReserveCurrencyLiquidator {
         // 4.c. If at this point we were not able to get the required amount of collateral (due to insufficient reserve
         // or not enough collateral in the contract) the script should try to liquidate as much as it can regardless.
         // Update the values of total collateral to the current collateral balance and re-compute the tokenShortfall
-        // as the maximum tokens that could be liquidated.
-        if (
-            totalCollateralRequired.isGreaterThan(
-                FixedPoint.Unsigned(IERC20(fc.collateralCurrency()).balanceOf(address(this)))
-            )
-        ) {
-            totalCollateralRequired = FixedPoint.Unsigned(IERC20(fc.collateralCurrency()).balanceOf(address(this)));
-            collateralToMintShortfall = totalCollateralRequired.sub(
-                IStore(IFinder(fc.finder()).getImplementationAddress("Store")).computeFinalFee(fc.collateralCurrency())
-            );
+        // as the maximum tokens that could be liquidated at the current GCR.
+        if (totalCollateralRequired.isGreaterThan(getCollateralBalance(fc))) {
+            totalCollateralRequired = getCollateralBalance(fc);
+            collateralToMintShortfall = totalCollateralRequired.sub(getFinalFee(fc));
             tokenShortfall = collateralToMintShortfall.divCeil(gcr);
         }
         // 5. Mint the shortfall synthetics with collateral. Note we are minting at the GCR.
@@ -118,9 +106,7 @@ contract ReserveCurrencyLiquidator {
         // The liquidatableTokens is either the maxTokensToLiquidate (if we were able to buy/mint enough) or the full
         // token token balance at this point if there was a shortfall.
         FixedPoint.Unsigned memory liquidatableTokens = maxTokensToLiquidate;
-        if (
-            maxTokensToLiquidate.isGreaterThan(FixedPoint.Unsigned(IERC20(fc.tokenCurrency()).balanceOf(address(this))))
-        ) liquidatableTokens = FixedPoint.Unsigned(IERC20(fc.tokenCurrency()).balanceOf(address(this)));
+        if (maxTokensToLiquidate.isGreaterThan(getSyntheticBalance(fc))) liquidatableTokens = getSyntheticBalance(fc);
 
         // 6. Liquidate position with newly minted synthetics.
         TransferHelper.safeApprove(fc.tokenCurrency(), address(fc), liquidatableTokens.rawValue);
@@ -140,6 +126,21 @@ contract ReserveCurrencyLiquidator {
         returns (FixedPoint.Unsigned memory)
     {
         return b.isGreaterThanOrEqual(a) ? FixedPoint.fromUnscaledUint(0) : a.sub(b);
+    }
+
+    // Helper method to return the current final fee for a given financial contract instance.
+    function getFinalFee(IFinancialContract fc) internal returns (FixedPoint.Unsigned memory) {
+        return IStore(IFinder(fc.finder()).getImplementationAddress("Store")).computeFinalFee(fc.collateralCurrency());
+    }
+
+    // Helper method to return the collateral balance of this contract.
+    function getCollateralBalance(IFinancialContract fc) internal returns (FixedPoint.Unsigned memory) {
+        return FixedPoint.Unsigned(IERC20(fc.collateralCurrency()).balanceOf(address(this)));
+    }
+
+    // Helper method to return the synthetic balance of this contract.
+    function getSyntheticBalance(IFinancialContract fc) internal returns (FixedPoint.Unsigned memory) {
+        return FixedPoint.Unsigned(IERC20(fc.tokenCurrency()).balanceOf(address(this)));
     }
 }
 

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -128,11 +128,11 @@ class ProxyTransactionWrapper {
         this.reserveToken.methods.balanceOf(this.dsProxyManager.getDSProxyAddress()).call(),
         this.collateralToken.methods.balanceOf(this.dsProxyManager.getDSProxyAddress()).call()
       ]);
-      let maxPurchasableCollateral = this.toBN("0"); // set to the reserve token balance (if reserve==collateral) or the max purchasable.
+      let maxPurchasableCollateral; // set to the reserve token balance ( if reserve==collateral) or the max purchasable.
 
       // If the reserve currency is the collateral currency then there is no trading needed.
       if (this.toChecksumAddress(this.reserveToken._address) === this.toChecksumAddress(this.collateralToken._address))
-        maxPurchasableCollateral = this.toBN(reserveTokenBalance);
+        maxPurchasableCollateral = reserveTokenBalance;
       // Else, work out how much collateral could be purchased using all the reserve currency.
       else {
         // Instantiate uniswap factory to fetch the pair address.

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -36,7 +36,6 @@ class ProxyTransactionWrapper {
     useDsProxyToLiquidate = false,
     proxyTransactionWrapperConfig
   }) {
-    console.log("proxyTransactionWrapperConfig", proxyTransactionWrapperConfig);
     this.web3 = web3;
     this.financialContract = financialContract;
     this.gasEstimator = gasEstimator;
@@ -102,8 +101,7 @@ class ProxyTransactionWrapper {
         "Must provide a reserve currency address to use the proxy transaction wrapper!"
       );
     }
-    console.log("liquidatorReserveCurrencyAddress", this.liquidatorReserveCurrencyAddress);
-    console.log("collateralTOken", this.collateralToken._address);
+
     this.reserveToken = new this.web3.eth.Contract(getAbi("ExpandedERC20"), this.liquidatorReserveCurrencyAddress);
     this.ReserveCurrencyLiquidator = getTruffleContract("ReserveCurrencyLiquidator", this.web3, "latest");
   }

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -36,6 +36,7 @@ class ProxyTransactionWrapper {
     useDsProxyToLiquidate = false,
     proxyTransactionWrapperConfig
   }) {
+    console.log("proxyTransactionWrapperConfig", proxyTransactionWrapperConfig);
     this.web3 = web3;
     this.financialContract = financialContract;
     this.gasEstimator = gasEstimator;
@@ -101,7 +102,8 @@ class ProxyTransactionWrapper {
         "Must provide a reserve currency address to use the proxy transaction wrapper!"
       );
     }
-
+    console.log("liquidatorReserveCurrencyAddress", this.liquidatorReserveCurrencyAddress);
+    console.log("collateralTOken", this.collateralToken._address);
     this.reserveToken = new this.web3.eth.Contract(getAbi("ExpandedERC20"), this.liquidatorReserveCurrencyAddress);
     this.ReserveCurrencyLiquidator = getTruffleContract("ReserveCurrencyLiquidator", this.web3, "latest");
   }
@@ -128,11 +130,11 @@ class ProxyTransactionWrapper {
         this.reserveToken.methods.balanceOf(this.dsProxyManager.getDSProxyAddress()).call(),
         this.collateralToken.methods.balanceOf(this.dsProxyManager.getDSProxyAddress()).call()
       ]);
-      let maxPurchasableCollateral; // set to the reserve token balance ( if reserve==collateral) or the max purchasable.
+      let maxPurchasableCollateral = this.toBN("0"); // set to the reserve token balance (if reserve==collateral) or the max purchasable.
 
       // If the reserve currency is the collateral currency then there is no trading needed.
       if (this.toChecksumAddress(this.reserveToken._address) === this.toChecksumAddress(this.collateralToken._address))
-        maxPurchasableCollateral = reserveTokenBalance;
+        maxPurchasableCollateral = this.toBN(reserveTokenBalance);
       // Else, work out how much collateral could be purchased using all the reserve currency.
       else {
         // Instantiate uniswap factory to fetch the pair address.

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -35,9 +35,9 @@ const { assert } = require("chai");
 // 2) non-matching 8 collateral & 18 synthetic for legacy UMA synthetics.
 // 3) matching 8 collateral & 8 synthetic for current UMA synthetics.
 const configs = [
-  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 }
-  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
-  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
+  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 },
+  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
+  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
 ];
 
 let iterationTestVersion; // store the test version between tests that is currently being tested.
@@ -1892,7 +1892,7 @@ contract("Liquidator.js", function(accounts) {
               });
             }
           );
-          versionedIt([{ contractType: "any", contractVersion: "any" }], true)(
+          versionedIt([{ contractType: "any", contractVersion: "any" }])(
             "Correctly liquidates positions using DSProxy",
             async function() {
               // sponsor1 creates a position with 125 units of collateral, creating 100 synthetic tokens.
@@ -2024,25 +2024,10 @@ contract("Liquidator.js", function(accounts) {
               }
             }
           );
-          versionedIt([{ contractType: "any", contractVersion: "any" }], true)(
+          versionedIt([{ contractType: "any", contractVersion: "any" }])(
             "Correctly deals with reserve being the same as collateral currency using DSProxy",
             async function() {
               // create a new liquidator and set the reserve currency to the collateral currency.
-              console.log("CONF", {
-                ...liquidatorConfig,
-                proxyTransactionWrapperConfig: {
-                  useDsProxyToLiquidate: true,
-                  uniswapRouterAddress: uniswapRouter.address,
-                  uniswapFactoryAddress: uniswapFactory.address,
-                  liquidatorReserveCurrencyAddress: await financialContract.collateralCurrency()
-                }
-              });
-              console.log("EMP in client", financialContractClient.financialContractAddress);
-              console.log("EMP address used in tests", financialContract.address);
-              console.log("await financialContract.collateralCurrency()", await financialContract.collateralCurrency());
-              console.log("collateral address", collateralToken.address);
-
-              // set the reserve currency to the collateral currency
               const proxyTransactionWrapper = new ProxyTransactionWrapper({
                 web3,
                 financialContract: financialContract.contract,
@@ -2113,7 +2098,6 @@ contract("Liquidator.js", function(accounts) {
               // to liquidate the min sponsor size. The bot should correctly report this without generating any errors
               // or throwing any txs.
 
-              console.log("COLLATERAL BEFORE STEP 2", (await collateralToken.balanceOf(dsProxy.address)).toString());
               priceFeedMock.setCurrentPrice(convertPrice("2"));
               await liquidator.update();
               await liquidator.liquidatePositions();
@@ -2128,7 +2112,6 @@ contract("Liquidator.js", function(accounts) {
               assert.isTrue(spyLogIncludes(spy, 4, "Executed function on a freshly deployed library"));
               assert.isTrue(spyLogIncludes(spy, 5, "Position has been liquidated"));
               assert.isTrue(spyLogIncludes(spy, 6, "Insufficient balance to liquidate the minimum sponsor size"));
-              console.log("COLLATERAL After STEP 2", (await collateralToken.balanceOf(dsProxy.address)).toString());
             }
           );
           versionedIt([{ contractType: "any", contractVersion: "any" }])(

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -35,9 +35,9 @@ const { assert } = require("chai");
 // 2) non-matching 8 collateral & 18 synthetic for legacy UMA synthetics.
 // 3) matching 8 collateral & 8 synthetic for current UMA synthetics.
 const configs = [
-  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 },
-  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
-  { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
+  { tokenSymbol: "WETH", collateralDecimals: 18, syntheticDecimals: 18, priceFeedDecimals: 18 }
+  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 18, priceFeedDecimals: 8 },
+  // { tokenSymbol: "BTC", collateralDecimals: 8, syntheticDecimals: 8, priceFeedDecimals: 18 }
 ];
 
 let iterationTestVersion; // store the test version between tests that is currently being tested.
@@ -1892,7 +1892,7 @@ contract("Liquidator.js", function(accounts) {
               });
             }
           );
-          versionedIt([{ contractType: "any", contractVersion: "any" }])(
+          versionedIt([{ contractType: "any", contractVersion: "any" }], true)(
             "Correctly liquidates positions using DSProxy",
             async function() {
               // sponsor1 creates a position with 125 units of collateral, creating 100 synthetic tokens.
@@ -2024,10 +2024,41 @@ contract("Liquidator.js", function(accounts) {
               }
             }
           );
-          versionedIt([{ contractType: "any", contractVersion: "any" }])(
+          versionedIt([{ contractType: "any", contractVersion: "any" }], true)(
             "Correctly deals with reserve being the same as collateral currency using DSProxy",
             async function() {
               // create a new liquidator and set the reserve currency to the collateral currency.
+              console.log("CONF", {
+                ...liquidatorConfig,
+                proxyTransactionWrapperConfig: {
+                  useDsProxyToLiquidate: true,
+                  uniswapRouterAddress: uniswapRouter.address,
+                  uniswapFactoryAddress: uniswapFactory.address,
+                  liquidatorReserveCurrencyAddress: await financialContract.collateralCurrency()
+                }
+              });
+              console.log("EMP in client", financialContractClient.financialContractAddress);
+              console.log("EMP address used in tests", financialContract.address);
+              console.log("await financialContract.collateralCurrency()", await financialContract.collateralCurrency());
+              console.log("collateral address", collateralToken.address);
+
+              // set the reserve currency to the collateral currency
+              const proxyTransactionWrapper = new ProxyTransactionWrapper({
+                web3,
+                financialContract: financialContract.contract,
+                gasEstimator,
+                syntheticToken: syntheticToken.contract,
+                collateralToken: collateralToken.contract,
+                account: accounts[0],
+                dsProxyManager,
+                proxyTransactionWrapperConfig: {
+                  useDsProxyToLiquidate: true,
+                  uniswapRouterAddress: uniswapRouter.address,
+                  uniswapFactoryAddress: uniswapFactory.address,
+                  liquidatorReserveCurrencyAddress: await financialContract.collateralCurrency()
+                }
+              });
+
               const liquidator = new Liquidator({
                 logger: spyLogger,
                 financialContractClient: financialContractClient,
@@ -2037,15 +2068,7 @@ contract("Liquidator.js", function(accounts) {
                 priceFeed: priceFeedMock,
                 account: accounts[0],
                 financialContractProps,
-                liquidatorConfig: {
-                  ...liquidatorConfig,
-                  proxyTransactionWrapperConfig: {
-                    useDsProxyToLiquidate: true,
-                    uniswapRouterAddress: uniswapRouter.address,
-                    uniswapFactoryAddress: uniswapFactory.address,
-                    liquidatorReserveCurrencyAddress: collateralToken.address
-                  }
-                }
+                liquidatorConfig
               });
               await financialContract.create(
                 { rawValue: convertCollateral("120") },
@@ -2090,6 +2113,7 @@ contract("Liquidator.js", function(accounts) {
               // to liquidate the min sponsor size. The bot should correctly report this without generating any errors
               // or throwing any txs.
 
+              console.log("COLLATERAL BEFORE STEP 2", (await collateralToken.balanceOf(dsProxy.address)).toString());
               priceFeedMock.setCurrentPrice(convertPrice("2"));
               await liquidator.update();
               await liquidator.liquidatePositions();
@@ -2104,6 +2128,7 @@ contract("Liquidator.js", function(accounts) {
               assert.isTrue(spyLogIncludes(spy, 4, "Executed function on a freshly deployed library"));
               assert.isTrue(spyLogIncludes(spy, 5, "Position has been liquidated"));
               assert.isTrue(spyLogIncludes(spy, 6, "Insufficient balance to liquidate the minimum sponsor size"));
+              console.log("COLLATERAL After STEP 2", (await collateralToken.balanceOf(dsProxy.address)).toString());
             }
           );
           versionedIt([{ contractType: "any", contractVersion: "any" }])(


### PR DESCRIPTION
**Motivation**

After testing out some more edge cases with the `ReserveCurrencyLiquidator` I realized there is a scenario that the contracts were not designed to handle and were not tested against. In particular what happens when the `ReserveCurrencyLiquidator` is told to liquidate a position that is larger than the sum of all reserve and collateral currency the DSProxy has access to? 


In the previous implementation, the transaction would revert. After this PR the DSProxy will liquidate as much as it can, using all reserves in the process.

**Summary**

Added extra logic and unit tests to the `ReserveCurrencyLiquidator` to accommodate a token shortfall.


**Details**

In addition to the make changes done in this PR I also refactored `ReserveCurrencyLiquidator` a small amount by pulling out common logic into some functions that can be re-used.

I also realized that the tests that were meant to test this within the `Liquidator` Tests were wrong. After this PR this has been addressed.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
