### PR TITLE
feat(kpi): example bDigg KPI implementation

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -24,17 +24,17 @@ contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Lockable 
         nonReentrantView()
         returns (FixedPoint.Unsigned memory)
     {
-        // If price request is made before expiry, return 2. Thus we can keep the contract 100% collateralized with
-        // each token backed 1:2 by collateral currency. Post-expiry, leave unchanged.
+        // If price request is made before expiry, return 0.001. Thus we can keep the contract 100% collateralized with
+        // each token backed 1:0.001 by collateral currency. Post-expiry, leave unchanged.
         if (requestTime < ExpiringContractInterface(msg.sender).expirationTimestamp()) {
-            return FixedPoint.fromUnscaledUint(2);
+            return FixedPoint.fromUnscaledUint(0.001);
         } else {
             return oraclePrice;
         }
     }
 
     /**
-     * @notice Returns a transformed collateral requirement that is set to be equivalent to 2 tokens pre-expiry.
+     * @notice Returns a transformed collateral requirement that is set to be equivalent to 0.001 tokens pre-expiry.
      * @param oraclePrice price from the oracle to transform the collateral requirement.
      * @param collateralRequirement financial products collateral requirement to be scaled to a flat rate.
      * @return transformedCollateralRequirement the input collateral requirement with the transformation logic applied to it.

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -27,7 +27,7 @@ contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Lockable 
         // If price request is made before expiry, return 0.001. Thus we can keep the contract 100% collateralized with
         // each token backed 1:0.001 by collateral currency. Post-expiry, leave unchanged.
         if (requestTime < ExpiringContractInterface(msg.sender).expirationTimestamp()) {
-            return 1000000000000000;
+            return FixedPoint.fromUnsigned(1000000000000000);
         } else {
             return oraclePrice;
         }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -7,7 +7,7 @@ import "../../../common/implementation/Lockable.sol";
 /**
  * @title KPI Options Financial Product Library
  * @notice Adds custom tranformation logic to modify the price and collateral requirement behavior of the expiring multi party contract.
- * If a price request is made pre-expiry, the price should always be set to 2 and the collateral requirement should be set to 1.
+ * If a price request is made pre-expiry, the price should always be set to 0.001 and the collateral requirement should be set to 1.
  * Post-expiry, the collateral requirement is left as 1 and the price is left unchanged.
  */
 contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Lockable {
@@ -27,7 +27,7 @@ contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Lockable 
         // If price request is made before expiry, return 0.001. Thus we can keep the contract 100% collateralized with
         // each token backed 1:0.001 by collateral currency. Post-expiry, leave unchanged.
         if (requestTime < ExpiringContractInterface(msg.sender).expirationTimestamp()) {
-            return FixedPoint.fromUnscaledUint(0.001);
+            return 1000000000000000;
         } else {
             return oraclePrice;
         }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol
@@ -27,7 +27,7 @@ contract KpiOptionsFinancialProductLibrary is FinancialProductLibrary, Lockable 
         // If price request is made before expiry, return 0.001. Thus we can keep the contract 100% collateralized with
         // each token backed 1:0.001 by collateral currency. Post-expiry, leave unchanged.
         if (requestTime < ExpiringContractInterface(msg.sender).expirationTimestamp()) {
-            return FixedPoint.fromUnsigned(1000000000000000);
+            return FixedPoint.Unsigned(1000000000000000);
         } else {
             return oraclePrice;
         }


### PR DESCRIPTION
Should not be merged in. PR is up simply for review.

This follows the same pattern as the previously used [KPI Options FPL](https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/financial-templates/common/financial-product-libraries/KpiOptionsFinancialProductLibrary.sol), except for it transforms the pre-expiry price to 0.001 instead of 2. 

