### PR TITLE
fix(core): fix typescript exports

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ cache
 types
 contract-types
 packages/core/index.ts
+packages/core/browser.ts

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -125,14 +125,14 @@ Note: this is a work in progress and the typescript API will likely change and i
 The best support is for Ethers contract types. To construct an Ethers contract in node, simply import from the ethers factories:
 
 ```ts
-import { EthersFactories } from "@uma/core";
+import { EthersContracts } from "@uma/core";
 const provider = new ethers.providers.JsonRpcProvider(RPC_HOST)
-const votingInstance = Voting__factory.connect(VOTING_ADDRESS, provider)
+const votingInstance = EthersContracts.Voting__factory.connect(VOTING_ADDRESS, provider)
 
 
 // Raw type rather than the factory.
-import type { EthersTypes } from "@uma/core";
-const { Voting } = EthersTypes;
+import type { EthersContracts } from "@uma/core";
+const { Voting } = EthersContracts;
 ```
 
 ### Truffle
@@ -140,8 +140,8 @@ const { Voting } = EthersTypes;
 Truffle has well-defined contract types as well, but there are no built-in truffle factories.
 
 ```ts
-import type { TruffleTypes } from "@uma/core/contract-types/truffle";
-const { VotingInstance, VotingContract } = TruffleTypes;
+import type { TruffleContracts } from "@uma/core/contract-types/truffle";
+const { VotingInstance, VotingContract } = TruffleContracts;
 
 import { getTruffleContract } from "@uma/core";
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -122,25 +122,17 @@ Note: this is a work in progress and the typescript API will likely change and i
 
 ### Ethers
 
-The best support is for Ethers contract types. To construct an Ethers contract, simply import from the ethers factories:
+The best support is for Ethers contract types. To construct an Ethers contract in node, simply import from the ethers factories:
 
 ```ts
-import { Voting__factory } from "@uma/core/contract-types/ethers"
-
-// Alternative import style to avoid loading anything unnecessary
-// import { Voting__factory } from "@uma/core/contract-types/ethers/factories/Voting__factory"
-
+import { EthersFactories } from "@uma/core";
 const provider = new ethers.providers.JsonRpcProvider(RPC_HOST)
 const votingInstance = Voting__factory.connect(VOTING_ADDRESS, provider)
-```
 
-If you just want the raw type, you can import as follows:
 
-```ts
-import type { Voting } from "@uma/core/contract-types/ethers";
-
-// Alternative import styles
-// import type { Voting } from "@uma/core/contract-types/ethers/Voting";
+// Raw type rather than the factory.
+import type { EthersTypes } from "@uma/core";
+const { Voting } = EthersTypes;
 ```
 
 ### Truffle
@@ -148,10 +140,8 @@ import type { Voting } from "@uma/core/contract-types/ethers";
 Truffle has well-defined contract types as well, but there are no built-in truffle factories.
 
 ```ts
-import type { VotingInstance, VotingContract } from "@uma/core/contract-types/truffle";
-
-// Alternative import style
-// import type { VotingInstance, VotingContract } from "@uma/core/contract-types/truffle/Voting";
+import type { TruffleTypes } from "@uma/core/contract-types/truffle";
+const { VotingInstance, VotingContract } = TruffleTypes;
 
 import { getTruffleContract } from "@uma/core";
 
@@ -161,8 +151,8 @@ const voting = Voting.deployed(); // Should be a VotingInstance.
 
 ### Web3
 
-Web3 types can be imported similarly to truffle. However, the import syntax is quite limited. There is no way to import
-all UMA web3 types from the same import. Each contract is specified in a separate file.
+Web3 types can't be imported directly from the index file. However, if you are able to import via path, you can import
+this way:
 
 ```ts
 import type { Voting } from "@uma/core/contract-types/web3/Voting";

--- a/packages/core/browser.ts
+++ b/packages/core/browser.ts
@@ -1,0 +1,4 @@
+import type * as TruffleTypes from "./contract-types/truffle";
+import type * as EthersTypes from "./contract-types/ethers";
+export type { TruffleTypes, EthersTypes };
+export * as EthersFactories from "./contract-types/ethers";

--- a/packages/core/browser.ts
+++ b/packages/core/browser.ts
@@ -1,4 +1,3 @@
-import type * as TruffleTypes from "./contract-types/truffle";
-import type * as EthersTypes from "./contract-types/ethers";
-export type { TruffleTypes, EthersTypes };
-export * as EthersFactories from "./contract-types/ethers";
+import type * as TruffleContracts from "./contract-types/truffle";
+export type { TruffleContracts };
+export * as EthersContracts from "./contract-types/ethers";

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,9 +8,10 @@ const truffleContract = require("@truffle/contract");
 
 // Re-export the types from index.ts for truffle and ethers for convenience.
 // Note: because typechain doesn't construct a web3 index.d.ts, we'd have to import each type manually.
-import type * as TruffleContracts from "./contract-types/truffle";
-import type * as EthersContracts from "./contract-types/ethers";
-export type { TruffleContracts, EthersContracts };
+import type * as TruffleTypes from "./contract-types/truffle";
+import type * as EthersTypes from "./contract-types/ethers";
+export type { TruffleTypes, EthersTypes };
+export * as EthersFactories from "./contract-types/ethers";
 
 declare const hardhatTestingAddresses: any;
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,10 +8,9 @@ const truffleContract = require("@truffle/contract");
 
 // Re-export the types from index.ts for truffle and ethers for convenience.
 // Note: because typechain doesn't construct a web3 index.d.ts, we'd have to import each type manually.
-import type * as TruffleTypes from "./contract-types/truffle";
-import type * as EthersTypes from "./contract-types/ethers";
-export type { TruffleTypes, EthersTypes };
-export * as EthersFactories from "./contract-types/ethers";
+import type * as TruffleContracts from "./contract-types/truffle";
+export type { TruffleContracts };
+export * as EthersContracts from "./contract-types/ethers";
 
 declare const hardhatTestingAddresses: any;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
     "url": "git+https://github.com/UMAprotocol/protocol.git"
   },
   "main": "dist/index.js",
+  "browser": "dist/browser.js",
   "types": "types/index.d.ts",
   "files": [
     "/contracts/**/*.sol",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "esModuleInterop": true,
-  "include": ["contract-types/**/*.ts", "index.ts", "src/**/*.ts"],
+  "include": ["contract-types/**/*.ts", "index.ts", "browser.ts", "src/**/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,


### PR DESCRIPTION
**Motivation**

The current typescript exports are broken for frontend imports because you can't do imports like `@uma/core/x/y/z`.

**Summary**

This change improves the types exported from the index file so they can be imported that way and includes the ethers factories.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
