### PR TITLE
feat(default-pf-config): Add DEXTFUSD and USDDEXTF price feed configs

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -952,6 +952,34 @@ const defaultConfigs = {
       },
     },
   },
+  USDDEXTF: {
+    type: "expression",
+    expression: "ETHDEXTF * USDETH",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    twapLength: 300,
+    customFeeds: {
+      ETHDEXTF: {
+        type: "uniswap",
+        uniswapAddress: "0xa1444ac5b8ac4f20f748558fe4e848087f528e00",
+        invertPrice: true,
+      },
+    },
+  },
+  DEXTFUSD: {
+    type: "expression",
+    expression: "1 / (ETHDEXTF * USDETH)",
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    twapLength: 300,
+    customFeeds: {
+      ETHDEXTF: {
+        type: "uniswap",
+        uniswapAddress: "0xa1444ac5b8ac4f20f748558fe4e848087f528e00",
+        invertPrice: true,
+      },
+    },
+  },
 };
 
 // Pull in the number of decimals for each identifier from the common getPrecisionForIdentifier. This is used within the


### PR DESCRIPTION
**Motivation**

Adds [DEXTFUSD](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-91.md#technical-specifications-5) and [USDDEXTF](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-91.md#technical-specifications-5) default price feed configs. 

This closes #2986, which was having issues with commit history/dco. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

Closes #2986
