### PR TITLE
feat(affiliates): uniswap v3 fetch state proof of concept

### DIFF
--- a/packages/affiliates/.gitignore
+++ b/packages/affiliates/.gitignore
@@ -1,0 +1,1 @@
+artifacts

--- a/packages/affiliates/libs/uniswap/models.ts
+++ b/packages/affiliates/libs/uniswap/models.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { exists } from "./utils";
+import { exists, getPositionKey } from "./utils";
 import { ethers } from "ethers";
 
 type CacheType = {
@@ -17,7 +17,7 @@ export const Cache = (table = new Map<string | number, CacheType>()) => {
     list
   };
 };
-type NftPosition = {
+export type NftPosition = {
   id?: string;
   tokenId: string;
   amount?: string;
@@ -74,12 +74,11 @@ export const NftPositions = (config: any, table: ReturnType<typeof Cache>) => {
     list: table.list
   };
 };
-type Position = {
+export type Position = {
   id?: string;
   operator: string;
   tickLower: string;
   tickUpper: string;
-  nonce?: string;
   token0?: string;
   token1?: string;
   liquidity?: string;
@@ -93,30 +92,7 @@ type Position = {
 // These positions are from core pool contracts and are indexed using hash of upper/lower/user address.
 export const Positions = (config: any, table: ReturnType<typeof Cache>) => {
   function makeId(data: Position) {
-    const encoded = ethers.utils.defaultAbiCoder.encode(
-      [
-        ethers.utils.ParamType.from({
-          indexed: true,
-          name: "owner",
-          type: "address"
-        }),
-        ethers.utils.ParamType.from({
-          indexed: true,
-          baseType: "int24",
-          name: "tickLower",
-          type: "int24"
-        }),
-        ethers.utils.ParamType.from({
-          indexed: true,
-          baseType: "int24",
-          name: "tickUpper",
-          type: "int24"
-        })
-      ],
-      [data.operator, data.tickLower, data.tickUpper]
-    );
-    // this is how positions are indexed in the v3 core contract
-    return ethers.utils.keccak256(encoded);
+    return getPositionKey(data.operator, data.tickLower, data.tickUpper);
   }
   async function create(data: Position) {
     const id = makeId(data);
@@ -155,7 +131,7 @@ export const Positions = (config: any, table: ReturnType<typeof Cache>) => {
   };
 };
 
-type GlobalState = {
+export type GlobalState = {
   id?: string;
   token0: string;
   token1: string;
@@ -213,25 +189,25 @@ export const Pools = (config: any, table: ReturnType<typeof Cache>) => {
   };
 };
 
-type TickInfo = {
-  //     // the total position liquidity that references this tick
+export type TickInfo = {
+  // the total position liquidity that references this tick
   liquidityGross?: string;
-  //     // amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left),
+  // amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left),
   liquidityNet?: string;
-  //     // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
-  //     // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+  // only has relative meaning, not absolute — the value depends on when the tick is initialized
   feeGrowthOutside0X128?: string;
   feeGrowthOutside1X128?: string;
-  //     // the cumulative tick value on the other side of the tick
+  // the cumulative tick value on the other side of the tick
   tickCumulativeOutside?: string;
-  //     // the seconds per unit of liquidity on the _other_ side of this tick (relative to the current tick)
-  //     // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  // the seconds per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+  // only has relative meaning, not absolute — the value depends on when the tick is initialized
   secondsPerLiquidityOutsideX128?: string;
-  //     // the seconds spent on the other side of the tick (relative to the current tick)
-  //     // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  // the seconds spent on the other side of the tick (relative to the current tick)
+  // only has relative meaning, not absolute — the value depends on when the tick is initialized
   secondsOutside?: string;
-  //     // true iff the tick is initialized, i.e. the value is exactly equivalent to the expression liquidityGross != 0
-  //     // these 8 bits are set to prevent fresh sstores when crossing newly initialized ticks
+  // true iff the tick is initialized, i.e. the value is exactly equivalent to the expression liquidityGross != 0
+  // these 8 bits are set to prevent fresh sstores when crossing newly initialized ticks
   initialized?: boolean;
   pool?: string;
   index?: string;

--- a/packages/affiliates/libs/uniswap/models.ts
+++ b/packages/affiliates/libs/uniswap/models.ts
@@ -1,0 +1,277 @@
+import assert from "assert";
+import { exists } from "./utils";
+import { ethers } from "ethers";
+
+type CacheType = {
+  [key: string]: string | number | boolean;
+};
+export const Cache = (table = new Map<string | number, CacheType>()) => {
+  function list() {
+    return [...table.values()];
+  }
+  return {
+    has: table.has.bind(table),
+    set: table.set.bind(table),
+    get: table.get.bind(table),
+    delete: table.delete.bind(table),
+    list
+  };
+};
+type NftPosition = {
+  id?: string;
+  tokenId: string;
+  amount?: string;
+  amount0?: string;
+  amount1?: string;
+  token0?: string;
+  token1?: string;
+  liquidity?: string;
+  feeGrowthInside0LastX128?: string;
+  feeGrowthInside1LastX128?: string;
+  tokensOwed0?: string;
+  tokensOwed1?: string;
+  pool?: string;
+};
+
+// Nft positions are gathered from the nft contract, and require slightly different indexing than the positions in pool contract
+export const NftPositions = (config: any, table: ReturnType<typeof Cache>) => {
+  function makeId(data: NftPosition) {
+    return data.tokenId;
+  }
+  async function create(data: NftPosition) {
+    const id = makeId(data);
+    assert(!(await has(id)), "Position exists");
+    return set({ id, ...data });
+  }
+  async function set(data: NftPosition) {
+    assert(data.id, "Position requires id");
+    await table.set(data.id, { ...data });
+    return data;
+  }
+  async function get(id: string) {
+    assert(await table.has(id), "Position does not exist");
+    return table.get(id);
+  }
+  async function has(id: string) {
+    return table.has(id);
+  }
+  async function forEach(cb: (value: NftPosition, index: number, array: NftPosition[]) => void) {
+    const list: NftPosition[] = (await table.list()) as NftPosition[];
+    list.forEach(cb);
+  }
+  async function update(id: string, data: any = {}) {
+    const position = await get(id);
+    return set({ ...position, ...data });
+  }
+
+  return {
+    create,
+    set,
+    get,
+    has,
+    update,
+    forEach,
+    list: table.list
+  };
+};
+type Position = {
+  id?: string;
+  operator: string;
+  tickLower: string;
+  tickUpper: string;
+  nonce?: string;
+  token0?: string;
+  token1?: string;
+  liquidity?: string;
+  feeGrowthInside0LastX128?: string;
+  feeGrowthInside1LastX128?: string;
+  tokensOwed0?: string;
+  tokensOwed1?: string;
+  pool?: string;
+};
+
+// These positions are from core pool contracts and are indexed using hash of upper/lower/user address.
+export const Positions = (config: any, table: ReturnType<typeof Cache>) => {
+  function makeId(data: Position) {
+    const encoded = ethers.utils.defaultAbiCoder.encode(
+      [
+        ethers.utils.ParamType.from({
+          indexed: true,
+          name: "owner",
+          type: "address"
+        }),
+        ethers.utils.ParamType.from({
+          indexed: true,
+          baseType: "int24",
+          name: "tickLower",
+          type: "int24"
+        }),
+        ethers.utils.ParamType.from({
+          indexed: true,
+          baseType: "int24",
+          name: "tickUpper",
+          type: "int24"
+        })
+      ],
+      [data.operator, data.tickLower, data.tickUpper]
+    );
+    // this is how positions are indexed in the v3 core contract
+    return ethers.utils.keccak256(encoded);
+  }
+  async function create(data: Position) {
+    const id = makeId(data);
+    assert(!(await has(id)), "Position exists");
+    return set({ id, ...data });
+  }
+  async function set(data: Position) {
+    assert(data.id, "Position requires id");
+    await table.set(data.id, { ...data });
+    return data;
+  }
+  async function get(id: string) {
+    assert(await table.has(id), "Position does not exist");
+    return table.get(id);
+  }
+  async function has(id: string) {
+    return table.has(id);
+  }
+  async function forEach(cb: (value: Position, index: number, array: Position[]) => void) {
+    const list: Position[] = (await table.list()) as Position[];
+    list.forEach(cb);
+  }
+  async function update(id: string, data: any = {}) {
+    const position = await get(id);
+    return set({ ...position, ...data });
+  }
+
+  return {
+    create,
+    set,
+    get,
+    has,
+    update,
+    forEach,
+    list: table.list
+  };
+};
+
+type GlobalState = {
+  id?: string;
+  token0: string;
+  token1: string;
+  fee: string;
+  sqrtPriceX96?: string;
+  tick?: number;
+  liquidity?: string;
+  feeProtocol?: number;
+  feeGrowthGlobal0X128?: string;
+  feeGrowthGlobal1X128?: string;
+  protocolFeesToken0?: string;
+  protocolFeesToken1?: string;
+  address?: string;
+};
+// pool id is tokenA, tokenB, fee
+export const Pools = (config: any, table: ReturnType<typeof Cache>) => {
+  function makeId(state: GlobalState) {
+    const { token0, token1, fee } = state;
+    if (token0 < token1) {
+      return [token0, token1, fee].join("!");
+    }
+    return [token1, token0, fee].join("!");
+  }
+  async function create(state: GlobalState) {
+    const id = makeId(state);
+    assert(!(await has(id)), "State already exists:" + id);
+    return set({ id, ...state });
+  }
+  async function set(state: GlobalState) {
+    assert(state.id, "requires id");
+    await table.set(state.id, state);
+    return state;
+  }
+  async function get(id: string) {
+    assert(await has(id), "No such pool state");
+    return table.get(id);
+  }
+  async function has(id: string) {
+    return table.has(id);
+  }
+  async function update(id: string, data: any = {}) {
+    const pool = await get(id);
+    return set({ ...pool, ...data });
+  }
+  async function list() {
+    return table.list();
+  }
+  return {
+    create,
+    set,
+    get,
+    has,
+    update,
+    list
+  };
+};
+
+type TickInfo = {
+  //     // the total position liquidity that references this tick
+  liquidityGross?: string;
+  //     // amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left),
+  liquidityNet?: string;
+  //     // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+  //     // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  feeGrowthOutside0X128?: string;
+  feeGrowthOutside1X128?: string;
+  //     // the cumulative tick value on the other side of the tick
+  tickCumulativeOutside?: string;
+  //     // the seconds per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+  //     // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  secondsPerLiquidityOutsideX128?: string;
+  //     // the seconds spent on the other side of the tick (relative to the current tick)
+  //     // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  secondsOutside?: string;
+  //     // true iff the tick is initialized, i.e. the value is exactly equivalent to the expression liquidityGross != 0
+  //     // these 8 bits are set to prevent fresh sstores when crossing newly initialized ticks
+  initialized?: boolean;
+  pool?: string;
+  index?: string;
+  id?: string;
+};
+export const Ticks = (config: any, table: ReturnType<typeof Cache>) => {
+  function makeId(state: TickInfo) {
+    const { pool, index } = state;
+    return [pool, index].join("!");
+  }
+  async function create(state: TickInfo) {
+    const id = makeId(state);
+    assert(!(await has(id)), "tick already exists:" + id);
+    return set({ id, ...state });
+  }
+  async function set(state: TickInfo) {
+    assert(state.id, "requires id");
+    await table.set(state.id, state);
+    return state;
+  }
+  async function get(id: string) {
+    assert(await has(id), "No such tick state");
+    return table.get(id);
+  }
+  async function has(id: string) {
+    return table.has(id);
+  }
+  async function update(id: string, data: any = {}) {
+    const got = await get(id);
+    return set({ ...got, ...data });
+  }
+  async function list() {
+    return table.list();
+  }
+  return {
+    create,
+    set,
+    get,
+    has,
+    update,
+    list
+  };
+};

--- a/packages/affiliates/libs/uniswap/models.ts
+++ b/packages/affiliates/libs/uniswap/models.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import lodash from "lodash";
 import { exists, getPositionKey } from "./utils";
 
-type Id = string | number;
+type Id = string;
 interface MaybeId {
   id?: Id;
 }
@@ -19,7 +19,6 @@ export function Table<T extends MaybeId>(config: { makeId: MakeId<T>; type: Id }
     return set({ id, ...data });
   }
   async function set(data: T & { id: Id }) {
-    assert(exists(data.id), `${type} requires id`);
     await store.set(data.id, { ...data });
     return data;
   }
@@ -138,7 +137,6 @@ export type Pool = {
 // pool id is tokenA, tokenB, fee
 export const Pools = () => {
   function makeId(state: Pool) {
-    assert(state.address, "requires address");
     return state.address;
   }
   const store = new Map<Id, Pool>();

--- a/packages/affiliates/libs/uniswap/processor.ts
+++ b/packages/affiliates/libs/uniswap/processor.ts
@@ -4,13 +4,7 @@ import { Positions, NftPositions, Pools, Position } from "./models";
 import { exists, convertValuesToString } from "./utils";
 import assert from "assert";
 import { BigNumberish } from "ethers";
-
-type Event = {
-  event: string;
-  args: any[];
-};
-
-type PoolsType = ReturnType<typeof Pools>;
+import { Event } from "@ethersproject/contracts/lib/";
 
 export function NftEvents({ positions }: { positions: ReturnType<typeof NftPositions> }) {
   const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
@@ -84,6 +78,8 @@ export function NftEvents({ positions }: { positions: ReturnType<typeof NftPosit
     }
   };
   async function handleEvent(event: Event) {
+    assert(event.event, "requires event name");
+    assert(event.args, "requires event args");
     assert(handlers[event.event], "No handler for event: " + event.event);
     try {
       await handlers[event.event](...event.args);
@@ -104,7 +100,7 @@ export function PoolEvents({
   pools
 }: {
   positions: ReturnType<typeof Positions>;
-  pools: PoolsType;
+  pools: Pools;
   id: string;
 }) {
   const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
@@ -191,6 +187,8 @@ export function PoolEvents({
     }
   };
   async function handleEvent(event: Event) {
+    assert(event.event, "requires event name");
+    assert(event.args, "requires event args");
     assert(handlers[event.event], "No handler for event: " + event.event);
     try {
       await handlers[event.event](...event.args);
@@ -206,7 +204,7 @@ export function PoolEvents({
   };
 }
 
-export function PoolFactory({ positions, pools }: { positions: ReturnType<typeof Positions>; pools: PoolsType }) {
+export function PoolFactory({ positions, pools }: { positions: ReturnType<typeof Positions>; pools: Pools }) {
   const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
     async FeeAmountEnabled(fee: BigNumberish | null, tickSpacing: BigNumberish | null) {
       // nothing
@@ -234,6 +232,8 @@ export function PoolFactory({ positions, pools }: { positions: ReturnType<typeof
     }
   };
   async function handleEvent(event: Event) {
+    assert(event.event, "requires event name");
+    assert(event.args, "requires event args");
     assert(handlers[event.event], "No handler for event: " + event.event);
     try {
       await handlers[event.event](...event.args);

--- a/packages/affiliates/libs/uniswap/processor.ts
+++ b/packages/affiliates/libs/uniswap/processor.ts
@@ -1,0 +1,223 @@
+// this file is meant to handle events from various contracts.
+// its mainly documenting all events based on uniswap typechain build output.
+import { Positions, Pools } from "./models";
+import { exists } from "./utils";
+import assert from "assert";
+import { BigNumberish } from "ethers";
+
+type Event = {
+  event: string;
+  args: any[];
+};
+
+type PoolsType = ReturnType<typeof Pools>;
+
+export function NftEvents({ positions }: { positions: ReturnType<typeof Positions> }) {
+  const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
+    async Approval(owner: string | null, approved: string | null, tokenId: BigNumberish | null) {
+      // nothing
+    },
+    async ApprovalForAll(owner: string | null, operator: string | null, approved: null) {
+      // nothing
+    },
+    async Collect(
+      tokenId: BigNumberish | null,
+      recipient: string | null,
+      amount0: BigNumberish | null,
+      amount1: BigNumberish | null
+    ) {
+      // nothing
+    },
+    async DecreaseLiquidity(
+      tokenId: BigNumberish | null,
+      liquidity: BigNumberish | null,
+      amount0: BigNumberish | null,
+      amount1: BigNumberish | null
+    ) {
+      assert(exists(tokenId), "requires token id");
+      assert(exists(liquidity), "requires liquidity");
+      assert(exists(amount0), "requires amount0");
+      assert(exists(amount1), "requires amount1");
+      await positions.update(tokenId.toString(), {
+        liquidity: liquidity.toString(),
+        amount0: amount0.toString(),
+        amount1: amount1.toString()
+      });
+    },
+    async IncreaseLiquidity(
+      tokenId: BigNumberish | null,
+      liquidity: BigNumberish | null,
+      amount0: BigNumberish | null,
+      amount1: BigNumberish | null
+    ) {
+      assert(exists(tokenId), "requires token id");
+      assert(exists(liquidity), "requires liquidity");
+      assert(exists(amount0), "requires amount0");
+      assert(exists(amount1), "requires amount1");
+
+      await positions.update(tokenId.toString(), {
+        liquidity: liquidity.toString(),
+        amount0: amount0.toString(),
+        amount1: amount1.toString()
+      });
+    },
+    async Transfer(from: string | null, to: string | null, tokenId: BigNumberish | null) {
+      // nothing
+    }
+  };
+  async function handleEvent(event: Event) {
+    assert(handlers[event.event], "No handler for event: " + event.event);
+    handlers[event.event](...event.args);
+  }
+  return {
+    handleEvent,
+    positions
+  };
+}
+
+export function PoolEvents({
+  positions,
+  id,
+  pools
+}: {
+  positions: ReturnType<typeof Positions>;
+  pools: PoolsType;
+  id: string;
+}) {
+  const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
+    async Burn(
+      owner: string | null,
+      tickLower: BigNumberish | null,
+      tickUpper: BigNumberish | null,
+      amount: null,
+      amount0: null,
+      amount1: null
+    ) {
+      // nothing
+    },
+    async Collect(
+      owner: string | null,
+      recipient: null,
+      tickLower: BigNumberish | null,
+      tickUpper: BigNumberish | null,
+      amount0: null,
+      amount1: null
+    ) {
+      // nothing
+    },
+    async CollectProtocol(sender: string | null, recipient: string | null, amount0: null, amount1: null) {
+      // nothing
+    },
+
+    async Flash(
+      sender: string | null,
+      recipient: string | null,
+      amount0: null,
+      amount1: null,
+      paid0: null,
+      paid1: null
+    ) {
+      // nothing
+    },
+
+    async IncreaseObservationCardinalityNext(observationCardinalityNextOld: null, observationCardinalityNextNew: null) {
+      // nothing
+    },
+
+    async Initialize(sqrtPriceX96: null, tick: null) {
+      // nothing
+    },
+
+    async Mint(
+      sender: null,
+      owner: string | null,
+      tickLower: BigNumberish | null,
+      tickUpper: BigNumberish | null,
+      amount: null,
+      amount0: null,
+      amount1: null
+    ) {
+      assert(exists(owner), "requires owner");
+      assert(exists(tickLower), "requires tickLower");
+      assert(exists(tickUpper), "requires tickUpper");
+      await positions.create({
+        operator: owner,
+        tickLower: tickLower.toString(),
+        tickUpper: tickUpper.toString()
+      });
+    },
+
+    async SetFeeProtocol(feeProtocol0Old: null, feeProtocol1Old: null, feeProtocol0New: null, feeProtocol1New: null) {
+      // nothing
+    },
+
+    async Swap(
+      sender: string | null,
+      recipient: string | null,
+      amount0: BigNumberish | null,
+      amount1: BigNumberish | null,
+      sqrtPriceX96: BigNumberish | null,
+      tick: BigNumberish | null
+    ) {
+      assert(exists(sqrtPriceX96), "requires price");
+      assert(exists(tick), "requires tick");
+      await pools.update(id, { tick, sqrtPriceX96: sqrtPriceX96.toString() });
+    }
+  };
+  async function handleEvent(event: Event) {
+    assert(handlers[event.event], "No handler for event: " + event.event);
+    try {
+      await handlers[event.event](...event.args);
+    } catch (err) {
+      console.error(event);
+      throw err;
+    }
+  }
+  return {
+    handleEvent,
+    pools,
+    positions
+  };
+}
+
+export function PoolFactory({ positions, pools }: { positions: ReturnType<typeof Positions>; pools: PoolsType }) {
+  const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
+    async FeeAmountEnabled(fee: BigNumberish | null, tickSpacing: BigNumberish | null) {
+      // nothing
+    },
+    async OwnerChanged(oldOwner: string | null, newOwner: string | null) {
+      // nothing
+    },
+    async PoolCreated(
+      token0: string | null,
+      token1: string | null,
+      fee: BigNumberish | null,
+      tickSpacing: BigNumberish | null,
+      pool: string | null
+    ) {
+      assert(token0, "requires token 0");
+      assert(token1, "requires token 1");
+      assert(fee, "requires fee");
+      assert(pool, "requires pool");
+      await pools.create({
+        token0,
+        token1,
+        fee: fee.toString(),
+        address: pool
+      });
+    }
+  };
+  async function handleEvent(event: Event) {
+    assert(handlers[event.event], "No handler for event: " + event.event);
+    try {
+      await handlers[event.event](...event.args);
+    } catch (err) {
+      console.log(event);
+      throw err;
+    }
+  }
+  return {
+    handleEvent,
+    positions
+  };
+}

--- a/packages/affiliates/libs/uniswap/processor.ts
+++ b/packages/affiliates/libs/uniswap/processor.ts
@@ -6,22 +6,21 @@ import assert from "assert";
 import { BigNumberish } from "ethers";
 import { Event } from "@ethersproject/contracts/lib/";
 
+const HandleEvent = (handlers: { [key: string]: (...args: any[]) => Promise<void> }) => async (event: Event) => {
+  assert(event.event, "requires event name");
+  assert(event.args, "requires event args");
+  // ignore events without handlers
+  if (handlers[event.event] == null) return;
+  try {
+    await handlers[event.event](...event.args);
+  } catch (err) {
+    console.log(event);
+    throw err;
+  }
+};
+
 export function NftEvents({ positions }: { positions: ReturnType<typeof NftPositions> }) {
   const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
-    async Approval(owner: string | null, approved: string | null, tokenId: BigNumberish | null) {
-      // nothing
-    },
-    async ApprovalForAll(owner: string | null, operator: string | null, approved: null) {
-      // nothing
-    },
-    async Collect(
-      tokenId: BigNumberish | null,
-      recipient: string | null,
-      amount0: BigNumberish | null,
-      amount1: BigNumberish | null
-    ) {
-      // nothing
-    },
     async DecreaseLiquidity(
       tokenId: BigNumberish | null,
       liquidity: BigNumberish | null,
@@ -72,26 +71,9 @@ export function NftEvents({ positions }: { positions: ReturnType<typeof NftPosit
           amount1: amount1.toString()
         });
       }
-    },
-    async Transfer(from: string | null, to: string | null, tokenId: BigNumberish | null) {
-      // nothing
     }
   };
-  async function handleEvent(event: Event) {
-    assert(event.event, "requires event name");
-    assert(event.args, "requires event args");
-    assert(handlers[event.event], "No handler for event: " + event.event);
-    try {
-      await handlers[event.event](...event.args);
-    } catch (err) {
-      console.log(event);
-      throw err;
-    }
-  }
-  return {
-    handleEvent,
-    positions
-  };
+  return HandleEvent(handlers);
 }
 
 export function PoolEvents({
@@ -104,49 +86,6 @@ export function PoolEvents({
   id: string;
 }) {
   const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
-    async Burn(
-      owner: string | null,
-      tickLower: BigNumberish | null,
-      tickUpper: BigNumberish | null,
-      amount: null,
-      amount0: null,
-      amount1: null
-    ) {
-      // nothing
-    },
-    async Collect(
-      owner: string | null,
-      recipient: null,
-      tickLower: BigNumberish | null,
-      tickUpper: BigNumberish | null,
-      amount0: null,
-      amount1: null
-    ) {
-      // nothing
-    },
-    async CollectProtocol(sender: string | null, recipient: string | null, amount0: null, amount1: null) {
-      // nothing
-    },
-
-    async Flash(
-      sender: string | null,
-      recipient: string | null,
-      amount0: null,
-      amount1: null,
-      paid0: null,
-      paid1: null
-    ) {
-      // nothing
-    },
-
-    async IncreaseObservationCardinalityNext(observationCardinalityNextOld: null, observationCardinalityNextNew: null) {
-      // nothing
-    },
-
-    async Initialize(sqrtPriceX96: null, tick: null) {
-      // nothing
-    },
-
     async Mint(
       sender: string | null,
       owner: string | null,
@@ -168,11 +107,6 @@ export function PoolEvents({
         })
       );
     },
-
-    async SetFeeProtocol(feeProtocol0Old: null, feeProtocol1Old: null, feeProtocol0New: null, feeProtocol1New: null) {
-      // nothing
-    },
-
     async Swap(
       sender: string | null,
       recipient: string | null,
@@ -186,32 +120,11 @@ export function PoolEvents({
       await pools.update(id, convertValuesToString({ tick, sqrtPriceX96 }));
     }
   };
-  async function handleEvent(event: Event) {
-    assert(event.event, "requires event name");
-    assert(event.args, "requires event args");
-    assert(handlers[event.event], "No handler for event: " + event.event);
-    try {
-      await handlers[event.event](...event.args);
-    } catch (err) {
-      console.error(event);
-      throw err;
-    }
-  }
-  return {
-    handleEvent,
-    pools,
-    positions
-  };
+  return HandleEvent(handlers);
 }
 
 export function PoolFactory({ positions, pools }: { positions: ReturnType<typeof Positions>; pools: Pools }) {
   const handlers: { [key: string]: (...args: any[]) => Promise<void> } = {
-    async FeeAmountEnabled(fee: BigNumberish | null, tickSpacing: BigNumberish | null) {
-      // nothing
-    },
-    async OwnerChanged(oldOwner: string | null, newOwner: string | null) {
-      // nothing
-    },
     async PoolCreated(
       token0: string | null,
       token1: string | null,
@@ -231,19 +144,5 @@ export function PoolFactory({ positions, pools }: { positions: ReturnType<typeof
       });
     }
   };
-  async function handleEvent(event: Event) {
-    assert(event.event, "requires event name");
-    assert(event.args, "requires event args");
-    assert(handlers[event.event], "No handler for event: " + event.event);
-    try {
-      await handlers[event.event](...event.args);
-    } catch (err) {
-      console.log(event);
-      throw err;
-    }
-  }
-  return {
-    handleEvent,
-    positions
-  };
+  return HandleEvent(handlers);
 }

--- a/packages/affiliates/libs/uniswap/utils.ts
+++ b/packages/affiliates/libs/uniswap/utils.ts
@@ -1,0 +1,15 @@
+// taken from uniswap subgraph, not sure if correct yet
+const Q192: BigInt = 2n ** 192n;
+export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt): string[] {
+  const num = BigInt(sqrtPriceX96) * BigInt(sqrtPriceX96);
+  const denom = Q192;
+  const price1 = BigInt(num) / BigInt(denom);
+  const price0 = 1n / price1;
+  return [price0.toString(), price1.toString()];
+}
+
+// check if a value is not null or undefined, useful for numbers which could be 0
+/* eslint-disable-next-line @typescript-eslint/ban-types */
+export function exists(value: any): value is {} {
+  return value !== null && value !== undefined;
+}

--- a/packages/affiliates/libs/uniswap/utils.ts
+++ b/packages/affiliates/libs/uniswap/utils.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+import { ethers } from "ethers";
 // taken from uniswap subgraph, not sure if correct yet
 const Q192: BigInt = 2n ** 192n;
 export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt): string[] {
@@ -12,4 +14,20 @@ export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt): string[] {
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export function exists(value: any): value is {} {
   return value !== null && value !== undefined;
+}
+
+// taken from uniswap code:
+// https://github.com/Uniswap/uniswap-v3-core/blob/main/test/shared/utilities.ts
+export function getPositionKey(address: string, lowerTick: string, upperTick: string): string {
+  return ethers.utils.keccak256(
+    ethers.utils.solidityPack(["address", "int24", "int24"], [address, lowerTick, upperTick])
+  );
+}
+
+export function convertValuesToString<T>(obj: { [k: string]: any }): T {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      return [key, value.toString()];
+    })
+  ) as T;
 }

--- a/packages/affiliates/libs/uniswap/utils.ts
+++ b/packages/affiliates/libs/uniswap/utils.ts
@@ -1,16 +1,17 @@
 import assert from "assert";
 import { ethers } from "ethers";
-// taken from uniswap subgraph, not sure if correct yet
-const Q192: BigInt = 2n ** 192n;
-export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt): string[] {
-  const num = BigInt(sqrtPriceX96) * BigInt(sqrtPriceX96);
-  const denom = Q192;
-  const price1 = BigInt(num) / BigInt(denom);
-  const price0 = 1n / price1;
-  return [price0.toString(), price1.toString()];
-}
+// taken from uniswap subgraph, not sure if correct yet. this is currently not used and for reference only.
+// const Q192 = 2n ** 192n;
+// export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt): string[] {
+//   const num = BigInt(sqrtPriceX96) ** 2n
+//   const denom = Q192;
+//   const price1 = BigInt(num) / BigInt(denom);
+//   const price0 = 1n / price1;
+//   return [price0.toString(), price1.toString()];
+// }
 
-// check if a value is not null or undefined, useful for numbers which could be 0
+// check if a value is not null or undefined, useful for numbers which could be 0.
+// "is" syntax: https://stackoverflow.com/questions/40081332/what-does-the-is-keyword-do-in-typescript
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export function exists(value: any): value is {} {
   return value !== null && value !== undefined;

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -17,7 +17,7 @@
     "moment": "^2.29.1",
     "prompt": "^1.1.0",
     "@uniswap/v3-core": "1.0.0-rc.2",
-    "@uniswap/v3-periphery": "1.0.0-beta.21"
+    "@uniswap/v3-periphery": "1.0.0-beta.23"
   },
   "devDependencies": {
     "mocha": "^8.2.0",

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -15,7 +15,9 @@
     "lodash": "^4.17.20",
     "mkdirp": "^1.0.4",
     "moment": "^2.29.1",
-    "prompt": "^1.1.0"
+    "prompt": "^1.1.0",
+    "@uniswap/v3-core": "1.0.0-rc.2",
+    "@uniswap/v3-periphery": "1.0.0-beta.21"
   },
   "devDependencies": {
     "mocha": "^8.2.0",
@@ -30,6 +32,8 @@
     "test": "yarn test-mocha && yarn test-truffle",
     "test-mocha": "mocha test test/mocha/*.js --network mainnet_mnemonic --exit",
     "test-truffle": "truffle test ./test/truffle/*.js test/truffle/liquidity-mining/*.js --network test && truffle test ./test/truffle/gas-rebate/*.js --network mainnet_mnemonic --migrations_directory migrations_null",
-    "test-e2e": "mocha test/e2e/*.js --network=mainnet_mnemonic --exit"
+    "test-e2e": "mocha test/e2e/*.js --network=mainnet_mnemonic --exit",
+    "build": "tsc -b",
+    "watch": "tsc -w"
   }
 }

--- a/packages/affiliates/scripts/univ3.js
+++ b/packages/affiliates/scripts/univ3.js
@@ -1,0 +1,166 @@
+// proof of concept script to interface and get state from univ3
+require("dotenv").config();
+const { ethers } = require("ethers");
+const Promise = require("bluebird");
+
+const V3CoreFactory = require("@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json");
+const UniswapV3Pool = require("@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json");
+const NFTPositionManager = require("@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json");
+
+const { Pools, Cache, Positions, Ticks } = require("../build/libs/uniswap/models");
+const { PoolFactory, PoolEvents, NftEvents } = require("../build/libs/uniswap/processor");
+
+const networks = new Map([
+  [
+    "kovan",
+    {
+      v3CoreFactoryAddress: "0x7046f9311663DB8B7cf218BC7B6F3f17B0Ea1047",
+      weth9Address: "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
+      multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+      proxyAdminAddress: "0x8dF824f7885611c587AA45924BF23153EC832b89",
+      tickLensAddress: "0x3b1aC1c352F3A18A58471908982b8b870c836EC0",
+      quoterAddress: "0x539BF58f052dE91ae369dAd59f1ac6887dF39Bc5",
+      swapRouter: "0xbBca0fFBFE60F60071630A8c80bb6253dC9D6023",
+      nonfungibleTokenPositionDescriptorAddress: "0xc4b81504F9a2bd6a6f2617091FB01Efb38D119c8",
+      descriptorProxyAddress: "0xDbe2c61E85D06eaA6E7916049f38B93288BA30f3",
+      nonfungibleTokenPositionManagerAddress: "0xd3808aBF85aC69D2DBf53794DEa08e75222Ad9a1",
+      v3MigratorAddress: "0x9dF511178D1438065F7672379414F5C46D5B51b4"
+    }
+  ],
+  [
+    "rinkeby",
+    {
+      // v3CoreFactoryAddress: "0xd3808aBF85aC69D2DBf53794DEa08e75222Ad9a1",
+      v3CoreFactoryAddress: "0xFeabCc62240297F1e4b238937D68e7516f0918D7",
+
+      weth9Address: "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+      multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+      proxyAdminAddress: "0x9dF511178D1438065F7672379414F5C46D5B51b4",
+      tickLensAddress: "0x2051F6Fb61077b5A2A2c17535d31A1F2C858994f",
+      quoterAddress: "0x58f6b77148BE49BF7898472268ae8f26377d0AA6",
+      swapRouter: "0xeb86f5BE368c3C5e562f7eA1470ACC431d30fB0C",
+      nonfungibleTokenPositionDescriptorAddress: "0xB79bDE60fc227217f4EE2102dC93fa1264E33DaB",
+      descriptorProxyAddress: "0x865F20efC14A5186bF985aD42c64f5e71C055376",
+      nonfungibleTokenPositionManagerAddress: "0x1988F2e49A72C4D73961C7f4Bb896819d3d2F6a3",
+      v3MigratorAddress: "0x40b8b8657d756D163e1255B78419bD8bCC14dCB3"
+    }
+  ],
+  [
+    "ropsten",
+    {
+      v3CoreFactoryAddress: "0xDbe2c61E85D06eaA6E7916049f38B93288BA30f3",
+      weth9Address: "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+      multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+      proxyAdminAddress: "0xd3808aBF85aC69D2DBf53794DEa08e75222Ad9a1",
+      tickLensAddress: "0x9dF511178D1438065F7672379414F5C46D5B51b4",
+      quoterAddress: "0x2051F6Fb61077b5A2A2c17535d31A1F2C858994f",
+      swapRouter: "0x58f6b77148BE49BF7898472268ae8f26377d0AA6",
+      nonfungibleTokenPositionDescriptorAddress: "0xeb86f5BE368c3C5e562f7eA1470ACC431d30fB0C",
+      descriptorProxyAddress: "0xB79bDE60fc227217f4EE2102dC93fa1264E33DaB",
+      nonfungibleTokenPositionManagerAddress: "0x865F20efC14A5186bF985aD42c64f5e71C055376",
+      v3MigratorAddress: "0x1988F2e49A72C4D73961C7f4Bb896819d3d2F6a3"
+    }
+  ]
+]);
+const infura = process.env.infura;
+const network = "rinkeby";
+
+async function getPoolState(pool, provider) {
+  const contract = new ethers.Contract(pool.address, UniswapV3Pool.abi, provider);
+  const slot0 = await contract.slot0();
+  const liquidity = await contract.liquidity();
+  return {
+    ...slot0,
+    liquidity: liquidity.toString()
+  };
+}
+async function processNftEvents({ provider, positions }) {
+  const nftHandler = NftEvents({ positions });
+  const contract = new ethers.Contract(
+    networks.get(network)["nonfungibleTokenPositionManagerAddress"],
+    NFTPositionManager.abi,
+    provider
+  );
+  const events = await contract.queryFilter({});
+  await Promise.map(events, nftHandler.handleEvent);
+}
+async function processPoolEvents({ pools, pool, provider, positions }) {
+  const poolHandler = PoolEvents({ positions, id: pool.id, pools });
+  const contract = new ethers.Contract(pool.address, UniswapV3Pool.abi, provider);
+  const events = await contract.queryFilter({});
+  await Promise.map(events, poolHandler.handleEvent);
+}
+async function getPositionState({ position, provider, pool }) {
+  const contract = new ethers.Contract(pool.address, UniswapV3Pool.abi, provider);
+  return contract.positions(position.id);
+}
+
+const IsPositionActive = tick => position => {
+  if (BigInt(position.liquidity.toString()) === 0n) return false;
+  if (BigInt(tick.toString()) > BigInt(position.tickUpper.toString())) return false;
+  if (BigInt(tick.toString()) < BigInt(position.tickLower.toString())) return false;
+  return true;
+};
+
+function getTickInfo({ pool, provider }) {
+  const contract = new ethers.Contract(pool.address, UniswapV3Pool.abi, provider);
+  return contract.ticks(pool.tick);
+}
+
+async function run() {
+  const provider = ethers.getDefaultProvider(infura);
+
+  const pools = Pools({}, Cache());
+  const positions = Positions({}, Cache());
+  const nftPositions = Positions({}, Cache());
+  const ticks = Ticks({}, Cache());
+  let activePositions;
+
+  // see all pools created
+  const factory = new ethers.Contract(networks.get(network)["v3CoreFactoryAddress"], V3CoreFactory.abi, provider);
+  // get all factory events
+  const events = await factory.queryFilter({});
+
+  // init event handler with pools
+  const factoryHandler = PoolFactory({ pools });
+
+  // handle events and update pools
+  await Promise.mapSeries(events, factoryHandler.handleEvent);
+
+  // loop through all pools
+  await Promise.mapSeries(await pools.list(), async pool => {
+    // update pool with latest state
+    await pools.update(pool.id, await getPoolState(pool, provider));
+    // handle all pool events to get positions
+    await processPoolEvents({ pools, pool, provider, positions });
+
+    // get position state from pools
+    await Promise.mapSeries(await positions.list(), async position => {
+      return positions.update(position.id, await getPositionState({ position, provider, pool }));
+    });
+
+    const updatedPool = await pools.get(pool.id);
+    const { address, tick } = updatedPool;
+    // get tick states
+    await ticks.create({ pool: address, index: tick, ...(await getTickInfo({ pool: updatedPool, provider })) });
+    // filter active positions only
+    const activeMap = new Map((await positions.list()).filter(IsPositionActive(tick)).map(x => [x.id, x]));
+    // create active position table
+    activePositions = Positions({}, Cache(activeMap));
+  });
+
+  // afaik nft contract holds all positions across all pools
+  await processNftEvents({ provider, positions: nftPositions });
+
+  // log everything to spot check all the stat is there
+  console.log(await pools.list());
+  console.log(await positions.list());
+  console.log(await ticks.list());
+  console.log(await activePositions.list());
+  console.log((await activePositions.list()).length);
+  console.log((await nftPositions.list()).length);
+}
+
+run()
+  .then(console.log)
+  .catch(console.log);

--- a/packages/affiliates/scripts/univ3.ts
+++ b/packages/affiliates/scripts/univ3.ts
@@ -91,7 +91,7 @@ async function processNftEvents(params: { provider: any; positions: ReturnType<t
     provider
   );
   const events = await contract.queryFilter({});
-  await Promise.map(events, nftHandler.handleEvent);
+  await Promise.map(events, nftHandler);
 }
 async function getNftPositionState(params: { provider: any; position: NftPosition }) {
   const { provider, position } = params;
@@ -114,7 +114,7 @@ async function processPoolEvents(params: {
   const poolHandler = PoolEvents({ positions, id: pool.id, pools });
   const contract = new ethers.Contract(pool.address, UniswapV3Pool.abi, provider);
   const events = await contract.queryFilter({});
-  await Promise.map(events, poolHandler.handleEvent);
+  await Promise.map(events, poolHandler);
 }
 async function getPositionState(params: { position: Position; provider: any; pool: Pool }) {
   const { position, provider, pool } = params;
@@ -161,7 +161,7 @@ async function run() {
   const factoryHandler = PoolFactory({ pools, positions });
 
   // handle events and update pools
-  await Promise.mapSeries(events, factoryHandler.handleEvent);
+  await Promise.mapSeries(events, factoryHandler);
 
   // loop through all pools
   await Promise.mapSeries(await pools.list(), async pool => {

--- a/packages/affiliates/tsconfig.json
+++ b/packages/affiliates/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["**/*.ts"],
   "compilerOptions": {
     "outDir": "build",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   }
 }

--- a/packages/affiliates/tsconfig.json
+++ b/packages/affiliates/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "include": ["**/*.ts"],
+  "compilerOptions": {
+    "outDir": "build",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/563/interface-with-uniswap-v3-to-get-lp-positions

**Summary**
This mainly shows how we can relevenat uniswap v3 liquidity mining state. pools, positions and ticks through events and contract queries.  This will be useful for determining reward values for liquidity mining.  This is very much a work in progress, but its a good checkpoint before the code gets too large. 


**Details**

You will notice this uses ethers, this is mainly becuase I was building typechain files from uniswap and it built to ethers, so all types were based on this. This could probably be switched to web3 with a bit of work.

Most of the logic is split between 3 files:
- `scripts/univ3` - this shows how to fetch events and state from contracts and put them into models
- `libs/uniswap/models` - these are uniswap v3 specific data, it includes `Positions`, `NftPositions`, `Ticks` and `Pools`. Most of the logic is the same across tables.
- `libs/uniswap/processors` - these are the event handlers which handle specific contract events and fill up the models: `NftEvents`,  `PoolEvents`, `PoolFactory`.

**Remaining Challenges**
- still need to be able to get this state for arbitrary block numbers 
- break down uniswap liquidity and sqrtPrice into virtual X/Y amounts
- use virtual liquidity to calcluate a USD value for either positions or pools
- might want to be able to compare pools to each other, this requires usd price normalization
- add a flexible weighting or scaling system so that we can experiment with per pool reward weighting


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
https://app.clubhouse.io/uma-project/story/563/interface-with-uniswap-v3-to-get-lp-positions