### PR TITLE
fix(TruffleConfig): Increase networkCheckTimeout for slower connections

### DIFF
--- a/packages/common/src/TruffleConfig.js
+++ b/packages/common/src/TruffleConfig.js
@@ -58,7 +58,7 @@ function getNodeUrl(networkName, useHttps = false) {
 // shell environment.
 function addPublicNetwork(networks, name, networkId, customTruffleConfig) {
   const options = {
-    networkCheckTimeout: 10000,
+    networkCheckTimeout: 15000,
     network_id: networkId,
     gas: customTruffleConfig?.gas || gas,
     gasPrice: customTruffleConfig?.gasPrice || gasPx,


### PR DESCRIPTION
**Motivation**

Every time I try use the truffle console with a GCKMS provider I get a timeout that looks like this:

![image](https://user-images.githubusercontent.com/12886084/119640339-ce072780-be18-11eb-96d0-de9adaf42816.png)

If I increase the timeout this error goes away. I suspect it's due to me being down at the tip of Africa and GCKMS providers require a fair amount of back and forth with GCP.

**Summary**

Updates the default truffle config to include a longer timeout.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
