### PR TITLE
fix(default-pf-config): Fix lookback period for BALUSD price id

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -874,7 +874,7 @@ const defaultConfigs = {
       SPOT_BALANCER_ETH: {
         type: "balancer",
         twapLength: 2,
-        lookback: 3600,
+        lookback: 7200,
         balancerAddress: "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
         balancerTokenIn: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
         balancerTokenOut: "0xba100000625a3754423978a60c9317c58a424e3D",


### PR DESCRIPTION
**Motivation**

The `lookback` was set incorrectly for the `SPOT_BALANCER_ETH` component of the `BALUSD` default price feed config.

Although this has no impact on the calculated price, this can cause issues for bot operators and voters being able to query for the BALUSD price.


**Summary**

Changes BALUSD `lookback` specification to `7200`.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
