### PR TITLE
fix(common-ContractUtils): Add web3 param injection to createContractObjectFromJson

### DIFF
--- a/packages/common/src/ContractUtils.js
+++ b/packages/common/src/ContractUtils.js
@@ -32,6 +32,7 @@ const revertWrapper = (result) => {
 /**
  * create a truffle contract from a json object, usually read in from an artifact.
  * @param {*} contractJsonObject json object representing a contract.
+ * @param {Object} web3 instance. In unit tests this is globally accessable but when used in production needs injection.
  * @returns truffle contract instance
  */
 const createContractObjectFromJson = (contractJsonObject, web3) => {

--- a/packages/common/src/ContractUtils.js
+++ b/packages/common/src/ContractUtils.js
@@ -34,7 +34,7 @@ const revertWrapper = (result) => {
  * @param {*} contractJsonObject json object representing a contract.
  * @returns truffle contract instance
  */
-const createContractObjectFromJson = (contractJsonObject) => {
+const createContractObjectFromJson = (contractJsonObject, web3) => {
   let truffleContractCreator = truffleContract(contractJsonObject);
   truffleContractCreator.setProvider(web3.currentProvider);
   return truffleContractCreator;

--- a/packages/common/src/ContractUtils.js
+++ b/packages/common/src/ContractUtils.js
@@ -35,9 +35,9 @@ const revertWrapper = (result) => {
  * @param {Object} web3 instance. In unit tests this is globally accessable but when used in production needs injection.
  * @returns truffle contract instance
  */
-const createContractObjectFromJson = (contractJsonObject, web3) => {
+const createContractObjectFromJson = (contractJsonObject, _web3 = web3) => {
   let truffleContractCreator = truffleContract(contractJsonObject);
-  truffleContractCreator.setProvider(web3.currentProvider);
+  truffleContractCreator.setProvider(_web3.currentProvider);
   return truffleContractCreator;
 };
 /**

--- a/packages/common/src/UniswapV3Helpers.js
+++ b/packages/common/src/UniswapV3Helpers.js
@@ -22,8 +22,8 @@ function decodePriceSqrt(priseSqrt) {
 }
 
 // Fetch the decoded price from a uniswap pool from slot0.
-async function getCurrentPrice(poolAddress) {
-  const pool = await createContractObjectFromJson(UniswapV3Pool).at(poolAddress);
+async function getCurrentPrice(poolAddress, web3) {
+  const pool = await createContractObjectFromJson(UniswapV3Pool, web3).at(poolAddress);
 
   const slot0 = await pool.slot0();
 

--- a/packages/core/test/bot-helpers/atomic-disputer/ReserveCurrencyDisputer.js
+++ b/packages/core/test/bot-helpers/atomic-disputer/ReserveCurrencyDisputer.js
@@ -115,15 +115,15 @@ contract("ReserveTokenDisputer", function (accounts) {
     await collateralToken.mint(liquidator, toWei("100000000000000"));
 
     // deploy Uniswap V2 Factory & router.
-    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
-    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, collateralToken.address, {
+    factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02, web3).new(factory.address, collateralToken.address, {
       from: deployer,
     });
 
     // initialize the pair
     await factory.createPair(reserveToken.address, collateralToken.address, { from: deployer });
     pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
     await reserveToken.mint(pairAddress, toBN(toWei("1000")).muln(10000000));
     await collateralToken.mint(pairAddress, toBN(toWei("1")).muln(10000000));

--- a/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
+++ b/packages/core/test/bot-helpers/atomic-liquidator/ReserveCurrencyLiquidator.js
@@ -142,15 +142,15 @@ contract("ReserveTokenLiquidator", function (accounts) {
     await collateralToken.mint(sponsor2, toWei("100000000000000"));
 
     // deploy Uniswap V2 Factory & router.
-    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
-    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, collateralToken.address, {
+    factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02, web3).new(factory.address, collateralToken.address, {
       from: deployer,
     });
 
     // initialize the pair
     await factory.createPair(reserveToken.address, collateralToken.address, { from: deployer });
     pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
     await reserveToken.mint(pairAddress, startingReservePoolAmount);
     await collateralToken.mint(pairAddress, startingCollateralPoolAmount);
@@ -477,11 +477,11 @@ contract("ReserveTokenLiquidator", function (accounts) {
     const convertSynthetic = Convert(9);
 
     // create a new router and pair to re-initalize from fresh.
-    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
-    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, collateralToken.address);
+    factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02, web3).new(factory.address, collateralToken.address);
     await factory.createPair(reserveToken.address, collateralToken.address, { from: deployer });
     pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
     // Add in the exact reserves as seen on the live pools. At these reserve ratios the starting price is 0.0797.
     await reserveToken.mint(pairAddress, "10881694425");
@@ -566,11 +566,11 @@ contract("ReserveTokenLiquidator", function (accounts) {
     const convertSynthetic = Convert(6);
 
     // create a new router and pair to re-initalize from fresh.
-    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
-    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, collateralToken.address);
+    factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02, web3).new(factory.address, collateralToken.address);
     await factory.createPair(reserveToken.address, collateralToken.address, { from: deployer });
     pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
     // Add liquidity to the pool such that the price is 1000 ETH/USDC.
     await reserveToken.mint(pairAddress, toWei("1000")); // 1000 Weth.

--- a/packages/core/test/bot-helpers/uniswap-broker/UniswapV2Broker.js
+++ b/packages/core/test/bot-helpers/uniswap-broker/UniswapV2Broker.js
@@ -45,8 +45,8 @@ contract("UniswapV2Broker", function (accounts) {
   before(async () => {
     const WETH = await WETH9.new();
     // deploy Uniswap V2 Factory & router.
-    factory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
-    router = await createContractObjectFromJson(UniswapV2Router02).new(factory.address, WETH.address, {
+    factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
+    router = await createContractObjectFromJson(UniswapV2Router02, web3).new(factory.address, WETH.address, {
       from: deployer,
     });
 
@@ -72,7 +72,7 @@ contract("UniswapV2Broker", function (accounts) {
     // initialize the pair
     await factory.createPair(tokenA.address, tokenB.address, { from: deployer });
     pairAddress = await factory.getPair(tokenA.address, tokenB.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
     // For these test, say the synthetic starts trading at uniswap at 1000 TokenA/TokenB. To set this up we will seed the
     // pair with 1000x units of TokenA, relative to TokenB.

--- a/packages/core/test/bot-helpers/uniswap-broker/UniswapV3Broker.js
+++ b/packages/core/test/bot-helpers/uniswap-broker/UniswapV3Broker.js
@@ -88,23 +88,25 @@ contract("UniswapV3Broker", function (accounts) {
 
     weth = await WETH9.new();
     // deploy Uniswap V3 Factory, router, position manager, position descriptor and tickLens.
-    factory = await createContractObjectFromJson(UniswapV3Factory).new({ from: deployer });
-    router = await createContractObjectFromJson(SwapRouter).new(factory.address, weth.address, { from: deployer });
+    factory = await createContractObjectFromJson(UniswapV3Factory, web3).new({ from: deployer });
+    router = await createContractObjectFromJson(SwapRouter, web3).new(factory.address, weth.address, {
+      from: deployer,
+    });
 
     const PositionDescriptor = createContractObjectFromJson(NonfungibleTokenPositionDescriptor);
     await PositionDescriptor.detectNetwork();
 
-    PositionDescriptor.link(await createContractObjectFromJson(NFTDescriptor).new({ from: deployer }));
+    PositionDescriptor.link(await createContractObjectFromJson(NFTDescriptor, web3).new({ from: deployer }));
     positionDescriptor = await PositionDescriptor.new(weth.address, { from: deployer });
 
-    positionManager = await createContractObjectFromJson(NonfungiblePositionManager).new(
+    positionManager = await createContractObjectFromJson(NonfungiblePositionManager, web3).new(
       factory.address,
       weth.address,
       positionDescriptor.address,
       { from: deployer }
     );
 
-    tickLens = await createContractObjectFromJson(TickLens).new({ from: deployer });
+    tickLens = await createContractObjectFromJson(TickLens, web3).new({ from: deployer });
   });
   beforeEach(async () => {
     // deploy tokens
@@ -130,7 +132,7 @@ contract("UniswapV3Broker", function (accounts) {
       await addLiquidityToPool(toWei("1000"), toWei("100"), getTickFromPrice(8, fee), getTickFromPrice(15, fee));
 
       // The starting price should be 10.
-      assert.equal((await getCurrentPrice(poolAddress)).toNumber(), 10);
+      assert.equal((await getCurrentPrice(poolAddress, web3)).toNumber(), 10);
 
       // Validate the liquidity is within the range. There is one LP within the pool and their range is between 8 and 15.
       const liquidityInRange = await tickLens.getPopulatedTicksInWord(
@@ -174,7 +176,7 @@ contract("UniswapV3Broker", function (accounts) {
       // With just one liquidity provider, uniswapV3 acts like a standard AMM.
       await addLiquidityToPool(toWei("1000"), toWei("100"), getTickFromPrice(8, fee), getTickFromPrice(15, fee));
       // The starting price should be 10.
-      assert.equal((await getCurrentPrice(poolAddress)).toNumber(), 10);
+      assert.equal((await getCurrentPrice(poolAddress, web3)).toNumber(), 10);
     });
     it("Broker can correctly move the price up with a single liquidity provider", async function () {
       // The broker should be able to trade up to a desired price. The starting price is 10. Try trade the market to 13.
@@ -190,7 +192,7 @@ contract("UniswapV3Broker", function (accounts) {
       );
 
       // check the price moved up to 13 correctly.
-      const postTradePrice = (await getCurrentPrice(poolAddress)).toNumber();
+      const postTradePrice = (await getCurrentPrice(poolAddress, web3)).toNumber();
       assert.equal(postTradePrice, 13);
     });
 
@@ -208,7 +210,7 @@ contract("UniswapV3Broker", function (accounts) {
       );
 
       // check the price moved up to 12 correctly.
-      const postTradePrice = (await getCurrentPrice(poolAddress)).toNumber();
+      const postTradePrice = (await getCurrentPrice(poolAddress, web3)).toNumber();
       assert.equal(postTradePrice, 8.5);
     });
   });
@@ -225,7 +227,7 @@ contract("UniswapV3Broker", function (accounts) {
       await addLiquidityToPool(toWei("65"), toWei("6.5"), getTickFromPrice(10, fee), getTickFromPrice(11, fee));
       await addLiquidityToPool(toWei("65"), toWei("6.5"), getTickFromPrice(8.5, fee), getTickFromPrice(9, fee));
       // The starting price should be 10 as all LPs added at the same price.
-      assert.equal((await getCurrentPrice(poolAddress)).toNumber(), 10);
+      assert.equal((await getCurrentPrice(poolAddress, web3)).toNumber(), 10);
     });
     it("Broker can correctly move the price up with a set of liquidity provider", async function () {
       // The broker should be able to trade up to a desired price. The starting price is 10. Try trade the market to 13.
@@ -241,7 +243,7 @@ contract("UniswapV3Broker", function (accounts) {
       );
 
       // check the price moved up to 12 correctly.
-      const postTradePrice = (await getCurrentPrice(poolAddress)).toNumber();
+      const postTradePrice = (await getCurrentPrice(poolAddress, web3)).toNumber();
       assert.equal(postTradePrice, 13);
     });
 
@@ -259,7 +261,7 @@ contract("UniswapV3Broker", function (accounts) {
       );
 
       // check the price moved up to 8.5 correctly.
-      const postTradePrice = (await getCurrentPrice(poolAddress)).toNumber();
+      const postTradePrice = (await getCurrentPrice(poolAddress, web3)).toNumber();
       assert.equal(postTradePrice, 8.5);
     });
   });

--- a/packages/core/test/bot-helpers/uniswap-broker/UniswapV3Broker.js
+++ b/packages/core/test/bot-helpers/uniswap-broker/UniswapV3Broker.js
@@ -93,7 +93,7 @@ contract("UniswapV3Broker", function (accounts) {
       from: deployer,
     });
 
-    const PositionDescriptor = createContractObjectFromJson(NonfungibleTokenPositionDescriptor);
+    const PositionDescriptor = createContractObjectFromJson(NonfungibleTokenPositionDescriptor, web3);
     await PositionDescriptor.detectNetwork();
 
     PositionDescriptor.link(await createContractObjectFromJson(NFTDescriptor, web3).new({ from: deployer }));

--- a/packages/disputer/test/Disputer.js
+++ b/packages/disputer/test/Disputer.js
@@ -1184,10 +1184,10 @@ contract("Disputer.js", function (accounts) {
             await reserveToken.addMember(1, contractCreator, { from: contractCreator });
 
             // deploy Uniswap V2 Factory & router.
-            uniswapFactory = await createContractObjectFromJson(UniswapV2Factory).new(contractCreator, {
+            uniswapFactory = await createContractObjectFromJson(UniswapV2Factory, web3).new(contractCreator, {
               from: contractCreator,
             });
-            uniswapRouter = await createContractObjectFromJson(UniswapV2Router02).new(
+            uniswapRouter = await createContractObjectFromJson(UniswapV2Router02, web3).new(
               uniswapFactory.address,
               collateralToken.address,
               { from: contractCreator }
@@ -1198,7 +1198,7 @@ contract("Disputer.js", function (accounts) {
               from: contractCreator,
             });
             pairAddress = await uniswapFactory.getPair(reserveToken.address, collateralToken.address);
-            pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+            pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
             // Seed the market. This sets up the initial price to be 1/1 reserve to collateral token. As the collateral
             // token is Dai this starts off the uniswap market at 1 reserve/collateral. Note the amount of collateral

--- a/packages/disputer/test/index.js
+++ b/packages/disputer/test/index.js
@@ -202,10 +202,10 @@ contract("index.js", function (accounts) {
         const reserveToken = await Token.new("Reserve Token", "RTKN", 18, { from: contractCreator });
         await reserveToken.addMember(1, contractCreator, { from: contractCreator });
         // deploy Uniswap V2 Factory & router.
-        const factory = await createContractObjectFromJson(UniswapV2Factory).new(contractCreator, {
+        const factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(contractCreator, {
           from: contractCreator,
         });
-        const router = await createContractObjectFromJson(UniswapV2Router02).new(
+        const router = await createContractObjectFromJson(UniswapV2Router02, web3).new(
           factory.address,
           collateralToken.address,
           { from: contractCreator }
@@ -214,7 +214,7 @@ contract("index.js", function (accounts) {
         // initialize the pair
         await factory.createPair(reserveToken.address, collateralToken.address);
         const pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
-        const pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+        const pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
         await reserveToken.mint(pairAddress, toBN(toWei("1000")).muln(10000000), { from: contractCreator });
         await collateralToken.mint(pairAddress, toBN(toWei("1")).muln(10000000), { from: contractCreator });

--- a/packages/liquidator/src/proxyTransactionWrapper.js
+++ b/packages/liquidator/src/proxyTransactionWrapper.js
@@ -130,10 +130,12 @@ class ProxyTransactionWrapper {
       // Else, work out how much collateral could be purchased using all the reserve currency.
       else {
         // Instantiate uniswap factory to fetch the pair address.
-        const uniswapFactory = await createContractObjectFromJson(UniswapV2Factory).at(this.uniswapFactoryAddress);
+        const uniswapFactory = await createContractObjectFromJson(UniswapV2Factory, this.web3).at(
+          this.uniswapFactoryAddress
+        );
 
         const pairAddress = await uniswapFactory.getPair(this.reserveToken._address, this.collateralToken._address);
-        const uniswapPair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+        const uniswapPair = await createContractObjectFromJson(IUniswapV2Pair, this.web3).at(pairAddress);
 
         // We can now fetch the reserves. At the same time, we can batch a few other required async calls.
         const [reserves, token0] = await Promise.all([uniswapPair.getReserves(), uniswapPair.token0()]);

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1717,10 +1717,10 @@ contract("Liquidator.js", function (accounts) {
             await reserveToken.addMember(1, contractCreator, { from: contractCreator });
 
             // deploy Uniswap V2 Factory & router.
-            uniswapFactory = await createContractObjectFromJson(UniswapV2Factory).new(contractCreator, {
+            uniswapFactory = await createContractObjectFromJson(UniswapV2Factory, web3).new(contractCreator, {
               from: contractCreator,
             });
-            uniswapRouter = await createContractObjectFromJson(UniswapV2Router02).new(
+            uniswapRouter = await createContractObjectFromJson(UniswapV2Router02, web3).new(
               uniswapFactory.address,
               collateralToken.address,
               { from: contractCreator }
@@ -1729,7 +1729,7 @@ contract("Liquidator.js", function (accounts) {
             // initialize the pair between the reserve and collateral token.
             await uniswapFactory.createPair(reserveToken.address, collateralToken.address, { from: contractCreator });
             pairAddress = await uniswapFactory.getPair(reserveToken.address, collateralToken.address);
-            pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+            pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
             // Seed the market. This sets up the initial price to be 1/1 reserve to collateral token. As the collateral
             // token is Dai this starts off the uniswap market at 1 reserve/collateral. Note the amount of collateral

--- a/packages/liquidator/test/index.js
+++ b/packages/liquidator/test/index.js
@@ -450,8 +450,8 @@ contract("index.js", function (accounts) {
         const reserveToken = await Token.new("Reserve Token", "RTKN", 18);
         await reserveToken.addMember(1, contractCreator);
         // deploy Uniswap V2 Factory & router.
-        const factory = await createContractObjectFromJson(UniswapV2Factory).new(contractCreator);
-        const router = await createContractObjectFromJson(UniswapV2Router02).new(
+        const factory = await createContractObjectFromJson(UniswapV2Factory, web3).new(contractCreator);
+        const router = await createContractObjectFromJson(UniswapV2Router02, web3).new(
           factory.address,
           collateralToken.address
         );
@@ -459,7 +459,7 @@ contract("index.js", function (accounts) {
         // initialize the pair
         await factory.createPair(reserveToken.address, collateralToken.address);
         const pairAddress = await factory.getPair(reserveToken.address, collateralToken.address);
-        const pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+        const pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
         await reserveToken.mint(pairAddress, toBN(toWei("1000")).muln(10000000));
         await collateralToken.mint(pairAddress, toBN(toWei("1")).muln(10000000));

--- a/packages/trader/test/UniswapV2Trader.ts
+++ b/packages/trader/test/UniswapV2Trader.ts
@@ -72,10 +72,14 @@ describe("UniswapV2Trader.js", function () {
 
     WETH = await WETH9.new();
     // deploy Uniswap V2 Factory & router.
-    uniswapFactory = await createContractObjectFromJson(UniswapV2Factory).new(deployer, { from: deployer });
-    uniswapRouter = await createContractObjectFromJson(UniswapV2Router02).new(uniswapFactory.address, WETH.address, {
-      from: deployer,
-    });
+    uniswapFactory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
+    uniswapRouter = await createContractObjectFromJson(UniswapV2Router02, web3).new(
+      uniswapFactory.address,
+      WETH.address,
+      {
+        from: deployer,
+      }
+    );
   });
 
   beforeEach(async function () {
@@ -90,7 +94,7 @@ describe("UniswapV2Trader.js", function () {
     // initialize the Uniswap pair
     await uniswapFactory.createPair(tokenA.address, tokenB.address, { from: deployer });
     pairAddress = await uniswapFactory.getPair(tokenA.address, tokenB.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair).at(pairAddress);
+    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
 
     // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston logs.
     spy = sinon.spy(); // Create a new spy for each test.


### PR DESCRIPTION
**Motivation**

`createContractObjectFromJson` requires a web3 instance to extract the current provider. This works fine when running in unit tests as the `web3` instance is global. however, when run in production, the `web3` instance is _not_ globle. This causes errors when running in production.

When running within the `proxytransaction` wrapper, for example, we would need to pass in the `web3` object.

This PR simply addresses this.
