### PR TITLE
feat(LSP): rename all instances and variants of "contract for difference" to "long short pair"

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
@@ -3,49 +3,43 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
-import "./ContractForDifferenceFinancialProductLibrary.sol";
+import "./LongShortPairFinancialProductLibrary.sol";
 import "../../../../common/implementation/Lockable.sol";
 
 /**
- * @title Binary Option Contract For Difference Financial Product Library.
- * @notice Adds settlement logic to binary option CFDs. Binary options settle with all collateral allocated to
+ * @title Binary Option Long Short Pair Financial Product Library.
+ * @notice Adds settlement logic to binary option LSPs. Binary options settle with all collateral allocated to
  * either the long or short side, depending on the settlement price. They can be used to make prediction markets or any
  * kind of binary bet. Settlement is defined using a strike price which informs which side of the bet was correct. If
  * settlement price is greater or equal to the strike then all value is sent to the long side. Otherwise, all value
  * is sent to the short side. The settlement price could be a scalar (like the price of ETH) or a binary bet with
  * settlement being 0 or 1 depending on the outcome.
  */
-contract BinaryOptionContractForDifferenceFinancialProductLibrary is
-    ContractForDifferenceFinancialProductLibrary,
-    Lockable
-{
+contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinancialProductLibrary, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using SafeMath for uint256;
 
-    struct binaryContractForDifferenceParameters {
+    struct binaryLongShortPairParameters {
         bool isSet;
         int256 strikePrice;
     }
 
-    mapping(address => binaryContractForDifferenceParameters) public contractForDifferenceParameters;
+    mapping(address => binaryLongShortPairParameters) public LongShortPairParameters;
 
     /**
      * @notice Enables any address to set the strike price for an associated binary option.
-     * @param contractForDifference address of the CFD.
+     * @param LongShortPair address of the LSP.
      * @param strikePrice the strike price for the binary option.
      * @dev Note: a) Any address can set the initial strike price b) A strike can be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
      * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setContractForDifferenceParameters(address contractForDifference, int256 strikePrice)
-        public
-        nonReentrant()
-    {
-        require(ExpiringContractInterface(contractForDifference).expirationTimestamp() != 0, "Invalid CFD address");
-        require(!contractForDifferenceParameters[contractForDifference].isSet, "Parameters already set");
+    function setLongShortPairParameters(address LongShortPair, int256 strikePrice) public nonReentrant() {
+        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        require(!LongShortPairParameters[LongShortPair].isSet, "Parameters already set");
 
-        contractForDifferenceParameters[contractForDifference] = binaryContractForDifferenceParameters({
+        LongShortPairParameters[LongShortPair] = binaryLongShortPairParameters({
             isSet: true,
             strikePrice: strikePrice
         });
@@ -54,12 +48,12 @@ contract BinaryOptionContractForDifferenceFinancialProductLibrary is
     /**
      * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
-     * @param expiryPrice price from the optimistic oracle for the CFD price identifier.
+     * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        binaryContractForDifferenceParameters memory params = contractForDifferenceParameters[msg.sender];
-        require(params.isSet, "Params not set for calling CFD");
+        binaryLongShortPairParameters memory params = LongShortPairParameters[msg.sender];
+        require(params.isSet, "Params not set for calling LSP");
 
         if (expiryPrice >= params.strikePrice) return FixedPoint.fromUnscaledUint(1).rawValue;
         else return FixedPoint.fromUnscaledUint(0).rawValue;

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
@@ -19,12 +19,12 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
     using FixedPoint for FixedPoint.Unsigned;
     using SafeMath for uint256;
 
-    struct binarylongShortPairParameters {
+    struct BinaryLongShortPairParameters {
         bool isSet;
         int256 strikePrice;
     }
 
-    mapping(address => binarylongShortPairParameters) public longShortPairParameters;
+    mapping(address => BinaryLongShortPairParameters) public longShortPairParameters;
 
     /**
      * @notice Enables any address to set the strike price for an associated binary option.
@@ -35,11 +35,11 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
      * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setlongShortPairParameters(address LongShortPair, int256 strikePrice) public nonReentrant() {
+    function setLongShortPairParameters(address LongShortPair, int256 strikePrice) public nonReentrant() {
         require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         require(!longShortPairParameters[LongShortPair].isSet, "Parameters already set");
 
-        longShortPairParameters[LongShortPair] = binarylongShortPairParameters({
+        longShortPairParameters[LongShortPair] = BinaryLongShortPairParameters({
             isSet: true,
             strikePrice: strikePrice
         });
@@ -52,7 +52,7 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        binarylongShortPairParameters memory params = longShortPairParameters[msg.sender];
+        BinaryLongShortPairParameters memory params = longShortPairParameters[msg.sender];
         require(params.isSet, "Params not set for calling LSP");
 
         if (expiryPrice >= params.strikePrice) return FixedPoint.fromUnscaledUint(1).rawValue;

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
@@ -19,12 +19,12 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
     using FixedPoint for FixedPoint.Unsigned;
     using SafeMath for uint256;
 
-    struct binaryLongShortPairParameters {
+    struct binarylongShortPairParameters {
         bool isSet;
         int256 strikePrice;
     }
 
-    mapping(address => binaryLongShortPairParameters) public LongShortPairParameters;
+    mapping(address => binarylongShortPairParameters) public longShortPairParameters;
 
     /**
      * @notice Enables any address to set the strike price for an associated binary option.
@@ -35,11 +35,11 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
      * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setLongShortPairParameters(address LongShortPair, int256 strikePrice) public nonReentrant() {
+    function setlongShortPairParameters(address LongShortPair, int256 strikePrice) public nonReentrant() {
         require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
-        require(!LongShortPairParameters[LongShortPair].isSet, "Parameters already set");
+        require(!longShortPairParameters[LongShortPair].isSet, "Parameters already set");
 
-        LongShortPairParameters[LongShortPair] = binaryLongShortPairParameters({
+        longShortPairParameters[LongShortPair] = binarylongShortPairParameters({
             isSet: true,
             strikePrice: strikePrice
         });
@@ -52,7 +52,7 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        binaryLongShortPairParameters memory params = LongShortPairParameters[msg.sender];
+        binarylongShortPairParameters memory params = longShortPairParameters[msg.sender];
         require(params.isSet, "Params not set for calling LSP");
 
         if (expiryPrice >= params.strikePrice) return FixedPoint.fromUnscaledUint(1).rawValue;

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
@@ -23,7 +23,7 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
     using FixedPoint for FixedPoint.Unsigned;
     using SafeMath for uint256;
 
-    mapping(address => uint256) public LongShortPairStrikePrices;
+    mapping(address => uint256) public longShortPairStrikePrices;
 
     /**
      * @notice Enables any address to set the strike price for an associated LSP.
@@ -34,11 +34,11 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
      * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setLongShortPairParameters(address LongShortPair, uint256 strikePrice) public nonReentrant() {
+    function setlongShortPairParameters(address LongShortPair, uint256 strikePrice) public nonReentrant() {
         require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
-        require(LongShortPairStrikePrices[LongShortPair] == 0, "Parameters already set");
+        require(longShortPairStrikePrices[LongShortPair] == 0, "Parameters already set");
 
-        LongShortPairStrikePrices[LongShortPair] = strikePrice;
+        longShortPairStrikePrices[LongShortPair] = strikePrice;
     }
 
     /**
@@ -48,7 +48,7 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        uint256 contractStrikePrice = LongShortPairStrikePrices[msg.sender];
+        uint256 contractStrikePrice = longShortPairStrikePrices[msg.sender];
 
         // If the expiry price is less than the strike price then the long options expire worthless (out of the money).
         // Note we do not consider negative expiry prices in this call option implementation.

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
-import "./ContractForDifferenceFinancialProductLibrary.sol";
+import "./LongShortPairFinancialProductLibrary.sol";
 import "../../../../common/implementation/Lockable.sol";
 
 /**
- * @title Covered call Contract For Difference Financial Product Library.
- * @notice Adds settlement logic to create covered call CFDs. The contract will payout a scaled amount of collateral
+ * @title Covered call Long Short Pair Financial Product Library.
+ * @notice Adds settlement logic to create covered call LSPs. The contract will payout a scaled amount of collateral
  * depending on where the settlement price lands relative to the call's strike price. If the settlement is below the
  * strike price then longs expire worthless. If the settlement is above the strike then the payout is the fraction above
  * the strike defined by (expiryPrice - strikePrice) / expiryPrice. For example, consider a covered call option
@@ -19,42 +19,36 @@ import "../../../../common/implementation/Lockable.sol";
  * - Say settlement price is 3500.  Then expiryPercentLong = (3500 - 3000) / 3500 = 0.143. The value of this 0.143 ETH
  * is worth 0.143*3500=500 which is the percentage of the collateralPerPair that was above the strike price.
  */
-contract CoveredCallContractForDifferenceFinancialProductLibrary is
-    ContractForDifferenceFinancialProductLibrary,
-    Lockable
-{
+contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinancialProductLibrary, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using SafeMath for uint256;
 
-    mapping(address => uint256) public contractForDifferenceStrikePrices;
+    mapping(address => uint256) public LongShortPairStrikePrices;
 
     /**
-     * @notice Enables any address to set the strike price for an associated CFD.
-     * @param contractForDifference address of the CFD.
-     * @param strikePrice the strike price for the covered call for the associated CFD.
+     * @notice Enables any address to set the strike price for an associated LSP.
+     * @param LongShortPair address of the LSP.
+     * @param strikePrice the strike price for the covered call for the associated LSP.
      * @dev Note: a) Any address can set the initial strike price b) A strike price cannot be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
      * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setContractForDifferenceParameters(address contractForDifference, uint256 strikePrice)
-        public
-        nonReentrant()
-    {
-        require(ExpiringContractInterface(contractForDifference).expirationTimestamp() != 0, "Invalid CFD address");
-        require(contractForDifferenceStrikePrices[contractForDifference] == 0, "Parameters already set");
+    function setLongShortPairParameters(address LongShortPair, uint256 strikePrice) public nonReentrant() {
+        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        require(LongShortPairStrikePrices[LongShortPair] == 0, "Parameters already set");
 
-        contractForDifferenceStrikePrices[contractForDifference] = strikePrice;
+        LongShortPairStrikePrices[LongShortPair] = strikePrice;
     }
 
     /**
      * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
-     * @param expiryPrice price from the optimistic oracle for the CFD price identifier.
+     * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        uint256 contractStrikePrice = contractForDifferenceStrikePrices[msg.sender];
+        uint256 contractStrikePrice = LongShortPairStrikePrices[msg.sender];
 
         // If the expiry price is less than the strike price then the long options expire worthless (out of the money).
         // Note we do not consider negative expiry prices in this call option implementation.

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
@@ -34,7 +34,7 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
      * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setlongShortPairParameters(address LongShortPair, uint256 strikePrice) public nonReentrant() {
+    function setLongShortPairParameters(address LongShortPair, uint256 strikePrice) public nonReentrant() {
         require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         require(longShortPairStrikePrices[LongShortPair] == 0, "Parameters already set");
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -3,57 +3,57 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
 
-import "./ContractForDifferenceFinancialProductLibrary.sol";
+import "./LongShortPairFinancialProductLibrary.sol";
 import "../../../../common/implementation/Lockable.sol";
 
 /**
- * @title Linear Contract For Difference Financial Product Library.
- * @notice Adds settlement logic to create linear CFDs. The contract will payout a scaled amount of collateral
+ * @title Linear Long Short Pair Financial Product Library.
+ * @notice Adds settlement logic to create linear LSPs. The contract will payout a scaled amount of collateral
  * depending on where the settlement price lands within a price range between an upperBound and a lowerBound. If
  * settlement price is within the price range then the expiryPercentLong is defined by
  * (expiryPrice - lowerBound) / (upperBound - lowerBound). This number represent the amount of collateral from the
  * collateralPerPair that will be sent to the long and short side. If the price is higher than the upperBound then
  * expiryPercentLong = 1. if the price is lower than the lower bound then expiryPercentLong = 0. For example, consider
- * a linear CFD on the price of ETH collateralized in USDC with an upperBound = 4000 and lowerBound = 2000 with a
+ * a linear LSP on the price of ETH collateralized in USDC with an upperBound = 4000 and lowerBound = 2000 with a
  * collateralPerPair of 1000 (i.e each pair of long and shorts is worth 1000 USDC). At settlement the expiryPercentLong
  * would equal 1 (each long worth 1000 and short worth 0) if ETH price was > 4000 and it would be equal 0 if < 2000
  * (each long is worthless and each short is worth 1000). If between the two (say 3500) then expiryPercentLong
  * = (3500 - 2000) / (4000 - 2000) = 0.75. Therefore each long is worth 750 and each short is worth 250.
  */
-contract LinearContractForDifferenceFinancialProductLibrary is ContractForDifferenceFinancialProductLibrary, Lockable {
+contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialProductLibrary, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using SignedSafeMath for int256;
 
-    struct LinearContractForDifferenceParameters {
+    struct LinearLongShortPairParameters {
         int256 upperBound;
         int256 lowerBound;
     }
 
-    mapping(address => LinearContractForDifferenceParameters) public contractForDifferenceParameters;
+    mapping(address => LinearLongShortPairParameters) public LongShortPairParameters;
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
-     * @param contractForDifference address of the CFD contract.
-     * @param upperBound the upper price that the linear CFD will operate within.
-     * @param lowerBound the lower price that the linear CFD will operate within.
-     * @dev Note: a) Any address can set these parameters b) existing CFD parameters for address not set.
+     * @param LongShortPair address of the LSP contract.
+     * @param upperBound the upper price that the linear LSP will operate within.
+     * @param lowerBound the lower price that the linear LSP will operate within.
+     * @dev Note: a) Any address can set these parameters b) existing LSP parameters for address not set.
      * c) upperBound > lowerBound.
      * d) parameters price can only be set once to prevent the deployer from changing the parameters after the fact.
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
      * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setContractForDifferenceParameters(
-        address contractForDifference,
+    function setLongShortPairParameters(
+        address LongShortPair,
         int256 upperBound,
         int256 lowerBound
     ) public nonReentrant() {
-        require(ExpiringContractInterface(contractForDifference).expirationTimestamp() != 0, "Invalid CFD address");
+        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         require(upperBound > lowerBound, "Invalid bounds");
 
-        LinearContractForDifferenceParameters memory params = contractForDifferenceParameters[contractForDifference];
+        LinearLongShortPairParameters memory params = LongShortPairParameters[LongShortPair];
         require(params.upperBound == 0 && params.lowerBound == 0, "Parameters already set");
 
-        contractForDifferenceParameters[contractForDifference] = LinearContractForDifferenceParameters({
+        LongShortPairParameters[LongShortPair] = LinearLongShortPairParameters({
             upperBound: upperBound,
             lowerBound: lowerBound
         });
@@ -62,11 +62,11 @@ contract LinearContractForDifferenceFinancialProductLibrary is ContractForDiffer
     /**
      * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
-     * @param expiryPrice price from the optimistic oracle for the CFD price identifier.
+     * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        LinearContractForDifferenceParameters memory params = contractForDifferenceParameters[msg.sender];
+        LinearLongShortPairParameters memory params = LongShortPairParameters[msg.sender];
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -24,12 +24,12 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
     using FixedPoint for FixedPoint.Unsigned;
     using SignedSafeMath for int256;
 
-    struct LinearLongShortPairParameters {
+    struct LinearlongShortPairParameters {
         int256 upperBound;
         int256 lowerBound;
     }
 
-    mapping(address => LinearLongShortPairParameters) public LongShortPairParameters;
+    mapping(address => LinearlongShortPairParameters) public longShortPairParameters;
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
@@ -42,7 +42,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
      * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setLongShortPairParameters(
+    function setlongShortPairParameters(
         address LongShortPair,
         int256 upperBound,
         int256 lowerBound
@@ -50,10 +50,10 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
         require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         require(upperBound > lowerBound, "Invalid bounds");
 
-        LinearLongShortPairParameters memory params = LongShortPairParameters[LongShortPair];
+        LinearlongShortPairParameters memory params = longShortPairParameters[LongShortPair];
         require(params.upperBound == 0 && params.lowerBound == 0, "Parameters already set");
 
-        LongShortPairParameters[LongShortPair] = LinearLongShortPairParameters({
+        longShortPairParameters[LongShortPair] = LinearlongShortPairParameters({
             upperBound: upperBound,
             lowerBound: lowerBound
         });
@@ -66,7 +66,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        LinearLongShortPairParameters memory params = LongShortPairParameters[msg.sender];
+        LinearlongShortPairParameters memory params = longShortPairParameters[msg.sender];
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -24,12 +24,12 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
     using FixedPoint for FixedPoint.Unsigned;
     using SignedSafeMath for int256;
 
-    struct LinearlongShortPairParameters {
+    struct LinearLongShortPairParameters {
         int256 upperBound;
         int256 lowerBound;
     }
 
-    mapping(address => LinearlongShortPairParameters) public longShortPairParameters;
+    mapping(address => LinearLongShortPairParameters) public longShortPairParameters;
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
@@ -42,7 +42,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
      * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setlongShortPairParameters(
+    function setLongShortPairParameters(
         address LongShortPair,
         int256 upperBound,
         int256 lowerBound
@@ -50,10 +50,10 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
         require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         require(upperBound > lowerBound, "Invalid bounds");
 
-        LinearlongShortPairParameters memory params = longShortPairParameters[LongShortPair];
+        LinearLongShortPairParameters memory params = longShortPairParameters[LongShortPair];
         require(params.upperBound == 0 && params.lowerBound == 0, "Parameters already set");
 
-        longShortPairParameters[LongShortPair] = LinearlongShortPairParameters({
+        longShortPairParameters[LongShortPair] = LinearLongShortPairParameters({
             upperBound: upperBound,
             lowerBound: lowerBound
         });
@@ -66,7 +66,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        LinearlongShortPairParameters memory params = longShortPairParameters[msg.sender];
+        LinearLongShortPairParameters memory params = longShortPairParameters[msg.sender];
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol
@@ -7,6 +7,6 @@ interface ExpiringContractInterface {
     function expirationTimestamp() external view returns (uint256);
 }
 
-abstract contract ContractForDifferenceFinancialProductLibrary {
+abstract contract LongShortPairFinancialProductLibrary {
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view virtual returns (uint256);
 }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -33,12 +33,12 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
     using FixedPoint for FixedPoint.Unsigned;
     using SignedSafeMath for int256;
 
-    struct RangeBondlongShortPairParameters {
+    struct RangeBondLongShortPairParameters {
         uint256 highPriceRange;
         uint256 lowPriceRange;
     }
 
-    mapping(address => RangeBondlongShortPairParameters) public longShortPairParameters;
+    mapping(address => RangeBondLongShortPairParameters) public longShortPairParameters;
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
@@ -53,7 +53,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
      * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setlongShortPairParameters(
+    function setLongShortPairParameters(
         address LongShortPair,
         uint256 highPriceRange,
         uint256 lowPriceRange
@@ -62,9 +62,9 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
 
         require(highPriceRange > lowPriceRange, "Invalid bounds");
 
-        RangeBondlongShortPairParameters memory params = longShortPairParameters[LongShortPair];
+        RangeBondLongShortPairParameters memory params = longShortPairParameters[LongShortPair];
 
-        longShortPairParameters[LongShortPair] = RangeBondlongShortPairParameters({
+        longShortPairParameters[LongShortPair] = RangeBondLongShortPairParameters({
             highPriceRange: highPriceRange,
             lowPriceRange: lowPriceRange
         });
@@ -77,7 +77,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        RangeBondlongShortPairParameters memory params = longShortPairParameters[msg.sender];
+        RangeBondLongShortPairParameters memory params = longShortPairParameters[msg.sender];
 
         // expiryPercentLong=[min(max(1/R2,1/P),1/R1)]/(1/R1)
         // This function's method must return a value between 0 and 1 to be used in conjunction with the LSP

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -33,12 +33,12 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
     using FixedPoint for FixedPoint.Unsigned;
     using SignedSafeMath for int256;
 
-    struct RangeBondLongShortPairParameters {
+    struct RangeBondlongShortPairParameters {
         uint256 highPriceRange;
         uint256 lowPriceRange;
     }
 
-    mapping(address => RangeBondLongShortPairParameters) public LongShortPairParameters;
+    mapping(address => RangeBondlongShortPairParameters) public longShortPairParameters;
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
@@ -53,7 +53,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
      * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setLongShortPairParameters(
+    function setlongShortPairParameters(
         address LongShortPair,
         uint256 highPriceRange,
         uint256 lowPriceRange
@@ -62,9 +62,9 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
 
         require(highPriceRange > lowPriceRange, "Invalid bounds");
 
-        RangeBondLongShortPairParameters memory params = LongShortPairParameters[LongShortPair];
+        RangeBondlongShortPairParameters memory params = longShortPairParameters[LongShortPair];
 
-        LongShortPairParameters[LongShortPair] = RangeBondLongShortPairParameters({
+        longShortPairParameters[LongShortPair] = RangeBondlongShortPairParameters({
             highPriceRange: highPriceRange,
             lowPriceRange: lowPriceRange
         });
@@ -77,7 +77,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        RangeBondLongShortPairParameters memory params = LongShortPairParameters[msg.sender];
+        RangeBondlongShortPairParameters memory params = longShortPairParameters[msg.sender];
 
         // expiryPercentLong=[min(max(1/R2,1/P),1/R1)]/(1/R1)
         // This function's method must return a value between 0 and 1 to be used in conjunction with the LSP

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
-import "./ContractForDifferenceFinancialProductLibrary.sol";
+import "./LongShortPairFinancialProductLibrary.sol";
 import "../../../../common/implementation/Lockable.sol";
 
 /**
- * @title Range Bond Contract For Difference Financial Product Library
- * @notice Adds settlement logic to create range bond CFDs. A range bond is the combination of a Yield dollar, short put
+ * @title Range Bond Long Short Pair Financial Product Library
+ * @notice Adds settlement logic to create range bond LSPs. A range bond is the combination of a Yield dollar, short put
  * option and long call option enabling the token sponsor to issue structured products to unlock DeFi treasuries.
  * A range bond is defined as = Yield Dollar - Put Option + Call option. Numerically this is found using:
  * N = Notional of bond
@@ -19,7 +19,7 @@ import "../../../../common/implementation/Lockable.sol";
  * R2 = high price range
  * T = min(N/P,N/R1) + max((N/R2*(P-R2))/P,0)
  * - At any price below the low price range (R1) the long side effectively holds a fixed number of collateral equal to
- * collateralPerPair from the CFD with the value of expiryPercentLong = 1. This is the max payout in collateral.
+ * collateralPerPair from the LSP with the value of expiryPercentLong = 1. This is the max payout in collateral.
  * - Any price between R1 and R2 gives a payout equivalent to a yield dollar (bond) of notional N. In this range the
  * expiryPercentLong shifts to keep the payout in dollar terms equal to the bond notional.
  * - At any price above R2 the long holders are entitled to a fixed, minimum number of collateral equal to N/R2 with a
@@ -27,47 +27,44 @@ import "../../../../common/implementation/Lockable.sol";
  * The expression for the number of tokens paid out to the long side (T above) can be algebraically simplified,
  * transformed to remove the notional and reframed to express the expiryPercentLong as [min(max(1/R2,1/P),1/R1)]/(1/R1)
  * With this equation, the contract deployer does not need to specify the bond notional N. The notional can be calculated
- * by taking R1*collateralPerPair from the CFD.
+ * by taking R1*collateralPerPair from the LSP.
  */
-contract RangeBondContractForDifferenceFinancialProductLibrary is
-    ContractForDifferenceFinancialProductLibrary,
-    Lockable
-{
+contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancialProductLibrary, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using SignedSafeMath for int256;
 
-    struct RangeBondContractForDifferenceParameters {
+    struct RangeBondLongShortPairParameters {
         uint256 highPriceRange;
         uint256 lowPriceRange;
     }
 
-    mapping(address => RangeBondContractForDifferenceParameters) public contractForDifferenceParameters;
+    mapping(address => RangeBondLongShortPairParameters) public LongShortPairParameters;
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
-     * @param contractForDifference address of the CFD contract.
+     * @param LongShortPair address of the LSP contract.
      * @param highPriceRange high price range after which the payout transforms from a yield dollar to a call option.
      * @param lowPriceRange low price range below which the payout transforms from a yield dollar to a short put option.
      * @dev between highPriceRange and lowPriceRange the contract will payout a fixed amount of
      * lowPriceRange*collateralPerPair (i.e the "notional" of the yield dollar).
-     * @dev Note: a) Any address can set these parameters b) existing CFD parameters for address not set.
+     * @dev Note: a) Any address can set these parameters b) existing LSP parameters for address not set.
      * c) highPriceRange > lowPriceRange.
      * d) parameters price can only be set once to prevent the deployer from changing the parameters after the fact.
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
      * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setContractForDifferenceParameters(
-        address contractForDifference,
+    function setLongShortPairParameters(
+        address LongShortPair,
         uint256 highPriceRange,
         uint256 lowPriceRange
     ) public nonReentrant() {
-        require(ExpiringContractInterface(contractForDifference).expirationTimestamp() != 0, "Invalid CFD address");
+        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
 
         require(highPriceRange > lowPriceRange, "Invalid bounds");
 
-        RangeBondContractForDifferenceParameters memory params = contractForDifferenceParameters[contractForDifference];
+        RangeBondLongShortPairParameters memory params = LongShortPairParameters[LongShortPair];
 
-        contractForDifferenceParameters[contractForDifference] = RangeBondContractForDifferenceParameters({
+        LongShortPairParameters[LongShortPair] = RangeBondLongShortPairParameters({
             highPriceRange: highPriceRange,
             lowPriceRange: lowPriceRange
         });
@@ -76,14 +73,14 @@ contract RangeBondContractForDifferenceFinancialProductLibrary is
     /**
      * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
-     * @param expiryPrice price from the optimistic oracle for the CFD price identifier.
+     * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
     function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
-        RangeBondContractForDifferenceParameters memory params = contractForDifferenceParameters[msg.sender];
+        RangeBondLongShortPairParameters memory params = LongShortPairParameters[msg.sender];
 
         // expiryPercentLong=[min(max(1/R2,1/P),1/R1)]/(1/R1)
-        // This function's method must return a value between 0 and 1 to be used in conjunction with the CFD
+        // This function's method must return a value between 0 and 1 to be used in conjunction with the LSP
         // collateralPerPair that allocates collateral between the short and long tokens on expiry.
 
         uint256 positiveExpiryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -33,7 +33,7 @@ contract LongShortPair is Testable, Lockable {
     using SafeERC20 for IERC20;
 
     /*********************************************
-     *  CONTRACT FOR DIFFERENCE DATA STRUCTURES  *
+     *  LONG SHORT PAIR DATA STRUCTURES  *
      *********************************************/
 
     enum ContractState { Open, ExpiredPriceRequested, ExpiredPriceReceived }

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import "../common/financial-product-libraries/contract-for-difference-libraries/ContractForDifferenceFinancialProductLibrary.sol";
+import "../common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol";
 
 import "../../common/implementation/Testable.sol";
 import "../../common/implementation/Lockable.sol";
@@ -24,11 +24,11 @@ import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
 import "../../oracle/implementation/Constants.sol";
 
 /**
- * @title Contract For Difference.
+ * @title Long Short Pair.
  * @notice Uses a combination of long and short tokens to tokenize the bounded price exposure to a given identifier.
  */
 
-contract ContractForDifference is Testable, Lockable {
+contract LongShortPair is Testable, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using SafeERC20 for IERC20;
 
@@ -59,7 +59,7 @@ contract ContractForDifference is Testable, Lockable {
 
     FinderInterface public finder;
 
-    ContractForDifferenceFinancialProductLibrary public financialProductLibrary;
+    LongShortPairFinancialProductLibrary public financialProductLibrary;
 
     bytes public customAncillaryData;
 
@@ -97,13 +97,13 @@ contract ContractForDifference is Testable, Lockable {
     }
 
     /**
-     * @notice Construct the ContractForDifference
+     * @notice Construct the LongShortPair
      * @param _expirationTimestamp unix timestamp of when the contract will expire.
      * @param _collateralPerPair how many units of collateral are required to mint one pair of synthetic tokens.
      * @param _priceIdentifier registered in the DVM for the synthetic.
-     * @param _longToken ERC20 token used as long in the CFD. Requires mint and burn needed by this contract.
-     * @param _shortToken ERC20 token used as short in the CFD. Mint and burn rights needed by this contract.
-     * @param _collateralToken ERC20 token used as collateral in the CFD.
+     * @param _longToken ERC20 token used as long in the LSP. Requires mint and burn needed by this contract.
+     * @param _shortToken ERC20 token used as short in the LSP. Mint and burn rights needed by this contract.
+     * @param _collateralToken ERC20 token used as collateral in the LSP.
      * @param _finder UMA protocol Finder used to discover other protocol contracts.
      * @param _financialProductLibrary Contract providing settlement payout logic.
      * @param _customAncillaryData Custom ancillary data to be passed along with the price request. If not needed, this
@@ -118,7 +118,7 @@ contract ContractForDifference is Testable, Lockable {
         ExpandedIERC20 _shortToken,
         IERC20 _collateralToken,
         FinderInterface _finder,
-        ContractForDifferenceFinancialProductLibrary _financialProductLibrary,
+        LongShortPairFinancialProductLibrary _financialProductLibrary,
         bytes memory _customAncillaryData,
         address _timerAddress
     ) Testable(_timerAddress) {

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -15,7 +15,7 @@ import "../common/financial-product-libraries/long-short-pair-libraries/LongShor
 
 /**
  * @title Long Short Pair Contract Creator.
- * @notice Factory contract to create and register new instances of contract for difference contracts.
+ * @notice Factory contract to create and register new instances of long short pair contracts.
  * Responsible for constraining the parameters used to construct a new LSP. These constraints can evolve over time and
  * are initially constrained to conservative values in this first iteration.
  */

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -10,16 +10,16 @@ import "../../common/implementation/AddressWhitelist.sol";
 import "../../common/implementation/Lockable.sol";
 import "../common/TokenFactory.sol";
 import "../common/SyntheticToken.sol";
-import "./ContractForDifference.sol";
-import "../common/financial-product-libraries/contract-for-difference-libraries/ContractForDifferenceFinancialProductLibrary.sol";
+import "./LongShortPair.sol";
+import "../common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol";
 
 /**
- * @title Contract For Difference Contract Creator.
+ * @title Long Short Pair Contract Creator.
  * @notice Factory contract to create and register new instances of contract for difference contracts.
- * Responsible for constraining the parameters used to construct a new CFD. These constraints can evolve over time and
+ * Responsible for constraining the parameters used to construct a new LSP. These constraints can evolve over time and
  * are initially constrained to conservative values in this first iteration.
  */
-contract ContractForDifferenceCreator is Testable, Lockable {
+contract LongShortPairCreator is Testable, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
 
     // Address of TokenFactory used to create a new synthetic token.
@@ -27,10 +27,10 @@ contract ContractForDifferenceCreator is Testable, Lockable {
 
     FinderInterface public finder;
 
-    event CreatedContractForDifference(address indexed contractForDifference, address indexed deployerAddress);
+    event CreatedLongShortPair(address indexed LongShortPair, address indexed deployerAddress);
 
     /**
-     * @notice Constructs the ContractForDifferenceCreator contract.
+     * @notice Constructs the LongShortPairCreator contract.
      * @param _finder UMA protocol Finder used to discover other protocol contracts.
      * @param _tokenFactory ERC20 token factory used to deploy synthetic token instances.
      * @param _timer Contract that stores the current time in a testing environment.
@@ -49,24 +49,24 @@ contract ContractForDifferenceCreator is Testable, Lockable {
      * @param collateralPerPair how many units of collateral are required to mint one pair of synthetic tokens.
      * @param priceIdentifier registered in the DVM for the synthetic.
      * @param syntheticName Name of the synthetic tokens to be created. The long tokens will have "Long Token" appended
-     *     to the end and the short token will "Short Token" appended to the end to distinguish within the CFD's tokens.
+     *     to the end and the short token will "Short Token" appended to the end to distinguish within the LSP's tokens.
      * @param syntheticSymbol Symbol of the synthetic tokens to be created. The long tokens will have "l" appended
-     *     to the start and the short token will "s" appended to the start to distinguish within the CFD's tokens.
-     * @param collateralToken ERC20 token used as as collateral in the CFD.
+     *     to the start and the short token will "s" appended to the start to distinguish within the LSP's tokens.
+     * @param collateralToken ERC20 token used as as collateral in the LSP.
      * @param financialProductLibrary Contract providing settlement payout logic.
      * @param customAncillaryData Custom ancillary data to be passed along with the price request. If not needed, this
      *                             should be left as a 0-length bytes array.
-     * @notice The created CFD is NOT registered within the registry as the CFD contract uses the DVM.
-     * @notice The CFD constructor does a number of validations on input params. These are not repeated here.
+     * @notice The created LSP is NOT registered within the registry as the LSP contract uses the DVM.
+     * @notice The LSP constructor does a number of validations on input params. These are not repeated here.
      */
-    function createContractForDifference(
+    function createLongShortPair(
         uint64 expirationTimestamp,
         uint256 collateralPerPair,
         bytes32 priceIdentifier,
         string memory syntheticName,
         string memory syntheticSymbol,
         IERC20Standard collateralToken,
-        ContractForDifferenceFinancialProductLibrary financialProductLibrary,
+        LongShortPairFinancialProductLibrary financialProductLibrary,
         bytes memory customAncillaryData
     ) public nonReentrant() returns (address) {
         // Create a new synthetic token using the params.
@@ -88,8 +88,8 @@ contract ContractForDifferenceCreator is Testable, Lockable {
                 string(abi.encodePacked("s", syntheticSymbol)),
                 collateralDecimals
             );
-        ContractForDifference cfd =
-            new ContractForDifference(
+        LongShortPair lsp =
+            new LongShortPair(
                 expirationTimestamp,
                 collateralPerPair,
                 priceIdentifier,
@@ -102,20 +102,20 @@ contract ContractForDifferenceCreator is Testable, Lockable {
                 timerAddress
             );
 
-        address cfdAddress = address(cfd);
+        address lspAddress = address(lsp);
 
-        // Give permissions to new cfd contract and then hand over ownership.
-        longToken.addMinter(cfdAddress);
-        longToken.addBurner(cfdAddress);
-        longToken.resetOwner(cfdAddress);
+        // Give permissions to new lsp contract and then hand over ownership.
+        longToken.addMinter(lspAddress);
+        longToken.addBurner(lspAddress);
+        longToken.resetOwner(lspAddress);
 
-        shortToken.addMinter(cfdAddress);
-        shortToken.addBurner(cfdAddress);
-        shortToken.resetOwner(cfdAddress);
+        shortToken.addMinter(lspAddress);
+        shortToken.addBurner(lspAddress);
+        shortToken.resetOwner(lspAddress);
 
-        emit CreatedContractForDifference(cfdAddress, msg.sender);
+        emit CreatedLongShortPair(lspAddress, msg.sender);
 
-        return cfdAddress;
+        return lspAddress;
     }
 
     /****************************************

--- a/packages/core/contracts/financial-templates/test/LongShortPairFinancialProjectLibraryTest.sol
+++ b/packages/core/contracts/financial-templates/test/LongShortPairFinancialProjectLibraryTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
-import "../common/financial-product-libraries/contract-for-difference-libraries/ContractForDifferenceFinancialProductLibrary.sol";
+import "../common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol";
 
 // Implements a simple FinancialProductLibrary to test price and collateral requirement transoformations.
-contract ContractForDifferenceFinancialProjectLibraryTest is ContractForDifferenceFinancialProductLibrary {
+contract LongShortPairFinancialProjectLibraryTest is LongShortPairFinancialProductLibrary {
     using FixedPoint for FixedPoint.Unsigned;
 
     uint256 public valueToReturn;

--- a/packages/core/contracts/financial-templates/test/LongShortPairMock.sol
+++ b/packages/core/contracts/financial-templates/test/LongShortPairMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-contract ContractForDifferenceMock {
+contract LongShortPairMock {
     uint256 public expirationTimestamp;
     uint256 public collateralPerPair;
 

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
@@ -2,22 +2,22 @@ const { didContractThrow, ZERO_ADDRESS } = require("@uma/common");
 const { assert } = require("chai");
 
 // Tested Contract
-const BinaryOptionContractForDifferenceFinancialProductLibrary = artifacts.require(
-  "BinaryOptionContractForDifferenceFinancialProductLibrary"
+const BinaryOptionLongShortPairFinancialProductLibrary = artifacts.require(
+  "BinaryOptionLongShortPairFinancialProductLibrary"
 );
 
-// helper contracts. To test CFD libraries we simply need a financial contract with an `expirationTimestamp` method.
+// helper contracts. To test LSP libraries we simply need a financial contract with an `expirationTimestamp` method.
 const ExpiringContractMock = artifacts.require("ExpiringMultiPartyMock");
 
 const { toWei, toBN, utf8ToHex } = web3.utils;
 const strikePrice = toBN(toWei("3000"));
 
-contract("BinaryOptionContractForDifferenceFinancialProductLibrary", function () {
-  let binaryCFDFPL;
+contract("BinaryOptionLongShortPairFinancialProductLibrary", function () {
+  let binaryLSPFPL;
   let expiringContractMock;
 
   beforeEach(async () => {
-    binaryCFDFPL = await BinaryOptionContractForDifferenceFinancialProductLibrary.new();
+    binaryLSPFPL = await BinaryOptionLongShortPairFinancialProductLibrary.new();
     expiringContractMock = await ExpiringContractMock.new(
       ZERO_ADDRESS, // _financialProductLibraryAddress
       "1000000", // _expirationTimestamp
@@ -26,47 +26,45 @@ contract("BinaryOptionContractForDifferenceFinancialProductLibrary", function ()
       ZERO_ADDRESS // _timerAddress
     );
   });
-  describe("Contract For difference Parameterization", () => {
+  describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await binaryCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
-      const setParams = await binaryCFDFPL.contractForDifferenceParameters(expiringContractMock.address);
+      const setParams = await binaryLSPFPL.LongShortPairParameters(expiringContractMock.address);
       assert.isTrue(setParams.isSet);
       assert.equal(setParams.strikePrice.toString(), strikePrice);
     });
-    it("Can not re-use existing CFD contract address", async () => {
-      await binaryCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice);
+    it("Can not re-use existing LSP contract address", async () => {
+      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
       // Second attempt should revert.
       assert(
-        await didContractThrow(
-          binaryCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice)
-        )
+        await didContractThrow(binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice))
       );
     });
-    it("Can not set invalid CFD contract address", async () => {
-      // CFD Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(binaryCFDFPL.setContractForDifferenceParameters(ZERO_ADDRESS, strikePrice)));
+    it("Can not set invalid LSP contract address", async () => {
+      // LSP Address must implement the `expirationTimestamp method.
+      assert(await didContractThrow(binaryLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, strikePrice)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await binaryCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than lower bound should return 0", async () => {
-      const expiraryTokensForCollateral = await binaryCFDFPL.computeExpiryTokensForCollateral.call(toWei("2500"), {
+      const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("2500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiraryTokensForCollateral.toString(), toWei("0"));
     });
     it("equal to upper bound should return 1", async () => {
-      const expiraryTokensForCollateral = await binaryCFDFPL.computeExpiryTokensForCollateral.call(toWei("3000"), {
+      const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("3000"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiraryTokensForCollateral.toString(), toWei("1"));
     });
     it("Higher than upper bound should return 1", async () => {
-      const expiraryTokensForCollateral = await binaryCFDFPL.computeExpiryTokensForCollateral.call(toWei("3500"), {
+      const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("3500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiraryTokensForCollateral.toString(), toWei("1"));
@@ -74,7 +72,7 @@ contract("BinaryOptionContractForDifferenceFinancialProductLibrary", function ()
 
     it("Arbitrary price between bounds should return correctly", async () => {
       for (const price of [toWei("1000"), toWei("2000"), toWei("3000"), toWei("4000"), toWei("5000"), toWei("10000")]) {
-        const expiraryTokensForCollateral = await binaryCFDFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(price, {
           from: expiringContractMock.address,
         });
         const expectedPrice = toBN(price).gte(toBN(strikePrice)) ? toWei("1") : toWei("0");

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
@@ -28,28 +28,28 @@ contract("BinaryOptionLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
 
-      const setParams = await binaryLSPFPL.LongShortPairParameters(expiringContractMock.address);
+      const setParams = await binaryLSPFPL.longShortPairParameters(expiringContractMock.address);
       assert.isTrue(setParams.isSet);
       assert.equal(setParams.strikePrice.toString(), strikePrice);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
 
       // Second attempt should revert.
       assert(
-        await didContractThrow(binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice))
+        await didContractThrow(binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice))
       );
     });
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(binaryLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, strikePrice)));
+      assert(await didContractThrow(binaryLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, strikePrice)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than lower bound should return 0", async () => {
       const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("2500"), {

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
@@ -28,28 +28,28 @@ contract("BinaryOptionLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
       const setParams = await binaryLSPFPL.longShortPairParameters(expiringContractMock.address);
       assert.isTrue(setParams.isSet);
       assert.equal(setParams.strikePrice.toString(), strikePrice);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
       // Second attempt should revert.
       assert(
-        await didContractThrow(binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice))
+        await didContractThrow(binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice))
       );
     });
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(binaryLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, strikePrice)));
+      assert(await didContractThrow(binaryLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, strikePrice)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await binaryLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
+      await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than lower bound should return 0", async () => {
       const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("2500"), {

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
@@ -29,27 +29,27 @@ contract("CoveredCallLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid strikes", async () => {
-      await callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
       const setStrike = await callOptionLSPFPL.longShortPairStrikePrices(expiringContractMock.address);
       assert.equal(setStrike.toString(), strikePrice);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
       // Second attempt should revert.
       assert(
-        await didContractThrow(callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice))
+        await didContractThrow(callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice))
       );
     });
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(callOptionLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, strikePrice)));
+      assert(await didContractThrow(callOptionLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, strikePrice)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than strike should return 0", async () => {
       const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(toWei("300"), {

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
@@ -29,27 +29,27 @@ contract("CoveredCallLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid strikes", async () => {
-      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
 
-      const setStrike = await callOptionLSPFPL.LongShortPairStrikePrices(expiringContractMock.address);
+      const setStrike = await callOptionLSPFPL.longShortPairStrikePrices(expiringContractMock.address);
       assert.equal(setStrike.toString(), strikePrice);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
 
       // Second attempt should revert.
       assert(
-        await didContractThrow(callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice))
+        await didContractThrow(callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice))
       );
     });
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(callOptionLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, strikePrice)));
+      assert(await didContractThrow(callOptionLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, strikePrice)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setlongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than strike should return 0", async () => {
       const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(toWei("300"), {

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
@@ -2,23 +2,23 @@ const { didContractThrow, ZERO_ADDRESS } = require("@uma/common");
 const { assert } = require("chai");
 
 // Tested Contract
-const CoveredCallContractForDifferenceFinancialProductLibrary = artifacts.require(
-  "CoveredCallContractForDifferenceFinancialProductLibrary"
+const CoveredCallLongShortPairFinancialProductLibrary = artifacts.require(
+  "CoveredCallLongShortPairFinancialProductLibrary"
 );
 
-// helper contracts. To test CFD libraries we simply need a financial contract with an `expirationTimestamp` method.
+// helper contracts. To test LSP libraries we simply need a financial contract with an `expirationTimestamp` method.
 
 const ExpiringContractMock = artifacts.require("ExpiringMultiPartyMock");
 
 const { toWei, toBN, utf8ToHex } = web3.utils;
 const strikePrice = toWei("400");
 
-contract("CoveredCallContractForDifferenceFinancialProductLibrary", function () {
-  let callOptionCFDFPL;
+contract("CoveredCallLongShortPairFinancialProductLibrary", function () {
+  let callOptionLSPFPL;
   let expiringContractMock;
 
   beforeEach(async () => {
-    callOptionCFDFPL = await CoveredCallContractForDifferenceFinancialProductLibrary.new();
+    callOptionLSPFPL = await CoveredCallLongShortPairFinancialProductLibrary.new();
     expiringContractMock = await ExpiringContractMock.new(
       ZERO_ADDRESS, // _financialProductLibraryAddress
       "1000000", // _expirationTimestamp
@@ -27,47 +27,45 @@ contract("CoveredCallContractForDifferenceFinancialProductLibrary", function () 
       ZERO_ADDRESS // _timerAddress
     );
   });
-  describe("Contract For difference Parameterization", () => {
+  describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid strikes", async () => {
-      await callOptionCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
-      const setStrike = await callOptionCFDFPL.contractForDifferenceStrikePrices(expiringContractMock.address);
+      const setStrike = await callOptionLSPFPL.LongShortPairStrikePrices(expiringContractMock.address);
       assert.equal(setStrike.toString(), strikePrice);
     });
-    it("Can not re-use existing CFD contract address", async () => {
-      await callOptionCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice);
+    it("Can not re-use existing LSP contract address", async () => {
+      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
 
       // Second attempt should revert.
       assert(
-        await didContractThrow(
-          callOptionCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice)
-        )
+        await didContractThrow(callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice))
       );
     });
-    it("Can not set invalid CFD contract address", async () => {
-      // CFD Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(callOptionCFDFPL.setContractForDifferenceParameters(ZERO_ADDRESS, strikePrice)));
+    it("Can not set invalid LSP contract address", async () => {
+      // LSP Address must implement the `expirationTimestamp method.
+      assert(await didContractThrow(callOptionLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, strikePrice)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await callOptionCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, strikePrice);
+      await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than strike should return 0", async () => {
-      const expiryTokensForCollateral = await callOptionCFDFPL.computeExpiryTokensForCollateral.call(toWei("300"), {
+      const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(toWei("300"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0"));
     });
     it("Higher than strike correct value", async () => {
-      const expiryTokensForCollateral = await callOptionCFDFPL.computeExpiryTokensForCollateral.call(toWei("500"), {
+      const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(toWei("500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.2"));
     });
     it("Arbitrary expiry price above strike should return correctly", async () => {
       for (const price of [toWei("500"), toWei("600"), toWei("1000"), toWei("1500"), toWei("2000")]) {
-        const expiryTokensForCollateral = await callOptionCFDFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(price, {
           from: expiringContractMock.address,
         });
         const expectedPrice = toBN(price)
@@ -79,7 +77,7 @@ contract("CoveredCallContractForDifferenceFinancialProductLibrary", function () 
     });
     it("Should never return a value greater than 1", async () => {
       // create a massive expiry price. 1e18*1e18. Under all conditions should return less than 1.
-      const expiryTokensForCollateral = await callOptionCFDFPL.computeExpiryTokensForCollateral.call(
+      const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(
         toWei(toWei("1")),
         { from: expiringContractMock.address }
       );

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
@@ -28,19 +28,19 @@ contract("LinearLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
 
-      const setParams = await linearLSPFPL.LongShortPairParameters(expiringContractMock.address);
+      const setParams = await linearLSPFPL.longShortPairParameters(expiringContractMock.address);
       assert.equal(setParams.upperBound.toString(), upperBound);
       assert.equal(setParams.lowerBound.toString(), lowerBound);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
 
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound)
+          linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound)
         )
       );
     });
@@ -48,18 +48,18 @@ contract("LinearLongShortPairFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, lowerBound, upperBound)
+          linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, lowerBound, upperBound)
         )
       );
     });
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(linearLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, upperBound, lowerBound)));
+      assert(await didContractThrow(linearLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, upperBound, lowerBound)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
     });
     it("Lower than lower bound should return 0", async () => {
       const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("900"), {

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
@@ -2,11 +2,9 @@ const { didContractThrow, ZERO_ADDRESS } = require("@uma/common");
 const { assert } = require("chai");
 
 // Tested Contract
-const LinearContractForDifferenceFinancialProductLibrary = artifacts.require(
-  "LinearContractForDifferenceFinancialProductLibrary"
-);
+const LinearLongShortPairFinancialProductLibrary = artifacts.require("LinearLongShortPairFinancialProductLibrary");
 
-// helper contracts. To test CFD libraries we simply need a financial contract with an `expirationTimestamp` method.
+// helper contracts. To test LSP libraries we simply need a financial contract with an `expirationTimestamp` method.
 
 const ExpiringContractMock = artifacts.require("ExpiringMultiPartyMock");
 
@@ -14,12 +12,12 @@ const { toWei, toBN, utf8ToHex } = web3.utils;
 const upperBound = toBN(toWei("2000"));
 const lowerBound = toBN(toWei("1000"));
 
-contract("LinearContractForDifferenceFinancialProductLibrary", function () {
-  let linearCFDFPL;
+contract("LinearLongShortPairFinancialProductLibrary", function () {
+  let linearLSPFPL;
   let expiringContractMock;
 
   beforeEach(async () => {
-    linearCFDFPL = await LinearContractForDifferenceFinancialProductLibrary.new();
+    linearLSPFPL = await LinearLongShortPairFinancialProductLibrary.new();
     expiringContractMock = await ExpiringContractMock.new(
       ZERO_ADDRESS, // _financialProductLibraryAddress
       "1000000", // _expirationTimestamp
@@ -28,21 +26,21 @@ contract("LinearContractForDifferenceFinancialProductLibrary", function () {
       ZERO_ADDRESS // _timerAddress
     );
   });
-  describe("Contract For difference Parameterization", () => {
+  describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await linearCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
 
-      const setParams = await linearCFDFPL.contractForDifferenceParameters(expiringContractMock.address);
+      const setParams = await linearLSPFPL.LongShortPairParameters(expiringContractMock.address);
       assert.equal(setParams.upperBound.toString(), upperBound);
       assert.equal(setParams.lowerBound.toString(), lowerBound);
     });
-    it("Can not re-use existing CFD contract address", async () => {
-      await linearCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, upperBound, lowerBound);
+    it("Can not re-use existing LSP contract address", async () => {
+      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
 
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          linearCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, upperBound, lowerBound)
+          linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound)
         )
       );
     });
@@ -50,35 +48,33 @@ contract("LinearContractForDifferenceFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          linearCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, lowerBound, upperBound)
+          linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, lowerBound, upperBound)
         )
       );
     });
-    it("Can not set invalid CFD contract address", async () => {
-      // CFD Address must implement the `expirationTimestamp method.
-      assert(
-        await didContractThrow(linearCFDFPL.setContractForDifferenceParameters(ZERO_ADDRESS, upperBound, lowerBound))
-      );
+    it("Can not set invalid LSP contract address", async () => {
+      // LSP Address must implement the `expirationTimestamp method.
+      assert(await didContractThrow(linearLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, upperBound, lowerBound)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await linearCFDFPL.setContractForDifferenceParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
     });
     it("Lower than lower bound should return 0", async () => {
-      const expiryTokensForCollateral = await linearCFDFPL.computeExpiryTokensForCollateral.call(toWei("900"), {
+      const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("900"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0"));
     });
     it("Higher than upper bound should return 1", async () => {
-      const expiryTokensForCollateral = await linearCFDFPL.computeExpiryTokensForCollateral.call(toWei("2100"), {
+      const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("2100"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("1"));
     });
     it("Midway between bounds should return 0.5", async () => {
-      const expiryTokensForCollateral = await linearCFDFPL.computeExpiryTokensForCollateral.call(toWei("1500"), {
+      const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("1500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.5"));
@@ -86,7 +82,7 @@ contract("LinearContractForDifferenceFinancialProductLibrary", function () {
 
     it("Arbitrary price between bounds should return correctly", async () => {
       for (const price of [toWei("1000"), toWei("1200"), toWei("1400"), toWei("1600"), toWei("1800"), toWei("2000")]) {
-        const expiryTokensForCollateral = await linearCFDFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(price, {
           from: expiringContractMock.address,
         });
         const numerator = toBN(price).sub(toBN(lowerBound));

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
@@ -28,19 +28,19 @@ contract("LinearLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
 
       const setParams = await linearLSPFPL.longShortPairParameters(expiringContractMock.address);
       assert.equal(setParams.upperBound.toString(), upperBound);
       assert.equal(setParams.lowerBound.toString(), lowerBound);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
 
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound)
+          linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound)
         )
       );
     });
@@ -48,18 +48,18 @@ contract("LinearLongShortPairFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, lowerBound, upperBound)
+          linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, lowerBound, upperBound)
         )
       );
     });
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
-      assert(await didContractThrow(linearLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, upperBound, lowerBound)));
+      assert(await didContractThrow(linearLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, upperBound, lowerBound)));
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await linearLSPFPL.setlongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
+      await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
     });
     it("Lower than lower bound should return 0", async () => {
       const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("900"), {

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
@@ -27,14 +27,14 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
+      await rangeBondLSPFPL.setlongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
 
-      const setParams = await rangeBondLSPFPL.LongShortPairParameters(lspMock.address);
+      const setParams = await rangeBondLSPFPL.longShortPairParameters(lspMock.address);
       assert.equal(setParams.lowPriceRange.toString(), lowPriceRange);
       assert.equal(setParams.highPriceRange.toString(), highPriceRange);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await rangeBondLSPFPL.setLongShortPairParameters(
+      await rangeBondLSPFPL.setlongShortPairParameters(
         lspMock.address,
 
         highPriceRange,
@@ -44,7 +44,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          rangeBondLSPFPL.setLongShortPairParameters(
+          rangeBondLSPFPL.setlongShortPairParameters(
             lspMock.address,
 
             lowPriceRange,
@@ -57,7 +57,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          rangeBondLSPFPL.setLongShortPairParameters(
+          rangeBondLSPFPL.setlongShortPairParameters(
             lspMock.address,
 
             lowPriceRange,
@@ -69,13 +69,13 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
       assert(
-        await didContractThrow(rangeBondLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, highPriceRange, lowPriceRange))
+        await didContractThrow(rangeBondLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, highPriceRange, lowPriceRange))
       );
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
+      await rangeBondLSPFPL.setlongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
     });
     it("Lower than low price range should return 1 (long side is short put option)", async () => {
       // If the price is lower than the low price range then the max payout per each long token is hit at the full

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
@@ -2,11 +2,11 @@ const { didContractThrow, ZERO_ADDRESS } = require("@uma/common");
 const { assert } = require("chai");
 
 // Tested Contract
-const RangeBondContractForDifferenceFinancialProductLibrary = artifacts.require(
-  "RangeBondContractForDifferenceFinancialProductLibrary"
+const RangeBondLongShortPairFinancialProductLibrary = artifacts.require(
+  "RangeBondLongShortPairFinancialProductLibrary"
 );
 
-const ContractForDifferenceMock = artifacts.require("ContractForDifferenceMock");
+const LongShortPairMock = artifacts.require("LongShortPairMock");
 
 const { toWei, toBN, BN } = web3.utils;
 const bondNotional = toBN(toWei("100"));
@@ -14,27 +14,27 @@ const lowPriceRange = toBN(toWei("10"));
 const highPriceRange = toBN(toWei("50"));
 const collateralPerPair = toBN(toWei("10"));
 
-contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
-  let rangeBondCFDFPL;
+contract("RangeBondLongShortPairFinancialProductLibrary", function () {
+  let rangeBondLSPFPL;
   let cfdMock;
 
   beforeEach(async () => {
-    rangeBondCFDFPL = await RangeBondContractForDifferenceFinancialProductLibrary.new();
-    cfdMock = await ContractForDifferenceMock.new(
+    rangeBondLSPFPL = await RangeBondLongShortPairFinancialProductLibrary.new();
+    cfdMock = await LongShortPairMock.new(
       "1000000", // _expirationTimestamp
       collateralPerPair // _collateralPerPair
     );
   });
-  describe("Contract For difference Parameterization", () => {
+  describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await rangeBondCFDFPL.setContractForDifferenceParameters(cfdMock.address, highPriceRange, lowPriceRange);
+      await rangeBondLSPFPL.setLongShortPairParameters(cfdMock.address, highPriceRange, lowPriceRange);
 
-      const setParams = await rangeBondCFDFPL.contractForDifferenceParameters(cfdMock.address);
+      const setParams = await rangeBondLSPFPL.LongShortPairParameters(cfdMock.address);
       assert.equal(setParams.lowPriceRange.toString(), lowPriceRange);
       assert.equal(setParams.highPriceRange.toString(), highPriceRange);
     });
-    it("Can not re-use existing CFD contract address", async () => {
-      await rangeBondCFDFPL.setContractForDifferenceParameters(
+    it("Can not re-use existing LSP contract address", async () => {
+      await rangeBondLSPFPL.setLongShortPairParameters(
         cfdMock.address,
 
         highPriceRange,
@@ -44,7 +44,7 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          rangeBondCFDFPL.setContractForDifferenceParameters(
+          rangeBondLSPFPL.setLongShortPairParameters(
             cfdMock.address,
 
             lowPriceRange,
@@ -57,7 +57,7 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          rangeBondCFDFPL.setContractForDifferenceParameters(
+          rangeBondLSPFPL.setLongShortPairParameters(
             cfdMock.address,
 
             lowPriceRange,
@@ -66,23 +66,21 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
         )
       );
     });
-    it("Can not set invalid CFD contract address", async () => {
-      // CFD Address must implement the `expirationTimestamp method.
+    it("Can not set invalid LSP contract address", async () => {
+      // LSP Address must implement the `expirationTimestamp method.
       assert(
-        await didContractThrow(
-          rangeBondCFDFPL.setContractForDifferenceParameters(ZERO_ADDRESS, highPriceRange, lowPriceRange)
-        )
+        await didContractThrow(rangeBondLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, highPriceRange, lowPriceRange))
       );
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await rangeBondCFDFPL.setContractForDifferenceParameters(cfdMock.address, highPriceRange, lowPriceRange);
+      await rangeBondLSPFPL.setLongShortPairParameters(cfdMock.address, highPriceRange, lowPriceRange);
     });
     it("Lower than low price range should return 1 (long side is short put option)", async () => {
       // If the price is lower than the low price range then the max payout per each long token is hit at the full
       // collateralPerPair. i.e each short token is worth 0*collateralPerPair and each long token is worth 1*collateralPerPair.
-      const expiryTokensForCollateral = await rangeBondCFDFPL.computeExpiryTokensForCollateral.call(toWei("9"), {
+      const expiryTokensForCollateral = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("9"), {
         from: cfdMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("1"));
@@ -91,7 +89,7 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
       // If the price is larger than the high price range then the long tokens are equal fixed amount of notional/highPriceRange
       // Considering the long token to compute the expiryPercentLong (notional/highPriceRange)/collateralPerPair=(100/50)/10=0.2.
       // i.e each short token is worth 0.8* collateralPerPair = 8 tokens and each long token is worth 0.2*collateralPerPair=2.
-      const expiryTokensForCollateral = await rangeBondCFDFPL.computeExpiryTokensForCollateral.call(toWei("60"), {
+      const expiryTokensForCollateral = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("60"), {
         from: cfdMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.2"));
@@ -101,14 +99,14 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
       // long token is worth the bond notional of 100. At a price of 20 we are between the bounds. Each long should be worth
       // 100 so there should be 100/20=5 UMA per long token. As each collateralPerPair is worth 10, expiryPercentLong should
       // be 10/5=0.5, thereby allocating half to the long and half to the short.
-      const expiryTokensForCollateral1 = await rangeBondCFDFPL.computeExpiryTokensForCollateral.call(toWei("20"), {
+      const expiryTokensForCollateral1 = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("20"), {
         from: cfdMock.address,
       });
       assert.equal(expiryTokensForCollateral1.toString(), toWei("0.5"));
 
       // Equally, at a price of 40 each long should still be worth 100 so there should be 100/40=2.5 UMA per long. As
       // each collateralPerPair=10 expiryPercentLong should be 10/2.5=0.25, thereby allocating 25% to long and the remaining to short.
-      const expiryTokensForCollateral2 = await rangeBondCFDFPL.computeExpiryTokensForCollateral.call(toWei("20"), {
+      const expiryTokensForCollateral2 = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("20"), {
         from: cfdMock.address,
       });
       assert.equal(expiryTokensForCollateral2.toString(), toWei("0.5"));
@@ -125,7 +123,7 @@ contract("RangeBondContractForDifferenceFinancialProductLibrary", function () {
       // form of the range bond equation where as the library uses an algebraic simplification of this equation. This
       // test validates the correct mapping between these two forms.
       for (const price of [toWei("5.555"), toWei("11"), toWei("33"), toWei("55"), toWei("66"), toWei("111")]) {
-        const expiryTokensForCollateral = await rangeBondCFDFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiryTokensForCollateral = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(price, {
           from: cfdMock.address,
         });
         //

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
@@ -27,14 +27,14 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
   });
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid values", async () => {
-      await rangeBondLSPFPL.setlongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
+      await rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
 
       const setParams = await rangeBondLSPFPL.longShortPairParameters(lspMock.address);
       assert.equal(setParams.lowPriceRange.toString(), lowPriceRange);
       assert.equal(setParams.highPriceRange.toString(), highPriceRange);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await rangeBondLSPFPL.setlongShortPairParameters(
+      await rangeBondLSPFPL.setLongShortPairParameters(
         lspMock.address,
 
         highPriceRange,
@@ -44,7 +44,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          rangeBondLSPFPL.setlongShortPairParameters(
+          rangeBondLSPFPL.setLongShortPairParameters(
             lspMock.address,
 
             lowPriceRange,
@@ -57,7 +57,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          rangeBondLSPFPL.setlongShortPairParameters(
+          rangeBondLSPFPL.setLongShortPairParameters(
             lspMock.address,
 
             lowPriceRange,
@@ -69,13 +69,13 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
     it("Can not set invalid LSP contract address", async () => {
       // LSP Address must implement the `expirationTimestamp method.
       assert(
-        await didContractThrow(rangeBondLSPFPL.setlongShortPairParameters(ZERO_ADDRESS, highPriceRange, lowPriceRange))
+        await didContractThrow(rangeBondLSPFPL.setLongShortPairParameters(ZERO_ADDRESS, highPriceRange, lowPriceRange))
       );
     });
   });
   describe("Compute expiry tokens for collateral", () => {
     beforeEach(async () => {
-      await rangeBondLSPFPL.setlongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
+      await rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
     });
     it("Lower than low price range should return 1 (long side is short put option)", async () => {
       // If the price is lower than the low price range then the max payout per each long token is hit at the full

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -93,7 +93,7 @@ contract("LongShortPair", function (accounts) {
 
     longShortPair = await LongShortPair.new(...Object.values(constructorParams));
 
-    // Add mint and burn roles for the long and short tokens to the contract for difference.
+    // Add mint and burn roles for the long and short tokens to the long short pair.
     await longToken.addMember(1, longShortPair.address, { from: deployer });
     await shortToken.addMember(1, longShortPair.address, { from: deployer });
     await longToken.addMember(2, longShortPair.address, { from: deployer });
@@ -198,7 +198,7 @@ contract("LongShortPair", function (accounts) {
       assert.equal(await longToken.balanceOf(sponsor), toWei("0"));
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), toWei("975")); // 925 after redemption + 12.5 redeemed for long and 37.5 for short.
 
-      // Contract for difference should have no collateral left in it as everything has been redeemed.
+      // long short pair should have no collateral left in it as everything has been redeemed.
       assert.equal((await collateralToken.balanceOf(longShortPair.address)).toString(), toWei("0"));
     });
     it("Events are correctly emitted", async function () {

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -38,9 +38,9 @@ const priceFeedIdentifier = utf8ToHex("TEST_IDENTIFIER");
 const collateralPerPair = toWei("1"); // each pair of long and short tokens need 1 unit of collateral to mint.
 
 const proposeAndSettleOptimisticOraclePrice = async (priceFeedIdentifier, requestTime, price) => {
-  await optimisticOracle.proposePrice(LongShortPair.address, priceFeedIdentifier, requestTime, ancillaryData, price);
+  await optimisticOracle.proposePrice(longShortPair.address, priceFeedIdentifier, requestTime, ancillaryData, price);
   await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()) + optimisticOracleLiveness);
-  await optimisticOracle.settle(LongShortPair.address, priceFeedIdentifier, requestTime, ancillaryData);
+  await optimisticOracle.settle(longShortPair.address, priceFeedIdentifier, requestTime, ancillaryData);
 };
 
 contract("LongShortPair", function (accounts) {
@@ -104,7 +104,7 @@ contract("LongShortPair", function (accounts) {
       // Invalid expiration time.
       assert(
         await didContractThrow(
-          longShortPair.new(
+          LongShortPair.new(
             ...Object.values({ ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 1 })
           )
         )
@@ -113,20 +113,20 @@ contract("LongShortPair", function (accounts) {
       // Invalid price identifier time.
       assert(
         await didContractThrow(
-          longShortPair.new(...Object.values({ ...constructorParams, priceFeedIdentifier: "BAD-IDENTIFIER" }))
+          LongShortPair.new(...Object.values({ ...constructorParams, priceFeedIdentifier: "BAD-IDENTIFIER" }))
         )
       );
       // Invalid LSP library address.
       assert(
         await didContractThrow(
-          longShortPair.new(...Object.values({ ...constructorParams, longShortPairLibraryAddress: ZERO_ADDRESS }))
+          LongShortPair.new(...Object.values({ ...constructorParams, longShortPairLibraryAddress: ZERO_ADDRESS }))
         )
       );
 
       // Invalid Finder address.
       assert(
         await didContractThrow(
-          longShortPair.new(...Object.values({ ...constructorParams, finderAddress: ZERO_ADDRESS }))
+          LongShortPair.new(...Object.values({ ...constructorParams, finderAddress: ZERO_ADDRESS }))
         )
       );
 
@@ -139,7 +139,7 @@ contract("LongShortPair", function (accounts) {
       const remainingLength = maxLength - (ooAncillary.length - 2) / 2; // Remove the 0x and divide by 2 to get bytes.
       assert(
         await didContractThrow(
-          longShortPair.new(
+          LongShortPair.new(
             ...Object.values({ ...constructorParams, ancillaryData: web3.utils.randomHex(remainingLength + 1) })
           )
         )

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -6,10 +6,8 @@ const { assert } = require("chai");
 const { interfaceName, didContractThrow, MAX_UINT_VAL, ZERO_ADDRESS } = require("@uma/common");
 
 // Tested Contract
-const ContractForDifference = artifacts.require("ContractForDifference");
-const ContractForDifferenceFinancialProjectLibraryTest = artifacts.require(
-  "ContractForDifferenceFinancialProjectLibraryTest"
-);
+const LongShortPair = artifacts.require("LongShortPair");
+const LongShortPairFinancialProjectLibraryTest = artifacts.require("LongShortPairFinancialProjectLibraryTest");
 
 // Helper contracts
 const AddressWhitelist = artifacts.require("AddressWhitelist");
@@ -23,8 +21,8 @@ const Token = artifacts.require("ExpandedERC20");
 let collateralToken;
 let longToken;
 let shortToken;
-let contractForDifference;
-let contractForDifferenceLibrary;
+let longShortPair;
+let longShortPairLibrary;
 let collateralWhitelist;
 let identifierWhitelist;
 let optimisticOracle;
@@ -40,18 +38,12 @@ const priceFeedIdentifier = utf8ToHex("TEST_IDENTIFIER");
 const collateralPerPair = toWei("1"); // each pair of long and short tokens need 1 unit of collateral to mint.
 
 const proposeAndSettleOptimisticOraclePrice = async (priceFeedIdentifier, requestTime, price) => {
-  await optimisticOracle.proposePrice(
-    contractForDifference.address,
-    priceFeedIdentifier,
-    requestTime,
-    ancillaryData,
-    price
-  );
+  await optimisticOracle.proposePrice(LongShortPair.address, priceFeedIdentifier, requestTime, ancillaryData, price);
   await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()) + optimisticOracleLiveness);
-  await optimisticOracle.settle(contractForDifference.address, priceFeedIdentifier, requestTime, ancillaryData);
+  await optimisticOracle.settle(LongShortPair.address, priceFeedIdentifier, requestTime, ancillaryData);
 };
 
-contract("ContractForDifference", function (accounts) {
+contract("LongShortPair", function (accounts) {
   const deployer = accounts[0];
   const sponsor = accounts[1];
   const holder = accounts[2];
@@ -83,8 +75,8 @@ contract("ContractForDifference", function (accounts) {
       from: deployer,
     });
 
-    // Create CFD library and CFD contract.
-    contractForDifferenceLibrary = await ContractForDifferenceFinancialProjectLibraryTest.new();
+    // Create LSP library and LSP contract.
+    longShortPairLibrary = await LongShortPairFinancialProjectLibraryTest.new();
 
     constructorParams = {
       expirationTimestamp,
@@ -94,25 +86,25 @@ contract("ContractForDifference", function (accounts) {
       shortTokenAddress: shortToken.address,
       collateralTokenAddress: collateralToken.address,
       finderAddress: finder.address,
-      contractForDifferenceLibraryAddress: contractForDifferenceLibrary.address,
+      LongShortPairLibraryAddress: longShortPairLibrary.address,
       ancillaryData,
       timerAddress: timer.address,
     };
 
-    contractForDifference = await ContractForDifference.new(...Object.values(constructorParams));
+    longShortPair = await LongShortPair.new(...Object.values(constructorParams));
 
     // Add mint and burn roles for the long and short tokens to the contract for difference.
-    await longToken.addMember(1, contractForDifference.address, { from: deployer });
-    await shortToken.addMember(1, contractForDifference.address, { from: deployer });
-    await longToken.addMember(2, contractForDifference.address, { from: deployer });
-    await shortToken.addMember(2, contractForDifference.address, { from: deployer });
+    await longToken.addMember(1, longShortPair.address, { from: deployer });
+    await shortToken.addMember(1, longShortPair.address, { from: deployer });
+    await longToken.addMember(2, longShortPair.address, { from: deployer });
+    await shortToken.addMember(2, longShortPair.address, { from: deployer });
   });
   describe("Basic Functionality", () => {
     it("Rejects invalid constructor parameters", async function () {
       // Invalid expiration time.
       assert(
         await didContractThrow(
-          ContractForDifference.new(
+          longShortPair.new(
             ...Object.values({ ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 1 })
           )
         )
@@ -121,22 +113,20 @@ contract("ContractForDifference", function (accounts) {
       // Invalid price identifier time.
       assert(
         await didContractThrow(
-          ContractForDifference.new(...Object.values({ ...constructorParams, priceFeedIdentifier: "BAD-IDENTIFIER" }))
+          longShortPair.new(...Object.values({ ...constructorParams, priceFeedIdentifier: "BAD-IDENTIFIER" }))
         )
       );
-      // Invalid CFD library address.
+      // Invalid LSP library address.
       assert(
         await didContractThrow(
-          ContractForDifference.new(
-            ...Object.values({ ...constructorParams, contractForDifferenceLibraryAddress: ZERO_ADDRESS })
-          )
+          longShortPair.new(...Object.values({ ...constructorParams, longShortPairLibraryAddress: ZERO_ADDRESS }))
         )
       );
 
       // Invalid Finder address.
       assert(
         await didContractThrow(
-          ContractForDifference.new(...Object.values({ ...constructorParams, finderAddress: ZERO_ADDRESS }))
+          longShortPair.new(...Object.values({ ...constructorParams, finderAddress: ZERO_ADDRESS }))
         )
       );
 
@@ -149,7 +139,7 @@ contract("ContractForDifference", function (accounts) {
       const remainingLength = maxLength - (ooAncillary.length - 2) / 2; // Remove the 0x and divide by 2 to get bytes.
       assert(
         await didContractThrow(
-          ContractForDifference.new(
+          longShortPair.new(
             ...Object.values({ ...constructorParams, ancillaryData: web3.utils.randomHex(remainingLength + 1) })
           )
         )
@@ -161,8 +151,8 @@ contract("ContractForDifference", function (accounts) {
       assert.equal(await longToken.balanceOf(sponsor), toWei("0"));
       assert.equal(await shortToken.balanceOf(sponsor), toWei("0"));
 
-      await collateralToken.approve(contractForDifference.address, MAX_UINT_VAL, { from: sponsor });
-      await contractForDifference.create(toWei("100"), { from: sponsor });
+      await collateralToken.approve(longShortPair.address, MAX_UINT_VAL, { from: sponsor });
+      await longShortPair.create(toWei("100"), { from: sponsor });
 
       // Collateral should have decreased by tokensMinted/collateral per token. Long & short should have increase by tokensMinted.
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), toWei("900")); // 1000 starting balance - 100 for mint.
@@ -173,7 +163,7 @@ contract("ContractForDifference", function (accounts) {
       await longToken.transfer(holder, toWei("50"), { from: sponsor });
 
       // Token sponsor redeems half their remaining long tokens, along with the associated short tokens.
-      await contractForDifference.redeem(toWei("25"), { from: sponsor });
+      await longShortPair.redeem(toWei("25"), { from: sponsor });
 
       // Sponsor should have 25 remaining long tokens and 75 remaining short tokens. They should have been refunded 25 collateral.
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), toWei("925")); // 900 after mint + 25 redeemed.
@@ -181,45 +171,45 @@ contract("ContractForDifference", function (accounts) {
       assert.equal(await shortToken.balanceOf(sponsor), toWei("75"));
 
       // holder should not be able to call redeem as they only have the long token and redemption requires a pair.
-      assert(await didContractThrow(contractForDifference.redeem(toWei("25"), { from: holder })));
+      assert(await didContractThrow(longShortPair.redeem(toWei("25"), { from: holder })));
 
       // Advance past the expiry timestamp and settle the contract.
       await timer.setCurrentTime(expirationTimestamp + 1);
 
-      assert.equal(await contractForDifference.contractState(), 0); // state should be Open before.
-      await contractForDifference.expire();
-      assert.equal(await contractForDifference.contractState(), 1); // state should be ExpiredPriceRequested before.
+      assert.equal(await longShortPair.contractState(), 0); // state should be Open before.
+      await longShortPair.expire();
+      assert.equal(await longShortPair.contractState(), 1); // state should be ExpiredPriceRequested before.
 
       await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
 
       // Redemption value scaled between 0 and 1, indicating how much of the collateralPerPair is split between the long and
       // short tokens. Setting to 0.5 makes each long token worth 0.5 collateral and each short token worth 0.5 collateral.
 
-      await contractForDifferenceLibrary.setValueToReturn(toWei("0.5"));
+      await longShortPairLibrary.setValueToReturn(toWei("0.5"));
 
-      await contractForDifference.settle(toWei("50"), toWei("0"), { from: holder }); // holder redeem their 50 long tokens.
+      await longShortPair.settle(toWei("50"), toWei("0"), { from: holder }); // holder redeem their 50 long tokens.
       assert.equal(await longToken.balanceOf(holder), toWei("0")); // they should have no long tokens left.
       assert.equal((await collateralToken.balanceOf(holder)).toString(), toWei("25")); // they should have gotten 0.5 collateral per synthetic.
 
       // Sponsor redeem remaining tokens. They return the remaining 25 long and 75 short. Each should be redeemable for 0.5 collateral.
-      await contractForDifference.settle(toWei("25"), toWei("75"), { from: sponsor });
+      await longShortPair.settle(toWei("25"), toWei("75"), { from: sponsor });
 
       assert.equal(await longToken.balanceOf(sponsor), toWei("0"));
       assert.equal(await longToken.balanceOf(sponsor), toWei("0"));
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), toWei("975")); // 925 after redemption + 12.5 redeemed for long and 37.5 for short.
 
       // Contract for difference should have no collateral left in it as everything has been redeemed.
-      assert.equal((await collateralToken.balanceOf(contractForDifference.address)).toString(), toWei("0"));
+      assert.equal((await collateralToken.balanceOf(longShortPair.address)).toString(), toWei("0"));
     });
     it("Events are correctly emitted", async function () {
-      await collateralToken.approve(contractForDifference.address, MAX_UINT_VAL, { from: sponsor });
-      const createTx = await contractForDifference.create(toWei("100"), { from: sponsor });
+      await collateralToken.approve(longShortPair.address, MAX_UINT_VAL, { from: sponsor });
+      const createTx = await longShortPair.create(toWei("100"), { from: sponsor });
 
       truffleAssert.eventEmitted(createTx, "TokensCreated", (ev) => {
         return ev.sponsor == sponsor && ev.collateralUsed == toWei("100") && ev.tokensMinted == toWei("100");
       });
 
-      const redeemTx = await contractForDifference.redeem(toWei("25"), { from: sponsor });
+      const redeemTx = await longShortPair.redeem(toWei("25"), { from: sponsor });
 
       truffleAssert.eventEmitted(redeemTx, "TokensRedeemed", (ev) => {
         return ev.sponsor == sponsor && ev.collateralReturned == toWei("25") && ev.tokensRedeemed == toWei("25");
@@ -228,7 +218,7 @@ contract("ContractForDifference", function (accounts) {
       // Advance past the expiry timestamp and settle the contract.
       await timer.setCurrentTime(expirationTimestamp + 1);
 
-      const expireTx = await contractForDifference.expire();
+      const expireTx = await longShortPair.expire();
 
       truffleAssert.eventEmitted(expireTx, "ContractExpired", (ev) => {
         return ev.caller == deployer;
@@ -236,9 +226,9 @@ contract("ContractForDifference", function (accounts) {
 
       await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
 
-      await contractForDifferenceLibrary.setValueToReturn(toWei("0.5"));
+      await longShortPairLibrary.setValueToReturn(toWei("0.5"));
 
-      const settleTx = await contractForDifference.settle(toWei("75"), toWei("75"), { from: sponsor });
+      const settleTx = await longShortPair.settle(toWei("75"), toWei("75"), { from: sponsor });
 
       truffleAssert.eventEmitted(settleTx, "PositionSettled", (ev) => {
         return (
@@ -251,9 +241,9 @@ contract("ContractForDifference", function (accounts) {
     });
     it("Ancillary data is correctly set in the OO", async function () {
       await timer.setCurrentTime(expirationTimestamp + 1);
-      await contractForDifference.expire();
+      await longShortPair.expire();
       const request = await optimisticOracle.getRequest(
-        contractForDifference.address,
+        longShortPair.address,
         priceFeedIdentifier,
         expirationTimestamp,
         ancillaryData
@@ -264,63 +254,63 @@ contract("ContractForDifference", function (accounts) {
   });
   describe("Settlement Functionality", () => {
     // Create a position, advance time, expire contract and propose price. Manually set different expiryPercentLong values
-    // using the test contractForDifferenceLibrary that bypass the OO return value so we dont need to test the lib here.
+    // using the test longShortPairLibrary that bypass the OO return value so we dont need to test the lib here.
     let sponsorCollateralBefore;
     beforeEach(async () => {
-      await collateralToken.approve(contractForDifference.address, MAX_UINT_VAL, { from: sponsor });
-      await contractForDifference.create(toWei("100"), { from: sponsor });
+      await collateralToken.approve(longShortPair.address, MAX_UINT_VAL, { from: sponsor });
+      await longShortPair.create(toWei("100"), { from: sponsor });
       await timer.setCurrentTime(expirationTimestamp + 1);
-      await contractForDifference.expire();
+      await longShortPair.expire();
       await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
       sponsorCollateralBefore = await collateralToken.balanceOf(sponsor);
     });
     it("expiryPercentLong = 1 should give all collateral to long tokens", async function () {
-      await contractForDifferenceLibrary.setValueToReturn(toWei("1"));
+      await longShortPairLibrary.setValueToReturn(toWei("1"));
 
       // Redeeming only short tokens should send 0 collateral as the short tokens are worthless.
-      await contractForDifference.settle(toWei("0"), toWei("100"), { from: sponsor });
+      await longShortPair.settle(toWei("0"), toWei("100"), { from: sponsor });
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), sponsorCollateralBefore.toString());
 
       // Redeeming the long tokens should send the full amount of collateral to the sponsor.
-      await contractForDifference.settle(toWei("100"), toWei("0"), { from: sponsor });
+      await longShortPair.settle(toWei("100"), toWei("0"), { from: sponsor });
       assert.equal(
         (await collateralToken.balanceOf(sponsor)).toString(),
         sponsorCollateralBefore.add(toBN(toWei("100"))).toString()
       );
     });
     it("expiryPercentLong = 0 should give all collateral to short tokens", async function () {
-      await contractForDifferenceLibrary.setValueToReturn(toWei("0"));
+      await longShortPairLibrary.setValueToReturn(toWei("0"));
       // Redeeming only long tokens should send 0 collateral as the long tokens are worthless.
-      await contractForDifference.settle(toWei("100"), toWei("0"), { from: sponsor });
+      await longShortPair.settle(toWei("100"), toWei("0"), { from: sponsor });
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), sponsorCollateralBefore.toString());
 
       // Redeeming the short tokens should send the full amount of collateral to the sponsor.
-      await contractForDifference.settle(toWei("0"), toWei("100"), { from: sponsor });
+      await longShortPair.settle(toWei("0"), toWei("100"), { from: sponsor });
       assert.equal(
         (await collateralToken.balanceOf(sponsor)).toString(),
         sponsorCollateralBefore.add(toBN(toWei("100"))).toString()
       );
     });
     it("expiryTokensForCollateral > 1 should ceil to 1", async function () {
-      // anything above 1 for the expiryPercentLong is nonsensical and the CFD should act as if it's set to 1.
-      await contractForDifferenceLibrary.setValueToReturn(toWei("1.5"));
+      // anything above 1 for the expiryPercentLong is nonsensical and the LSP should act as if it's set to 1.
+      await longShortPairLibrary.setValueToReturn(toWei("1.5"));
 
       // Redeeming long short tokens should send no collateral.
-      await contractForDifference.settle(toWei("0"), toWei("100"), { from: sponsor });
+      await longShortPair.settle(toWei("0"), toWei("100"), { from: sponsor });
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), sponsorCollateralBefore.toString());
 
       // Redeeming long tokens should send all the collateral.
-      await contractForDifference.settle(toWei("100"), toWei("0"), { from: sponsor });
+      await longShortPair.settle(toWei("100"), toWei("0"), { from: sponsor });
       assert.equal(
         (await collateralToken.balanceOf(sponsor)).toString(),
         sponsorCollateralBefore.add(toBN(toWei("100"))).toString()
       );
     });
     it("expiryPercentLong = 0.25 should give 25% to long and 75% to short", async function () {
-      await contractForDifferenceLibrary.setValueToReturn(toWei("0.25"));
+      await longShortPairLibrary.setValueToReturn(toWei("0.25"));
 
       // Redeeming long tokens should send 25% of the collateral.
-      await contractForDifference.settle(toWei("100"), toWei("0"), { from: sponsor });
+      await longShortPair.settle(toWei("100"), toWei("0"), { from: sponsor });
       assert.equal(
         (await collateralToken.balanceOf(sponsor)).toString(),
         sponsorCollateralBefore.add(toBN(toWei("25"))).toString()
@@ -328,7 +318,7 @@ contract("ContractForDifference", function (accounts) {
       const sponsorCollateralAfterLongRedeem = await collateralToken.balanceOf(sponsor);
 
       // Redeeming short tokens should send the remaining 75% of the collateral.
-      await contractForDifference.settle(toWei("0"), toWei("100"), { from: sponsor });
+      await longShortPair.settle(toWei("0"), toWei("100"), { from: sponsor });
       assert.equal(
         (await collateralToken.balanceOf(sponsor)).toString(),
         sponsorCollateralAfterLongRedeem.add(toBN(toWei("75"))).toString()
@@ -336,35 +326,35 @@ contract("ContractForDifference", function (accounts) {
     });
     it("Cannot settle more tokens than in wallet", async function () {
       // Sponsor only has 100 long and 100 short. anything more than this should revert.
-      assert(await didContractThrow(contractForDifference.settle(toWei("110"), toWei("100"), { from: sponsor })));
+      assert(await didContractThrow(longShortPair.settle(toWei("110"), toWei("100"), { from: sponsor })));
     });
   });
   describe("Contract States", () => {
     beforeEach(async () => {
-      await collateralToken.approve(contractForDifference.address, MAX_UINT_VAL, { from: sponsor });
-      await contractForDifference.create(toWei("100"), { from: sponsor });
+      await collateralToken.approve(longShortPair.address, MAX_UINT_VAL, { from: sponsor });
+      await longShortPair.create(toWei("100"), { from: sponsor });
     });
     it("Can not expire pre expirationTimestamp", async function () {
-      assert(await didContractThrow(contractForDifference.expire()));
-      assert(await didContractThrow(contractForDifference.settle(toWei("100"), toWei("100"), { from: sponsor })));
+      assert(await didContractThrow(longShortPair.expire()));
+      assert(await didContractThrow(longShortPair.settle(toWei("100"), toWei("100"), { from: sponsor })));
     });
     it("Can not create or redeem post expiry", async function () {
       await timer.setCurrentTime(expirationTimestamp + 1);
-      assert(await didContractThrow(contractForDifference.create(toWei("100"))), { from: sponsor });
-      assert(await didContractThrow(contractForDifference.redeem(toWei("100"))), { from: sponsor });
+      assert(await didContractThrow(longShortPair.create(toWei("100"))), { from: sponsor });
+      assert(await didContractThrow(longShortPair.redeem(toWei("100"))), { from: sponsor });
     });
     it("Can not settle before price returned from OO", async function () {
       // Set time after expiration, add a price to OO but dont pass OO liveness.
       await timer.setCurrentTime(expirationTimestamp + 1);
-      await contractForDifference.expire();
+      await longShortPair.expire();
       await optimisticOracle.proposePrice(
-        contractForDifference.address,
+        longShortPair.address,
         priceFeedIdentifier,
         expirationTimestamp,
         ancillaryData,
         toWei("0.5")
       );
-      assert(await didContractThrow(contractForDifference.settle(toWei("100"), toWei("100"), { from: sponsor })));
+      assert(await didContractThrow(longShortPair.settle(toWei("100"), toWei("100"), { from: sponsor })));
     });
   });
 });

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
@@ -6,11 +6,9 @@ const { assert } = require("chai");
 const { interfaceName, didContractThrow, ZERO_ADDRESS } = require("@uma/common");
 
 // Tested Contract
-const ContractForDifference = artifacts.require("ContractForDifference");
-const ContractForDifferenceCreator = artifacts.require("ContractForDifferenceCreator");
-const ContractForDifferenceFinancialProjectLibraryTest = artifacts.require(
-  "ContractForDifferenceFinancialProjectLibraryTest"
-);
+const LongShortPair = artifacts.require("LongShortPair");
+const LongShortPairCreator = artifacts.require("LongShortPairCreator");
+const LongShortPairFinancialProjectLibraryTest = artifacts.require("LongShortPairFinancialProjectLibraryTest");
 
 // Helper contracts
 const AddressWhitelist = artifacts.require("AddressWhitelist");
@@ -22,8 +20,8 @@ const Token = artifacts.require("ExpandedERC20");
 const TokenFactory = artifacts.require("TokenFactory");
 
 let collateralToken;
-let contractForDifferenceLibrary;
-let contractForDifferenceCreator;
+let longShortPairLibrary;
+let longShortPairCreator;
 let collateralWhitelist;
 let identifierWhitelist;
 let optimisticOracle;
@@ -36,11 +34,11 @@ const expirationTimestamp = startTimestamp + 10000;
 const optimisticOracleLiveness = 7200;
 const priceFeedIdentifier = utf8ToHex("TEST_IDENTIFIER");
 const collateralPerPair = toWei("1"); // each pair of long and short tokens need 1 unit of collateral to mint.
-const syntheticName = "Test CFD";
+const syntheticName = "Test LSP";
 const syntheticSymbol = "tCFD";
 const ancillaryData = web3.utils.utf8ToHex("some-address-field:0x1234");
 
-contract("ContractForDifferenceCreator", function (accounts) {
+contract("LongShortPairCreator", function (accounts) {
   const deployer = accounts[0];
   const sponsor = accounts[1];
 
@@ -68,13 +66,13 @@ contract("ContractForDifferenceCreator", function (accounts) {
       from: deployer,
     });
 
-    contractForDifferenceCreator = await ContractForDifferenceCreator.new(
+    longShortPairCreator = await LongShortPairCreator.new(
       finder.address,
       (await TokenFactory.deployed()).address,
       timer.address
     );
 
-    contractForDifferenceLibrary = await ContractForDifferenceFinancialProjectLibraryTest.new();
+    longShortPairLibrary = await LongShortPairFinancialProjectLibraryTest.new();
 
     // Define an object to easily re-use constructor params
     constructorParams = {
@@ -84,28 +82,24 @@ contract("ContractForDifferenceCreator", function (accounts) {
       syntheticName,
       syntheticSymbol,
       collateralAddress: collateralToken.address,
-      financialProductLibraryAddress: contractForDifferenceLibrary.address,
+      financialProductLibraryAddress: longShortPairLibrary.address,
       ancillaryData,
     };
   });
 
-  it("Can correctly create a CFD with valid params", async function () {
-    // Can create a new CFD with the creator.
-    const cfdAddress = await contractForDifferenceCreator.createContractForDifference.call(
-      ...Object.values(constructorParams)
-    );
+  it("Can correctly create a LSP with valid params", async function () {
+    // Can create a new LSP with the creator.
+    const cfdAddress = await longShortPairCreator.createLongShortPair.call(...Object.values(constructorParams));
 
-    const cfdCreateTx = await contractForDifferenceCreator.createContractForDifference(
-      ...Object.values(constructorParams)
-    );
+    const cfdCreateTx = await longShortPairCreator.createLongShortPair(...Object.values(constructorParams));
 
     // Event should be emitted correctly.
-    truffleAssert.eventEmitted(cfdCreateTx, "CreatedContractForDifference", (ev) => {
-      return ev.contractForDifference == cfdAddress && ev.deployerAddress == deployer;
+    truffleAssert.eventEmitted(cfdCreateTx, "CreatedLongShortPair", (ev) => {
+      return ev.LongShortPair == cfdAddress && ev.deployerAddress == deployer;
     });
 
-    // Validate CFD parameters are set correctly.
-    const cfd = await ContractForDifference.at(cfdAddress);
+    // Validate LSP parameters are set correctly.
+    const cfd = await LongShortPair.at(cfdAddress);
     assert.equal(await cfd.expirationTimestamp(), expirationTimestamp);
     assert.equal((await cfd.collateralPerPair()).toString(), collateralPerPair.toString());
     assert.equal(hexToUtf8(await cfd.priceIdentifier()), hexToUtf8(priceFeedIdentifier));
@@ -132,14 +126,13 @@ contract("ContractForDifferenceCreator", function (accounts) {
   it("Correctly respects non-18 decimal collateral currencies", async function () {
     const non18Collateral = await Token.new("USD Coin", "USDC", 6, { from: deployer });
     await collateralWhitelist.addToWhitelist(non18Collateral.address);
-    await contractForDifferenceCreator.createContractForDifference(
+    await longShortPairCreator.createLongShortPair(
       ...Object.values({ ...constructorParams, collateralAddress: non18Collateral.address })
     );
 
-    const cfdAddress = (await contractForDifferenceCreator.getPastEvents("CreatedContractForDifference"))[0]
-      .returnValues.contractForDifference;
+    const cfdAddress = (await longShortPairCreator.getPastEvents("CreatedLongShortPair"))[0].returnValues.LongShortPair;
 
-    const cfd = await ContractForDifference.at(cfdAddress);
+    const cfd = await LongShortPair.at(cfdAddress);
 
     assert.equal(await (await Token.at(await cfd.longToken())).decimals(), "6");
     assert.equal(await (await Token.at(await cfd.shortToken())).decimals(), "6");
@@ -148,7 +141,7 @@ contract("ContractForDifferenceCreator", function (accounts) {
   it("Rejects on past expirationTimestamp", async function () {
     assert(
       await didContractThrow(
-        contractForDifferenceCreator.createContractForDifference(
+        longShortPairCreator.createLongShortPair(
           ...Object.values({ ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 100 })
         )
       )
@@ -157,7 +150,7 @@ contract("ContractForDifferenceCreator", function (accounts) {
   it("Rejects on unregistered priceIdentifier", async function () {
     assert(
       await didContractThrow(
-        contractForDifferenceCreator.createContractForDifference(
+        longShortPairCreator.createLongShortPair(
           ...Object.values({ ...constructorParams, priceFeedIdentifier: utf8ToHex("UNREGISTERED_IDENTIFIER") })
         )
       )
@@ -166,7 +159,7 @@ contract("ContractForDifferenceCreator", function (accounts) {
   it("Rejects on unregistered collateralToken", async function () {
     assert(
       await didContractThrow(
-        contractForDifferenceCreator.createContractForDifference(
+        longShortPairCreator.createLongShortPair(
           ...Object.values({ ...constructorParams, collateralAddress: ZERO_ADDRESS })
         )
       )
@@ -175,7 +168,7 @@ contract("ContractForDifferenceCreator", function (accounts) {
   it("Rejects on invalid financialProductLibrary", async function () {
     assert(
       await didContractThrow(
-        contractForDifferenceCreator.createContractForDifference(
+        longShortPairCreator.createLongShortPair(
           ...Object.values({ ...constructorParams, financialProductLibraryAddress: ZERO_ADDRESS })
         )
       )
@@ -184,16 +177,12 @@ contract("ContractForDifferenceCreator", function (accounts) {
   it("Rejects on invalid synthetic token details", async function () {
     assert(
       await didContractThrow(
-        contractForDifferenceCreator.createContractForDifference(
-          ...Object.values({ ...constructorParams, syntheticName: "" })
-        )
+        longShortPairCreator.createLongShortPair(...Object.values({ ...constructorParams, syntheticName: "" }))
       )
     );
     assert(
       await didContractThrow(
-        contractForDifferenceCreator.createContractForDifference(
-          ...Object.values({ ...constructorParams, syntheticSymbol: "" })
-        )
+        longShortPairCreator.createLongShortPair(...Object.values({ ...constructorParams, syntheticSymbol: "" }))
       )
     );
   });

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
@@ -89,39 +89,39 @@ contract("LongShortPairCreator", function (accounts) {
 
   it("Can correctly create a LSP with valid params", async function () {
     // Can create a new LSP with the creator.
-    const cfdAddress = await longShortPairCreator.createLongShortPair.call(...Object.values(constructorParams));
+    const lspAddress = await longShortPairCreator.createLongShortPair.call(...Object.values(constructorParams));
 
-    const cfdCreateTx = await longShortPairCreator.createLongShortPair(...Object.values(constructorParams));
+    const lspCreateTx = await longShortPairCreator.createLongShortPair(...Object.values(constructorParams));
 
     // Event should be emitted correctly.
-    truffleAssert.eventEmitted(cfdCreateTx, "CreatedLongShortPair", (ev) => {
-      return ev.LongShortPair == cfdAddress && ev.deployerAddress == deployer;
+    truffleAssert.eventEmitted(lspCreateTx, "CreatedLongShortPair", (ev) => {
+      return ev.LongShortPair == lspAddress && ev.deployerAddress == deployer;
     });
 
     // Validate LSP parameters are set correctly.
-    const cfd = await LongShortPair.at(cfdAddress);
-    assert.equal(await cfd.expirationTimestamp(), expirationTimestamp);
-    assert.equal((await cfd.collateralPerPair()).toString(), collateralPerPair.toString());
-    assert.equal(hexToUtf8(await cfd.priceIdentifier()), hexToUtf8(priceFeedIdentifier));
-    assert.equal(await cfd.collateralToken(), collateralToken.address);
-    assert.equal(await cfd.customAncillaryData(), ancillaryData);
+    const lsp = await LongShortPair.at(lspAddress);
+    assert.equal(await lsp.expirationTimestamp(), expirationTimestamp);
+    assert.equal((await lsp.collateralPerPair()).toString(), collateralPerPair.toString());
+    assert.equal(hexToUtf8(await lsp.priceIdentifier()), hexToUtf8(priceFeedIdentifier));
+    assert.equal(await lsp.collateralToken(), collateralToken.address);
+    assert.equal(await lsp.customAncillaryData(), ancillaryData);
 
     // Validate token information and permissions are set correctly.
-    const longToken = await Token.at(await cfd.longToken());
+    const longToken = await Token.at(await lsp.longToken());
     assert.equal(await longToken.name(), syntheticName + " Long Token");
     assert.equal(await longToken.symbol(), "l" + syntheticSymbol);
     assert.equal((await longToken.decimals()).toString(), (await collateralToken.decimals()).toString());
-    assert.isTrue(await longToken.holdsRole("0", cfdAddress));
-    assert.isTrue(await longToken.holdsRole("1", cfdAddress));
-    assert.isTrue(await longToken.holdsRole("2", cfdAddress));
+    assert.isTrue(await longToken.holdsRole("0", lspAddress));
+    assert.isTrue(await longToken.holdsRole("1", lspAddress));
+    assert.isTrue(await longToken.holdsRole("2", lspAddress));
 
-    const shortToken = await Token.at(await cfd.shortToken());
+    const shortToken = await Token.at(await lsp.shortToken());
     assert.equal(await shortToken.name(), syntheticName + " Short Token");
     assert.equal(await shortToken.symbol(), "s" + syntheticSymbol);
     assert.equal((await shortToken.decimals()).toString(), (await collateralToken.decimals()).toString());
-    assert.isTrue(await shortToken.holdsRole("0", cfdAddress));
-    assert.isTrue(await shortToken.holdsRole("1", cfdAddress));
-    assert.isTrue(await shortToken.holdsRole("2", cfdAddress));
+    assert.isTrue(await shortToken.holdsRole("0", lspAddress));
+    assert.isTrue(await shortToken.holdsRole("1", lspAddress));
+    assert.isTrue(await shortToken.holdsRole("2", lspAddress));
   });
   it("Correctly respects non-18 decimal collateral currencies", async function () {
     const non18Collateral = await Token.new("USD Coin", "USDC", 6, { from: deployer });
@@ -130,12 +130,12 @@ contract("LongShortPairCreator", function (accounts) {
       ...Object.values({ ...constructorParams, collateralAddress: non18Collateral.address })
     );
 
-    const cfdAddress = (await longShortPairCreator.getPastEvents("CreatedLongShortPair"))[0].returnValues.LongShortPair;
+    const lspAddress = (await longShortPairCreator.getPastEvents("CreatedLongShortPair"))[0].returnValues.LongShortPair;
 
-    const cfd = await LongShortPair.at(cfdAddress);
+    const lsp = await LongShortPair.at(lspAddress);
 
-    assert.equal(await (await Token.at(await cfd.longToken())).decimals(), "6");
-    assert.equal(await (await Token.at(await cfd.shortToken())).decimals(), "6");
+    assert.equal(await (await Token.at(await lsp.longToken())).decimals(), "6");
+    assert.equal(await (await Token.at(await lsp.shortToken())).decimals(), "6");
   });
 
   it("Rejects on past expirationTimestamp", async function () {


### PR DESCRIPTION
**Motivation**

The UMA team has chosen to re-name the "contract for difference" (CFD) to "long short pair" (LSP). This PR updates the contracts and tests through the `core` package to this effect.
