### PR TITLE
fix(cw-pricefeed): Fix getCurrentPrice when twapLength and invertPrice is defined

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -67,7 +67,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
 
   getCurrentPrice() {
     if (!this.twapLength && this.invertPrice) {
-      // The price should only be inverted if invertPrice is true and twapLength is not defined./
+      // The price should only be inverted if invertPrice is true and twapLength is not defined.
       // If twapLength is defined and invertPrice is true, the price will be inverted in _computeTwap().
       return this._invertPriceSafely(this.currentPrice);
     } else {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -66,7 +66,11 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   }
 
   getCurrentPrice() {
-    return this.invertPrice ? this._invertPriceSafely(this.currentPrice) : this.currentPrice;
+    return this.twapLength
+      ? this.currentPrice
+      : this.invertPrice
+      ? this._invertPriceSafely(this.currentPrice)
+      : this.currentPrice;
   }
 
   async getHistoricalPrice(time, verbose = false) {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -66,11 +66,13 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   }
 
   getCurrentPrice() {
-    return this.twapLength
-      ? this.currentPrice
-      : this.invertPrice
-      ? this._invertPriceSafely(this.currentPrice)
-      : this.currentPrice;
+    if (!this.twapLength && this.invertPrice) {
+      // The price should only be inverted if invertPrice is true and twapLength is not defined./
+      // If twapLength is defined and invertPrice is true, the price will be inverted in _computeTwap(), so the returned value should not be inverted here.
+      return this._invertPriceSafely(this.currentPrice);
+    } else {
+      return this.currentPrice;
+    }
   }
 
   async getHistoricalPrice(time, verbose = false) {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js
@@ -68,7 +68,7 @@ class CryptoWatchPriceFeed extends PriceFeedInterface {
   getCurrentPrice() {
     if (!this.twapLength && this.invertPrice) {
       // The price should only be inverted if invertPrice is true and twapLength is not defined./
-      // If twapLength is defined and invertPrice is true, the price will be inverted in _computeTwap(), so the returned value should not be inverted here.
+      // If twapLength is defined and invertPrice is true, the price will be inverted in _computeTwap().
       return this._invertPriceSafely(this.currentPrice);
     } else {
       return this.currentPrice;


### PR DESCRIPTION
**Motivation**

There is a bug in the CryptowatchPriceFeed `getCurrentPrice` method, where an incorrectly inverted value is returned if `twapLength` and `invertPrice` is defined.

This is because the price is being inverted twice. Once in `_computeTwap()` and once in `getCurrentPrice()`.


**Summary**

Changes `getCurrentPrice()` to only invert if twapLength is not defined.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
