### PR TITLE
fix(financial-templates-lib): add rounding to the funding rate price identifier

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -859,7 +859,7 @@ const defaultConfigs = {
     type: "expression",
     expression: `
         ETHBTC_FV = ETH\\/BTC * PERP_FRM;
-        max(-0.00001, min(0.00001, (ETHBTC_FV - ETHBTC_PERP) / ETHBTC_FV / 86400))
+        round(max(-0.00001, min(0.00001, (ETHBTC_FV - ETHBTC_PERP) / ETHBTC_FV / 86400)), 9)
     `,
     lookback: 7200,
     minTimeBetweenUpdates: 60,


### PR DESCRIPTION
**Motivation**

To make sure all bots do the same rounding on the funding rate identifier, and that the identifier implementation matches the UMIP, we need to add rounding to the identifier, itself.

**Summary**

Add round(..., 9) to the outermost operation in the expression.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
