### PR TITLE
feat(voting-script): Update USDETH rounding specification to 8 decimals

### DIFF
--- a/packages/core/scripts/local/getHistoricalPrice.js
+++ b/packages/core/scripts/local/getHistoricalPrice.js
@@ -20,7 +20,7 @@ require("dotenv").config();
 
 const UMIP_PRECISION = {
   USDBTC: 8,
-  USDETH: 5,
+  USDETH: 8,
   BTCDOM: 2,
   ALTDOM: 2,
   BCHNBTC: 8,


### PR DESCRIPTION
**Motivation**

Based upon multiple community discussions, the rounding specification for the USDETH price identifier was determined to not use enough decimals. This updates the rounding specification in the getHistoricalPrice script to be 8 decimals. This is accompanied by an update to the [UMIP](https://github.com/UMAprotocol/UMIPs/pull/311).


**Summary**

Updates script.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**

NA