### PR TITLE
fix(core,affiliates): log warning to console.error, make json piping …

### DIFF
--- a/packages/affiliates/libs/affiliates/utils.js
+++ b/packages/affiliates/libs/affiliates/utils.js
@@ -362,7 +362,14 @@ function makeUnixPipe(cb, stdin = process.stdin) {
         return result + str;
       })
       // once string is final, we try to parse it as json. We assume that our caller is passing us a valid json string.
-      .map(x => JSON.parse(x))
+      .map(x => {
+        try {
+          return JSON.parse(x);
+        } catch (err) {
+          console.error(x);
+          throw err;
+        }
+      })
       // once we have the json object we call the callback passing it as a param
       .map(async x => cb(x))
       // we need to do this to extract the result of the promise in the stream.

--- a/packages/core/src/FindContractVersion.js
+++ b/packages/core/src/FindContractVersion.js
@@ -6,7 +6,7 @@ let latestVersionMap = {};
 try {
   latestVersionMap = JSON.parse(fs.readFileSync(`${path.resolve(__dirname)}/../build/contract-type-hash-map.json`));
 } catch (error) {
-  console.log("WARNING: latest version map was not found in the build directory! Run `yarn build` from core first!");
+  console.error("WARNING: latest version map was not found in the build directory! Run `yarn build` from core first!");
 }
 
 /**


### PR DESCRIPTION
…easier to find issues

Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#2912 


**Summary**

Simply change warning log to console.error, so that it does not interfere with affiliates piping. In general warnings like this should log to error to prevent unexpected output to standard out.  Related change to affiliates pipe handler to log full output before throwing error, to ease debugging.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #2912
