### PR TITLE
feat(serverless): make spoke stream stdout and stderr to parent

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -82,12 +82,18 @@ spoke.post("/", async (req, res) => {
 
 function _execShellCommand(cmd, inputEnv) {
   return new Promise(resolve => {
-    exec(cmd, { env: { ...process.env, ...inputEnv, stdio: "inherit", shell: true } }, (error, stdout, stderr) => {
-      // The output from the process execution contains a punctuation marks and escape chars that should be stripped.
-      stdout = _stripExecStdout(stdout);
-      stderr = _stripExecStdError(stderr);
-      resolve({ error, stdout, stderr });
-    });
+    const { stdout, stderr } = exec(
+      cmd,
+      { env: { ...process.env, ...inputEnv }, stdio: "inherit" },
+      (error, stdout, stderr) => {
+        // The output from the process execution contains a punctuation marks and escape chars that should be stripped.
+        stdout = _stripExecStdout(stdout);
+        stderr = _stripExecStdError(stderr);
+        resolve({ error, stdout, stderr });
+      }
+    );
+    stdout.pipe(process.stdout);
+    stderr.pipe(process.stderr);
   });
 }
 


### PR DESCRIPTION
**Motivation**

Hanging or timeout processes are very difficult to debug if you can't track progress within the child process.

**Summary**

Adds a simple few lines that will tell the child process to stream its output to the parent's output streams. No changes to existing logs.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
