### PR TITLE
improve(beacon-oracle): Audit Response for L2 infrastructure contracts

### DIFF
--- a/packages/core/contracts/chainbridge/BeaconOracle.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracle.sol
@@ -31,14 +31,12 @@ abstract contract BeaconOracle {
     FinderInterface public finder;
 
     event PriceRequestAdded(
-        address indexed requester,
         uint8 indexed chainID,
         bytes32 indexed identifier,
         uint256 time,
         bytes ancillaryData
     );
     event PushedPrice(
-        address indexed pusher,
         uint8 indexed chainID,
         bytes32 indexed identifier,
         uint256 time,
@@ -78,7 +76,7 @@ abstract contract BeaconOracle {
         Price storage lookup = prices[priceRequestId];
         if (lookup.state == RequestState.NeverRequested) {
             lookup.state = RequestState.PendingRequest;
-            emit PriceRequestAdded(msg.sender, chainID, identifier, time, ancillaryData);
+            emit PriceRequestAdded(chainID, identifier, time, ancillaryData);
         }
     }
 
@@ -114,7 +112,7 @@ abstract contract BeaconOracle {
         require(lookup.state == RequestState.Requested, "Price request is not currently pending");
         lookup.price = price;
         lookup.state = RequestState.PendingResolve;
-        emit PushedPrice(msg.sender, chainID, identifier, time, ancillaryData, lookup.price);
+        emit PushedPrice(chainID, identifier, time, ancillaryData, lookup.price);
     }
 
     function _finalizePublish(

--- a/packages/core/contracts/chainbridge/BeaconOracle.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracle.sol
@@ -8,7 +8,7 @@ import "../oracle/implementation/Constants.sol";
 /**
  * @title Simple implementation of the OracleInterface used to communicate price request data cross-chain between
  * EVM networks. Can be extended either into a "Source" or "Sink" oracle that specializes in making and resolving
- * cross-chain price requests, respectivly. The "Source" Oracle is the originator or source of price resolution data
+ * cross-chain price requests, respectively. The "Source" Oracle is the originator or source of price resolution data
  * and can only resolve prices already published by the DVM. The "Sink" Oracle receives the price resolution data
  * from the Source Oracle and makes it available on non-Mainnet chains. The "Sink" Oracle can also be used to trigger
  * price requests from the DVM on Mainnet.
@@ -24,7 +24,7 @@ abstract contract BeaconOracle {
     // Chain ID for this Oracle.
     uint8 public currentChainID;
 
-    // Mapping of encoded price requests {identifier, time, ancillaryData} to Price objects.
+    // Mapping of encoded price requests {chainID, identifier, time, ancillaryData} to Price objects.
     mapping(bytes32 => Price) internal prices;
 
     // Finder to provide addresses for DVM system contracts.
@@ -65,8 +65,8 @@ abstract contract BeaconOracle {
     }
 
     /**
-     * @notice Enqueues a request (if a request isn't already present) for the given (identifier, time, ancillary data)
-     * pair. Will revert if request has been requested already.
+     * @notice Enqueues a request (if a request isn't already present) for the given (chainID, identifier, time, 
+     * ancillary data) combination. Will only emit an event if the request has never been requested.
      */
     function _requestPrice(
         uint8 chainID,

--- a/packages/core/contracts/chainbridge/BeaconOracle.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracle.sol
@@ -65,7 +65,7 @@ abstract contract BeaconOracle {
     }
 
     /**
-     * @notice Enqueues a request (if a request isn't already present) for the given (chainID, identifier, time, 
+     * @notice Enqueues a request (if a request isn't already present) for the given (chainID, identifier, time,
      * ancillary data) combination. Will only emit an event if the request has never been requested.
      */
     function _requestPrice(

--- a/packages/core/contracts/chainbridge/BeaconOracle.sol
+++ b/packages/core/contracts/chainbridge/BeaconOracle.sol
@@ -30,12 +30,7 @@ abstract contract BeaconOracle {
     // Finder to provide addresses for DVM system contracts.
     FinderInterface public finder;
 
-    event PriceRequestAdded(
-        uint8 indexed chainID,
-        bytes32 indexed identifier,
-        uint256 time,
-        bytes ancillaryData
-    );
+    event PriceRequestAdded(uint8 indexed chainID, bytes32 indexed identifier, uint256 time, bytes ancillaryData);
     event PushedPrice(
         uint8 indexed chainID,
         bytes32 indexed identifier,

--- a/packages/core/contracts/chainbridge/SinkOracle.sol
+++ b/packages/core/contracts/chainbridge/SinkOracle.sol
@@ -83,7 +83,7 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
      * @dev This method should basically check that the `Bridge.deposit()` was triggered by a valid price request,
      * specifically one that has not resolved yet and was called by a registered contract. Without this check,
      * `Bridge.deposit()` could be called by non-registered contracts to make price requests to the DVM.
-     * @param sinkChainID Chain ID of for this contract.
+     * @param sinkChainID Chain ID for this contract.
      * @param identifier Identifier of price request.
      * @param time Timestamp of price request.
      * @param ancillaryData extra data of price request.
@@ -175,9 +175,9 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
      *     len(data)                              uint256     bytes  0  - 32
      *     data                                   bytes       bytes  64 - END
      * @param chainID Chain ID for this contract.
-     * @param identifier Identifier of price request to request.
-     * @param time Timestamp of price request to request.
-     * @param ancillaryData extra data of price request to request.
+     * @param identifier Identifier of price request.
+     * @param time Timestamp of price request.
+     * @param ancillaryData extra data of price request.
      * @return bytes Formatted metadata.
      */
     function formatMetadata(

--- a/packages/core/contracts/chainbridge/SinkOracle.sol
+++ b/packages/core/contracts/chainbridge/SinkOracle.sol
@@ -19,6 +19,12 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
     // Chain ID of the Source Oracle that will communicate this contract's price request to the DVM on Mainnet.
     uint8 public destinationChainID;
 
+    /**
+     * @notice Constructor.
+     * @param _finderAddress Address of Finder that this contract uses to locate Bridge.
+     * @param _chainID Chain ID for this contract.
+     * @param _destinationChainID Chain ID for SourceOracle that will resolve price requests sent from this contract.
+     */
     constructor(
         address _finderAddress,
         uint8 _chainID,
@@ -44,6 +50,9 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
      * price request as Requested, and therefore able to receive the ultimate price resolution data, and also
      * calls the local Bridge's deposit() method which will emit a Deposit event in order to signal to an off-chain
      * relayer to begin the cross-chain process.
+     * @param identifier Identifier of price request.
+     * @param time Timestamp of price request.
+     * @param ancillaryData extra data of price request.
      */
     function requestPrice(
         bytes32 identifier,
@@ -74,6 +83,10 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
      * @dev This method should basically check that the `Bridge.deposit()` was triggered by a valid price request,
      * specifically one that has not resolved yet and was called by a registered contract. Without this check,
      * `Bridge.deposit()` could be called by non-registered contracts to make price requests to the DVM.
+     * @param sinkChainID Chain ID of for this contract.
+     * @param identifier Identifier of price request.
+     * @param time Timestamp of price request.
+     * @param ancillaryData extra data of price request.
      */
     function validateDeposit(
         uint8 sinkChainID,
@@ -95,6 +108,10 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
      * which call `GenericHandler.executeProposal()` and ultimately this method.
      * @dev This method should publish the price data for a requested price request. If this method fails for some
      * reason, then it means that the price was never requested. Can only be called by the `GenericHandler`.
+     * @param sinkChainID Chain ID for this contract.
+     * @param identifier Identifier of price request to resolve.
+     * @param time Timestamp of price request to resolve.
+     * @param ancillaryData extra data of price request to resolve.
      */
     function executePublishPrice(
         uint8 sinkChainID,
@@ -109,6 +126,9 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
 
     /**
      * @notice Returns whether a price has resolved for the request.
+     * @param identifier Identifier of price request.
+     * @param time Timestamp of price request
+     * @param ancillaryData extra data of price request.
      * @return True if a price is available, False otherwise. If true, then getPrice will succeed for the request.
      */
     function hasPrice(
@@ -122,6 +142,10 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
 
     /**
      * @notice Returns resolved price for the request.
+     * @dev Reverts if price is not available.
+     * @param identifier Identifier of price request.
+     * @param time Timestamp of price request
+     * @param ancillaryData extra data of price request.
      * @return int256 Price, or reverts if no resolved price for any reason.
      */
 
@@ -148,8 +172,13 @@ contract SinkOracle is BeaconOracle, OracleAncillaryInterface {
     /**
      * @notice This helper method is useful for calling Bridge.deposit().
      * @dev GenericHandler.deposit() expects data to be formatted as:
-     *     len(data)                              uint256     bytes  0  - 64
+     *     len(data)                              uint256     bytes  0  - 32
      *     data                                   bytes       bytes  64 - END
+     * @param chainID Chain ID for this contract.
+     * @param identifier Identifier of price request to request.
+     * @param time Timestamp of price request to request.
+     * @param ancillaryData extra data of price request to request.
+     * @return bytes Formatted metadata.
      */
     function formatMetadata(
         uint8 chainID,

--- a/packages/core/contracts/chainbridge/SourceOracle.sol
+++ b/packages/core/contracts/chainbridge/SourceOracle.sol
@@ -17,6 +17,11 @@ import "../oracle/interfaces/OracleAncillaryInterface.sol";
  * @dev This contract must be a registered financial contract in order to call DVM methods.
  */
 contract SourceOracle is BeaconOracle {
+    /**
+     * @notice Constructor.
+     * @param _finderAddress Address of Finder that this contract uses to locate Bridge.
+     * @param _chainID Chain ID for this contract.
+     */
     constructor(address _finderAddress, uint8 _chainID) BeaconOracle(_finderAddress, _chainID) {}
 
     /***************************************************************
@@ -29,6 +34,10 @@ contract SourceOracle is BeaconOracle {
      * @dev Publishes the DVM resolved price for the price request, or reverts if not resolved yet. Will call the
      * local Bridge's deposit() method which will emit a Deposit event in order to signal to an off-chain
      * relayer to begin the cross-chain process.
+     * @param sinkChainID Chain ID of SinkOracle that this price should ultimately be sent to.
+     * @param identifier Identifier of price request to resolve.
+     * @param time Timestamp of price request to resolve.
+     * @param ancillaryData extra data of price request to resolve.
      */
     function publishPrice(
         uint8 sinkChainID,
@@ -53,6 +62,11 @@ contract SourceOracle is BeaconOracle {
      * @notice This method will ultimately be called after `publishPrice` calls `Bridge.deposit()`, which will call
      * `GenericHandler.deposit()` and ultimately this method.
      * @dev This method should basically check that the `Bridge.deposit()` was triggered by a valid publish event.
+     * @param sinkChainID Chain ID of SinkOracle that this price should ultimately be sent to.
+     * @param identifier Identifier of price request to resolve.
+     * @param time Timestamp of price request to resolve.
+     * @param ancillaryData extra data of price request to resolve.
+     * @param price Price resolved on DVM to send to SinkOracle.
      */
     function validateDeposit(
         uint8 sinkChainID,
@@ -78,6 +92,10 @@ contract SourceOracle is BeaconOracle {
      * local network, which call `GenericHandler.executeProposal()` and ultimately this method.
      * @dev This method should prepare this oracle to receive a published price and then forward the price request
      * to the DVM. Can only be called by the `GenericHandler`.
+     * @param sinkChainID Chain ID of SinkOracle that originally sent price request.
+     * @param identifier Identifier of price request.
+     * @param time Timestamp of price request.
+     * @param ancillaryData extra data of price request.
      */
 
     function executeRequestPrice(
@@ -108,10 +126,16 @@ contract SourceOracle is BeaconOracle {
     }
 
     /**
-     * @notice This helper method is useful for calling Bridge.deposit().
+     * @notice This helper method is useful for shaping metadata that is passed into Bridge.deposit() that will
+     * ultimately be used to publish a price on the SinkOracle.
      * @dev GenericHandler.deposit() expects data to be formatted as:
-     *     len(data)                              uint256     bytes  0  - 64
+     *     len(data)                              uint256     bytes  0  - 32
      *     data                                   bytes       bytes  64 - END
+     * @param chainID Chain ID of SinkOracle to publish price to.
+     * @param identifier Identifier of price request to publish.
+     * @param time Timestamp of price request to publish.
+     * @param ancillaryData extra data of price request to publish.
+     * @return bytes Formatted metadata.
      */
     function formatMetadata(
         uint8 chainID,

--- a/packages/core/test/chainbridge/beaconOracle.js
+++ b/packages/core/test/chainbridge/beaconOracle.js
@@ -40,7 +40,6 @@ contract("BeaconOracle", async (accounts) => {
       txn,
       "PriceRequestAdded",
       (event) =>
-        event.requester.toLowerCase() === owner.toLowerCase() &&
         event.chainID.toString() === chainID.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(testIdentifier) &&
         event.time.toString() === testRequestTime.toString() &&
@@ -56,7 +55,6 @@ contract("BeaconOracle", async (accounts) => {
       txn,
       "PushedPrice",
       (event) =>
-        event.pusher.toLowerCase() === owner.toLowerCase() &&
         event.chainID.toString() === chainID.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(testIdentifier) &&
         event.time.toString() === testRequestTime.toString() &&

--- a/packages/core/test/chainbridge/e2e.js
+++ b/packages/core/test/chainbridge/e2e.js
@@ -198,7 +198,6 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
       depositTxn,
       "PriceRequestAdded",
       (event) =>
-        event.requester.toLowerCase() === depositerAddress.toLowerCase() &&
         event.chainID.toString() === sidechainId.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(identifier) &&
         event.time.toString() === requestTime.toString() &&
@@ -249,7 +248,6 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
       internalTx,
       "PriceRequestAdded",
       (event) =>
-        event.requester.toLowerCase() === genericHandlerMainnet.address.toLowerCase() &&
         event.chainID.toString() === sidechainId.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(identifier) &&
         event.time.toString() === requestTime.toString() &&
@@ -260,7 +258,6 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
       internalTx,
       "PriceRequestAdded",
       (event) =>
-        event.requester.toLowerCase() === sourceOracle.address.toLowerCase() &&
         hexToUtf8(event.identifier) === hexToUtf8(identifier) &&
         event.time.toString() === requestTime.toString() &&
         event.ancillaryData.toLowerCase() === ancillaryData.toLowerCase()
@@ -292,7 +289,6 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
     // Bridge emits a Deposit event and the SinkOracle emitted a PushedPrice event.
     TruffleAssert.eventEmitted(depositTxn, "PushedPrice", (event) => {
       return (
-        event.pusher.toLowerCase() === depositerAddress.toLowerCase() &&
         event.chainID.toString() === sidechainId.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(identifier) &&
         event.time.toString() === requestTime.toString() &&
@@ -345,7 +341,6 @@ contract("GenericHandler - [UMA Cross-chain Communication]", async (accounts) =>
     const internalTx = await TruffleAssert.createTransactionResult(sinkOracle, executeProposalTx.tx);
     TruffleAssert.eventEmitted(internalTx, "PushedPrice", (event) => {
       return (
-        event.pusher.toLowerCase() === genericHandlerSidechain.address.toLowerCase() &&
         event.chainID.toString() === sidechainId.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(identifier) &&
         event.time.toString() === requestTime.toString() &&

--- a/packages/core/test/chainbridge/sinkOracle.js
+++ b/packages/core/test/chainbridge/sinkOracle.js
@@ -73,7 +73,6 @@ contract("SinkOracle", async (accounts) => {
       txn,
       "PriceRequestAdded",
       (event) =>
-        event.requester.toLowerCase() === owner.toLowerCase() &&
         event.chainID.toString() === chainID.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(testIdentifier) &&
         event.time.toString() === testRequestTime.toString() &&

--- a/packages/core/test/chainbridge/sourceOracle.js
+++ b/packages/core/test/chainbridge/sourceOracle.js
@@ -97,7 +97,6 @@ contract("SourceOracle", async (accounts) => {
         txn,
         "PushedPrice",
         (event) =>
-          event.pusher.toLowerCase() === owner.toLowerCase() &&
           event.chainID.toString() === destinationChainID.toString() &&
           hexToUtf8(event.identifier) === hexToUtf8(testIdentifier) &&
           event.time.toString() === testRequestTime.toString() &&
@@ -165,7 +164,6 @@ contract("SourceOracle", async (accounts) => {
       txn,
       "PriceRequestAdded",
       (event) =>
-        event.requester.toLowerCase() === rando.toLowerCase() &&
         event.chainID.toString() === destinationChainID.toString() &&
         hexToUtf8(event.identifier) === hexToUtf8(testIdentifier) &&
         event.time.toString() === testRequestTime.toString() &&


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Audit response to Pull Requests #2903 and #3013

These PRs use Chainbridge to send messages between different EVM-compatible chains. In particular, DVM price requests are passed from another chain to the Ethereum mainnet, where the standard resolution mechanism can occur. Once resolved, the price is pushed back to the "sink" chain where it can be utilized. This allows UMA financial contracts to be deployed in multiple different chains but still use the Ethereum mainnet DVM to resolve prices as required.

**Summary**

Contract changes:
- On both chains, the [`PriceRequestAdded` event](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/BeaconOracle.sol#L81) includes the `msg.sender` as the `requester`. However, in the `SourceOracle`, [this will be the `GenericHandler` contract](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/SourceOracle.sol#L88), not the address that requested the price. Similarly, the `SinkOracle` will emit the `GenericHandler` as the `pusher` in the `PushedPrice` event. In both cases, consider passing the original sender over the bridge so it can be emitted on the destination chain.
- Solution: remove `requester` and `pusher` param from `PriceRequestAdded` and `PushedPrice` events, respectively. `pusher` is not useful information and `requester` is not added to the event of the same name in the ` Voting` contract. Ultimately, `requester` is not super useful information, and will be captured by the `OptimisticOracle` assuming that the OO is the contract requesting prices from the `SinkOracle`.

Improvements to comments:
- The [`_requestPrice` function comment](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/BeaconOracle.sol#L69) says the function will revert if it's already been requested. In fact, it returns without doing anything.
- The `_formatMetadata` function comments on [the `SinkOracle`](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/SinkOracle.sol#L151-L152) and [the `SourceOracle`](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/SourceOracle.sol#L113-L114) claim the `uint256` length field takes up 64 bytes instead of 32.
- `SourceOracle` and `SinkOracle` are missing natspec comments.

The following comments pertain to the BeaconOracle:
- [Line 11](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/BeaconOracle.sol#L11) says "respectivly".
- [Line 27](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/BeaconOracle.sol#L27) excludes `chainId` from the list of encoded values
- [Line 68](https://github.com/UMAprotocol/protocol/blob/2814e8021294adb2578649ed57fb066e86bb5b73/packages/core/contracts/chainbridge/BeaconOracle.sol#L68) also excludes `chainId` and refers to the whole collection of values as a "pair"

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
