### PR TITLE
fix(Logger): address flaky error reporting

### DIFF
--- a/packages/financial-templates-lib/src/logger/Logger.js
+++ b/packages/financial-templates-lib/src/logger/Logger.js
@@ -47,12 +47,11 @@ function errorStackTracerFormatter(logEntry) {
   return logEntry;
 }
 
-// Handle case where `error` is an array of errors and we want to display all
-// of the error stacks recursively. i.e. `error` is in the shape:
-// [[Error, Error], [Error], [Error, Error]]
+// Handle case where `error` is an array of errors and we want to display all of the error stacks recursively.
+// i.e. `error` is in the shape: [[Error, Error], [Error], [Error, Error]]
 function handleRecursiveErrorArray(error) {
   // If error is not an array, then just return the stack for there is no need to recurse further.
-  if (!Array.isArray(error)) return error.stack;
+  if (!Array.isArray(error)) return error.stack || error.message || error.toString();
   // Recursively add all errors to an array and flatten the output.
   return error.map(handleRecursiveErrorArray).flat();
 }

--- a/packages/financial-templates-lib/src/logger/Logger.js
+++ b/packages/financial-templates-lib/src/logger/Logger.js
@@ -50,8 +50,8 @@ function errorStackTracerFormatter(logEntry) {
 // Handle case where `error` is an array of errors and we want to display all of the error stacks recursively.
 // i.e. `error` is in the shape: [[Error, Error], [Error], [Error, Error]]
 function handleRecursiveErrorArray(error) {
-  // If error is not an array, then just return the stack for there is no need to recurse further.
-  if (!Array.isArray(error)) return error.stack || error.message || error.toString();
+  // If error is not an array, then just return error information for there is no need to recurse further.
+  if (!Array.isArray(error)) return error.stack || error.message || error.toString() || "could not extract error info";
   // Recursively add all errors to an array and flatten the output.
   return error.map(handleRecursiveErrorArray).flat();
 }


### PR DESCRIPTION
**Motivation**

Sometimes the logger transport provides very useless errors, like this:
![image](https://user-images.githubusercontent.com/12886084/119638125-a57e2e00-be16-11eb-8eb2-2ca0011c4b58.png)


These are hard to debug.

The source of the problem is the `Logger` where we try and extract the `stack` from `Error` message. This PR modifies this to try and pull other parts of the log message to not return `null`.

**Summary**

I discovered this by looking in the spoke logs and saw this:
![image](https://user-images.githubusercontent.com/12886084/119638738-3bb25400-be17-11eb-841d-50db0ded09ba.png)
 
In the case of this error, there is no `stack`. this is why the error showed up as `null`. Rather, we should first try extract the `stack` and if this does not exist then go for the `message`. Further, we can try calling the `.toString()` method that every `Error` object has. Finally, if this does not exist produce an error string to inform that something went wrong.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested