### PR TITLE
clean(bot-tests): remove repeated function from repo

### DIFF
--- a/packages/core/test/bot-helpers/atomic-disputer/ReserveCurrencyDisputer.js
+++ b/packages/core/test/bot-helpers/atomic-disputer/ReserveCurrencyDisputer.js
@@ -1,7 +1,12 @@
-const { MAX_UINT_VAL, MAX_SAFE_ALLOWANCE, ZERO_ADDRESS, interfaceName } = require("@uma/common");
+const {
+  MAX_UINT_VAL,
+  MAX_SAFE_ALLOWANCE,
+  ZERO_ADDRESS,
+  interfaceName,
+  createContractObjectFromJson,
+} = require("@uma/common");
 const { toWei, toBN, fromWei, padRight, utf8ToHex } = web3.utils;
 const { getTruffleContract } = require("@uma/core");
-const truffleContract = require("@truffle/contract");
 const { assert } = require("chai");
 
 // Tested Contract
@@ -51,13 +56,6 @@ const getPoolSpotPrice = async () => {
   const poolTokenABallance = await reserveToken.balanceOf(pairAddress);
   const poolTokenBBallance = await collateralToken.balanceOf(pairAddress);
   return Number(fromWei(poolTokenABallance.mul(toBN(toWei("1"))).div(poolTokenBBallance))).toFixed(4);
-};
-
-// Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
-const createContractObjectFromJson = (contractJsonObject) => {
-  let truffleContractCreator = truffleContract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
-  return truffleContractCreator;
 };
 
 contract("ReserveTokenDisputer", function (accounts) {

--- a/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
+++ b/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
@@ -1,7 +1,13 @@
-const { MAX_UINT_VAL, MAX_SAFE_ALLOWANCE, ZERO_ADDRESS, didContractThrow, parseFixed } = require("@uma/common");
+const {
+  MAX_UINT_VAL,
+  MAX_SAFE_ALLOWANCE,
+  ZERO_ADDRESS,
+  didContractThrow,
+  parseFixed,
+  createContractObjectFromJson,
+} = require("@uma/common");
 const { toWei, toBN, fromWei, padRight, utf8ToHex } = web3.utils;
 const { getTruffleContract } = require("@uma/core");
-const truffleContract = require("@truffle/contract");
 const { assert } = require("chai");
 
 // Tested Contract
@@ -63,13 +69,6 @@ const computeExpectedTokenBuy = async (tokensToLiquidate) => {
     .mul(fixedPointAdjustment)
     .div(toBN((await financialContract.totalTokensOutstanding()).toString()));
   return tokensToLiquidate.mul(contractGcr).div(fixedPointAdjustment).add(finalFeeAmount);
-};
-
-// Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
-const createContractObjectFromJson = (contractJsonObject) => {
-  let truffleContractCreator = truffleContract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
-  return truffleContractCreator;
 };
 
 contract("ReserveTokenLiquidator", function (accounts) {

--- a/packages/core/test/bot-helpers/uniswap-broker/UniswapV2Broker.js
+++ b/packages/core/test/bot-helpers/uniswap-broker/UniswapV2Broker.js
@@ -1,7 +1,6 @@
-const { MAX_UINT_VAL } = require("@uma/common");
+const { MAX_UINT_VAL, createContractObjectFromJson } = require("@uma/common");
 const { toWei, toBN, fromWei } = web3.utils;
 const { getTruffleContract } = require("@uma/core");
-const truffleContract = require("@truffle/contract");
 
 // Tested Contract
 const UniswapV2Broker = getTruffleContract("UniswapV2Broker", web3);
@@ -20,13 +19,6 @@ let router;
 let uniswapV2Broker;
 let pair;
 let pairAddress;
-
-// Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
-const createContractObjectFromJson = (contractJsonObject) => {
-  let truffleContractCreator = truffleContract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
-  return truffleContractCreator;
-};
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {

--- a/packages/disputer/test/Disputer.js
+++ b/packages/disputer/test/Disputer.js
@@ -1,7 +1,6 @@
 const { toWei, toBN, utf8ToHex, padRight, isAddress } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
-const truffleContract = require("@truffle/contract");
 const {
   PostWithdrawLiquidationRewardsStatusTranslations,
   LiquidationStatesEnum,
@@ -12,6 +11,7 @@ const {
   createConstructorParamsForContractVersion,
   TESTED_CONTRACT_VERSIONS,
   parseFixed,
+  createContractObjectFromJson,
 } = require("@uma/common");
 const { getTruffleContract } = require("@uma/core");
 
@@ -1177,14 +1177,6 @@ contract("Disputer.js", function (accounts) {
           let pair;
           let dsProxyFactory;
           let dsProxy;
-
-          // Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
-          // TODO: refactor this to be from a common file
-          const createContractObjectFromJson = (contractJsonObject) => {
-            let truffleContractCreator = truffleContract(contractJsonObject);
-            truffleContractCreator.setProvider(web3.currentProvider);
-            return truffleContractCreator;
-          };
 
           beforeEach(async () => {
             // Create the reserve currency for the liquidator to hold.

--- a/packages/disputer/test/index.js
+++ b/packages/disputer/test/index.js
@@ -1,5 +1,4 @@
 const { toWei, utf8ToHex, padRight, toBN } = web3.utils;
-const truffleContract = require("@truffle/contract");
 const {
   MAX_UINT_VAL,
   ZERO_ADDRESS,
@@ -7,6 +6,7 @@ const {
   addGlobalHardhatTestingAddress,
   createConstructorParamsForContractVersion,
   TESTED_CONTRACT_VERSIONS,
+  createContractObjectFromJson,
 } = require("@uma/common");
 const { getTruffleContract } = require("@uma/core");
 
@@ -19,12 +19,6 @@ const { SpyTransport, spyLogLevel, spyLogIncludes } = require("@uma/financial-te
 const UniswapV2Factory = require("@uniswap/v2-core/build/UniswapV2Factory.json");
 const IUniswapV2Pair = require("@uniswap/v2-core/build/IUniswapV2Pair.json");
 const UniswapV2Router02 = require("@uniswap/v2-periphery/build/UniswapV2Router02.json");
-
-const createContractObjectFromJson = (contractJsonObject) => {
-  let truffleContractCreator = truffleContract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
-  return truffleContractCreator;
-};
 
 // Script to test
 const Poll = require("../index.js");

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -1,7 +1,10 @@
 const assert = require("assert");
-const truffleContract = require("@truffle/contract");
-
-const { createObjectFromDefaultProps, runTransaction, blockUntilBlockMined } = require("@uma/common");
+const {
+  createObjectFromDefaultProps,
+  runTransaction,
+  blockUntilBlockMined,
+  createContractObjectFromJson,
+} = require("@uma/common");
 const { getAbi, getTruffleContract } = require("@uma/core");
 
 const UniswapV2Factory = require("@uniswap/v2-core/build/UniswapV2Factory.json");
@@ -104,13 +107,6 @@ class ProxyTransactionWrapper {
     this.ReserveCurrencyLiquidator = getTruffleContract("ReserveCurrencyLiquidator", this.web3);
   }
 
-  // TODO: wrap this into a common util.
-  createContractObjectFromJson(contractJsonObject) {
-    let truffleContractCreator = truffleContract(contractJsonObject);
-    truffleContractCreator.setProvider(this.web3.currentProvider);
-    return truffleContractCreator;
-  }
-
   // Get the effective synthetic token balance. If the bot is executing in normal mode (liquidations sent from an EOA)
   // then this is simply the token balance of the unlocked account. If the liquidator is using a DSProxy to liquidate,
   // then consider the synthetics could be minted, + any synthetics the DSProxy already has.
@@ -134,10 +130,10 @@ class ProxyTransactionWrapper {
       // Else, work out how much collateral could be purchased using all the reserve currency.
       else {
         // Instantiate uniswap factory to fetch the pair address.
-        const uniswapFactory = await this.createContractObjectFromJson(UniswapV2Factory).at(this.uniswapFactoryAddress);
+        const uniswapFactory = await createContractObjectFromJson(UniswapV2Factory).at(this.uniswapFactoryAddress);
 
         const pairAddress = await uniswapFactory.getPair(this.reserveToken._address, this.collateralToken._address);
-        const uniswapPair = await this.createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+        const uniswapPair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
 
         // We can now fetch the reserves. At the same time, we can batch a few other required async calls.
         const [reserves, token0] = await Promise.all([uniswapPair.getReserves(), uniswapPair.token0()]);

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1,7 +1,6 @@
 const { toWei, toBN, utf8ToHex, padRight, isAddress, fromWei } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
-const truffleContract = require("@truffle/contract");
 const {
   parseFixed,
   interfaceName,
@@ -12,6 +11,7 @@ const {
   TESTED_CONTRACT_VERSIONS,
   MAX_SAFE_ALLOWANCE,
   MAX_UINT_VAL,
+  createContractObjectFromJson,
 } = require("@uma/common");
 const { getTruffleContract } = require("@uma/core");
 
@@ -1702,14 +1702,6 @@ contract("Liquidator.js", function (accounts) {
           let pair;
           let dsProxyFactory;
           let dsProxy;
-
-          // Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
-          // TODO: refactor this to be from a common file
-          const createContractObjectFromJson = (contractJsonObject) => {
-            let truffleContractCreator = truffleContract(contractJsonObject);
-            truffleContractCreator.setProvider(web3.currentProvider);
-            return truffleContractCreator;
-          };
 
           const getPoolSpotPrice = async () => {
             const poolTokenABallance = await reserveToken.balanceOf(pairAddress);

--- a/packages/liquidator/test/index.js
+++ b/packages/liquidator/test/index.js
@@ -1,5 +1,4 @@
 const { toBN, toWei, utf8ToHex, padRight } = web3.utils;
-const truffleContract = require("@truffle/contract");
 const { assert } = require("chai");
 
 const {
@@ -8,6 +7,7 @@ const {
   addGlobalHardhatTestingAddress,
   createConstructorParamsForContractVersion,
   TESTED_CONTRACT_VERSIONS,
+  createContractObjectFromJson,
 } = require("@uma/common");
 
 const { getTruffleContract } = require("@uma/core");
@@ -21,12 +21,6 @@ const { SpyTransport, spyLogLevel, spyLogIncludes, FinancialContractClient } = r
 const UniswapV2Factory = require("@uniswap/v2-core/build/UniswapV2Factory.json");
 const IUniswapV2Pair = require("@uniswap/v2-core/build/IUniswapV2Pair.json");
 const UniswapV2Router02 = require("@uniswap/v2-periphery/build/UniswapV2Router02.json");
-
-const createContractObjectFromJson = (contractJsonObject) => {
-  let truffleContractCreator = truffleContract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
-  return truffleContractCreator;
-};
 
 // Script to test
 const Poll = require("../index.js");

--- a/packages/trader/test/UniswapV2Trader.ts
+++ b/packages/trader/test/UniswapV2Trader.ts
@@ -12,6 +12,7 @@ import {
   UniswapV2PriceFeed,
 } from "@uma/financial-templates-lib";
 import { getTruffleContract } from "@uma/core";
+import { createContractObjectFromJson } from "@uma/common";
 
 // Script to test
 import { RangeTrader } from "../src/RangeTrader";
@@ -52,16 +53,6 @@ let pair: any;
 let pairAddress: any;
 let WETH: any;
 let dsProxyFactory: any;
-
-// Takes in a json object from a compiled contract and returns a truffle contract instance that can be deployed.
-// TODO: these methods are taken from the UniswapV2Broker tests verbatim. they should be refactored to a common util that
-// can be re-used between different uniswap tests.
-const createContractObjectFromJson = (contractJsonObject: any) => {
-  const contract = require("@truffle/contract");
-  const truffleContractCreator = contract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
-  return truffleContractCreator;
-};
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {


### PR DESCRIPTION
**Motivation**

There are a number of common places through the monorepo where the method `createContractObjectFromJson` are repeated over and over. This PR removes this.
