### PR TITLE
feat(CFD): Add range bond financial template library

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.sol
@@ -70,8 +70,7 @@ contract RangeBondContractForDifferenceFinancialProductLibrary is
         // multiplications. However this introduces rounding issues. By keeping it in this form this is avoided.
         // NOTE: the ternary is used over Math.max for the second term to avoid negative numbers.
 
-        uint256 positiveExpiraryPrice = 0;
-        if (expiryPrice > 0) positiveExpiraryPrice = uint256(expiryPrice);
+        uint256 positiveExpiraryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;
 
         FixedPoint.Unsigned memory longTokensRedeemed =
             FixedPoint

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.sol
@@ -45,6 +45,11 @@ contract RangeBondContractForDifferenceFinancialProductLibrary is
             "Parameters already set"
         );
 
+        uint256 cfdCollateralPerPair = ContractForDifferenceInterface(contractForDifferenceAddress).collateralPerPair();
+
+        require(FixedPoint.Unsigned(cfdCollateralPerPair).mul(lowPriceRange).isEqual(bondNotional), "Bad params");
+        require(FixedPoint.Unsigned(bondNotional).div(highPriceRange).isLessThan(cfdCollateralPerPair), "Bad params");
+
         contractForDifferenceParameters[contractForDifferenceAddress] = RangeBondContractForDifferenceParameters({
             bondNotional: bondNotional,
             lowPriceRange: lowPriceRange,

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+import "./ContractForDifferenceFinancialProductLibrary.sol";
+import "../../../../common/implementation/Lockable.sol";
+
+interface ContractForDifferenceInterface {
+    function collateralPerPair() external view returns (uint256);
+}
+
+contract RangeBondContractForDifferenceFinancialProductLibrary is
+    ContractForDifferenceFinancialProductLibrary,
+    Lockable
+{
+    using FixedPoint for FixedPoint.Unsigned;
+    using SignedSafeMath for int256;
+
+    struct RangeBondContractForDifferenceParameters {
+        uint256 bondNotional;
+        uint256 highPriceRange;
+        uint256 lowPriceRange;
+    }
+
+    mapping(address => RangeBondContractForDifferenceParameters) public contractForDifferenceParameters;
+
+    function setContractForDifferenceParameters(
+        address contractForDifferenceAddress,
+        uint256 bondNotional,
+        uint256 highPriceRange,
+        uint256 lowPriceRange
+    ) public nonReentrant() {
+        require(
+            ExpiringContractInterface(contractForDifferenceAddress).expirationTimestamp() != 0,
+            "Invalid CFD address"
+        );
+        require(highPriceRange > lowPriceRange, "Invalid bounds");
+
+        RangeBondContractForDifferenceParameters memory params =
+            contractForDifferenceParameters[contractForDifferenceAddress];
+        require(
+            params.bondNotional == 0 && params.lowPriceRange == 0 && params.highPriceRange == 0,
+            "Parameters already set"
+        );
+
+        contractForDifferenceParameters[contractForDifferenceAddress] = RangeBondContractForDifferenceParameters({
+            bondNotional: bondNotional,
+            lowPriceRange: lowPriceRange,
+            highPriceRange: highPriceRange
+        });
+    }
+
+    function computeExpiraryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
+        RangeBondContractForDifferenceParameters memory params = contractForDifferenceParameters[msg.sender];
+
+        // A range bond is defined as = Yield Dollar - Put Option + Call option. Numerically this is found using:
+        // N = Notional of bond (100)
+        // P = price of token
+        // T = number of tokens
+        // R1 = Low Price Range
+        // R2 = High Price Range
+        // T = min(N/P,N/R1) + max((N/R2*(P-R2))/P,0)
+        // This represents the value of the long token(range bond holder). This function's method must return a value
+        //  between 0 and 1 to be used as a collateralPerPair that allocates collateral between the short and long tokens.
+        // We can use the value of the long token to compute the relative distribution between long and short CFD tokens
+        // by simply computing longTokenRedeemed using equation above devided by the collateralPerPair of the CFD.
+        // NOTE: the equation's second term could be simplified slightly alebraically to have fewer devided and
+        // multiplications. However this introduces rounding issues. By keeping it in this form this is avoided.
+        // NOTE: the ternary is used over Math.max for the second term to avoid negative numbers.
+
+        uint256 positiveExpiraryPrice = 0;
+        if (expiryPrice > 0) positiveExpiraryPrice = uint256(expiryPrice);
+
+        FixedPoint.Unsigned memory longTokensRedeemed =
+            FixedPoint
+                .Unsigned(
+                Math.min(
+                    FixedPoint.Unsigned(params.bondNotional).div(FixedPoint.Unsigned(positiveExpiraryPrice)).rawValue,
+                    FixedPoint.Unsigned(params.bondNotional).div(FixedPoint.Unsigned(params.lowPriceRange)).rawValue
+                )
+            )
+                .add(
+                FixedPoint.Unsigned(positiveExpiraryPrice).isGreaterThan(FixedPoint.Unsigned(params.highPriceRange))
+                    ? FixedPoint
+                        .Unsigned(params.bondNotional)
+                        .divCeil(FixedPoint.Unsigned(params.highPriceRange))
+                        .mulCeil(
+                        (FixedPoint.Unsigned(positiveExpiraryPrice).sub(FixedPoint.Unsigned(params.highPriceRange)))
+                            .divCeil(FixedPoint.Unsigned(positiveExpiraryPrice))
+                    )
+                    : FixedPoint.Unsigned(0)
+            );
+
+        uint256 cfdCollateralPerPair = ContractForDifferenceInterface(msg.sender).collateralPerPair();
+
+        return longTokensRedeemed.div(FixedPoint.Unsigned(cfdCollateralPerPair)).rawValue;
+    }
+}

--- a/packages/core/contracts/financial-templates/test/ContractForDifferenceMock.sol
+++ b/packages/core/contracts/financial-templates/test/ContractForDifferenceMock.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+contract ContractForDifferenceMock {
+    uint256 public expirationTimestamp;
+    uint256 public collateralPerPair;
+
+    constructor(uint256 _expirationTimestamp, uint256 _collateralPerPair) {
+        expirationTimestamp = _expirationTimestamp;
+        collateralPerPair = _collateralPerPair;
+    }
+}

--- a/packages/core/test/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.js
@@ -1,0 +1,162 @@
+const { didContractThrow, ZERO_ADDRESS } = require("@uma/common");
+const { assert } = require("chai");
+
+// Tested Contract
+const RangeBondContractForDifferenceFinancialProductLibrary = artifacts.require(
+  "RangeBondContractForDifferenceFinancialProductLibrary"
+);
+
+const ContractForDifferenceMock = artifacts.require("ContractForDifferenceMock");
+
+const { toWei, toBN, BN } = web3.utils;
+const bondNotional = toBN(toWei("100"));
+const lowPriceRange = toBN(toWei("10"));
+const highPriceRange = toBN(toWei("50"));
+const collateralPerPair = toBN(toWei("10"));
+
+contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
+  let rangeBondCFDFPL;
+  let cfdMock;
+
+  beforeEach(async () => {
+    rangeBondCFDFPL = await RangeBondContractForDifferenceFinancialProductLibrary.new();
+    cfdMock = await ContractForDifferenceMock.new(
+      "1000000", // _expirationTimestamp
+      collateralPerPair // _collateralPerPair
+    );
+  });
+  describe("Contract For diffrence Paramaterization", () => {
+    it("Can set and fetch valid values", async () => {
+      await rangeBondCFDFPL.setContractForDifferenceParameters(
+        cfdMock.address,
+        bondNotional,
+        highPriceRange,
+        lowPriceRange
+      );
+
+      const setParams = await rangeBondCFDFPL.contractForDifferenceParameters(cfdMock.address);
+      assert.equal(setParams.bondNotional.toString(), bondNotional);
+      assert.equal(setParams.lowPriceRange.toString(), lowPriceRange);
+      assert.equal(setParams.highPriceRange.toString(), highPriceRange);
+    });
+    it("Can not re-use existing CFD contract address", async () => {
+      await rangeBondCFDFPL.setContractForDifferenceParameters(
+        cfdMock.address,
+        bondNotional,
+        highPriceRange,
+        lowPriceRange
+      );
+
+      // Second attempt should revert.
+      assert(
+        await didContractThrow(
+          rangeBondCFDFPL.setContractForDifferenceParameters(
+            cfdMock.address,
+            bondNotional,
+            lowPriceRange,
+            highPriceRange
+          )
+        )
+      );
+    });
+    it("Can not set invalid bounds", async () => {
+      // upper bound larger than lower bound by swapping upper and lower
+      assert(
+        await didContractThrow(
+          rangeBondCFDFPL.setContractForDifferenceParameters(cfdMock.address, lowPriceRange, highPriceRange)
+        )
+      );
+    });
+    it("Can not set invalid CFD contract address", async () => {
+      // CFD Address must implement the `expirationTimestamp method.
+      assert(
+        await didContractThrow(
+          rangeBondCFDFPL.setContractForDifferenceParameters(ZERO_ADDRESS, bondNotional, highPriceRange, lowPriceRange)
+        )
+      );
+    });
+  });
+  describe("Compute expirary tokens for collateral", () => {
+    beforeEach(async () => {
+      await rangeBondCFDFPL.setContractForDifferenceParameters(
+        cfdMock.address,
+        bondNotional,
+        highPriceRange,
+        lowPriceRange
+      );
+    });
+    it("Lower than low price range should return 1 (long side is short put option)", async () => {
+      // If the price is lower than the low price range then the max payout per each long token is hit at the full
+      // collateralPerPair. i.e each short token is worth 0*collateralPerPair and each long token is worth 1*collateralPerPair.
+      const expiraryTokensForCollateral = await rangeBondCFDFPL.computeExpiraryTokensForCollateral.call(toWei("9"), {
+        from: cfdMock.address,
+      });
+      assert.equal(expiraryTokensForCollateral.toString(), toWei("1"));
+    });
+    it("Higher than upper bound should return 0.2 (long side is long call option)", async () => {
+      // If the price is larger than the high price range then the long tokens are equal fixed amount of notional/highPriceRange
+      // Considering the long token to compute the expiryPercentLong (notional/highPriceRange)/collateralPerpair=(100/50)/10=0.2.
+      // i.e each short token is worth 0.8* collateralPerpair = 8 tokens and each long token is worth 0.2*collateralPerpair=2.
+      const expiraryTokensForCollateral = await rangeBondCFDFPL.computeExpiraryTokensForCollateral.call(toWei("60"), {
+        from: cfdMock.address,
+      });
+      assert.equal(expiraryTokensForCollateral.toString(), toWei("0.2"));
+    });
+    it("Midway between bounds should return long worth bond notional (long side is long yield dollar)", async () => {
+      // If the price is between the low and high price ranges then the payout is simply that of a yield dollar. i.e every
+      // long token is worth the bond notional of 100. At a price of 20 we are between the bounds. Each long should be worth
+      // 100 so there should be 100/20=5 UMA per long token. As each collateralPerpair is worth 10, expiryPercentLong should
+      // be 10/5=0.5, thereby allocating half to the long and half to the short.
+      const expiraryTokensForCollateral1 = await rangeBondCFDFPL.computeExpiraryTokensForCollateral.call(toWei("20"), {
+        from: cfdMock.address,
+      });
+      assert.equal(expiraryTokensForCollateral1.toString(), toWei("0.5"));
+
+      // Equally, at a price of 40 each long should still be worth 100 so there should be 100/40=2.5 UMA per long. As
+      // each collateralPerpair=10 expiryPercentLong should be 10/2.5=0.25, thereby allocating 25% to long and the remaining to short.
+      const expiraryTokensForCollateral2 = await rangeBondCFDFPL.computeExpiraryTokensForCollateral.call(toWei("20"), {
+        from: cfdMock.address,
+      });
+      assert.equal(expiraryTokensForCollateral2.toString(), toWei("0.5"));
+    });
+
+    it("Arbitary price should return correctly", async () => {
+      // Value of long token: T = min(N/P,N/R1) + max((N/R2*(P-R2))/P),0)
+      // expected payout is T/collateralPerPair. We can compute the exact numerical amount for a set of input prices
+      // and double check the payout maps to what is expected.
+
+      const fixedPointAdjustment = toBN(toWei("1"));
+
+      for (const price of [toWei("5"), toWei("10"), toWei("30"), toWei("50"), toWei("60"), toWei("100")]) {
+        const expiraryTokensForCollateral = await rangeBondCFDFPL.computeExpiraryTokensForCollateral.call(price, {
+          from: cfdMock.address,
+        });
+        //
+        const term1 = BN.min(
+          toBN(bondNotional).mul(fixedPointAdjustment).div(toBN(price)),
+          toBN(bondNotional).mul(fixedPointAdjustment).div(toBN(lowPriceRange))
+        );
+        console.log("term1", term1.toString());
+
+        const term2 = BN.max(
+          toBN(bondNotional)
+            .div(toBN(highPriceRange))
+            .mul(fixedPointAdjustment)
+            .mul(toBN(price).sub(toBN(highPriceRange)))
+            .div(toBN(price))
+            .addn(1),
+          toBN("0")
+        );
+        console.log("term2", term2.toString());
+
+        const longTokenRedemptionInCollateral = term1.add(term2);
+        const expectedExpiraryTokensForCollateral = longTokenRedemptionInCollateral
+          .mul(fixedPointAdjustment)
+          .div(collateralPerPair);
+
+        console.log("expectedExpiraryTokensForCollateral", expectedExpiraryTokensForCollateral.toString());
+        assert.equal(expiraryTokensForCollateral.toString(), expectedExpiraryTokensForCollateral.toString());
+      }
+    });
+  });
+});

