### PR TITLE
fix: Alternate rounding implementation to address GCP logging issue

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -39,8 +39,8 @@ const UMIP_ROUNDING = {
   "STABLESPREAD/BTC": 8,
   "STABLESPREAD/USDC": 6,
   STABLESPREAD: 8,
-  "ELASTIC_STABLESPREAD/USDC": 6
-  // ETHBTC_FR: 9
+  "ELASTIC_STABLESPREAD/USDC": 6,
+  ETHBTC_FR: 9
 };
 
 const getRoundingForIdentifier = identifier => {

--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -39,8 +39,8 @@ const UMIP_ROUNDING = {
   "STABLESPREAD/BTC": 8,
   "STABLESPREAD/USDC": 6,
   STABLESPREAD: 8,
-  "ELASTIC_STABLESPREAD/USDC": 6,
-  ETHBTC_FR: 9
+  "ELASTIC_STABLESPREAD/USDC": 6
+  // ETHBTC_FR: 9
 };
 
 const getRoundingForIdentifier = identifier => {

--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -25,6 +25,28 @@ const getPrecisionForIdentifier = identifier => {
   return IDENTIFIER_NON_18_PRECISION[identifier] ? IDENTIFIER_NON_18_PRECISION[identifier] : 18;
 };
 
+// UMIP's specify to what decimal place rounding should take place for prices. Note that this rounding is independent
+// of identifier token precision (above struct).
+const UMIP_ROUNDING = {
+  USDBTC: 8,
+  USDETH: 5,
+  BTCDOM: 2,
+  ALTDOM: 2,
+  BCHNBTC: 8,
+  "GASETH-TWAP-1Mx1M": 18,
+  "USD-[bwBTC/ETH SLP]": 18,
+  "USD/bBadger": 18,
+  "STABLESPREAD/BTC": 8,
+  "STABLESPREAD/USDC": 6,
+  STABLESPREAD: 8,
+  "ELASTIC_STABLESPREAD/USDC": 6,
+  ETHBTC_FR: 9
+};
+
+const getRoundingForIdentifier = identifier => {
+  return UMIP_ROUNDING[identifier] ? UMIP_ROUNDING[identifier] : null;
+};
+
 // The optimistic oracle proposer should skip proposing prices for these identifiers, for expired EMP contracts,
 // because they map to self-referential pricefeeds pre-expiry, but have different price resolution ogic post-expiry.
 // For example, please see [UMIP47](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-47.md):
@@ -41,5 +63,7 @@ module.exports = {
   IDENTIFIER_BLACKLIST,
   IDENTIFIER_NON_18_PRECISION,
   getPrecisionForIdentifier,
-  OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY
+  OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY,
+  UMIP_ROUNDING,
+  getRoundingForIdentifier
 };

--- a/packages/core/scripts/local/getHistoricalPrice.js
+++ b/packages/core/scripts/local/getHistoricalPrice.js
@@ -17,22 +17,8 @@ const { createReferencePriceFeedForFinancialContract, Networker } = require("@um
 const winston = require("winston");
 const argv = require("minimist")(process.argv.slice(), { string: ["identifier", "time"] });
 require("dotenv").config();
+const { getRoundingForIdentifier } = require("@uma/common");
 
-const UMIP_PRECISION = {
-  USDBTC: 8,
-  USDETH: 5,
-  BTCDOM: 2,
-  ALTDOM: 2,
-  BCHNBTC: 8,
-  "GASETH-TWAP-1Mx1M": 18,
-  "USD-[bwBTC/ETH SLP]": 18,
-  "USD/bBadger": 18,
-  "STABLESPREAD/BTC": 8,
-  "STABLESPREAD/USDC": 6,
-  STABLESPREAD: 8,
-  "ELASTIC_STABLESPREAD/USDC": 6,
-  ETHBTC_FR: 9
-};
 const DEFAULT_PRECISION = 5;
 
 async function getHistoricalPrice(callback) {
@@ -92,7 +78,9 @@ async function getHistoricalPrice(callback) {
     // The default exchanges to fetch prices for (and from which the median is derived) are based on UMIP's and can be found in:
     // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
     const queryPrice = await defaultPriceFeed.getHistoricalPrice(queryTime, true);
-    const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
+    const precisionToUse = getRoundingForIdentifier(queryIdentifier)
+      ? getRoundingForIdentifier(queryIdentifier)
+      : DEFAULT_PRECISION;
     console.log(`\n⚠️ Truncating price to ${precisionToUse} decimals`);
     console.log(
       `\n💹 Median ${queryIdentifier} price @ ${queryTime} = ${Number(fromWei(queryPrice.toString())).toFixed(

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -143,27 +143,25 @@ class Disputer {
               });
             }
           }
-          const price = this.toBN(
-            formatPriceToPricefeedPrecision(
+          // Price is available, use it to determine if the liquidation is disputable
+          if (
+            _price &&
+            this.financialContractClient.isDisputable(liquidation, _price) &&
+            this.financialContractClient.getLastUpdateTime() >= Number(liquidationTime) + this.disputeDelay
+          ) {
+            const price = formatPriceToPricefeedPrecision(
               _price,
               this.priceFeed.getPriceFeedDecimals(),
               this.financialContractIdentifier
-            )
-          );
-          // Price is available, use it to determine if the liquidation is disputable
-          if (
-            price &&
-            this.financialContractClient.isDisputable(liquidation, price) &&
-            this.financialContractClient.getLastUpdateTime() >= Number(liquidationTime) + this.disputeDelay
-          ) {
+            );
             this.logger.debug({
               at: "Disputer",
               message: "Detected a disputable liquidation",
-              price: price.toString(),
+              price,
               liquidation: JSON.stringify(liquidation)
             });
 
-            return { ...liquidation, price: price.toString() };
+            return { ...liquidation, price };
           }
 
           return null;

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -859,7 +859,7 @@ const defaultConfigs = {
     type: "expression",
     expression: `
         ETHBTC_FV = ETH\\/BTC * PERP_FRM;
-        round(max(-0.00001, min(0.00001, (ETHBTC_FV - ETHBTC_PERP) / ETHBTC_FV / 86400)), 9)
+        max(-0.00001, min(0.00001, (ETHBTC_FV - ETHBTC_PERP) / ETHBTC_FV / 86400))
     `,
     lookback: 7200,
     minTimeBetweenUpdates: 60,

--- a/packages/funding-rate-proposer/src/proposer.js
+++ b/packages/funding-rate-proposer/src/proposer.js
@@ -5,7 +5,7 @@ const {
   isDeviationOutsideErrorMargin,
   aggregateTransactionsAndCall
 } = require("@uma/financial-templates-lib");
-const { createObjectFromDefaultProps, runTransaction } = require("@uma/common");
+const { createObjectFromDefaultProps, runTransaction, parseFixed, formatFixed } = require("@uma/common");
 const { getAbi } = require("@uma/core");
 const Promise = require("bluebird");
 const assert = require("assert");
@@ -77,6 +77,13 @@ class FundingRateProposer {
           return !isNaN(x);
           // Negative allowed-margins might be useful based on the implementation
           // of `isDeviationOutsideErrorMargin()`
+        }
+      },
+      precision: {
+        //   "precision":9 ->  # of decimals to round fundingRate to.
+        value: 9,
+        isValid: x => {
+          return !isNaN(x) && x >= 0 && x <= 18;
         }
       }
     };
@@ -172,9 +179,9 @@ class FundingRateProposer {
     const requestTimestamp = usePriceFeedTime
       ? priceFeed.getLastUpdateTime()
       : (await this.web3.eth.getBlock("latest")).timestamp;
-    let pricefeedPrice;
+    let _pricefeedPrice;
     try {
-      pricefeedPrice = (await priceFeed.getHistoricalPrice(Number(requestTimestamp))).toString();
+      _pricefeedPrice = (await priceFeed.getHistoricalPrice(Number(requestTimestamp))).toString();
     } catch (error) {
       this.logger.error({
         at: "PerpetualProposer",
@@ -185,6 +192,7 @@ class FundingRateProposer {
       });
       return;
     }
+    const pricefeedPrice = this._formatPriceToPricefeedPrecision(_pricefeedPrice, priceFeed);
     let onchainFundingRate = currentFundingRateData.rate.toString();
 
     // Check that pricefeedPrice is within [configStore.minFundingRate, configStore.maxFundingRate]
@@ -399,6 +407,20 @@ class FundingRateProposer {
         currentConfig
       }
     };
+  }
+
+  _formatPriceToPricefeedPrecision(price, priceFeed) {
+    // Round `price` to desired number of decimals by converting back and forth between the pricefeed's
+    // configured precision:
+    return parseFixed(
+      // 1) `formatFixed` converts the price in wei to a floating point.
+      // 2) `toFixed` removes decimals beyond `this.precision` in the floating point.
+      // 3) `parseFixed` converts the floating point back into wei.
+      Number(formatFixed(price.toString(), priceFeed.getPriceFeedDecimals()))
+        .toFixed(this.precision)
+        .toString(),
+      priceFeed.getPriceFeedDecimals()
+    ).toString();
   }
 }
 

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -210,13 +210,12 @@ class Liquidator {
     const _price = liquidatorOverridePrice
       ? this.toBN(liquidatorOverridePrice.toString())
       : this.priceFeed.getCurrentPrice();
+    if (!_price) {
+      throw new Error("Cannot liquidate: price feed returned invalid value");
+    }
     const price = this.toBN(
       formatPriceToPricefeedPrecision(_price, this.priceFeed.getPriceFeedDecimals(), this.financialContractIdentifier)
     );
-
-    if (!price) {
-      throw new Error("Cannot liquidate: price feed returned invalid value");
-    }
 
     // The `price` is a BN that is used to determine if a position is liquidatable. The higher the
     // `price` value, the more collateral that the position is required to have to be correctly collateralized.

--- a/packages/liquidator/src/liquidator.js
+++ b/packages/liquidator/src/liquidator.js
@@ -4,6 +4,7 @@ const {
   revertWrapper,
   runTransaction
 } = require("@uma/common");
+const { formatPriceToPricefeedPrecision } = require("@uma/financial-templates-lib");
 
 const LiquidationStrategy = require("./liquidationStrategy");
 
@@ -206,9 +207,12 @@ class Liquidator {
       liquidatorOverridePrice
     });
     // If an override is provided, use that price. Else, get the latest price from the price feed.
-    const price = liquidatorOverridePrice
+    const _price = liquidatorOverridePrice
       ? this.toBN(liquidatorOverridePrice.toString())
       : this.priceFeed.getCurrentPrice();
+    const price = this.toBN(
+      formatPriceToPricefeedPrecision(_price, this.priceFeed.getPriceFeedDecimals(), this.financialContractIdentifier)
+    );
 
     if (!price) {
       throw new Error("Cannot liquidate: price feed returned invalid value");

--- a/packages/optimistic-oracle/src/proposer.js
+++ b/packages/optimistic-oracle/src/proposer.js
@@ -4,7 +4,14 @@ const {
   setAllowance,
   isDeviationOutsideErrorMargin
 } = require("@uma/financial-templates-lib");
-const { createObjectFromDefaultProps, runTransaction, OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY } = require("@uma/common");
+const {
+  createObjectFromDefaultProps,
+  runTransaction,
+  OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY,
+  getRoundingForIdentifier,
+  parseFixed,
+  formatFixed
+} = require("@uma/common");
 const { getAbi } = require("@uma/core");
 
 class OptimisticOracleProposer {
@@ -168,9 +175,9 @@ class OptimisticOracleProposer {
 
     // With pricefeed successfully constructed, get a proposal price
     await priceFeed.update();
-    let proposalPrice;
+    let _proposalPrice;
     try {
-      proposalPrice = (await priceFeed.getHistoricalPrice(Number(priceRequest.timestamp))).toString();
+      _proposalPrice = (await priceFeed.getHistoricalPrice(Number(priceRequest.timestamp))).toString();
     } catch (error) {
       this.logger.error({
         at: "OptimisticOracleProposer#sendProposals",
@@ -180,6 +187,8 @@ class OptimisticOracleProposer {
       });
       return;
     }
+
+    const proposalPrice = this._formatPriceToPricefeedPrecision(_proposalPrice, priceFeed, priceRequest.identifier);
 
     // Get successful transaction receipt and return value or error.
     const proposal = this.optimisticOracleContract.methods.proposePrice(
@@ -260,9 +269,9 @@ class OptimisticOracleProposer {
 
     // With pricefeed successfully constructed, confirm the proposal price
     await priceFeed.update();
-    let disputePrice;
+    let _disputePrice;
     try {
-      disputePrice = (await priceFeed.getHistoricalPrice(Number(priceRequest.timestamp))).toString();
+      _disputePrice = (await priceFeed.getHistoricalPrice(Number(priceRequest.timestamp))).toString();
     } catch (error) {
       this.logger.error({
         at: "OptimisticOracleProposer#sendDisputes",
@@ -272,6 +281,8 @@ class OptimisticOracleProposer {
       });
       return;
     }
+
+    const disputePrice = this._formatPriceToPricefeedPrecision(_disputePrice, priceFeed, priceRequest.identifier);
 
     // If proposal price is not equal to the dispute price within margin of error, then
     // prepare dispute. We're assuming that the `disputePrice` is the baseline or "expected"
@@ -480,6 +491,24 @@ class OptimisticOracleProposer {
     );
     if (newPriceFeed) this.priceFeedCache[identifier] = newPriceFeed;
     return newPriceFeed;
+  }
+
+  _formatPriceToPricefeedPrecision(price, priceFeed, identifier) {
+    if (!getRoundingForIdentifier(identifier)) {
+      return price.toString();
+    } else {
+      // Round `price` to custom number of decimals by converting back and forth between the pricefeed's
+      // configured precision:
+      return parseFixed(
+        // 1) `formatFixed` converts the price in wei to a floating point.
+        // 2) `toFixed` removes decimals beyond `this.precision` in the floating point.
+        // 3) `parseFixed` converts the floating point back into wei.
+        Number(formatFixed(price.toString(), priceFeed.getPriceFeedDecimals()))
+          .toFixed(getRoundingForIdentifier(identifier))
+          .toString(),
+        priceFeed.getPriceFeedDecimals()
+      ).toString();
+    }
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `round(x)` element of the expression used to construct the `ExpressionPriceFeed` introduced in [this PR](https://github.com/UMAprotocol/protocol/commit/22017d22d2ad3cc8c43c898b14fda47554012181) causes GCP logging to hang when [this code path](https://github.com/UMAprotocol/protocol/blob/master/packages/funding-rate-proposer/src/proposer.js#L147) in the `funding-rate-proposer` is entered. This is a point where the `ExpressionPriceFeed` has been constructed and updated, but no price is fetched. The GCP logging does NOT hang when either a funding rate is proposed, or the funding rate to propose is within some margin of error. This is strange behavior and we're not sure yet why this breaks, but removing the `round` from the expression empirically works locally.

This alternative implementation of rounding also causes GCP logging to succeed. It ensures that the same rounding is applied in all bots that push prices on-chain: `optimistic-oracle-proposer`, `funding-rate-proposer`, `liquidator`, and `disputer`.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested