### PR TITLE
fix(OO): Address wrong log pathing

### DIFF
--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -156,6 +156,7 @@ async function Poll(callback) {
       at: "OptimisticOracle#index",
       message: "OO proposer execution error🚨",
       error: typeof error === "string" ? new Error(error) : error,
+      notificationPath: "infrastructure-error",
     });
     await waitForLogger(Logger);
     callback(error);


### PR DESCRIPTION
**Motivation**

The OO is missing a notification path which means that its logs are sometimes sent to the wrong chat on slack. this PR address this by updating the notification path to match that of the other bots.

**Summary**

updates a log in the OO.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

Fixes #XXXX
