### PR TITLE
improve(core): make getHistoricalPrice give better results when price lookups fail

### DIFF
--- a/packages/core/scripts/local/getHistoricalPrice.js
+++ b/packages/core/scripts/local/getHistoricalPrice.js
@@ -33,7 +33,7 @@ const UMIP_PRECISION = {
   "ELASTIC_STABLESPREAD/USDC": 6,
   ETHBTC_FR: 9,
 };
-const DEFAULT_PRECISION = 5;
+const DEFAULT_PRECISION = 18;
 
 async function getHistoricalPrice(callback) {
   try {
@@ -93,7 +93,7 @@ async function getHistoricalPrice(callback) {
     // protocol/financial-templates-lib/src/price-feed/CreatePriceFeed.js
     const queryPrice = await defaultPriceFeed.getHistoricalPrice(queryTime, true);
     const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
-    console.log(`\n⚠️ Truncating price to ${precisionToUse} decimals`);
+    console.log(`\n⚠️ Truncating price to ${precisionToUse} decimals (default: 18)`);
     console.log(
       `\n💹 Median ${queryIdentifier} price @ ${queryTime} = ${Number(fromWei(queryPrice.toString())).toFixed(
         precisionToUse

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -134,7 +134,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
     const returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
     if (verbose) {
       console.group(`\n(${this.exchange}:${this.pair}) Historical OHLC @ ${match.closeTime}`);
-      console.log(`- ✅ Open Price:${formatFixed(returnPrice.toString(), this.priceFeedDecimals)}`);
+      console.log(`- ✅ Open Price: ${formatFixed(returnPrice.toString(), this.priceFeedDecimals)}`);
       console.log(
         `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${match.closeTime}&before=${match.closeTime}&periods=60`
       );


### PR DESCRIPTION
**Motivation**

Recent cryptowatch changes can sometimes cause historical price lookups to fail. We should provide useful information to allow the user to make informed decisions about what price to use.


**Summary**

Added error logs in the CW price feed to output the closest prices when an exact OHLC isn't available. Also added minor usability improvements to the CW price feed and getHistoricalPrice script.

Sample output:
```
$ yarn truffle exec scripts/local/getHistoricalPrice.js --time 1621430236 --identifier USDOCEAN --network test
yarn run v1.22.5
$ /Users/matt/git/protocol/node_modules/.bin/truffle exec scripts/local/getHistoricalPrice.js --time 1621430236 --identifier USDOCEAN --network test
> Warning: possible unsupported (undocumented in help) command line option: --time,--identifier
Using network 'test'.

⏰ Fetching nearest prices for the timestamp: Wed, 19 May 2021 13:17:16 GMT

(binance:oceanusdt) Historical OHLC @ 1621430280
  - ✅ Open Price: 1.650165016501650165
  - ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: 
  - https://api.cryptowat.ch/markets/binance/oceanusdt/ohlc?after=1621430280&before=1621430280&periods=60
  - This will return an OHLC data packet as "result", which contains in order: 
  - [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].
  - We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH.

(bittrex:oceanusdt) Historical OHLC @ 1621430280
  - ✅ Open Price: 1.535101366888029307
  - ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: 
  - https://api.cryptowat.ch/markets/bittrex/oceanusdt/ohlc?after=1621430280&before=1621430280&periods=60
  - This will return an OHLC data packet as "result", which contains in order: 
  - [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].
  - We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH.
Error: 
        Cryptowatch price feed Cryptowatch-bitz-oceanusdt didn't return an ohlc for time 1621430236.
        Closest price point before is close time: 1621430220, close price: 1.653411815280831996.
        Closest price point after is open time: 1621430280, open price: 1.62686275785774712.
        To see these prices, make a GET request to:
        https://api.cryptowat.ch/markets/bitz/oceanusdt/ohlc?after=1621430220&before=1621430340&periods=60
      
Truffle v5.2.4 (core: 5.2.4)
Node v14.15.4
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
