### PR TITLE
fix(common): fix build issue

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "hardhat test ./test/*",
-    "build": "tsc"
+    "build": "rm -rf dist && tsc"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"


### PR DESCRIPTION
**Motivation**

Common breaks when being rebuilt.

**Summary**

Common erroneously detects the dist folder as being build inputs and throws and error when trying to overwrite (not sure why), so this adds a step to delete the folder before rebuilding.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