--- a/packages/core/test/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.js
@@ -63,7 +63,27 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          rangeBondCFDFPL.setContractForDifferenceParameters(cfdMock.address, lowPriceRange, highPriceRange)
+          rangeBondCFDFPL.setContractForDifferenceParameters(
+            cfdMock.address,
+            bondNotional,
+            lowPriceRange,
+            highPriceRange
+          )
+        )
+      );
+
+      // Bounds and notional relative to collateralPerPair must be valid. For a Range bond, at the exact price of the
+      // minPriceRange, the value of the payout of long tokens should be worth exactly the notional as at this point
+      // all short tokens are worth 0 and all long tokens are worth the full collateralPerPair. Using this we can enforce
+      // that collateralPerPair*lowPriceRange=bondNotional.
+      assert(
+        await didContractThrow(
+          rangeBondCFDFPL.setContractForDifferenceParameters(
+            cfdMock.address,
+            bondNotional.addn(100), // a notational of 1001e18+100 is wrong relative to the lowPriceRange.
+            lowPriceRange,
+            highPriceRange
+          )
         )
       );
     });

--- a/packages/core/test/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/contract-for-difference-libraries/RangeBondContractForDifferenceFinancialProductLibrary.js
@@ -136,7 +136,6 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
           toBN(bondNotional).mul(fixedPointAdjustment).div(toBN(price)),
           toBN(bondNotional).mul(fixedPointAdjustment).div(toBN(lowPriceRange))
         );
