### PR TITLE
fix (CircleCI): Restore packages tests on master

### DIFF
--- a/ci/check_lerna_packages.sh
+++ b/ci/check_lerna_packages.sh
@@ -3,7 +3,14 @@
 set -o errexit
 set -o nounset
 
-HASH=$(git merge-base HEAD master)
+if [[ $(git branch | awk '/^\* / { print $2 }') = master ]]; then
+  HASH=$(git merge-base HEAD~1 master)
+  echo "You are using master, comparing changes with commit $HASH"
+else
+  HASH=$(git merge-base HEAD master)
+  echo "You are not using master, comparing changes with commit $HASH"
+fi
+
 yarn lerna ls --since ${HASH} --include-dependents > lerna_output
 if [[ $(cat lerna_output | grep @) ]]; then
   cat lerna_output | grep @ > lerna_packages


### PR DESCRIPTION
**Motivation**

The current test process depends on compare edit packages from last master commit. On master branch that was a problem comparing the latest commit with himself. This PR fix that logic to test the past commit.

**Testing**

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested