### PR TITLE
feat(price-feed): Add default pf configs for PUNKETH_TWAP and USDXIO

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -938,6 +938,26 @@ const defaultConfigs = {
     uniswapAddress: "0x360acfeb5c1548bad3583c559a646d803077236d",
     twapLength: 7200,
     invertPrice: false
+  },
+  PUNKETH_TWAP: {
+    type: "uniswap",
+    uniswapAddress: "0x6E01DB46b183593374A49c0025e42c4bB7Ee3ffA",
+    twapLength: 7200,
+    invertPrice: false
+  },
+  USDXIO: {
+    type: "expression",
+    expression: "ETHXIO * USDETH",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    twapLength: 3600,
+    customFeeds: {
+      ETHXIO: {
+        type: "uniswap",
+        uniswapAddress: "0xe0cc5afc0ff2c76183416fb8d1a29f6799fb2cdf",
+        invertPrice: true
+      }
+    }
   }
 };
 


### PR DESCRIPTION
**Motivation**

The [PUNKETH_TWAP](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-84.md) and [USDXIO](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-71.md) price identifiers need price feed configs. USDXIO is in this PR because pr #2940 has some minor CI issues. This closes 2940.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
