### PR TITLE
fix (CircleCI): Upgrade executor size

### DIFF
--- a/ci/generate_lerna_config.sh
+++ b/ci/generate_lerna_config.sh
@@ -45,6 +45,7 @@ else
         - image: trufflesuite/ganache-cli
           command: ganache-cli -i 1234 -l 9000000 -p 9545
       working_directory: ~/protocol
+      resource_class: medium+
       steps:
         - restore_cache:
             key: protocol-completed-build-{{ .Environment.CIRCLE_SHA1 }}

--- a/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
+++ b/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
@@ -60,7 +60,7 @@ class FinancialContractEventClient {
       contractVersion !== "1.2.0" &&
       contractVersion !== "1.2.1" &&
       contractVersion !== "1.2.2" &&
-      contractVersion !== "2.0.1"
+      contractVersion !== "latest"
     )
       throw new Error(
         `Invalid contract version provided: ${contractVersion}! The financial product client only supports 1.2.0, 1.2.1, 1.2.2 or latest`
@@ -147,7 +147,7 @@ class FinancialContractEventClient {
     // Set the last block to search up until.
     const lastBlockToSearch = this.lastBlockToSearchUntil
       ? this.lastBlockToSearchUntil
-      : await this.web3.eth.getBlockNumber();
+      : await this.web3.eth.Contract();
 
     // Define a config to bound the queries by.
     const blockSearchConfig = {

--- a/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
+++ b/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
@@ -60,7 +60,7 @@ class FinancialContractEventClient {
       contractVersion !== "1.2.0" &&
       contractVersion !== "1.2.1" &&
       contractVersion !== "1.2.2" &&
-      contractVersion !== "latest"
+      contractVersion !== "2.0.1"
     )
       throw new Error(
         `Invalid contract version provided: ${contractVersion}! The financial product client only supports 1.2.0, 1.2.1, 1.2.2 or latest`

--- a/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
+++ b/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
@@ -147,7 +147,7 @@ class FinancialContractEventClient {
     // Set the last block to search up until.
     const lastBlockToSearch = this.lastBlockToSearchUntil
       ? this.lastBlockToSearchUntil
-      : await this.web3.eth.Contract();
+      : await this.web3.eth.getBlockNumber();
 
     // Define a config to bound the queries by.
     const blockSearchConfig = {

--- a/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
+++ b/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
@@ -373,3 +373,5 @@ class FinancialContractEventClient {
 module.exports = {
   FinancialContractEventClient
 };
+
+// test comment for CI tests

--- a/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
+++ b/packages/financial-templates-lib/src/clients/FinancialContractEventClient.js
@@ -373,5 +373,3 @@ class FinancialContractEventClient {
 module.exports = {
   FinancialContractEventClient
 };
-
-// test comment for CI tests


### PR DESCRIPTION
Signed-off-by: uma-mining <contato@evaldofelipe.com>

**Motivation**

On the newest tests, we received output Exit code `137` - Out of memory. This MR upgrade the memory size to avoid it.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
