### PR TITLE
fix(readme.md): add back broken logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UMA Protocol
 
 <p align="center">
-  <img alt="UMA Logo" src="./documentation/Logo.png" width="440">
+  <img alt="UMA Logo" src="https://umaproject.org/assets/images/logo.svg" width="440">
 </p>
 
 [![<UMAprotocol>](https://circleci.com/gh/UMAprotocol/protocol.svg?style=shield)](https://app.circleci.com/pipelines/github/UMAprotocol/protocol)


### PR DESCRIPTION

**Motivation**

After removing the docs site, we broke the logo in the readme. This PR fixes this.

Before:
![image](https://user-images.githubusercontent.com/12886084/119305788-7e362e00-bc69-11eb-932c-10bda63044c5.png)

After:
![image](https://user-images.githubusercontent.com/12886084/119305825-89895980-bc69-11eb-9d45-169f8a1dfee3.png)
