### PR TITLE
feat(price-feed): added USDXIO price feed in DefaultPriceFeedConfigs.js

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -941,7 +941,7 @@ const defaultConfigs = {
   },
   USDXIO: {
     type: "expression",
-    expression: "XIOETH * ETHUSD",
+    expression: "XIOETH * USDETH",
     lookback: 7200,
     minTimeBetweenUpdates: 60,
     twapLength: 3600,
@@ -949,11 +949,6 @@ const defaultConfigs = {
       XIOETH: {
         type: "uniswap",
         uniswapAddress: "0xe0cc5afc0ff2c76183416fb8d1a29f6799fb2cdf",
-        invertPrice: true
-      },
-      ETHUSD: {
-        type: "uniswap",
-        uniswapAddress: "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
         invertPrice: true
       }
     }

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -941,12 +941,12 @@ const defaultConfigs = {
   },
   USDXIO: {
     type: "expression",
-    expression: "XIOETH * USDETH",
+    expression: "ETHXIO * USDETH",
     lookback: 7200,
     minTimeBetweenUpdates: 60,
     twapLength: 3600,
     customFeeds: {
-      XIOETH: {
+      ETHXIO: {
         type: "uniswap",
         uniswapAddress: "0xe0cc5afc0ff2c76183416fb8d1a29f6799fb2cdf",
         invertPrice: true

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -938,6 +938,25 @@ const defaultConfigs = {
     uniswapAddress: "0x360acfeb5c1548bad3583c559a646d803077236d",
     twapLength: 7200,
     invertPrice: false
+  },
+  USDXIO: {
+    type: "expression",
+    expression: "XIOETH * ETHUSD",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    twapLength: 3600,
+    customFeeds: {
+      XIOETH: {
+        type: "uniswap",
+        uniswapAddress: "0xe0cc5afc0ff2c76183416fb8d1a29f6799fb2cdf",
+        invertPrice: true
+      },
+      ETHUSD: {
+        type: "uniswap",
+        uniswapAddress: "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+        invertPrice: true
+      }
+    }
   }
 };
 


### PR DESCRIPTION
**Motivation**

Default price feed config for USDXIO price identifier, [UIMP-71](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-71.md).

**Summary**

Default config for the USDXIO price identifier is created in the file DefaultPriceFeedConfigs.js.


**Details**

The config is of type expression. It uses uniswap pairs of XIO/ETH and ETH/USDT to calculate the price of USD in terms of XIO.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested
