### PR TITLE
feat(liquidator): add maxSlippage parameter to single reserve currency liquidator

### DIFF
--- a/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
+++ b/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
@@ -33,7 +33,7 @@ contract ReserveCurrencyLiquidator {
      * @param financialContract address of the financial contract on which the liquidation is occurring.
      * @param reserveCurrency address of the token to swap for collateral. THis is the common currency held by the DSProxy.
      * @param liquidatedSponsor address of the sponsor to be liquidated.
-     * @param maxReserveTokenSpent maximum number of reserve tokens to spend in the trade. Bounds slippage.
+     * @param maxSlippage max slip the trade on uniswap will accept before reverting.
      * @param minCollateralPerTokenLiquidated abort the liquidation if the position's collateral per token is below this value.
      * @param maxCollateralPerTokenLiquidated abort the liquidation if the position's collateral per token exceeds this value.
      * @param maxTokensToLiquidate max number of tokens to liquidate. For a full liquidation this is the full position debt.
@@ -44,10 +44,10 @@ contract ReserveCurrencyLiquidator {
         address financialContract,
         address reserveCurrency,
         address liquidatedSponsor,
-        FixedPoint.Unsigned calldata maxReserveTokenSpent,
         FixedPoint.Unsigned calldata minCollateralPerTokenLiquidated,
         FixedPoint.Unsigned calldata maxCollateralPerTokenLiquidated,
-        FixedPoint.Unsigned calldata maxTokensToLiquidate,
+        FixedPoint.Unsigned memory maxTokensToLiquidate,
+        uint256 maxSlippage,
         uint256 deadline
     ) public {
         IFinancialContract fc = IFinancialContract(financialContract);
@@ -67,28 +67,32 @@ contract ReserveCurrencyLiquidator {
 
         // 4.a. Calculate how much collateral needs to be purchased. If the DSProxy already has some collateral then this
         // will factor this in. If the DSProxy has more collateral than the total amount required the purchased = 0.
-        FixedPoint.Unsigned memory collateralToBePurchased =
-            subOrZero(totalCollateralRequired, getCollateralBalance(fc));
+        uint256 collateralToBePurchased = subOrZero(totalCollateralRequired, getCollateralBalance(fc)).rawValue;
 
         // 4.b. If there is some collateral to be purchased, execute a trade on uniswap to meet the shortfall.
         // Note the path assumes a direct route from the reserve currency to the collateral currency.
-        if (collateralToBePurchased.isGreaterThan(0) && reserveCurrency != fc.collateralCurrency()) {
+        // Note the maxInputAmount is computed by taking the 11000000 wei trade as the spot price from the router,
+        // multiplied by collateral to be purchased to arrive at a "zero slippage input amount". This would be the amount of
+        // required input to buy the amountOut, assuming zero slippage. This is then scalded by maxSlippage & swap fees
+        // to find the amountInMax that factors in the max tolerable exchange slippage.
+        if (collateralToBePurchased > 0 && reserveCurrency != fc.collateralCurrency()) {
             IUniswapV2Router01 router = IUniswapV2Router01(uniswapRouter);
             address[] memory path = new address[](2);
             path[0] = reserveCurrency;
             path[1] = fc.collateralCurrency();
 
-            TransferHelper.safeApprove(reserveCurrency, address(router), maxReserveTokenSpent.rawValue);
+            TransferHelper.safeApprove(reserveCurrency, address(router), type(uint256).max);
             router.swapTokensForExactTokens(
-                collateralToBePurchased.rawValue,
-                maxReserveTokenSpent.rawValue,
+                collateralToBePurchased, // amountOut
+                (router.getAmountsIn(1000000, path)[0] * collateralToBePurchased * (1e18 + maxSlippage / 2) * 997) /
+                    (1000000e18 * 1000), // amountInMax
                 path,
                 address(this),
                 deadline
             );
         }
 
-        // 4.c. If at this point we were not able to get the required amount of collateral (due to insufficient reserve
+        // 4.c. If at this point we were not able to get `the required amount of collateral (due to insufficient reserve
         // or not enough collateral in the contract) the script should try to liquidate as much as it can regardless.
         // Update the values of total collateral to the current collateral balance and re-compute the tokenShortfall
         // as the maximum tokens that could be liquidated at the current GCR.
@@ -105,16 +109,15 @@ contract ReserveCurrencyLiquidator {
 
         // The liquidatableTokens is either the maxTokensToLiquidate (if we were able to buy/mint enough) or the full
         // token token balance at this point if there was a shortfall.
-        FixedPoint.Unsigned memory liquidatableTokens = maxTokensToLiquidate;
-        if (maxTokensToLiquidate.isGreaterThan(getSyntheticBalance(fc))) liquidatableTokens = getSyntheticBalance(fc);
+        if (maxTokensToLiquidate.isGreaterThan(getSyntheticBalance(fc))) maxTokensToLiquidate = getSyntheticBalance(fc);
 
         // 6. Liquidate position with newly minted synthetics.
-        TransferHelper.safeApprove(fc.tokenCurrency(), address(fc), liquidatableTokens.rawValue);
+        TransferHelper.safeApprove(fc.tokenCurrency(), address(fc), maxTokensToLiquidate.rawValue);
         fc.createLiquidation(
             liquidatedSponsor,
             minCollateralPerTokenLiquidated,
             maxCollateralPerTokenLiquidated,
-            liquidatableTokens,
+            maxTokensToLiquidate,
             deadline
         );
     }
@@ -154,17 +157,17 @@ interface IFinancialContract {
         uint256 transferPositionRequestPassTimestamp;
     }
 
-    function positions(address sponsor) external returns (PositionData memory);
+    function positions(address sponsor) external view returns (PositionData memory);
 
-    function collateralCurrency() external returns (address);
+    function collateralCurrency() external view returns (address);
 
-    function tokenCurrency() external returns (address);
+    function tokenCurrency() external view returns (address);
 
-    function finder() external returns (address);
+    function finder() external view returns (address);
 
-    function pfc() external returns (FixedPoint.Unsigned memory);
+    function pfc() external view returns (FixedPoint.Unsigned memory);
 
-    function totalTokensOutstanding() external returns (FixedPoint.Unsigned memory);
+    function totalTokensOutstanding() external view returns (FixedPoint.Unsigned memory);
 
     function create(FixedPoint.Unsigned memory collateralAmount, FixedPoint.Unsigned memory numTokens) external;
 
@@ -184,7 +187,7 @@ interface IFinancialContract {
 }
 
 interface IStore {
-    function computeFinalFee(address currency) external returns (FixedPoint.Unsigned memory);
+    function computeFinalFee(address currency) external view returns (FixedPoint.Unsigned memory);
 }
 
 interface IFinder {

--- a/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
+++ b/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
@@ -71,10 +71,13 @@ contract ReserveCurrencyLiquidator {
 
         // 4.b. If there is some collateral to be purchased, execute a trade on uniswap to meet the shortfall.
         // Note the path assumes a direct route from the reserve currency to the collateral currency.
-        // Note the maxInputAmount is computed by taking the 11000000 wei trade as the spot price from the router,
+        // Note the maxInputAmount is computed by taking the 1000000 wei trade as the spot price from the router,
         // multiplied by collateral to be purchased to arrive at a "zero slippage input amount". This would be the amount of
         // required input to buy the amountOut, assuming zero slippage. This is then scalded by maxSlippage & swap fees
-        // to find the amountInMax that factors in the max tolerable exchange slippage.
+        // to find the amountInMax that factors in the max tolerable exchange slippage. The maxSlippage is divided by two
+        // as slippage in an AMM is constituted by the inputToken going up and the outputToken going down in proportion.
+        // the +1e18 is used to offset the slippage percentage provided. i.e a 5% will be input at 0.05e18, offset by 1e18
+        // to bring it up to 1.05e18. the *997 and *1000 in the numerator and denominator respectively are for uniswap fees.
         if (collateralToBePurchased > 0 && reserveCurrency != fc.collateralCurrency()) {
             IUniswapV2Router01 router = IUniswapV2Router01(uniswapRouter);
             address[] memory path = new address[](2);

--- a/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
+++ b/packages/core/contracts/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.sol
@@ -88,7 +88,7 @@ contract ReserveCurrencyLiquidator {
             router.swapTokensForExactTokens(
                 collateralToBePurchased, // amountOut
                 (router.getAmountsIn(1000000, path)[0] * collateralToBePurchased * (1e18 + maxSlippage / 2) * 997) /
-                    (1000000e18 * 1000), // amountInMax
+                    (1000000 * 1e18 * 1000), // amountInMax
                 path,
                 address(this),
                 deadline

--- a/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
+++ b/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
@@ -372,19 +372,7 @@ contract("ReserveTokenLiquidator", function (accounts) {
 
     // Build the transaction call data. This differs from the previous tests in that it uses the collateral as reserve token.
     // Also, note that the maxTokensToLiquidate is more than the bot could do with just 1 wei of collateral.
-    const callData = reserveCurrencyLiquidator.contract.methods
-      .swapMintLiquidate(
-        router.address, // uniswapRouter
-        financialContract.address, // financialContract
-        collateralToken.address, // reserveCurrency
-        sponsor1, // liquidatedSponsor
-        { rawValue: 0 }, // minCollateralPerTokenLiquidated
-        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
-        { rawValue: toWei("1000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
-        toWei("0.5"), // maxSlippage above any achievable slippage given the pool sizes (50%)
-        unreachableDeadline
-      )
-      .encodeABI();
+    let callData = buildCallData(collateralToken.address, toWei("0.5")); // maxSlippage above any achievable slippage given the pool sizes (50%)
 
     await dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
       from: liquidator,

--- a/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
+++ b/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
@@ -1,4 +1,4 @@
-const { MAX_UINT_VAL, MAX_SAFE_ALLOWANCE, ZERO_ADDRESS } = require("@uma/common");
+const { MAX_UINT_VAL, MAX_SAFE_ALLOWANCE, ZERO_ADDRESS, didContractThrow, parseFixed } = require("@uma/common");
 const { toWei, toBN, fromWei, padRight, utf8ToHex } = web3.utils;
 const { getTruffleContract } = require("@uma/core");
 const truffleContract = require("@truffle/contract");
@@ -39,16 +39,27 @@ let identifierWhitelist;
 let timer;
 let finder;
 let store;
+// set the starting pool price at 1000 reserveToken/collateralToken
+let startingReservePoolAmount = toBN(toWei("1000")).muln(50);
+let startingCollateralPoolAmount = toBN(toWei("1")).muln(50);
 
 const priceFeedIdentifier = padRight(utf8ToHex("TEST_IDENTIFIER"), 64);
 const unreachableDeadline = 4772084478; // 100 years in the future
 const finalFeeAmount = toBN(toWei("0.1"));
+const fixedPointAdjustment = toBN(toWei("1"));
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {
   const poolTokenABallance = await reserveToken.balanceOf(pairAddress);
   const poolTokenBBallance = await collateralToken.balanceOf(pairAddress);
-  return Number(fromWei(poolTokenABallance.mul(toBN(toWei("1"))).div(poolTokenBBallance))).toFixed(4);
+  return Number(fromWei(poolTokenABallance.mul(fixedPointAdjustment).div(poolTokenBBallance))).toFixed(4);
+};
+
+const computeExpectedTokenBuy = async (tokensToLiquidate) => {
+  const contractGcr = toBN((await financialContract.pfc()).toString())
+    .mul(fixedPointAdjustment)
+    .div(toBN((await financialContract.totalTokensOutstanding()).toString()));
+  return tokensToLiquidate.mul(contractGcr).div(fixedPointAdjustment).add(finalFeeAmount);
 };
 
 // Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
@@ -85,10 +96,10 @@ contract("ReserveTokenLiquidator", function (accounts) {
         financialContract.address, // financialContract
         reserveToken.address, // reserveCurrency
         sponsor1, // liquidatedSponsor
-        { rawValue: MAX_UINT_VAL }, // maxReserverTokenSpent
         { rawValue: 0 }, // minCollateralPerTokenLiquidated
         { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
         { rawValue: toWei("1000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.5"), // maxSlippage set to 50% to not worry about slippage in inital tests.
         unreachableDeadline
       )
       .encodeABI();
@@ -135,8 +146,8 @@ contract("ReserveTokenLiquidator", function (accounts) {
     pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
     pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
 
-    await reserveToken.mint(pairAddress, toBN(toWei("1000")).muln(10000000));
-    await collateralToken.mint(pairAddress, toBN(toWei("1")).muln(10000000));
+    await reserveToken.mint(pairAddress, startingReservePoolAmount);
+    await collateralToken.mint(pairAddress, startingCollateralPoolAmount);
     await pair.sync({ from: deployer });
     assert.equal(await getPoolSpotPrice(), "1000.0000"); // price should be exactly 1000 reserveToken/collateralToken.
 
@@ -322,10 +333,10 @@ contract("ReserveTokenLiquidator", function (accounts) {
         financialContract.address, // financialContract
         collateralToken.address, // reserveCurrency
         sponsor1, // liquidatedSponsor
-        { rawValue: MAX_UINT_VAL }, // maxReserverTokenSpent
         { rawValue: 0 }, // minCollateralPerTokenLiquidated
         { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
         { rawValue: toWei("1000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.5"),
         unreachableDeadline
       )
       .encodeABI();
@@ -372,10 +383,10 @@ contract("ReserveTokenLiquidator", function (accounts) {
         financialContract.address, // financialContract
         collateralToken.address, // reserveCurrency
         sponsor1, // liquidatedSponsor
-        { rawValue: MAX_UINT_VAL }, // maxReserverTokenSpent
         { rawValue: 0 }, // minCollateralPerTokenLiquidated
         { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
         { rawValue: toWei("1000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.5"), //maxSlippage above any achievable slippage given the pool sizes (50%)
         unreachableDeadline
       )
       .encodeABI();
@@ -407,5 +418,334 @@ contract("ReserveTokenLiquidator", function (accounts) {
     assert.equal((await financialContract.getPastEvents("PositionCreated")).length, 1);
     assert.equal((await pair.getPastEvents("Swap")).length, 0);
     assert.equal((await financialContract.getPastEvents("LiquidationCreated")).length, 1);
+  });
+  it("correctly respects max slippage tolerance", async function () {
+    await reserveToken.mint(dsProxy.address, toWei("10000"));
+
+    // To test the slippage tolerances of the smart contract we can compute how much the price will move for a given trade
+    // and then ensure that the contract will revert if the slippage is large than the tolerance. The position size being
+    // liquidated is 1000 units of synthetics. We can compute how much the bot will need to buy to mint this size by
+    // calculating the amount of collateral to mint at the GCR + the final fee. From the size of the position of 1000
+    // synthetics and a GCR of 2.5 the bot will need 2.5 units of collateral to mint + 0.1 for the final fee, totalling 2.6.
+    // Based on the pool size of 50000 reserve to 50 collateral a purchase of 2.6 collateral with reserve will require a
+    // reserve input of 2750.86.
+
+    const expectedTokenBuy = await computeExpectedTokenBuy(toBN(toWei("1000"))); // how much collateral to liquidate the full 1000 unit position
+    const amountsIn = await router.getAmountsIn(expectedTokenBuy, [reserveToken.address, collateralToken.address]);
+
+    // compute the resultant price by considering how much the pools will mode due to the amounts in/out. This is
+    // (50000+2750.86)/(50-2.6)=1112.8875
+    const numerator = startingReservePoolAmount.add(amountsIn[0]);
+    const denominator = startingCollateralPoolAmount.sub(amountsIn[1]);
+    const expectedResultantPrice = numerator.mul(fixedPointAdjustment).div(denominator);
+
+    // The expected slippage is the resultant price (post trade) divided by the original price, minus 1. This is
+    // 1112.8875/1000-1=0.1128875 (i.e 11.28875%). Trying to execute a trade with a slippage tolerance of 11 should fail
+    // but 12 should pass.
+    const expectedTradeSlippage = expectedResultantPrice
+      .mul(fixedPointAdjustment)
+      .div(toBN(toWei(await getPoolSpotPrice())))
+      .sub(fixedPointAdjustment);
+    assert.equal(Number(fromWei(expectedTradeSlippage)).toFixed(7), "0.1128875"); // check the expected slip matches our calculations
+
+    // Build the transaction call data with a slippage tolerance below the expected slippage. This should revert.
+    let callData = reserveCurrencyLiquidator.contract.methods
+      .swapMintLiquidate(
+        router.address, // uniswapRouter
+        financialContract.address, // financialContract
+        reserveToken.address, // reserveCurrency
+        sponsor1, // liquidatedSponsor
+        { rawValue: 0 }, // minCollateralPerTokenLiquidated
+        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
+        { rawValue: toWei("1000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.11"), // maxSlippage 11.2% is below the expected slippage of 11.28%. should revert
+        unreachableDeadline
+      )
+      .encodeABI();
+
+    assert(
+      await didContractThrow(
+        dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
+          from: liquidator,
+        })
+      )
+    );
+
+    // Build the transaction call data with a slippage tolerance right above the threshold. this should not revert.
+    callData = reserveCurrencyLiquidator.contract.methods
+      .swapMintLiquidate(
+        router.address, // uniswapRouter
+        financialContract.address, // financialContract
+        reserveToken.address, // reserveCurrency
+        sponsor1, // liquidatedSponsor
+        { rawValue: 0 }, // minCollateralPerTokenLiquidated
+        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
+        { rawValue: toWei("1000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.12"), // maxSlippage 12% is above the expected slippage of 11.28. should not revert
+        unreachableDeadline
+      )
+      .encodeABI();
+
+    await dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
+      from: liquidator,
+    });
+
+    // There should be one liquidation after the call and the properties on the liquidation should match what is expected.
+    const liquidations = await financialContract.getLiquidations(sponsor1);
+    await validateLiquidationOutput(liquidations);
+
+    // To validate some of our assumptions the expected price from before should equal the resultant uniswap price.
+    assert.equal(await getPoolSpotPrice(), Number(fromWei(expectedResultantPrice)).toFixed(4));
+  });
+  it("correctly swaps against very small denominated pools", async function () {
+    // Some pools have wacky sizing, such as SLP-DIGG-WBTC which has a total supply of 0.000000071317329372. The underlying
+    // tokens in these pools have 8 and 9 decimals for WBTC and DIGG respectively,  but the LP tokens have 18, leading to
+    // the strange sizing.To ensure slippage tolerances are correctly respected on this kind of pool we can mimic the exact SLP setup.
+
+    // Create the reserve,collateral and synthetic tokens afresh using new decimals. Reserve token in this case is wBTC
+    // and collateral token is DIGG.
+
+    reserveToken = await Token.new("reserveToken", "wBTC", 8);
+    // Synthetic and collateral precision must match.
+    collateralToken = await Token.new("collateralToken", "DIGG", 9);
+    syntheticToken = await Token.new("Test Synthetic Token", "SYNTH", 9);
+
+    await reserveToken.addMember(1, deployer, { from: deployer });
+    await collateralToken.addMember(1, deployer, { from: deployer });
+    await syntheticToken.addMember(1, deployer, { from: deployer });
+
+    // Create some unit conversion utils to help with the testing.
+    const Convert = (decimals) => (number) => (number ? parseFixed(number.toString(), decimals).toString() : number);
+    const convertReserve = Convert(8);
+    const convertCollateral = Convert(9);
+    const convertSynthetic = Convert(9);
+
+    // create a new router and pair to re-initalize from fresh.
+    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, collateralToken.address);
+    await factory.createPair(reserveToken.address, collateralToken.address, { from: deployer });
+    pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
+    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+
+    // Add in the exact reserves as seen on the live pools. At these reserve ratios the starting price is 0.0797.
+    await reserveToken.mint(pairAddress, "10881694425");
+    await collateralToken.mint(pairAddress, "136567052391");
+    await pair.sync({ from: deployer });
+
+    // Create the EMP to mint positions.
+    const constructorParams = {
+      expirationTimestamp: unreachableDeadline,
+      withdrawalLiveness: "100",
+      collateralAddress: collateralToken.address,
+      tokenAddress: syntheticToken.address,
+      finderAddress: finder.address,
+      priceFeedIdentifier: priceFeedIdentifier,
+      liquidationLiveness: "100",
+      collateralRequirement: { rawValue: toWei("1.5") },
+      disputeBondPercentage: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPercentage: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPercentage: { rawValue: toWei("0.1") },
+      minSponsorTokens: { rawValue: convertSynthetic("100") },
+      timerAddress: timer.address,
+      financialProductLibraryAddress: ZERO_ADDRESS,
+    };
+
+    await identifierWhitelist.addSupportedIdentifier(priceFeedIdentifier, { from: deployer });
+
+    financialContract = await ExpiringMultiParty.new(constructorParams);
+    await syntheticToken.addMinter(financialContract.address);
+    await syntheticToken.addBurner(financialContract.address);
+
+    // Create one sponsor that we will attempt to liquidate and validate slippage.
+    await collateralToken.mint(sponsor1, toWei("100000000000000"));
+    await collateralToken.approve(financialContract.address, MAX_UINT_VAL, { from: sponsor1 });
+    await await financialContract.create(
+      { rawValue: convertCollateral("20") },
+      { rawValue: convertSynthetic("10000") },
+      { from: sponsor1 }
+    );
+
+    // mint some reserve to the dsproxy.
+    await reserveToken.mint(dsProxy.address, convertReserve("1000000")); // mint some reserve tokens.
+
+    // We know the exact number of tokens in the pool and the number of tokens required to mint at the GCR. The GCR is
+    // 2e9 / 1000e9=0.0002. To liquidate 1000 units of debt, while minting at the GCR the dsProxy will also need 2e9 units
+    // of collateral. To find the exchange rate we can use the getAmountsIn method, as before. to compute the expected output
+    // we can use numerator=reserveIn*amountOut*1000; denominator=(reserveOut-amountOut)*997; amountIn=numerator/denominator
+    // numerator=10881694425*20e9*1000; denominator=(136567052391-20e9)*997; amountIn = 1872645403. From this, the resultant
+    // price is expected to be (10881694425+1872645403)/(136567052391-20e9)=0.1094. From this, we can see the expected slippage
+    // is 0.1094/0.0797-1 ≈ 0.37. A slippage tolerance of 30% should revert but and a tolerance of 40% should not.
+
+    let callData = reserveCurrencyLiquidator.contract.methods
+      .swapMintLiquidate(
+        router.address, // uniswapRouter
+        financialContract.address, // financialContract
+        reserveToken.address, // reserveCurrency
+        sponsor1, // liquidatedSponsor
+        { rawValue: 0 }, // minCollateralPerTokenLiquidated
+        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
+        { rawValue: convertSynthetic("10000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.34"), // maxSlippage. 34% is below the expected slippage of 37% for this liquidation. should revert.
+        unreachableDeadline
+      )
+      .encodeABI();
+
+    assert(
+      await didContractThrow(
+        dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
+          from: liquidator,
+        })
+      )
+    );
+
+    // Build the transaction call data with a slippage tolerance right above the threshold. this should not revert.
+    callData = reserveCurrencyLiquidator.contract.methods
+      .swapMintLiquidate(
+        router.address, // uniswapRouter
+        financialContract.address, // financialContract
+        reserveToken.address, // reserveCurrency
+        sponsor1, // liquidatedSponsor
+        { rawValue: 0 }, // minCollateralPerTokenLiquidated
+        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
+        { rawValue: convertSynthetic("10000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.4"), // maxSlippage. 40% is above the expected slippage of 37% for this liquidation. should not revert.
+        unreachableDeadline
+      )
+      .encodeABI();
+
+    await dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
+      from: liquidator,
+    });
+
+    // There should be one liquidation after the call and the properties on the liquidation should match what is expected.
+    const liquidations = await financialContract.getLiquidations(sponsor1);
+    assert.equal(liquidations.length, 1);
+    assert.equal(liquidations[0].sponsor, sponsor1); // The selected sponsor should be liquidated.
+    assert.equal(liquidations[0].liquidator, dsProxy.address); // The dSProxy did the liquidation.
+
+    // Validate the calculations we had at the top of the unit test by ensuring the post trade spot price matches our expectation.
+    assert.equal(await getPoolSpotPrice(), "0.1094");
+  });
+  it("correctly swaps against pools with large differences in token decimals", async function () {
+    // Some pools have have wide ranges in token decimals. For example USDC has 6 decimals while WETH has 18. Validate
+    // that slippage is correctly accounted for when buying lower decimal reserve currencies in this way.
+
+    reserveToken = await Token.new("reserveToken", "WETH", 18);
+    // Synthetic and collateral precision must match.
+    collateralToken = await Token.new("collateralToken", "USDC", 6);
+    syntheticToken = await Token.new("Test Synthetic Token", "SYNTH", 6);
+
+    await reserveToken.addMember(1, deployer, { from: deployer });
+    await collateralToken.addMember(1, deployer, { from: deployer });
+    await syntheticToken.addMember(1, deployer, { from: deployer });
+
+    // Create some unit conversion utils to help with the testing.
+    const Convert = (decimals) => (number) => (number ? parseFixed(number.toString(), decimals).toString() : number);
+    const convertCollateral = Convert(6);
+    const convertSynthetic = Convert(6);
+
+    // create a new router and pair to re-initalize from fresh.
+    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, collateralToken.address);
+    await factory.createPair(reserveToken.address, collateralToken.address, { from: deployer });
+    pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
+    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+
+    // Add liquidity to the pool such that the price is 1000 ETH/USDC.
+    await reserveToken.mint(pairAddress, toWei("1000")); // 1000 Weth.
+    await collateralToken.mint(pairAddress, convertCollateral("1000000")); // 1000x1000 USDC to make a price of 1000 ETH/USD
+    await pair.sync({ from: deployer });
+
+    // Create the EMP to mint positions.
+    const constructorParams = {
+      expirationTimestamp: unreachableDeadline,
+      withdrawalLiveness: "100",
+      collateralAddress: collateralToken.address,
+      tokenAddress: syntheticToken.address,
+      finderAddress: finder.address,
+      priceFeedIdentifier: priceFeedIdentifier,
+      liquidationLiveness: "100",
+      collateralRequirement: { rawValue: toWei("1.5") },
+      disputeBondPercentage: { rawValue: toWei("0.1") },
+      sponsorDisputeRewardPercentage: { rawValue: toWei("0.1") },
+      disputerDisputeRewardPercentage: { rawValue: toWei("0.1") },
+      minSponsorTokens: { rawValue: convertSynthetic("100") },
+      timerAddress: timer.address,
+      financialProductLibraryAddress: ZERO_ADDRESS,
+    };
+
+    await identifierWhitelist.addSupportedIdentifier(priceFeedIdentifier, { from: deployer });
+
+    financialContract = await ExpiringMultiParty.new(constructorParams);
+    await syntheticToken.addMinter(financialContract.address);
+    await syntheticToken.addBurner(financialContract.address);
+
+    // Create one sponsor that we will attempt to liquidate and validate slippage.
+    await collateralToken.mint(sponsor1, toWei("100000000000000"));
+    await collateralToken.approve(financialContract.address, MAX_UINT_VAL, { from: sponsor1 });
+    await await financialContract.create(
+      { rawValue: convertCollateral("20000") }, // put in 2000 USDC
+      { rawValue: convertSynthetic("10000") }, // mint 1000 synthetics. CR at 2.
+      { from: sponsor1 }
+    );
+
+    // mint some reserve to the dsproxy.
+    await reserveToken.mint(dsProxy.address, toWei("100000")); // mint some reserve tokens.
+
+    // With reserves of 1000e18 weth and 1000000e6 USDC, the starting price is 1000 ETH/USD. To liquidate 10000 tokens
+    // we will need 20000 units of collateral. The expected amount in for a given buy of 20000e6 price after this trade
+    // will be 1000e18 * 20000e6 * 1000 / ((1000000e6 - 20000e6) * 997)=2.046957e18. Considering this, the dex price will be
+    // (1000e18+20.469e18)/(1000000e6-20000e6)=1041295481.61. This is then divided by 1e6 to remove the decimals from the price
+    // yielding 1041.2. Therefore, the price slippage is 4.12% to preform this liquidation, from the starting price of 1000.
+
+    let callData = reserveCurrencyLiquidator.contract.methods
+      .swapMintLiquidate(
+        router.address, // uniswapRouter
+        financialContract.address, // financialContract
+        reserveToken.address, // reserveCurrency
+        sponsor1, // liquidatedSponsor
+        { rawValue: 0 }, // minCollateralPerTokenLiquidated
+        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
+        { rawValue: toWei("10000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.04"), // maxSlippage. 4% is below the expected slippage of 4.12% for this liquidation. should revert.
+        unreachableDeadline
+      )
+      .encodeABI();
+
+    assert(
+      await didContractThrow(
+        dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
+          from: liquidator,
+        })
+      )
+    );
+
+    // Build the transaction call data with a slippage tolerance right above the threshold. this should not revert.
+    callData = reserveCurrencyLiquidator.contract.methods
+      .swapMintLiquidate(
+        router.address, // uniswapRouter
+        financialContract.address, // financialContract
+        reserveToken.address, // reserveCurrency
+        sponsor1, // liquidatedSponsor
+        { rawValue: 0 }, // minCollateralPerTokenLiquidated
+        { rawValue: MAX_SAFE_ALLOWANCE }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
+        { rawValue: convertSynthetic("10000") }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        toWei("0.05"), // maxSlippage. 5% is above the expected slippage of 4.12% for this liquidation. should not revert.
+        unreachableDeadline
+      )
+      .encodeABI();
+
+    await dsProxy.contract.methods["execute(address,bytes)"](reserveCurrencyLiquidator.address, callData).send({
+      from: liquidator,
+    });
+
+    // There should be one liquidation after the call and the properties on the liquidation should match what is expected.
+    const liquidations = await financialContract.getLiquidations(sponsor1);
+    assert.equal(liquidations.length, 1);
+    assert.equal(liquidations[0].sponsor, sponsor1); // The selected sponsor should be liquidated.
+    assert.equal(liquidations[0].liquidator, dsProxy.address); // The dSProxy did the liquidation.
+
+    // Validate the calculations we had at the top of the unit test by ensuring the post trade spot price matches our expectation.
+    assert.equal(await getPoolSpotPrice(), "1041295481.6135");
   });
 });

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -78,7 +78,7 @@ class ProxyTransactionWrapper {
         // default to reverting on >10% slippage on trades.
         value: this.toWei("0.1"),
         isValid: (x) => {
-          return typeof x == "string";
+          return typeof x == "string" && this.toBN(x).gt(this.toBN("0"));
         },
       },
     };

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const truffleContract = require("@truffle/contract");
 
-const { createObjectFromDefaultProps, runTransaction, blockUntilBlockMined, MAX_UINT_VAL } = require("@uma/common");
+const { createObjectFromDefaultProps, runTransaction, blockUntilBlockMined } = require("@uma/common");
 const { getAbi, getTruffleContract } = require("@uma/core");
 
 const UniswapV2Factory = require("@uniswap/v2-core/build/UniswapV2Factory.json");

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -74,8 +74,9 @@ class ProxyTransactionWrapper {
           return this.web3.utils.isAddress(x) || x === "";
         },
       },
-      maxReserverTokenSpent: {
-        value: MAX_UINT_VAL,
+      maxAcceptableSlippage: {
+        // default to reverting on >10% slippage on trades.
+        value: this.toWei("0.1"),
         isValid: (x) => {
           return typeof x == "string";
         },
@@ -228,10 +229,10 @@ class ProxyTransactionWrapper {
         this.financialContract._address, // financialContract
         this.reserveToken._address, // reserveCurrency
         liquidationArgs[0], // liquidatedSponsor
-        { rawValue: this.maxReserverTokenSpent }, // maxReserverTokenSpent
         { rawValue: liquidationArgs[1].rawValue }, // minCollateralPerTokenLiquidated
         { rawValue: liquidationArgs[2].rawValue }, // maxCollateralPerTokenLiquidated. This number need to be >= the token price.
         { rawValue: liquidationArgs[3].rawValue }, // maxTokensToLiquidate. This is how many tokens the positions has (liquidated debt).
+        this.maxAcceptableSlippage, // maxSlippage. liquidation will revert if the slippage on the dex is more than this.
         liquidationArgs[4]
       )
       .encodeABI();

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -2335,7 +2335,7 @@ contract("Liquidator.js", function (accounts) {
               // The contract GCR is now (125+175+200)/(100+100+100)=1.666. To liquidate one sponsor with 100 units of
               // debt we will need 1.666*100=collateral=166. After removing liquidity, the pool has 10000 reserve and
               // collateral tokens. The amount in for a given buy of 166 is 10000e18*166e18*1000/((10000e18-166e18)*997)
-              //=1.693100452E20. using this, the expected spot price after the trade is (10000e18+1.693100452e20)/(10000e18-166e18)
+              // =1.693100452E20. using this, the expected spot price after the trade is (10000e18+1.693100452e20)/(10000e18-166e18)
               // =1.0342. This is a price slippage of 3.42%. We can therefore check that if the slippage paramter is set
               // to something more than this (say 5%) the bot correctly liquidates and something less than this (say 3%) it reverts.
 


### PR DESCRIPTION



**Motivation**

In the most recent market downturn, it became apparent that the single reserve currency liquidator might trade poorly, resulting in high slippage, when pools are shallow. This PR adds logic to bound slippage within the single reserve currency liquidator.

**Summary**

Added in a `maxSlippage` that bounds the maximum trade slippage the bot will execute under.


**Details**

Please see detailed comments in the PR & smart contracts explaining the numerical technique used to bound slippage.

**Testing**



- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
