### PR TITLE
improve(price-feed): Remove quandl feed from backup pricefeed

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -599,13 +599,6 @@ const defaultConfigs = {
         minuteLookback: 7200,
         hourlyLookback: 259200,
         minTimeBetweenUpdates: 60
-      },
-      {
-        type: "quandl",
-        // https://www.quandl.com/data/CHRIS/CME_MGC1-E-micro-Gold-Futures-Continuous-Contract-1-MGC1-Front-Month
-        datasetCode: "CHRIS",
-        databaseCode: "CME_MGC1",
-        lookback: 259200
       }
     ]
   },


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This data source is getting deprecated on June 30th and moreover I don't know for certain whether its using a similar process for computing the XAUUSD price as the tradermade pricefeed. For now, we should remove this pricefeed and longer term figure out a better back up for tradermade.

![Screen Shot 2021-05-12 at 11 06 18](https://user-images.githubusercontent.com/9457025/117999753-2a475300-b313-11eb-85ac-059bf9f7fe64.png)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested