### PR TITLE
fix(sdk): fix sdk publish

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,5 +45,9 @@
     "size-limit": "^4.10.2",
     "tsdx": "^0.14.1",
     "tslib": "^2.2.0"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com/",
+    "access": "public"
   }
 }


### PR DESCRIPTION
**Motivation**

Publish command in ci is failing.

**Summary**

sdk package is missing the package.json directive that tells it to use a public rather than private package (scoped packages default to private).

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A