### PR TITLE
improve: Nit changes made after integration testing OptimisticOracle + Oracle Tunnel system on Mumbai <> Goerli

### DIFF
--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -84,6 +84,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
         matic: [path.join(workingDir, "build/contracts"), path.join(workingDir, "deployments/matic")],
         rinkeby: [path.join(workingDir, "build/contracts"), path.join(workingDir, "deployments/rinkeby")],
         kovan: [path.join(workingDir, "build/contracts"), path.join(workingDir, "deployments/kovan")],
+        goerli: [path.join(workingDir, "build/contracts"), path.join(workingDir, "deployments/goerli")],
       },
     },
   };

--- a/packages/common/src/hardhat/tasks/identifiers.js
+++ b/packages/common/src/hardhat/tasks/identifiers.js
@@ -71,6 +71,7 @@ task("migrate-identifiers", "Adds all whitelisted identifiers on one IdentifierW
         if (!isIdentifierSupportedOnNewWhitelist[i]) {
           const receipt = await newWhitelist.methods.addSupportedIdentifier(identifiersToWhitelist[i]).send({
             from: deployer,
+            gasPrice: "1000000000000", // 1000 gwei
           });
           addSupportedIdentifierReceipts.push(receipt);
         }

--- a/packages/common/src/hardhat/tasks/identifiers.js
+++ b/packages/common/src/hardhat/tasks/identifiers.js
@@ -71,7 +71,6 @@ task("migrate-identifiers", "Adds all whitelisted identifiers on one IdentifierW
         if (!isIdentifierSupportedOnNewWhitelist[i]) {
           const receipt = await newWhitelist.methods.addSupportedIdentifier(identifiersToWhitelist[i]).send({
             from: deployer,
-            gasPrice: "1000000000000", // 1000 gwei
           });
           addSupportedIdentifierReceipts.push(receipt);
         }

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -543,7 +543,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Generates stamped ancillary data in the format that it would be used in the case of a price dispute.
      * @param ancillaryData ancillary data of the price being requested.
      * @param requester sender of the initial price request.
-     * @return the stampped ancillary bytes.
+     * @return the stamped ancillary bytes.
      */
     function stampAncillaryData(bytes memory ancillaryData, address requester)
         public

--- a/packages/core/contracts/polygon/OracleChildTunnel.sol
+++ b/packages/core/contracts/polygon/OracleChildTunnel.sol
@@ -104,6 +104,16 @@ contract OracleChildTunnel is OracleBaseTunnel, OracleAncillaryInterface, FxBase
     }
 
     /**
+     * @notice Generates stamped ancillary data in the format that it would be used in the case of a price request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param requester sender of the initial price request.
+     * @return the stamped ancillary bytes.
+     */
+    function stampAncillaryData(bytes memory ancillaryData, address requester) public view returns (bytes memory) {
+        return _stampAncillaryData(ancillaryData, requester);
+    }
+
+    /**
      * @dev We don't handle specifically the case where `ancillaryData` is not already readily translateable in utf8.
      * For those cases, we assume that the client will be able to strip out the utf8-translateable part of the
      * ancillary data that this contract stamps.

--- a/packages/core/deploy/012_deploy_optimistic_oracle.js
+++ b/packages/core/deploy/012_deploy_optimistic_oracle.js
@@ -8,7 +8,7 @@ const func = async function (hre) {
   // 2 hours.
   const defaultLiveness = 7200;
   const Finder = await deployments.get("Finder");
-  const Timer = (await deployments.getOrNull("Timer")) || ZERO_ADDRESS;
+  const Timer = (await deployments.getOrNull("Timer")) || { address: ZERO_ADDRESS };
 
   await deploy("OptimisticOracle", {
     from: deployer,

--- a/packages/core/networks/5.json
+++ b/packages/core/networks/5.json
@@ -1,7 +1,7 @@
 [
   {
     "contractName": "OracleRootTunnel",
-    "address": "0xCAb3a8602BBADad5B4934A9C94b2670F3c78B715"
+    "address": "0x240c4B8DBC6bc563ccC76728F26b6f21F911883A"
   },
   {
     "contractName": "Finder",

--- a/packages/core/networks/80001.json
+++ b/packages/core/networks/80001.json
@@ -25,7 +25,7 @@
   },
   {
     "contractName": "OptimisticOracle",
-    "address": "0x292A00f2368187073E80AB94fA03AFD8c796d450"
+    "address": "0xAB75727d4e89A7f7F04f57C00234a35950527115"
   },
   {
     "contractName": "TokenFactory",
@@ -57,6 +57,6 @@
   },
   {
     "contractName": "OracleChildTunnel",
-    "address": "0x02B8733763dD76f73b8573e668ecA3343a7D65e7"
+    "address": "0x61D5d43F227782F2Fa02Eb811420AB622A785d3a"
   }
 ]

--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -145,7 +145,8 @@ async function Poll(callback) {
       optimisticOracleProposerConfig: process.env.OPTIMISTIC_ORACLE_PROPOSER_CONFIG
         ? JSON.parse(process.env.OPTIMISTIC_ORACLE_PROPOSER_CONFIG)
         : {},
-      // Type of "Oracle" set for this network's Finder, default is "Voting". Other possible types include "SinkOracle".
+      // Type of "Oracle" set for this network's Finder, default is "Voting". Other possible types include "SinkOracle"
+      // and "OracleChildTunnel".
       oracleType: process.env.ORACLE_TYPE ? process.env.ORACLE_TYPE : "Voting",
     };
 


### PR DESCRIPTION
Signed-off-by: Nick Pai <npai.nyc@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

- Updated `OptimisticOracle`, `OracleChildTunnel`, and `OracleRootTunnel` deployments to reflect latest ancillary data logic.
- fixed typo in comment in `OptimisticOracle.sol`
- added `stampAncillaryData` read only method to `OracleChildTunnel.sol` for convenience
- fixed optimistic oracle deployment script
- updated `packages/optimistic-oracle/index.js` run script comments with instructions on how to run bot on sidechain where `OracleChildTunnel` is deployed as the Oracle
- 
**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
