### PR TITLE
feat(DSProxy): add DSGuard contracts to enable multi-dsproxy ownership

### DIFF
--- a/packages/core/contracts/common/implementation/dsproxy/DSGuardFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSGuardFactory.sol
@@ -1,4 +1,4 @@
-// This file was originally take from dapphub dsGuarg and modified. Original source code can be found
+// This file was originally take from dapphub DSGuard and modified. Original source code can be found
 // here: https://github.com/dapphub/ds-guard/blob/master/src/guard.sol
 // Changes are limited to updating the Solidity version and some stylistic modifications.
 

--- a/packages/core/contracts/common/implementation/dsproxy/DSGuardFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSGuardFactory.sol
@@ -1,0 +1,147 @@
+// This file was originally take from dapphub dsGuarg and modified. Original source code can be found
+// here: https://github.com/dapphub/ds-guard/blob/master/src/guard.sol
+// Changes are limited to updating the Solidity version and some stylistic modifications.
+
+// guard.sol -- simple whitelist implementation of DSAuthority
+
+// Copyright (C) 2017  DappHub, LLC
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.0;
+
+abstract contract DSAuthority {
+    function canCall(
+        address src,
+        address dst,
+        bytes4 sig
+    ) public view virtual returns (bool);
+}
+
+contract DSAuthEvents {
+    event LogSetAuthority(address indexed authority);
+    event LogSetOwner(address indexed owner);
+}
+
+contract DSAuth is DSAuthEvents {
+    DSAuthority public authority;
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+        emit LogSetOwner(msg.sender);
+    }
+
+    function setOwner(address owner_) public auth {
+        owner = owner_;
+        emit LogSetOwner(owner);
+    }
+
+    function setAuthority(DSAuthority authority_) public auth {
+        authority = authority_;
+        emit LogSetAuthority(address(authority));
+    }
+
+    modifier auth {
+        require(isAuthorized(msg.sender, msg.sig));
+        _;
+    }
+
+    function isAuthorized(address src, bytes4 sig) internal view returns (bool) {
+        if (src == address(this)) {
+            return true;
+        } else if (src == owner) {
+            return true;
+        } else if (authority == DSAuthority(address(0))) {
+            return false;
+        } else {
+            return authority.canCall(src, address(this), sig);
+        }
+    }
+}
+
+contract DSGuardEvents {
+    event LogPermit(bytes32 indexed src, bytes32 indexed dst, bytes32 indexed sig);
+
+    event LogForbid(bytes32 indexed src, bytes32 indexed dst, bytes32 indexed sig);
+}
+
+contract DSGuard is DSAuth, DSAuthority, DSGuardEvents {
+    bytes32 public constant ANY = bytes32(type(uint256).max);
+
+    mapping(bytes32 => mapping(bytes32 => mapping(bytes32 => bool))) acl;
+
+    function canCall(
+        address src_,
+        address dst_,
+        bytes4 sig
+    ) public view override returns (bool) {
+        bytes32 src = bytes32(bytes20(src_));
+        bytes32 dst = bytes32(bytes20(dst_));
+
+        return
+            acl[src][dst][sig] ||
+            acl[src][dst][ANY] ||
+            acl[src][ANY][sig] ||
+            acl[src][ANY][ANY] ||
+            acl[ANY][dst][sig] ||
+            acl[ANY][dst][ANY] ||
+            acl[ANY][ANY][sig] ||
+            acl[ANY][ANY][ANY];
+    }
+
+    function permit(
+        bytes32 src,
+        bytes32 dst,
+        bytes32 sig
+    ) public auth {
+        acl[src][dst][sig] = true;
+        emit LogPermit(src, dst, sig);
+    }
+
+    function forbid(
+        bytes32 src,
+        bytes32 dst,
+        bytes32 sig
+    ) public auth {
+        acl[src][dst][sig] = false;
+        emit LogForbid(src, dst, sig);
+    }
+
+    function permit(
+        address src,
+        address dst,
+        bytes32 sig
+    ) public {
+        permit(bytes32(bytes20(src)), bytes32(bytes20(dst)), sig);
+    }
+
+    function forbid(
+        address src,
+        address dst,
+        bytes32 sig
+    ) public {
+        forbid(bytes32(bytes20(src)), bytes32(bytes20(dst)), sig);
+    }
+}
+
+contract DSGuardFactory {
+    mapping(address => bool) public isGuard;
+
+    function newGuard() public returns (DSGuard guard) {
+        guard = new DSGuard();
+        guard.setOwner(msg.sender);
+        isGuard[address(guard)] = true;
+    }
+}

