### PR TITLE
fix(price-feeds): allow for cryptowatch price inversion when twapLength is defined

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -287,8 +287,10 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
       })
       .flat();
     const startTime = endTime - this.twapLength;
+    const twapPrice = computeTWAP(priceTimes, startTime, endTime, this.web3.utils.toBN("0"));
 
-    return computeTWAP(priceTimes, startTime, endTime, this.web3.utils.toBN("0"));
+    if (!this.invertPrice) return twapPrice;
+    else return this._invertPriceSafely(twapPrice);
   }
 
   _invertPriceSafely(priceBN) {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -289,8 +289,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     const startTime = endTime - this.twapLength;
     const twapPrice = computeTWAP(priceTimes, startTime, endTime, this.web3.utils.toBN("0"));
 
-    if (!this.invertPrice) return twapPrice;
-    else return this._invertPriceSafely(twapPrice);
+    return this.invertPrice ? this._invertPriceSafely(twapPrice) : twapPrice;
   }
 
   _invertPriceSafely(priceBN) {


### PR DESCRIPTION
**Motivation**

When a `twapLength` is defined for a cryptowatch price feed, `invertPrice` is not used. This PR allows for inverting cryptowatch prices while also using a twap.

To reproduce, define a non-zero `twapLength` config parameter for any cryptowatch default price feed config that also has an `invertPrice` value of true.

**Summary**

Inverts the twap returned from `_computeTwap()` when `invertPrice` is true.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

Tested locally by running a monitor bot, but did not add anything to the unit tests. Happy to do so if it is necessary.

**Issue(s)**

NA
