### PR TITLE
fix(get-historical-price-script): Do not cast to `Number` before truncating decimals

### DIFF
--- a/packages/core/scripts/local/getHistoricalPrice.js
+++ b/packages/core/scripts/local/getHistoricalPrice.js
@@ -94,11 +94,9 @@ async function getHistoricalPrice(callback) {
     const queryPrice = await defaultPriceFeed.getHistoricalPrice(queryTime, true);
     const precisionToUse = UMIP_PRECISION[queryIdentifier] ? UMIP_PRECISION[queryIdentifier] : DEFAULT_PRECISION;
     console.log(`\n⚠️ Truncating price to ${precisionToUse} decimals (default: 18)`);
-    console.log(
-      `\n💹 Median ${queryIdentifier} price @ ${queryTime} = ${Number(fromWei(queryPrice.toString())).toFixed(
-        precisionToUse
-      )}`
-    );
+    const [predec, postdec] = fromWei(queryPrice.toString()).split(".");
+    const truncated = [predec, postdec.slice(0, precisionToUse)].join(".");
+    console.log(`\n💹 Median ${queryIdentifier} price @ ${queryTime} = ${truncated}`);
   } catch (err) {
     callback(err);
     return;

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -752,7 +752,7 @@ const defaultConfigs = {
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [
       { type: "cryptowatch", exchange: "binance", pair: "oceanusdt" },
-      { type: "cryptowatch", exchange: "bittrex", pair: "oceanusdt" },
+      { type: "cryptowatch", exchange: "kraken", pair: "oceanusd" },
       { type: "cryptowatch", exchange: "bitz", pair: "oceanusdt" },
     ],
   },


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

`node.js`'s `Number` type loses precision after a certain amount of decimals, thus the truncation logic in this script that first casts to `Number` and then calls `.toFixed()` can lose precision. This fix performs string manipulation instead.

Also changes `bittrex:oceanusdt` to `kraken:oceanusd` in `DefaultPriceFeedConfig`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
