### PR TITLE
feat(GasEstimator): update the default to use fast gas price

### DIFF
--- a/packages/financial-templates-lib/src/helpers/GasEstimator.js
+++ b/packages/financial-templates-lib/src/helpers/GasEstimator.js
@@ -82,8 +82,8 @@ class GasEstimator {
     try {
       const response = await fetch(url);
       const json = await response.json();
-      if (json.fast) {
-        let price = json.fast;
+      if (json.fastest) {
+        let price = json.fastest;
         return price;
       } else {
         throw new Error("Etherchain API: bad json response");
@@ -99,8 +99,8 @@ class GasEstimator {
       try {
         const responseBackup = await fetch(backupUrl);
         const jsonBackup = await responseBackup.json();
-        if (jsonBackup.result && jsonBackup.result.SafeGasPrice) {
-          return jsonBackup.result.SafeGasPrice;
+        if (jsonBackup.result && jsonBackup.result.ProposeGasPrice) {
+          return jsonBackup.result.ProposeGasPrice;
         } else {
           throw new Error("Etherscan API: bad json response");
         }


### PR DESCRIPTION
**Motivation**

Right now the gas estimator returns the `SafeGasPrice` or `fast` gas price, depending on the API called. Ideally, we should always use the _fastest_ price returned. 

An example of where this matters is when proposing UMIPs. The script will use the recommended price and the gas price will move up a few GWEI and before you know it you are stuck with a pending transaction. At all times we should use the `fastest` recommendation to ensure transactions are mined as soon as posible. This should result in a general improvement in quality of life for proposers as well as indirectly improve the bots performance (and reduce how often we need to bump gas).

**Summary**

Update the default.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
