### PR TITLE
fix (CircleCI): Remove context from required jobs

### DIFF
--- a/ci/generate_lerna_config.sh
+++ b/ci/generate_lerna_config.sh
@@ -76,7 +76,6 @@ EOF
     do
       cat <<EOF >> $CI_CONFIG_FILE
       - test-${PACKAGE:5}:
-          context: api_keys
 EOF
   done
 


### PR DESCRIPTION
**Motivation**

The current tests method are not using variables for execute the jobs. This change allow the tests execution on pipeline for external users.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
