### PR TITLE
fix(financial-templates-lib): make CW price feed error on missing data

### DIFF
--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -138,16 +138,8 @@ contract("CryptoWatchPriceFeed.js", function () {
         .toString()
     );
 
-    // After period 3 should return the most recent price.
-    assert.equal(
-      // Should be equal to: toWei(1/1.5)
-      await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376521),
-      toBN(toWei("1"))
-        .mul(toBN(toWei("1")))
-        .div(toBN(toWei("1.5")))
-        .div(toBN("10").pow(toBN(18 - 10)))
-        .toString()
-    );
+    // After period 3 should error.
+    assert.isTrue(await invertedCryptoWatchPriceFeed.getHistoricalPrice(1588376521).catch(() => true));
   });
 
   it("No update", async function () {

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -175,8 +175,35 @@ contract("CryptoWatchPriceFeed.js", function () {
     // During period 3.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376515)).toString(), toWei("1.3"));
 
-    // After period 3 should return the most recent price.
-    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.5"));
+    // After period 3 should error.
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(1588376521).catch(() => true));
+  });
+
+  it("Missing historical data", async function () {
+    // Missing middle data point
+    networker.getJsonReturns = [
+      {
+        result: {
+          60: [
+            [1588376400, 1.1, 1.7, 0.5, 1.2, 281.73395575, 2705497.370853147],
+            [1588376520, 1.3, 1.9, 0.7, 1.4, 888.92215493, 8601704.133826157],
+          ],
+        },
+      },
+      {
+        result: {
+          price: 1.5,
+        },
+      },
+    ];
+
+    await cryptoWatchPriceFeed.update();
+
+    // During missing data point should fail.
+    assert.isTrue(await cryptoWatchPriceFeed.getHistoricalPrice(1588376405).catch(() => true));
+
+    // During last data point.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376515)).toString(), toWei("1.3"));
   });
 
   it("Basic TWAP price", async function () {


### PR DESCRIPTION
**Motivation**

Cryptowatch price feed should throw an error if it doesn't have an OHLC data point for a requested historical price rather than trying to fill the gap.


**Summary**

Slightly modified how the feed searches through the data to find a price.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