-        console.log("term1", term1.toString());
 
         const term2 = BN.max(
           toBN(bondNotional)
@@ -147,14 +146,12 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
             .addn(1),
           toBN("0")
         );
-        console.log("term2", term2.toString());
 
         const longTokenRedemptionInCollateral = term1.add(term2);
         const expectedExpiraryTokensForCollateral = longTokenRedemptionInCollateral
           .mul(fixedPointAdjustment)
           .div(collateralPerPair);
 
-        console.log("expectedExpiraryTokensForCollateral", expectedExpiraryTokensForCollateral.toString());
         assert.equal(expiraryTokensForCollateral.toString(), expectedExpiraryTokensForCollateral.toString());
       }
     });


### PR DESCRIPTION
**Motivation**

Add range bonds Contract for difference financial product library and unit tests.
A range bond is defined as = Yield Dollar - Put Option + Call option.

 Numerically this is found using:        
- `N` = Notional of bond
- `P` = price of token
- `T` = number of tokens
- `R1` = Low Price Range
- `R2` = High Price Range
- long token redemption: `T = min(N/P,N/R1) + max((N/R2*(P-R2))/P,0)`

As the financial product library returns a number between 0 and 1 for CFD payouts, we can take the long token redemption value `T` and divide it by the CFDs `collateralPerPair` to find a number between 0 and 1 that represents the long/short payout `expiryPercentLong`.