### PR TITLE
feat(hardhat): add default hardhat test fixture

### DIFF
--- a/packages/common/browser.js
+++ b/packages/common/browser.js
@@ -19,4 +19,5 @@ module.exports = {
   ...require("./src/VotingUtils"),
   ...require("./src/PriceIdentifierUtils"),
   ...require("./src/MultiVersionTestHelpers.js"),
+  ...require("./src/hardhat/fixtures"),
 };

--- a/packages/common/src/Constants.js
+++ b/packages/common/src/Constants.js
@@ -7,7 +7,6 @@ const interfaceName = {
   IdentifierWhitelist: "IdentifierWhitelist",
   CollateralWhitelist: "CollateralWhitelist",
   AddressWhitelist: "CollateralWhitelist",
-  FundingRateStore: "FundingRateStore",
   OptimisticOracle: "OptimisticOracle",
   Bridge: "Bridge",
   GenericHandler: "GenericHandler",

--- a/packages/common/src/hardhat/fixtures/default.js
+++ b/packages/common/src/hardhat/fixtures/default.js
@@ -9,7 +9,7 @@ async function runDefaultFixture({ deployments }) {
 
     const getDeployment = async (name) => {
       const contract = await deployments.get(name);
-      new web3.eth.Contract(contract.abi, contract.address);
+      return new web3.eth.Contract(contract.abi, contract.address);
     };
 
     // Setup finder.
@@ -40,7 +40,7 @@ async function runDefaultFixture({ deployments }) {
 
     // Set the minter to be the Voting contract.
     const { address: votingAddress } = await deployments.get("Voting");
-    await votingToken.addMember(minterRoleEnumValue, votingAddress, { from: deployer });
+    await votingToken.methods.addMember(minterRoleEnumValue, votingAddress).send({ from: deployer });
 
     // Setup Registry.
     const registry = await getDeployment("Registry");

--- a/packages/common/src/hardhat/fixtures/default.js
+++ b/packages/common/src/hardhat/fixtures/default.js
@@ -1,0 +1,67 @@
+const { interfaceName } = require("../../Constants");
+const { RegistryRolesEnum } = require("../../Enums");
+
+async function runDefaultFixture({ deployments }) {
+  const setup = deployments.createFixture(async ({ deployments, getNamedAccounts, web3 }) => {
+    const { padRight, toWei, utf8ToHex } = web3.utils;
+    await deployments.fixture();
+    const { deployer } = await getNamedAccounts();
+
+    const getDeployment = async (name) => {
+      const contract = await deployments.get(name);
+      new web3.eth.Contract(contract.abi, contract.address);
+    };
+
+    // Setup finder.
+    const finder = await getDeployment("Finder");
+
+    const addToFinder = async (deploymentName, finderName) => {
+      const { address } = await deployments.get(deploymentName);
+      const hexName = padRight(utf8ToHex(finderName));
+      await finder.methods.changeImplementationAddress(hexName, address).send({ from: deployer });
+    };
+
+    await addToFinder("FinancialContractsAdmin", interfaceName.FinancialContractsAdmin);
+    await addToFinder("Voting", interfaceName.Oracle);
+    await addToFinder("Registry", interfaceName.Registry);
+    await addToFinder("Store", interfaceName.Store);
+    await addToFinder("IdentifierWhitelist", interfaceName.IdentifierWhitelist);
+    await addToFinder("AddressWhitelist", interfaceName.CollateralWhitelist);
+    await addToFinder("OptimisticOracle", interfaceName.OptimisticOracle);
+    await addToFinder("Bridge", interfaceName.Bridge);
+    await addToFinder("GenericHandler", interfaceName.GenericHandler);
+
+    // Setup token
+    const votingToken = await getDeployment("VotingToken");
+    const minterRoleEnumValue = 1;
+    await votingToken.methods.addMember(minterRoleEnumValue, deployer).send({ from: deployer });
+    await votingToken.methods.mint(deployer, toWei("100000000")).send({ from: deployer });
+    await votingToken.methods.removeMember(minterRoleEnumValue, deployer).send({ from: deployer });
+
+    // Set the minter to be the Voting contract.
+    const { address: votingAddress } = await deployments.get("Voting");
+    await votingToken.addMember(minterRoleEnumValue, votingAddress, { from: deployer });
+
+    // Setup Registry
+    const registry = await getDeployment("Registry");
+
+    // Add creators
+    const { address: empCreatorAddress } = await deployments.get("ExpiringMultiPartyCreator");
+    const { address: perpCreatorAddress } = await deployments.get("PerpetualCreator");
+    await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, empCreatorAddress).send({ from: deployer });
+    await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, perpCreatorAddress).send({ from: deployer });
+
+    // Add pre-registered contracts
+    const { address: governorAddress } = await deployments.get("Governor");
+    const { address: optimisticOracleAddress } = await deployments.get("OptimisticOracle");
+    await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, deployer).send({ from: deployer });
+    await registry.methods.registerContract([], governorAddress).send({ from: deployer });
+    await registry.methods.registerContract([], optimisticOracleAddress).send({ from: deployer });
+    await registry.methods.removeMember(RegistryRolesEnum.CONTRACT_CREATOR, deployer).send({ from: deployer });
+  });
+  await setup();
+}
+
+module.exports = {
+  runDefaultFixture,
+};

--- a/packages/common/src/hardhat/fixtures/default.js
+++ b/packages/common/src/hardhat/fixtures/default.js
@@ -31,7 +31,7 @@ async function runDefaultFixture({ deployments }) {
     await addToFinder("Bridge", interfaceName.Bridge);
     await addToFinder("GenericHandler", interfaceName.GenericHandler);
 
-    // Setup token
+    // Setup token.
     const votingToken = await getDeployment("VotingToken");
     const minterRoleEnumValue = 1;
     await votingToken.methods.addMember(minterRoleEnumValue, deployer).send({ from: deployer });
@@ -42,16 +42,16 @@ async function runDefaultFixture({ deployments }) {
     const { address: votingAddress } = await deployments.get("Voting");
     await votingToken.addMember(minterRoleEnumValue, votingAddress, { from: deployer });
 
-    // Setup Registry
+    // Setup Registry.
     const registry = await getDeployment("Registry");
 
-    // Add creators
+    // Add creators.
     const { address: empCreatorAddress } = await deployments.get("ExpiringMultiPartyCreator");
     const { address: perpCreatorAddress } = await deployments.get("PerpetualCreator");
     await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, empCreatorAddress).send({ from: deployer });
     await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, perpCreatorAddress).send({ from: deployer });
 
-    // Add pre-registered contracts
+    // Add pre-registered contracts.
     const { address: governorAddress } = await deployments.get("Governor");
     const { address: optimisticOracleAddress } = await deployments.get("OptimisticOracle");
     await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, deployer).send({ from: deployer });

--- a/packages/common/src/hardhat/fixtures/index.js
+++ b/packages/common/src/hardhat/fixtures/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require("./default"),
+};


### PR DESCRIPTION
**Motivation**

To run tests completely with hardhat, we need a default fixture that is used alongside deployments to do additional setup.

**Summary**

This adds a fixtures directory and a default fixture to common/hardhat. The fixture essentially mirrors the additional logic in truffle migrations beyond the core deployments.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
