### PR TITLE
fix(common): explicitly require the hardhat etherscan verification plugin

### DIFF
--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -8,6 +8,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
   require("hardhat-gas-reporter");
   require("@nomiclabs/hardhat-web3");
   require("hardhat-deploy");
+  require("@nomiclabs/hardhat-etherscan");
 
   // Custom tasks to interact conveniently with smart contracts.
   require("./hardhat/tasks");


### PR DESCRIPTION
**Motivation**

The [hardhat docs](https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html) say you need to require the plugin in the config. We don't currently do this in our config.

Right now: `hardhat etherscan-verify` seems to work. However, this command seems to be slightly different from `hardhat verify`, which doesn't work unless the plugin is added to the config.

Not sure why this is this is the case or what the deep differences are, but we should do as recommended and put it in the config.

**Summary**

Added the require to the config.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
