### PR TITLE
fix(disputer-index): add a missing log field

### DIFF
--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -68,6 +68,7 @@ async function run({
       priceFeedConfig,
       disputerConfig,
       disputerOverridePrice,
+      proxyTransactionWrapperConfig,
     });
 
     // Load unlocked web3 accounts and get the networkId.


### PR DESCRIPTION
**Motivation**

The disputers startup logs are missing a field `proxyTransactionWrapperConfig`. This makes some debugging difficult.
