### PR TITLE
fix(bot-stratergy-runner): fix broken default setting

### DIFF
--- a/packages/bot-strategy-runner/src/index.ts
+++ b/packages/bot-strategy-runner/src/index.ts
@@ -177,9 +177,9 @@ function _reduceLog(
 // Apply defaults to the strategyRunnerConfig.
 function _setConfigDefaults(config: strategyRunnerConfig) {
   config.botNetwork = config.botNetwork ? config.botNetwork : defaultNetwork;
-  config.strategyTimeout = config.strategyTimeout ? config.strategyTimeout : defaultStrategyTimeout;
-  config.botConcurrency = config.botConcurrency ? config.botConcurrency : defaultBotConcurrency;
-  config.pollingDelay = config.pollingDelay ? config.pollingDelay : defaultPollingDelay;
+  config.strategyTimeout = config.strategyTimeout != undefined ? config.strategyTimeout : defaultStrategyTimeout;
+  config.botConcurrency = config.botConcurrency != undefined ? config.botConcurrency : defaultBotConcurrency;
+  config.pollingDelay = config.pollingDelay != undefined ? config.pollingDelay : defaultPollingDelay;
   return config;
 }
 


### PR DESCRIPTION
**Motivation**

When running in cloud run bot settings sometimes need to be set to `0`. For example `pollingDelay` must be set to `0` to run in serverless mode. The way the code was set up before makes this config impossible due to how defaults are set. This PR addresses this.