### PR TITLE
improve(beacon-oracles): validateDeposit should revert after first execution

### DIFF
--- a/packages/core/contracts/chainbridge/BeaconOracle.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracle.sol
@@ -14,7 +14,7 @@ import "../oracle/implementation/Constants.sol";
  * price requests from the DVM on Mainnet.
  */
 abstract contract BeaconOracle {
-    enum RequestState { NeverRequested, Requested, Resolved }
+    enum RequestState { NeverRequested, PendingRequest, Requested, PendingResolve, Resolved }
 
     struct Price {
         RequestState state;
@@ -77,8 +77,7 @@ abstract contract BeaconOracle {
         bytes32 priceRequestId = _encodePriceRequest(chainID, identifier, time, ancillaryData);
         Price storage lookup = prices[priceRequestId];
         if (lookup.state == RequestState.NeverRequested) {
-            // New query, change state to Requested:
-            lookup.state = RequestState.Requested;
+            lookup.state = RequestState.PendingRequest;
             emit PriceRequestAdded(msg.sender, chainID, identifier, time, ancillaryData);
         }
     }
@@ -98,7 +97,7 @@ abstract contract BeaconOracle {
         Price storage lookup = prices[priceRequestId];
         require(lookup.state == RequestState.Requested, "Price request is not currently pending");
         lookup.price = price;
-        lookup.state = RequestState.Resolved;
+        lookup.state = RequestState.PendingResolve;
         emit PushedPrice(msg.sender, chainID, identifier, time, ancillaryData, lookup.price);
     }
 

--- a/packages/core/contracts/chainbridge/BeaconOracle.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracle.sol
@@ -83,7 +83,7 @@ abstract contract BeaconOracle {
     }
 
     /**
-     * @notice Derived contract needs call this method in order to advance state from PendingRequest --> Requested 
+     * @notice Derived contract needs call this method in order to advance state from PendingRequest --> Requested
      * before _publishPrice can be called.
      */
     function _finalizeRequest(
@@ -128,7 +128,6 @@ abstract contract BeaconOracle {
         require(lookup.state == RequestState.PendingResolve, "Price has not been published");
         lookup.state = RequestState.Resolved;
     }
-
 
     /**
      * @notice Returns Bridge contract on network.

--- a/packages/core/contracts/chainbridge/BeaconOracleMock.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracleMock.sol
@@ -17,10 +17,7 @@ contract BeaconOracleMock is BeaconOracle {
         bytes memory ancillaryData
     ) public {
         _requestPrice(currentChainID, identifier, time, ancillaryData);
-        bytes32 priceRequestId = _encodePriceRequest(currentChainID, identifier, time, ancillaryData);
-        Price storage lookup = prices[priceRequestId];
-        require(lookup.state == RequestState.PendingRequest, "requestPrice was not called yet");
-        lookup.state = RequestState.Requested;
+        _finalizeRequest(currentChainID, identifier, time, ancillaryData);
     }
 
     function encodePriceRequest(

--- a/packages/core/contracts/chainbridge/BeaconOracleMock.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracleMock.sol
@@ -5,6 +5,8 @@ import "./BeaconOracle.sol";
 
 /**
  * @title Test implementation of BeaconOracle enabling unit tests on internal methods.
+ * @dev Unit tests should ensure that internal methods `_requestPrice` and `_publishPrice` emit the correct events
+ * and modify state as expected.
  */
 contract BeaconOracleMock is BeaconOracle {
     constructor(address _finderAddress, uint8 _chainID) BeaconOracle(_finderAddress, _chainID) {}

--- a/packages/core/contracts/chainbridge/BeaconOracleMock.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracleMock.sol
@@ -7,7 +7,7 @@ import "./BeaconOracle.sol";
  * @title Test implementation of BeaconOracle enabling unit tests on internal methods.
  */
 contract BeaconOracleMock is BeaconOracle {
-    constructor(address _finderAddress, uint8 _chainID) public BeaconOracle(_finderAddress, _chainID) {}
+    constructor(address _finderAddress, uint8 _chainID) BeaconOracle(_finderAddress, _chainID) {}
 
     function requestPrice(
         bytes32 identifier,
@@ -15,6 +15,10 @@ contract BeaconOracleMock is BeaconOracle {
         bytes memory ancillaryData
     ) public {
         _requestPrice(currentChainID, identifier, time, ancillaryData);
+        bytes32 priceRequestId = _encodePriceRequest(currentChainID, identifier, time, ancillaryData);
+        Price storage lookup = prices[priceRequestId];
+        require(lookup.state == RequestState.PendingRequest, "requestPrice was not called yet");
+        lookup.state = RequestState.Requested;
     }
 
     function encodePriceRequest(

--- a/packages/core/contracts/chainbridge/SinkOracle.sol
+++ b/packages/core/contracts/chainbridge/SinkOracle.sol
@@ -107,9 +107,9 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
         int256 price
     ) public onlyGenericHandlerContract() {
         _publishPrice(sinkChainID, identifier, time, ancillaryData, price);
-        // For completeness, we could mark the price request as Resolved, but that doesn't change this contract's
-        // logic at all, because subsequent calls to this method will always fail since the state should advance from
-        // Requested --> PendingResolve.
+        bytes32 priceRequestId = _encodePriceRequest(sinkChainID, identifier, time, ancillaryData);
+        Price storage lookup = prices[priceRequestId];
+        lookup.state = RequestState.Resolved;
     }
 
     /**

--- a/packages/core/contracts/chainbridge/SinkOracle.sol
+++ b/packages/core/contracts/chainbridge/SinkOracle.sol
@@ -53,6 +53,7 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
         bytes32 priceRequestId = _encodePriceRequest(currentChainID, identifier, time, ancillaryData);
         Price storage lookup = prices[priceRequestId];
         if (lookup.state != RequestState.NeverRequested) {
+            // Clients expect that `requestPrice` does not revert if a price is already requested, so return gracefully.
             return;
         } else {
             _requestPrice(currentChainID, identifier, time, ancillaryData);

--- a/packages/core/contracts/chainbridge/SinkOracle.sol
+++ b/packages/core/contracts/chainbridge/SinkOracle.sol
@@ -81,11 +81,8 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
         uint256 time,
         bytes memory ancillaryData
     ) public {
-        bytes32 priceRequestId = _encodePriceRequest(sinkChainID, identifier, time, ancillaryData);
-        Price storage lookup = prices[priceRequestId];
-        require(lookup.state == RequestState.PendingRequest, "Price has not been requested");
         // Advance state so that directly calling Bridge.deposit will revert and not emit a duplicate `Deposit` event.
-        lookup.state = RequestState.Requested;
+        _finalizeRequest(sinkChainID, identifier, time, ancillaryData);
     }
 
     /***************************************************************
@@ -107,9 +104,7 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
         int256 price
     ) public onlyGenericHandlerContract() {
         _publishPrice(sinkChainID, identifier, time, ancillaryData, price);
-        bytes32 priceRequestId = _encodePriceRequest(sinkChainID, identifier, time, ancillaryData);
-        Price storage lookup = prices[priceRequestId];
-        lookup.state = RequestState.Resolved;
+        _finalizePublish(sinkChainID, identifier, time, ancillaryData);
     }
 
     /**

--- a/packages/core/contracts/chainbridge/SourceOracle.sol
+++ b/packages/core/contracts/chainbridge/SourceOracle.sol
@@ -63,10 +63,9 @@ contract SourceOracle is BeaconOracle {
     ) public {
         bytes32 priceRequestId = _encodePriceRequest(sinkChainID, identifier, time, ancillaryData);
         Price storage lookup = prices[priceRequestId];
-        require(lookup.state == RequestState.PendingResolve, "Price has not been published");
         require(lookup.price == price, "Unexpected price published");
         // Advance state so that directly calling Bridge.deposit will revert and not emit a duplicate `Deposit` event.
-        lookup.state = RequestState.Resolved;
+        _finalizePublish(sinkChainID, identifier, time, ancillaryData);
     }
 
     /***************************************************************
@@ -88,9 +87,7 @@ contract SourceOracle is BeaconOracle {
         bytes memory ancillaryData
     ) public onlyGenericHandlerContract() {
         _requestPrice(sinkChainID, identifier, time, ancillaryData);
-        bytes32 priceRequestId = _encodePriceRequest(sinkChainID, identifier, time, ancillaryData);
-        Price storage lookup = prices[priceRequestId];
-        lookup.state = RequestState.Requested;
+        _finalizeRequest(sinkChainID, identifier, time, ancillaryData);
         _getOracle().requestPrice(identifier, time, ancillaryData);
     }
 

--- a/packages/core/contracts/chainbridge/SourceOracle.sol
+++ b/packages/core/contracts/chainbridge/SourceOracle.sol
@@ -88,10 +88,10 @@ contract SourceOracle is BeaconOracle {
         bytes memory ancillaryData
     ) public onlyGenericHandlerContract() {
         _requestPrice(sinkChainID, identifier, time, ancillaryData);
-        _getOracle().requestPrice(identifier, time, ancillaryData);
         bytes32 priceRequestId = _encodePriceRequest(sinkChainID, identifier, time, ancillaryData);
         Price storage lookup = prices[priceRequestId];
         lookup.state = RequestState.Requested;
+        _getOracle().requestPrice(identifier, time, ancillaryData);
     }
 
     /**

--- a/packages/core/test/chainbridge/beaconOracle.js
+++ b/packages/core/test/chainbridge/beaconOracle.js
@@ -46,9 +46,6 @@ contract("BeaconOracle", async (accounts) => {
         event.time.toString() === testRequestTime.toString() &&
         event.ancillaryData.toLowerCase() === testAncillary.toLowerCase()
     );
-    // Requesting another price does not throw an error or emit a PriceRequested event:
-    const txn2 = await beaconOracle.requestPrice(testIdentifier, testRequestTime, testAncillary, { from: owner });
-    TruffleAssert.eventNotEmitted(txn2, "PriceRequestAdded");
   });
   it("publishPrice", async function () {
     await beaconOracle.requestPrice(testIdentifier, testRequestTime, testAncillary, { from: owner });

--- a/packages/core/test/chainbridge/e2e.js
+++ b/packages/core/test/chainbridge/e2e.js
@@ -9,7 +9,7 @@ const TruffleAssert = require("truffle-assertions");
 const Ethers = require("ethers");
 
 const Helpers = require("./helpers");
-const { interfaceName, RegistryRolesEnum, ZERO_ADDRESS } = require("@uma/common");
+const { interfaceName, RegistryRolesEnum, ZERO_ADDRESS, didContractThrow } = require("@uma/common");
 const { assert } = require("chai");
 
 // Chainbridge Contracts:
@@ -217,6 +217,10 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
     // Now, we should be able to take the metadata stored in DepositRecord and execute the proposal on the mainnet
     // Bridge.
     const depositRecord = await genericHandlerSidechain.getDepositRecord(expectedDepositNonce, chainId);
+    assert(
+      await didContractThrow(bridgeSidechain.deposit(chainId, votingResourceId, depositRecord._metaData)),
+      "Should not be able to call Bridge.deposit directly"
+    );
     const proposalData = Helpers.createGenericDepositData(depositRecord._metaData);
     const proposalDataHash = Ethers.utils.keccak256(genericHandlerMainnet.address + proposalData.substr(2));
     TruffleAssert.passes(
@@ -309,6 +313,10 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
     // Now, we should be able to take the metadata stored in DepositRecord and execute the proposal on the sidechain
     // Bridge.
     const depositRecord = await genericHandlerMainnet.getDepositRecord(expectedDepositNonce, sidechainId);
+    assert(
+      await didContractThrow(bridgeMainnet.deposit(sidechainId, votingResourceId, depositRecord._metaData)),
+      "Should not be able to call Bridge.deposit directly"
+    );
     const proposalData = Helpers.createGenericDepositData(depositRecord._metaData);
     const proposalDataHash = Ethers.utils.keccak256(genericHandlerSidechain.address + proposalData.substr(2));
     TruffleAssert.passes(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently, anyone can call `Bridge.deposit` directly to induce duplicate `Deposit` events. This is problematic because an offchain Relayer monitoring the `Bridge` is expected to submit transactions to bridge messages across EVM networks.

**Summary**

This PR adds two pending states to the BeaconOracle `PriceRequest` struct. The idea is that an initial call to `SinkOracle.requestPrice` or `SourceOracle.publishPrice` should mark the state as `pendingRequest` and `pendingResolve` respectively. These calls will call `Bridge.deposit` which is expected to subsequently call back to `SinkOracle.validateDeposit` and `SourceOracle.validateDeposit`. These `validateDeposits` should then mark the states as `Requested` and `Resolved`, or revert if the state is not a pending one.

This fix ensures that no one can call `Bridge.deposit` directly after a `Deposit` event was already emitted.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
