### PR TITLE
fix(serverlesshub): reduce logging noise

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -121,8 +121,8 @@ hub.post("/", async (req, res) => {
 
       // Store block number data for this chain ID which we'll use to update the GCP cache later.
       blockNumbersForChain[chainId] = {
-        lastQueriedBlockNumber,
-        latestBlockNumber,
+        lastQueriedBlockNumber: Number(lastQueriedBlockNumber),
+        latestBlockNumber: Number(latestBlockNumber),
       };
     }
     logger.debug({

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -124,14 +124,13 @@ hub.post("/", async (req, res) => {
         lastQueriedBlockNumber,
         latestBlockNumber,
       };
-      logger.debug({
-        at: "ServerlessHub",
-        message: "Updated block numbers for network",
-        chainId,
-        lastQueriedBlockNumber,
-        latestBlockNumber,
-      });
     }
+    logger.debug({
+      at: "ServerlessHub",
+      message: "Updated block numbers for networks",
+      nodeUrlToChainIdCache,
+      blockNumbersForChain,
+    });
 
     // Now, that we've precomputed all of the last seen blocks for each chain, we can update their values in the
     // GCP Data Store. These will all be the fetched as the "lastQueriedBlockNumber" in the next iteration when the
@@ -158,16 +157,12 @@ hub.post("/", async (req, res) => {
           _rejectAfterDelay(hubConfig.rejectSpokeDelay, botName),
         ])
       );
-
-      logger.debug({
-        at: "ServerlessHub",
-        message: "Running bot on spoke",
-        chainId,
-        lastQueriedBlockNumber,
-        latestBlockNumber,
-        botConfig,
-      });
     }
+    logger.debug({
+      at: "ServerlessHub",
+      message: "Executing Serverless spokes",
+      botConfigs,
+    });
 
     // Loop through promise array and submit all in parallel. `allSettled` does not fail early if a promise is rejected.
     // This `results` object will contain all information sent back from the spokes. This contains the process exit code,

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -201,10 +201,10 @@ contract("ServerlessHub.js", function (accounts) {
     assert.isTrue(lastSpyLogIncludes(hubSpy, "All calls returned correctly")); // The hub should have exited correctly.
     assert.isTrue(lastSpyLogIncludes(spokeSpy, "Process exited with no error")); // The spoke should have exited correctly.
     assert.isTrue(lastSpyLogIncludes(spokeSpy, `${startingBlockNumber + 1}`)); // The spoke should have the correct starting block number.
-    assert.isTrue(spyLogIncludes(hubSpy, -2, `${startingBlockNumber}`), "should return block information for chain");
-    assert.isTrue(spyLogIncludes(hubSpy, -2, `${defaultChainId}`), "should return chain ID");
-    assert.isTrue(spyLogIncludes(hubSpy, -3, `${startingBlockNumber}`), "should return block information for chain");
-    assert.isTrue(spyLogIncludes(hubSpy, -3, `${defaultChainId}`), "should return chain ID");
+    assert.isTrue(spyLogIncludes(hubSpy, -3, startingBlockNumber), "should return block information for chain");
+    assert.isTrue(spyLogIncludes(hubSpy, -3, defaultChainId), "should return chain ID");
+    assert.isTrue(spyLogIncludes(hubSpy, -3, startingBlockNumber), "should return block information for chain");
+    assert.isTrue(spyLogIncludes(hubSpy, -3, defaultChainId), "should return chain ID");
     assert.isTrue(spyLogIncludes(hubSpy, -4, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
   });
   it("ServerlessHub correctly deals with rejected spoke calls", async function () {
@@ -371,7 +371,7 @@ contract("ServerlessHub.js", function (accounts) {
     // Check hub has correct logs.
     assert.isTrue(lastSpyLogIncludes(hubSpy, "All calls returned correctly")); // The hub should have exited correctly.
     assert.equal(lastSpyLogLevel(hubSpy), "debug"); // most recent log level should be "debug" (no error)
-    assert.isTrue(spyLogIncludes(hubSpy, -6, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
+    assert.isTrue(spyLogIncludes(hubSpy, -4, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
 
     // Check that each bot identifier returned the correct exit code within the final hub log.
     const lastSpyHubLog = hubSpy.getCall(-1).lastArg;
@@ -615,7 +615,7 @@ contract("ServerlessHub.js", function (accounts) {
     assert.equal(validResponse.res.statusCode, 200); // no error code
 
     // Check for two hub logs caching each unique chain ID seen:
-    assert.isTrue(spyLogIncludes(hubSpy, 3, `"chainId":${defaultChainId}`));
-    assert.isTrue(spyLogIncludes(hubSpy, 4, `"chainId":${alternateChainId}`));
+    assert.isTrue(spyLogIncludes(hubSpy, 3, defaultChainId));
+    assert.isTrue(spyLogIncludes(hubSpy, 3, alternateChainId));
   });
 });


### PR DESCRIPTION
**Motivation**

The most recent changes to the serverless hub made the logs **very** noisy. This PR reduces the noise by moving where logs are produced and opting for a more aggregate logging approach.

Before this PR: 
![image](https://user-images.githubusercontent.com/12886084/122181710-e6071f80-ce89-11eb-9065-deab4de8d4c1.png)


After this PR the logs are far more redacted: 
![image](https://user-images.githubusercontent.com/12886084/122201057-ec05fc00-ce9b-11eb-85b6-79fee6c36e75.png)

