### PR TITLE
fix (CircleCI): Remove context from tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,6 @@ workflows:
           requires:
             - checkout_and_install
       - test:
-          context: api_keys
           requires:
             - build
       - dapp_build:


### PR DESCRIPTION
Signed-off-by: uma-mining <contato@evaldofelipe.com>

**Motivation**

The old method used for tests, needed a specific context to execute. In the current improvement, we can avoid this step and allow execute the tests on each PR.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
