### PR TITLE
improve(financial-templates-lib): Update OCEANUSD default price confi…

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -761,7 +761,7 @@ const defaultConfigs = {
     minTimeBetweenUpdates: 60,
     medianizedFeeds: [
       { type: "cryptowatch", exchange: "binance", pair: "oceanusdt" },
-      { type: "cryptowatch", exchange: "bittrex", pair: "oceanusdt" },
+      { type: "cryptowatch", exchange: "kraken", pair: "oceanusd" },
       { type: "cryptowatch", exchange: "bitz", pair: "oceanusdt" },
     ],
   },


### PR DESCRIPTION
**Motivation**

OCEANUSD price identifier has a Binance, Kraken, Bitz as the three default price config data sources. During the recent price dispute for OCEANUSD price identifier, the community has identified that Bittrex's volume is low, and the price significantly deviates from other exhangse. According to Coingecko, OCEAN/USDT on Bittrex represents only 0.06% of the total daily trading volume. On the other hand, OCEAN/USD on Kraken has 1.12% of daily trading volume, 20 X of what Bittrex has. We suggest to update the price config from OCEAN/USDT on Bittrex to OCEAN/USD on Kraken.

In fact, in UMIP-46, the three selected data sources are indeed Binance, Kraken, and Bitz. Bittrex did not belong to the list.

**Summary**

Update the price pair configuration here to Kraken, which is already supported.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

I will update manual script run result here as well

**Issue(s)**

https://github.com/UMAprotocol/protocol/issues/3009
