### PR TITLE
feat: Add polygon networks to truffle and hardhat configs

### DIFF
--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -43,7 +43,11 @@ function getHardhatConfig(configOverrides) {
         accounts: { mnemonic }
       },
       mumbai: {
-        url: "https://rpc-mumbai.maticvigil.com/",
+        url: getNodeUrl("polygon-mumbai", true),
+        accounts: { mnemonic }
+      },
+      matic: {
+        url: getNodeUrl("polygon-matic", true),
         accounts: { mnemonic }
       }
     },

--- a/packages/common/src/PublicNetworks.js
+++ b/packages/common/src/PublicNetworks.js
@@ -48,8 +48,7 @@ const PublicNetworks = {
     etherscan: "https://explorer-mainnet.maticvigil.com/",
     customTruffleConfig: {
       confirmations: 2,
-      timeoutBlocks: 200,
-      gasPrice: 1000000000 // 1 gWei
+      timeoutBlocks: 200
     }
   },
   80001: {
@@ -57,8 +56,7 @@ const PublicNetworks = {
     etherscan: "https://explorer-mumbai.maticvigil.com/",
     customTruffleConfig: {
       confirmations: 2,
-      timeoutBlocks: 200,
-      gasPrice: 1000000000 // 1 gWei
+      timeoutBlocks: 200
     }
   }
 };

--- a/packages/common/src/PublicNetworks.js
+++ b/packages/common/src/PublicNetworks.js
@@ -43,9 +43,23 @@ const PublicNetworks = {
     daiAddress: "0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99",
     wethAddress: "0xd0A1E359811322d97991E03f863a0C30C2cF029C"
   },
+  137: {
+    name: "polygon-matic",
+    etherscan: "https://explorer-mainnet.maticvigil.com/",
+    customTruffleConfig: {
+      confirmations: 2,
+      timeoutBlocks: 200,
+      gasPrice: 1000000000 // 1 gWei
+    }
+  },
   80001: {
-    name: "mumbai",
-    etherscan: "https://explorer-mumbai.maticvigil.com/"
+    name: "polygon-mumbai",
+    etherscan: "https://explorer-mumbai.maticvigil.com/",
+    customTruffleConfig: {
+      confirmations: 2,
+      timeoutBlocks: 200,
+      gasPrice: 1000000000 // 1 gWei
+    }
   }
 };
 

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -56,12 +56,12 @@ function getNodeUrl(networkName, useHttps = false) {
 // Adds a public network.
 // Note: All public networks can be accessed using keys from GCS using the ManagedSecretProvider or using a mnemonic in the
 // shell environment.
-function addPublicNetwork(networks, name, networkId) {
+function addPublicNetwork(networks, name, networkId, customTruffleConfig) {
   const options = {
     networkCheckTimeout: 10000,
     network_id: networkId,
-    gas: gas,
-    gasPrice: gasPx
+    gas: customTruffleConfig?.gas || gas,
+    gasPrice: customTruffleConfig?.gasPrice || gasPx
   };
 
   const nodeUrl = getNodeUrl(name);
@@ -166,8 +166,8 @@ function addLocalNetwork(networks, name, customOptions) {
 let networks = {};
 
 // Public networks that need both a mnemonic and GCS ManagedSecretProvider network.
-for (const [id, { name }] of Object.entries(PublicNetworks)) {
-  addPublicNetwork(networks, name, id);
+for (const [id, { name, customTruffleConfig }] of Object.entries(PublicNetworks)) {
+  addPublicNetwork(networks, name, id, customTruffleConfig);
 }
 
 // Add test network.
@@ -176,6 +176,7 @@ addLocalNetwork(networks, "test");
 // Mainnet fork is just a local network with id 1 and a hardcoded gas limit because ganache has difficulty estimating gas on forks.
 // Note: this gas limit is the default ganache block gas limit.
 addLocalNetwork(networks, "mainnet-fork", { network_id: 1, gas: 6721975 });
+addLocalNetwork(networks, "polygon-matic-fork", { network_id: 137, gas: 6721975, gasPrice: 1000000000 });
 
 // MetaMask truffle provider requires a longer timeout so that user has time to point web browser with metamask to localhost:3333
 addLocalNetwork(networks, "metamask", {

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -35,7 +35,7 @@ const numKeys = process.env.NUM_KEYS ? parseInt(process.env.NUM_KEYS) : 2; // Ge
 let singletonProvider;
 
 // Default options
-const gasPx = argv.gasPrice ? Web3.utils.toWei(argv.gasPrice, "gwei") : 20000000000; // 20 gwei
+const gasPx = argv.gasPrice ? Web3.utils.toWei(argv.gasPrice, "gwei") : 1000000000; // 1 gwei
 const gas = undefined; // Defining this as undefined (rather than leaving undefined) forces truffle estimate gas usage.
 
 // If a custom node URL is provided, use that. Otherwise use an infura websocket connection.

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -61,7 +61,8 @@ function addPublicNetwork(networks, name, networkId, customTruffleConfig) {
     networkCheckTimeout: 10000,
     network_id: networkId,
     gas: customTruffleConfig?.gas || gas,
-    gasPrice: customTruffleConfig?.gasPrice || gasPx
+    gasPrice: customTruffleConfig?.gasPrice || gasPx,
+    ...customTruffleConfig
   };
 
   const nodeUrl = getNodeUrl(name);

--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -177,7 +177,7 @@ addLocalNetwork(networks, "test");
 // Mainnet fork is just a local network with id 1 and a hardcoded gas limit because ganache has difficulty estimating gas on forks.
 // Note: this gas limit is the default ganache block gas limit.
 addLocalNetwork(networks, "mainnet-fork", { network_id: 1, gas: 6721975 });
-addLocalNetwork(networks, "polygon-matic-fork", { network_id: 137, gas: 6721975, gasPrice: 1000000000 });
+addLocalNetwork(networks, "polygon-matic-fork", { network_id: 137, gas: 6721975 });
 
 // MetaMask truffle provider requires a longer timeout so that user has time to point web browser with metamask to localhost:3333
 addLocalNetwork(networks, "metamask", {


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Now that [infura](https://consensys.net/blog/press-release/infura-and-truffle-now-support-polygon/) supports Polygon, it makes adding the mainnet and testnet into our truffle config very easy.

**Summary**

Can now run truffle and hardhat commands like so:

- `yarn truffle migrate --network polygon-matic/mumbai`
- `yarn hardhat deploy --network matic/mumbai`


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
