### PR TITLE
feat(Winston-logger): add multiple escalation paths depending on message context

### DIFF
--- a/packages/bot-strategy-runner/src/BotEntryWrapper.ts
+++ b/packages/bot-strategy-runner/src/BotEntryWrapper.ts
@@ -15,7 +15,8 @@ interface commonBotSettings {
   syntheticSymbol: string;
   botIdentifier: string;
   botNetwork: string;
-  slackWebHook?: string;
+  slackConfig?: string;
+  pagerDutyConfig?: string;
   financialContractAddress: string;
   errorRetries?: number;
   errorRetriesTimeout?: number;
@@ -58,7 +59,7 @@ async function _executeBot(
     // continue to work within each executed strategy.
     const logger = createNewLogger(
       [new logCaptureTransport({ level: "debug" }, logs)],
-      { slackWebHook: config.slackWebHook, createConsoleTransport: false },
+      { slackWebHook: config.slackConfig, pagerdutyConfig: config.pagerDutyConfig, createConsoleTransport: false },
       botIdentifier
     );
 

--- a/packages/bot-strategy-runner/src/BotEntryWrapper.ts
+++ b/packages/bot-strategy-runner/src/BotEntryWrapper.ts
@@ -59,7 +59,7 @@ async function _executeBot(
     // continue to work within each executed strategy.
     const logger = createNewLogger(
       [new logCaptureTransport({ level: "debug" }, logs)],
-      { slackWebHook: config.slackConfig, pagerdutyConfig: config.pagerDutyConfig, createConsoleTransport: false },
+      { slackConfig: config.slackConfig, pagerdutyConfig: config.pagerDutyConfig, createConsoleTransport: false },
       botIdentifier
     );
 

--- a/packages/common/src/TransactionUtils.js
+++ b/packages/common/src/TransactionUtils.js
@@ -39,10 +39,8 @@ const runTransaction = async ({ web3, transaction, transactionConfig, availableA
   if (await accountHasPendingTransactions(web3, transactionConfig.from))
     transactionConfig.nonce = await getPendingTransactionCount(web3, transactionConfig.from);
   // Else, there is no pending transaction and we use the current account transaction count as the nonce.
-  // this method does not play niceley in tests. leave the nounce null to auto fill.
+  // This method does not play niceley in tests. Leave the nounce null to auto fill.
   else if (argv.network != "test") transactionConfig.nonce = await web3.eth.getTransactionCount(transactionConfig.from);
-
-  console.log("args", argv);
 
   // Next, simulate transaction and also extract return value if its a state-modifying transaction. If the function is state
   // modifying, then successfully sending it will return the transaction receipt, not the return value, so we grab it here.

--- a/packages/common/src/TransactionUtils.js
+++ b/packages/common/src/TransactionUtils.js
@@ -39,7 +39,10 @@ const runTransaction = async ({ web3, transaction, transactionConfig, availableA
   if (await accountHasPendingTransactions(web3, transactionConfig.from))
     transactionConfig.nonce = await getPendingTransactionCount(web3, transactionConfig.from);
   // Else, there is no pending transaction and we use the current account transaction count as the nonce.
-  else transactionConfig.nonce = await web3.eth.getTransactionCount(transactionConfig.from);
+  // this method does not play niceley in tests. leave the nounce null to auto fill.
+  else if (argv.network != "test") transactionConfig.nonce = await web3.eth.getTransactionCount(transactionConfig.from);
+
+  console.log("args", argv);
 
   // Next, simulate transaction and also extract return value if its a state-modifying transaction. If the function is state
   // modifying, then successfully sending it will return the transaction receipt, not the return value, so we grab it here.

--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -309,6 +309,7 @@ async function Poll(callback) {
       at: "Disputer#index",
       message: "Disputer execution error🚨",
       error: typeof error === "string" ? new Error(error) : error,
+      notificationPath: "infrastructure-error",
     });
     await waitForLogger(Logger);
     callback(error);

--- a/packages/financial-templates-lib/src/logger/PagerDutyTransport.js
+++ b/packages/financial-templates-lib/src/logger/PagerDutyTransport.js
@@ -24,7 +24,7 @@ module.exports = class PagerDutyTransport extends Transport {
       const logMessage = info.mrkdwn ? info.mrkdwn + `\n${info["bot-identifier"]}` : JSON.stringify(info);
 
       // If the log contains a notification path then use a custom PagerDuty service. This lets the transport route to
-      // diffrent pagerduty escilation paths depending on the context of the log.
+      // different pagerduty escilation paths depending on the context of the log.
       const serviceId = this.customServices[info.notificationPath] ?? this.defaultServiceId;
 
       await this.pd.incidents.createIncident(this.fromEmail, {

--- a/packages/financial-templates-lib/src/logger/PagerDutyTransport.js
+++ b/packages/financial-templates-lib/src/logger/PagerDutyTransport.js
@@ -10,11 +10,12 @@ const pdClient = require("node-pagerduty");
 module.exports = class PagerDutyTransport extends Transport {
   constructor(winstonOpts, pagerDutyOptions) {
     super(winstonOpts);
+
     this.pd = new pdClient(pagerDutyOptions.pdApiToken);
 
     this.fromEmail = pagerDutyOptions.fromEmail;
     this.defaultServiceId = pagerDutyOptions.defaultServiceId;
-    this.customServices = pagerDutyOptions.customServices;
+    this.customServices = pagerDutyOptions.customServices || {};
   }
 
   async log(info, callback) {
@@ -22,12 +23,16 @@ module.exports = class PagerDutyTransport extends Transport {
       // If the message has markdown then add it and the bot-identifer field. Else put the whole info object as a string
       const logMessage = info.mrkdwn ? info.mrkdwn + `\n${info["bot-identifier"]}` : JSON.stringify(info);
 
+      // If the log contains a notification path then use a custom PagerDuty service. This lets the transport route to
+      // diffrent pagerduty escilation paths depending on the context of the log.
+      const serviceId = this.customServices[info.notificationPath] ?? this.defaultServiceId;
+
       await this.pd.incidents.createIncident(this.fromEmail, {
         incident: {
           type: "incident",
           title: `${info.level}: ${info.at} ⭢ ${info.message}`,
           service: {
-            id: this.customServices[info.notificationPath] ?? this.defaultServiceId,
+            id: serviceId,
             type: "service_reference",
           },
           urgency: info.level == "warn" ? "low" : "high", // If level is warn then urgency is low. If level is error then urgency is high.

--- a/packages/financial-templates-lib/src/logger/PagerDutyTransport.js
+++ b/packages/financial-templates-lib/src/logger/PagerDutyTransport.js
@@ -10,9 +10,11 @@ const pdClient = require("node-pagerduty");
 module.exports = class PagerDutyTransport extends Transport {
   constructor(winstonOpts, pagerDutyOptions) {
     super(winstonOpts);
-    this.serviceId = pagerDutyOptions.pdServiceId;
-    this.fromEmail = pagerDutyOptions.fromEmail;
     this.pd = new pdClient(pagerDutyOptions.pdApiToken);
+
+    this.fromEmail = pagerDutyOptions.fromEmail;
+    this.defaultServiceId = pagerDutyOptions.defaultServiceId;
+    this.customServices = pagerDutyOptions.customServices;
   }
 
   async log(info, callback) {
@@ -25,7 +27,7 @@ module.exports = class PagerDutyTransport extends Transport {
           type: "incident",
           title: `${info.level}: ${info.at} ⭢ ${info.message}`,
           service: {
-            id: this.serviceId,
+            id: this.customServices[info.notificationPath] ?? this.defaultServiceId,
             type: "service_reference",
           },
           urgency: info.level == "warn" ? "low" : "high", // If level is warn then urgency is low. If level is error then urgency is high.

--- a/packages/financial-templates-lib/src/logger/SlackTransport.js
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.js
@@ -169,7 +169,8 @@ class SlackHook extends Transport {
     opts = opts || {};
     this.name = opts.name || "slackWebhook";
     this.level = opts.level || undefined;
-    this.webhookUrl = opts.webhookUrl;
+    this.customServices = opts.transportConfig.customServices;
+    this.defaultWebHookUrl = opts.transportConfig.defaultWebHookUrl;
     this.formatter = opts.formatter || undefined;
     this.mrkdwn = opts.mrkdwn || false;
 
@@ -177,6 +178,8 @@ class SlackHook extends Transport {
   }
 
   async log(info, callback) {
+    const webhookUrl = this.customServices[info.notificationPath] ?? this.defaultWebHookUrl;
+
     let payload = {
       mrkdwn: this.mrkdwn,
     };
@@ -188,7 +191,7 @@ class SlackHook extends Transport {
     let errorThrown = false;
     // If the overall payload is less than 3000 chars then we can send it all in one go to the slack API.
     if (JSON.stringify(payload).length < 3000) {
-      let response = await this.axiosInstance.post(this.webhookUrl, payload);
+      let response = await this.axiosInstance.post(webhookUrl, payload);
       if (response.status != 200) errorThrown = true;
     } else {
       // If it's more than 3000 chars then we need to split the message sent to slack API into multiple calls.
@@ -216,7 +219,7 @@ class SlackHook extends Transport {
       // Iterate over each message to send and generate a axios call for each message.
       for (const processedBlock of processedBlocks) {
         payload.blocks = processedBlock;
-        let response = await this.axiosInstance.post(this.webhookUrl, payload);
+        let response = await this.axiosInstance.post(webhookUrl, payload);
         if (response.status != 200) errorThrown = true;
       }
     }
@@ -225,10 +228,10 @@ class SlackHook extends Transport {
   }
 }
 
-function createSlackTransport(webHookUrl) {
+function createSlackTransport(transportConfig) {
   return new SlackHook({
     level: "info",
-    webhookUrl: webHookUrl,
+    transportConfig,
     formatter: (info) => {
       return slackFormatter(info);
     },

--- a/packages/financial-templates-lib/src/logger/SlackTransport.js
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.js
@@ -169,7 +169,7 @@ class SlackHook extends Transport {
     opts = opts || {};
     this.name = opts.name || "slackWebhook";
     this.level = opts.level || undefined;
-    this.escilationPathWebhookUrls = opts.transportConfig.escilationPathWebhookUrls || {};
+    this.escalationPathWebhookUrls = opts.transportConfig.escalationPathWebhookUrls || {};
     this.defaultWebHookUrl = opts.transportConfig.defaultWebHookUrl;
     this.formatter = opts.formatter || undefined;
     this.mrkdwn = opts.mrkdwn || false;
@@ -180,8 +180,7 @@ class SlackHook extends Transport {
   async log(info, callback) {
     // If the log contains a notification path then use a custom slack webhook service. This lets the transport route to
     // diffrent slack channels depending on the context of the log.
-    const webhookUrl = this.escilationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
-    // delete info.notificationPath; // Dont log the notification path.
+    const webhookUrl = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
 
     let payload = {
       mrkdwn: this.mrkdwn,

--- a/packages/financial-templates-lib/src/logger/Transports.js
+++ b/packages/financial-templates-lib/src/logger/Transports.js
@@ -16,7 +16,7 @@ function createTransports(transportsConfig = {}) {
   let transports = [];
 
   // If the logger is running in serverless mode then add the GCP winston transport and console transport.
-  if ((transportsConfig.environment ? transportsConfig.environment : process.env.ENVIRONMENT) == "serverless") {
+  if ((transportsConfig.environment ?? process.env.ENVIRONMENT) == "serverless") {
     const { LoggingWinston } = require("@google-cloud/logging-winston");
     require("@google-cloud/trace-agent").start();
     transports.push(new LoggingWinston());
@@ -24,7 +24,7 @@ function createTransports(transportsConfig = {}) {
   }
 
   // If the logger is running in production mode then add the GCE winston transport. Else, add a console transport.
-  else if ((transportsConfig.environment ? transportsConfig.environment : process.env.ENVIRONMENT) == "production") {
+  else if ((transportsConfig.environment ?? process.env.ENVIRONMENT) == "production") {
     const { LoggingWinston } = require("@google-cloud/logging-winston");
     require("@google-cloud/trace-agent").start();
     transports.push(new LoggingWinston());
@@ -36,9 +36,9 @@ function createTransports(transportsConfig = {}) {
   // If there is "test" in the environment then skip the slack or pagerduty.
   if (argv._.indexOf("test") == -1) {
     // If there is a slack web hook, add to the transports array to enable slack messages.
-    const slackWebHook = transportsConfig.slackWebHook ? transportsConfig.slackWebHook : process.env.SLACK_WEBHOOK;
-    if (slackWebHook) {
-      transports.push(SlackTransport.createSlackTransport(slackWebHook));
+    const slackConfig = transportsConfig.slackConfig ?? process.env.SLACK_CONFIG;
+    if (slackConfig) {
+      transports.push(SlackTransport.createSlackTransport(slackConfig));
     }
 
     // If there is a Pagerduty API key then add the pagerduty winston transport.
@@ -46,11 +46,9 @@ function createTransports(transportsConfig = {}) {
       transports.push(
         new PagerDutyTransport(
           { level: "warn" },
-          {
-            pdApiToken: transportsConfig.pdApiToken ? transportsConfig.pdApiToken : process.env.PAGERDUTY_API_KEY,
-            pdServiceId: transportsConfig.pdServiceId ? transportsConfig.pdServiceId : process.env.PAGERDUTY_SERVICE_ID,
-            fromEmail: transportsConfig.fromEmail ? transportsConfig.fromEmail : process.env.PAGERDUTY_FROM_EMAIL,
-          }
+          transportsConfig.pagerDutyConfig ?? process.env.PAGER_DUTY_CONFIG
+            ? JSON.stringify(process.env.PAGER_DUTY_CONFIG)
+            : {}
         )
       );
     }

--- a/packages/financial-templates-lib/src/logger/Transports.js
+++ b/packages/financial-templates-lib/src/logger/Transports.js
@@ -36,19 +36,17 @@ function createTransports(transportsConfig = {}) {
   // If there is "test" in the environment then skip the slack or pagerduty.
   if (argv._.indexOf("test") == -1) {
     // If there is a slack web hook, add to the transports array to enable slack messages.
-    const slackConfig = transportsConfig.slackConfig ?? process.env.SLACK_CONFIG;
+    const slackConfig = transportsConfig.slackConfig ?? JSON.parse(process.env.SLACK_CONFIG);
     if (slackConfig) {
       transports.push(SlackTransport.createSlackTransport(slackConfig));
     }
 
     // If there is a Pagerduty API key then add the pagerduty winston transport.
-    if (transportsConfig.pdApiToken || process.env.PAGERDUTY_API_KEY) {
+    if (transportsConfig.pdApiToken || process.env.PAGER_DUTY_CONFIG) {
       transports.push(
         new PagerDutyTransport(
           { level: "warn" },
-          transportsConfig.pagerDutyConfig ?? process.env.PAGER_DUTY_CONFIG
-            ? JSON.stringify(process.env.PAGER_DUTY_CONFIG)
-            : {}
+          transportsConfig.pagerDutyConfig ?? JSON.parse(process.env.PAGER_DUTY_CONFIG)
         )
       );
     }

--- a/packages/financial-templates-lib/src/logger/Transports.js
+++ b/packages/financial-templates-lib/src/logger/Transports.js
@@ -36,7 +36,7 @@ function createTransports(transportsConfig = {}) {
   // If there is "test" in the environment then skip the slack or pagerduty.
   if (argv._.indexOf("test") == -1) {
     // If there is a slack web hook, add to the transports array to enable slack messages.
-    const slackConfig = transportsConfig.slackConfig ?? JSON.parse(process.env.SLACK_CONFIG);
+    const slackConfig = transportsConfig.slackConfig ?? JSON.parse(process.env.SLACK_CONFIG || null);
     if (slackConfig) {
       transports.push(SlackTransport.createSlackTransport(slackConfig));
     }
@@ -46,7 +46,7 @@ function createTransports(transportsConfig = {}) {
       transports.push(
         new PagerDutyTransport(
           { level: "warn" },
-          transportsConfig.pagerDutyConfig ?? JSON.parse(process.env.PAGER_DUTY_CONFIG)
+          transportsConfig.pagerDutyConfig ?? JSON.parse(process.env.PAGER_DUTY_CONFIG || null)
         )
       );
     }

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -410,6 +410,7 @@ async function Poll(callback) {
       at: "Liquidator#index",
       message: "Liquidator execution error🚨",
       error: typeof error === "string" ? new Error(error) : error,
+      notificationPath: "infrastructure-error",
     });
     await waitForLogger(Logger);
     callback(error);

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -479,6 +479,7 @@ async function Poll(callback) {
       at: "Monitor#index",
       message: "Monitor execution error🚨",
       error: typeof error === "string" ? new Error(error) : error,
+      notificationPath: "infrastructure-error",
     });
     await waitForLogger(Logger);
     callback(error);

--- a/packages/monitors/src/BalanceMonitor.js
+++ b/packages/monitors/src/BalanceMonitor.js
@@ -144,6 +144,7 @@ class BalanceMonitor {
             "collateral",
             this.normalizeCollateralDecimals
           ),
+          notificationPath: "risk-management",
         });
       }
       if (this.toBN(this.client.getSyntheticBalance(monitoredAddress)).lt(this.toBN(bot.syntheticThreshold))) {
@@ -158,6 +159,7 @@ class BalanceMonitor {
             "synthetic",
             this.normalizeSyntheticDecimals
           ),
+          notificationPath: "risk-management",
         });
       }
       if (this.toBN(this.client.getEtherBalance(monitoredAddress)).lt(this.toBN(bot.etherThreshold))) {
@@ -172,6 +174,7 @@ class BalanceMonitor {
             "ether",
             (num) => this.toBN(num)
           ),
+          notificationPath: "risk-management",
         });
       }
     }

--- a/packages/monitors/src/CRMonitor.js
+++ b/packages/monitors/src/CRMonitor.js
@@ -199,6 +199,7 @@ class CRMonitor {
           at: "CRMonitor",
           message: "Collateralization ratio alert 🙅‍♂️!",
           mrkdwn: mrkdwn,
+          notificationPath: "risk-management",
         });
       }
     }

--- a/packages/monitors/src/CRMonitor.js
+++ b/packages/monitors/src/CRMonitor.js
@@ -198,7 +198,7 @@ class CRMonitor {
         this.logger[this.logOverrides.crThreshold || "warn"]({
           at: "CRMonitor",
           message: "Collateralization ratio alert 🙅‍♂️!",
-          mrkdwn: mrkdwn,
+          mrkdwn,
           notificationPath: "risk-management",
         });
       }

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -174,6 +174,7 @@ class ContractMonitor {
         at: "ContractMonitor",
         message: "New Sponsor Alert 🐣!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastNewSponsorBlockNumber = this._getLastSeenBlockNumber(latestNewSponsorEvents);
@@ -291,6 +292,7 @@ class ContractMonitor {
         at: "ContractMonitor",
         message: "Liquidation Alert 🧙‍♂️!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastLiquidationBlockNumber = this._getLastSeenBlockNumber(latestLiquidationEvents);
@@ -329,6 +331,7 @@ class ContractMonitor {
         at: "ContractMonitor",
         message: "Dispute Alert 👻!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastDisputeBlockNumber = this._getLastSeenBlockNumber(latestDisputeEvents);
@@ -376,6 +379,7 @@ class ContractMonitor {
           resolvedPrice,
           liquidationEvent,
           liquidationTimestamp,
+          notificationPath: "risk-management",
         });
       }
 
@@ -407,6 +411,7 @@ class ContractMonitor {
         at: "ContractMonitor",
         message: "Dispute Settlement Alert 👮‍♂️!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastDisputeSettlementBlockNumber = this._getLastSeenBlockNumber(latestDisputeSettlementEvents);
@@ -441,6 +446,7 @@ class ContractMonitor {
         at: "ContractMonitor",
         message: "Funding Rate Update Alert 🏵!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastFundingRateUpdatedBlockNumber = this._getLastSeenBlockNumber(latestFundingRateUpdatedEvents);

--- a/packages/monitors/src/ContractMonitor.js
+++ b/packages/monitors/src/ContractMonitor.js
@@ -173,7 +173,7 @@ class ContractMonitor {
       this.logger[this.logOverrides.newPositionCreated || "info"]({
         at: "ContractMonitor",
         message: "New Sponsor Alert 🐣!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -291,7 +291,7 @@ class ContractMonitor {
       this.logger.info({
         at: "ContractMonitor",
         message: "Liquidation Alert 🧙‍♂️!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -330,7 +330,7 @@ class ContractMonitor {
       this.logger.info({
         at: "ContractMonitor",
         message: "Dispute Alert 👻!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -410,7 +410,7 @@ class ContractMonitor {
       this.logger.info({
         at: "ContractMonitor",
         message: "Dispute Settlement Alert 👮‍♂️!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -445,7 +445,7 @@ class ContractMonitor {
       this.logger.info({
         at: "ContractMonitor",
         message: "Funding Rate Update Alert 🏵!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -101,7 +101,7 @@ class OptimisticOracleContractMonitor {
       ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Request Alert 👮🏻!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -138,7 +138,7 @@ class OptimisticOracleContractMonitor {
       ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Proposal Alert 🧞‍♂️!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -169,7 +169,7 @@ class OptimisticOracleContractMonitor {
       this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Dispute Alert ⛔️!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }
@@ -207,7 +207,7 @@ class OptimisticOracleContractMonitor {
       ]({
         at: "OptimisticOracleContractMonitor",
         message: "Price Settlement Alert 🏧!",
-        mrkdwn: mrkdwn,
+        mrkdwn,
         notificationPath: "risk-management",
       });
     }

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -102,6 +102,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: "Price Request Alert 👮🏻!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastRequestPriceBlockNumber = this._getLastSeenBlockNumber(latestEvents);
@@ -138,6 +139,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: "Price Proposal Alert 🧞‍♂️!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastProposePriceBlockNumber = this._getLastSeenBlockNumber(latestEvents);
@@ -168,6 +170,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: "Price Dispute Alert ⛔️!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastDisputePriceBlockNumber = this._getLastSeenBlockNumber(latestEvents);
@@ -205,6 +208,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: "Price Settlement Alert 🏧!",
         mrkdwn: mrkdwn,
+        notificationPath: "risk-management",
       });
     }
     this.lastSettlementBlockNumber = this._getLastSeenBlockNumber(latestEvents);

--- a/packages/monitors/src/SyntheticPegMonitor.js
+++ b/packages/monitors/src/SyntheticPegMonitor.js
@@ -189,6 +189,7 @@ class SyntheticPegMonitor {
           ". Error of " +
           this.formatDecimalString(deviationError.muln(100)) + // multiply by 100 to make the error a percentage
           "%.",
+        notificationPath: "risk-management",
       });
     }
   }
@@ -245,6 +246,7 @@ class SyntheticPegMonitor {
           " hour(s). Threshold is " +
           this.pegVolatilityAlertThreshold * 100 +
           "%.",
+        notificationPath: "risk-management",
       });
     }
   }
@@ -299,6 +301,7 @@ class SyntheticPegMonitor {
           " hour(s). Threshold is " +
           this.syntheticVolatilityAlertThreshold * 100 +
           "%.",
+        notificationPath: "risk-management",
       });
     }
   }

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -194,6 +194,7 @@ hub.post("/", async (req, res) => {
           }
         }), // eslint-disable-line indent
         validOutputs: Object.keys(errorOutput.validOutputs), // eslint-disable-line indent
+        notificationPath: "infrastructure-error",
       });
     }
     await delay(2); // Wait a few seconds to be sure the the winston logs are processed upstream.


### PR DESCRIPTION
**Motivation**

This PR adds the ability for Winston logs to be directed to different "paths" enabling more granular control over where messages are sent.

**Summary**

- Add two main paths: `notificationPath: "risk-management"` & `notificationPath: "infrastructure-error"`
- Refactor how configs are fed into these transports. NOTE this is a breaking change and updates to configs must be rolled out at the same time!

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
