### PR TITLE
feat(common): add retry provider

### DIFF
--- a/packages/common/browser.js
+++ b/packages/common/browser.js
@@ -12,6 +12,7 @@ module.exports = {
   ...require("./src/ObjectUtils"),
   ...require("./src/PublicNetworks"),
   ...require("./src/Random"),
+  ...require("./src/RetryProvider"),
   ...require("./src/SolcoverConfig"),
   ...require("./src/SolidityTestUtils"),
   ...require("./src/TimeUtils"),

--- a/packages/common/browser.js
+++ b/packages/common/browser.js
@@ -12,7 +12,6 @@ module.exports = {
   ...require("./src/ObjectUtils"),
   ...require("./src/PublicNetworks"),
   ...require("./src/Random"),
-  ...require("./src/RetryProvider"),
   ...require("./src/SolcoverConfig"),
   ...require("./src/SolidityTestUtils"),
   ...require("./src/TimeUtils"),

--- a/packages/common/index.js
+++ b/packages/common/index.js
@@ -8,7 +8,8 @@ const browserUnsafe = {
   ...require("./src/MigrationUtils"),
   ...require("./src/TruffleConfig"),
   ...require("./src/ProviderUtils"),
-  ...require("./src/HardhatConfig")
+  ...require("./src/HardhatConfig"),
+  ...require("./src/RetryProvider")
 };
 
 module.exports = {

--- a/packages/common/src/ProviderUtils.js
+++ b/packages/common/src/ProviderUtils.js
@@ -6,42 +6,53 @@ const Web3 = require("web3");
 const { getTruffleConfig, getNodeUrl } = require("./TruffleConfig");
 const argv = require("minimist")(process.argv.slice(), { string: ["network"] });
 const Url = require("url");
+const { RetryProvider } = require("./RetryProvider");
+
+// NODE_RETRY_CONFIG should be a JSON of the form (retries and delay are optional, they default to 1 and 0 respectively):
+// [
+//    {
+//      retries: 3,
+//      delay: 1
+//      url: https://mainnet.infura.io/v3/ACCOUNT_ID,
+//    },
+//    {
+//      retries: 5,
+//      delay: 1,
+//      url: ws://99.999.99.99
+//    }
+// ]
+const { NODE_RETRY_CONFIG } = process.env;
 
 // Set web3 to null
 let web3 = null;
 
-function createBasicProvider(url) {
-  const protocol = Url.parse(url).protocol;
+function createBasicProvider(nodeRetryConfig) {
+  return new RetryProvider(
+    nodeRetryConfig.map(configElement => {
+      const protocol = Url.parse(configElement.url).protocol;
+      let options = {
+        timeout: 10000 // 10 second timeout
+      };
 
-  // 10 second timeout
-  const timeout = 10000;
-
-  if (protocol.startsWith("ws")) {
-    // Websocket
-    const websocketOptions = {
-      timeout, // ms
-      clientConfig: {
-        maxReceivedFrameSize: 100000000, // Useful if requests result are large bytes - default: 1MiB
-        maxReceivedMessageSize: 100000000 // bytes - default: 8MiB
-      },
-      reconnect: {
-        auto: true, // Enable auto reconnection
-        delay: 5000, // ms
-        maxAttempts: 10,
-        onTimeout: false
+      if (protocol.startsWith("ws")) {
+        // Websocket
+        options = {
+          ...options,
+          clientConfig: {
+            maxReceivedFrameSize: 100000000, // Useful if requests result are large bytes - default: 1MiB
+            maxReceivedMessageSize: 100000000 // bytes - default: 8MiB
+          },
+          reconnect: {
+            auto: true, // Enable auto reconnection
+            delay: 5000, // ms
+            maxAttempts: 10,
+            onTimeout: false
+          }
+        };
       }
-    };
-
-    // Create websocket web3 provider. This contains the re-try logic on failed/timeout connections.
-    return new Web3.providers.WebsocketProvider(url, websocketOptions);
-  } else {
-    // If it isn't websocket, assume http.
-    const httpOptions = {
-      timeout
-    };
-
-    return new Web3.providers.HttpProvider(url, httpOptions);
-  }
+      return { options, ...configElement };
+    })
+  );
 }
 
 /**
@@ -66,7 +77,10 @@ function getWeb3(parameterizedNetwork = "test") {
 
   // Create basic web3 provider with no wallet connection based on the url alone.
   const network = argv.network || parameterizedNetwork; // Default to the test network (local network).
-  const basicProvider = createBasicProvider(getNodeUrl(network));
+  const nodeRetryConfig = NODE_RETRY_CONFIG
+    ? JSON.parse(NODE_RETRY_CONFIG)
+    : [{ url: getNodeUrl(network), retries: 0 }];
+  const basicProvider = createBasicProvider(nodeRetryConfig);
 
   // Use the basic provider to create a provider with an unlocked wallet. This piggybacks off the UMA common TruffleConfig
   // implementing all networks & wallet types. EG: mainnet_mnemonic, kovan_gckms. Errors if no argv.network.

--- a/packages/common/src/RetryProvider.js
+++ b/packages/common/src/RetryProvider.js
@@ -38,7 +38,12 @@ class RetryProvider {
       return new Promise((resolve, reject) => {
         provider.send(payload, (error, result) => {
           if (error) {
+            // Error thrown in the provider.
             reject(error);
+          } else if (result.error) {
+            // Error object returned from node.
+            // TODO: we may need to add additional logic to discern EVM execution errors from node connection errors.
+            reject(result);
           } else {
             resolve(result);
           }
@@ -66,7 +71,7 @@ class RetryProvider {
 
   _constructOrGetProvider(index) {
     const cache = this.providerCaches[index];
-    require(cache, "No provider for this index");
+    assert(cache, "No provider for this index");
     if (!cache.provider) {
       const { url, options } = cache;
       cache.provider = url.startsWith("ws")

--- a/packages/common/src/RetryProvider.js
+++ b/packages/common/src/RetryProvider.js
@@ -1,0 +1,97 @@
+const assert = require("assert");
+const Web3 = require("web3");
+
+// Wraps one or more web3 http/websocket providers and allows per-request retries and fallbacks.
+class RetryProvider {
+  /**
+   * @notice Constructs new retry provider.
+   * @param {Array} config config object:
+   *   [
+   *      {
+   *        retries: 3,
+   *        delay: 1
+   *        url: https://mainnet.infura.io/v3/ACCOUNT_ID,
+   *        options: {
+   *          timeout: 15000
+   *        }
+   *      },
+   *      {
+   *        retries: 5,
+   *        delay: 1,
+   *        url: ws://99.999.99.99
+   *      }
+   *   ]
+   */
+  constructor(configs) {
+    assert(configs.length > 0, "Must have at least one provider");
+    this.providerCaches = configs.map(config => ({
+      retries: 1,
+      delay: 0,
+      ...config
+    }));
+  }
+
+  // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.
+  send(payload, callback) {
+    // Turn callback into async-await internally.
+    const sendWithProvider = provider => {
+      return new Promise((resolve, reject) => {
+        provider.send(payload, (error, result) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(result);
+          }
+        });
+      });
+    };
+
+    // Turn retry promise result back into a callback.
+    this._runRetry(sendWithProvider).then(
+      result => callback(null, result),
+      reason => callback(reason, null)
+    );
+  }
+
+  disconnect(...all) {
+    for (const cache of this.providerCaches) {
+      cache?.provider.disconnect(...all);
+    }
+  }
+
+  supportsSubscriptions() {
+    return false; // return false for simplicity since some providers may be http, which doesn't support subscriptions.
+  }
+
+  _constructOrGetProvider(index) {
+    const cache = this.providerCaches[index];
+    require(cache, "No provider for this index");
+    if (!cache.provider) {
+      const { url, options } = cache;
+      cache.provider = url.startsWith("ws")
+        ? new Web3.providers.WebsocketProvider(url, options)
+        : new Web3.providers.HttpProvider(url, options);
+    }
+    return cache.provider;
+  }
+
+  // Returns a Promise that resolves to the wrapped provider.
+  async _runRetry(fn, providerIndex = 0, retryIndex = 0) {
+    const provider = this._constructOrGetProvider(providerIndex);
+    try {
+      return await fn(provider);
+    } catch (error) {
+      let nextRetryIndex = retryIndex + 1;
+      let nextProviderIndex = providerIndex;
+      if (this.providerCaches[providerIndex].retries === nextRetryIndex) {
+        nextRetryIndex = 0;
+        nextProviderIndex = providerIndex + 1;
+        if (nextProviderIndex >= this.providerCaches.length) throw error; // No more providers to try.
+      }
+
+      return await this._runRetry(fn, nextProviderIndex, nextRetryIndex);
+    }
+  }
+}
+
+module.exports = { RetryProvider };

--- a/packages/common/src/RetryProvider.js
+++ b/packages/common/src/RetryProvider.js
@@ -31,7 +31,7 @@ class RetryProvider {
     }));
   }
 
-  // Passes the call through. Requires that the wrapped provider has been created via, e.g., `constructWrappedProvider`.
+  // Passes the send through, catches errors, and retries on error.
   send(payload, callback) {
     // Turn callback into async-await internally.
     const sendWithProvider = provider => {
@@ -53,6 +53,7 @@ class RetryProvider {
     );
   }
 
+  // Pass through disconnect to any initialized providers.
   disconnect(...all) {
     for (const cache of this.providerCaches) {
       cache?.provider.disconnect(...all);


### PR DESCRIPTION
**Motivation**

To help the bots be more resilient in the face of flaky node behavior, it would be nice for providers to be able to do per-request retries.

**Summary**

Adds a retry provider that can be used to retry failing requests and fallback to secondary node providers for individual failing requests.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