--- a/packages/core/contracts/common/implementation/dsproxy/DSGuardFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSGuardFactory.sol
@@ -1,4 +1,4 @@
-// This file was originally take from dapphub DSGuard and modified. Original source code can be found
+// This file was originally taken from dapphub DSGuard and modified. Original source code can be found
 // here: https://github.com/dapphub/ds-guard/blob/master/src/guard.sol
 // Changes are limited to updating the Solidity version and some stylistic modifications.
 

--- a/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
@@ -2,10 +2,6 @@
 // here: https://etherscan.io/address/0xa26e15c895efc0616177b7c1e7270a4c7d51c997#code
 // Changes are limited to updating the Solidity version and some stylistic modifications.
 
-/**
- *Submitted for verification at Etherscan.io on 2018-06-22
- */
-
 // proxy.sol - execute actions atomically through the proxy's identity
 
 // Copyright (C) 2017  DappHub, LLC

--- a/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
@@ -1,4 +1,4 @@
-// This file was originally take from from Maker: DS Proxy Factory and modified. The original source code can be found
+// This file was originally take from the Maker DS Proxy Factory and modified. The original source code can be found
 // here: https://etherscan.io/address/0xa26e15c895efc0616177b7c1e7270a4c7d51c997#code
 // Changes are limited to updating the Solidity version and some stylistic modifications.
 
@@ -24,6 +24,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.8.0;
+
+// DSProxy
+// Allows code execution using a persistant identity This can be very
+// useful to execute a sequence of atomic actions. Since the owner of
+// the proxy can be changed, this allows for dynamic ownership models
+// i.e. a multisig
 
 abstract contract DSAuthority {
     function canCall(
@@ -99,11 +105,6 @@ contract DSNote {
     }
 }
 
-// DSProxy
-// Allows code execution using a persistant identity This can be very
-// useful to execute a sequence of atomic actions. Since the owner of
-// the proxy can be changed, this allows for dynamic ownership models
-// i.e. a multisig
 contract DSProxy is DSAuth, DSNote {
     DSProxyCache public cache; // global cache for contracts
 

--- a/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
@@ -1,4 +1,4 @@
-// This file was originally take from the Maker DS Proxy Factory and modified. The original source code can be found
+// This file was originally taken from the Maker DS Proxy Factory and modified. The original source code can be found
 // here: https://etherscan.io/address/0xa26e15c895efc0616177b7c1e7270a4c7d51c997#code
 // Changes are limited to updating the Solidity version and some stylistic modifications.
 

--- a/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
+++ b/packages/core/contracts/common/implementation/dsproxy/DSProxyFactory.sol
@@ -21,12 +21,6 @@
 
 pragma solidity ^0.8.0;
 
-// DSProxy
-// Allows code execution using a persistant identity This can be very
-// useful to execute a sequence of atomic actions. Since the owner of
-// the proxy can be changed, this allows for dynamic ownership models
-// i.e. a multisig
-
 abstract contract DSAuthority {
     function canCall(
         address src,
@@ -101,6 +95,11 @@ contract DSNote {
     }
 }
 
+// DSProxy
+// Allows code execution using a persistant identity This can be very
+// useful to execute a sequence of atomic actions. Since the owner of
+// the proxy can be changed, this allows for dynamic ownership models
+// i.e. a multisig
 contract DSProxy is DSAuth, DSNote {
     DSProxyCache public cache; // global cache for contracts
 

--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -76,6 +76,10 @@
     "address": "0xAB75727d4e89A7f7F04f57C00234a35950527115"
   },
   {
+    "contractName": "DSGuardFactory",
+    "address": "0x63200E25db9Af015d1e3240D30269d29D80830F6"
+  },
+  {
     "contractName": "Bridge",
     "address": "0xBA26bC014c4c889431826C123492861e886408b9"
   },


### PR DESCRIPTION
**Motivation**

To enable the DSPRoxy we use in liquidation to be accessible by multiple EOAs, we require a DSGuard & DSAuthority to set up permissions on who can and cant call methods on the DSProxy over and above the normal "owner" setup. This PR adds the associated smart contracts to facilitate this.
