### PR TITLE
fix(affiliates-ci): removed private from package.json

### DIFF
--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -27,7 +27,6 @@
     "registry": "https://registry.npmjs.com/",
     "access": "public"
   },
-  "private": true,
   "scripts": {
     "test": "yarn test-mocha && yarn test-truffle",
     "test-mocha": "mocha test test/mocha/*.js --network mainnet_mnemonic --exit",


### PR DESCRIPTION
**Motivation**

If packages are set to `"private": true` then they are not picked up in our new Lerna CI configuration. This PR modifies this to ensure that affiliates is no longer private so that the test will run in CI.

**Summary**

Fixed affiliates CI.


**Testing**


- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested