### PR TITLE
fix(tvl-calculator): filter out unrealistic numbers

### DIFF
--- a/packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
+++ b/packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
@@ -17,6 +17,8 @@ export async function calculateCurrentTvl() {
     }, toBN("0"))
     .div(fixedPointAdjustment)
     .toString();
+  // It is possible an error was introduced by a flaky API or some other reason that broke the sizing of the TVL. If it
+  // is larger than 100 billion or less than 10 million it is likely wrong. In this case, error out.
   if (toBN(currentTvl).gt(toBN("100000000000")) || toBN(currentTvl).lt(toBN("10000000")))
     throw new Error("The TVL calculation likely contained an error and is out of reasonable bounds!");
   return { currentTvl, currentTime: Math.round(new Date().getTime() / 1000) };

--- a/packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
+++ b/packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
@@ -17,6 +17,8 @@ export async function calculateCurrentTvl() {
     }, toBN("0"))
     .div(fixedPointAdjustment)
     .toString();
+  if (toBN(currentTvl).gt(toBN("100000000000")) || toBN(currentTvl).lt(toBN("10000000")))
+    throw new Error("The TVL calculation likely contained an error and is out of reasonable bounds!");
   return { currentTvl, currentTime: Math.round(new Date().getTime() / 1000) };
 }
 


### PR DESCRIPTION
**Motivation**

There have been scenarios where the TVL returned by the serverless script is orders of magnitude off. This PR adds a reasonable bound (less than 100 billion and more than 10 million) to the UMA tvl.

**Summary**

Errors in providers or APIs can manifest in erroneous TVL. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

