### PR TITLE
fix(LSP): Prevent parameter override on Range Bond Lib

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -63,6 +63,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         require(highPriceRange > lowPriceRange, "Invalid bounds");
 
         RangeBondLongShortPairParameters memory params = longShortPairParameters[LongShortPair];
+        require(params.highPriceRange == 0 && params.lowPriceRange == 0, "Parameters already set");
 
         longShortPairParameters[LongShortPair] = RangeBondLongShortPairParameters({
             highPriceRange: highPriceRange,

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
@@ -34,22 +34,12 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       assert.equal(setParams.highPriceRange.toString(), highPriceRange);
     });
     it("Can not re-use existing LSP contract address", async () => {
-      await rangeBondLSPFPL.setLongShortPairParameters(
-        lspMock.address,
-
-        highPriceRange,
-        lowPriceRange
-      );
+      await rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange);
 
       // Second attempt should revert.
       assert(
         await didContractThrow(
-          rangeBondLSPFPL.setLongShortPairParameters(
-            lspMock.address,
-
-            lowPriceRange,
-            highPriceRange
-          )
+          rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, highPriceRange, lowPriceRange)
         )
       );
     });
@@ -57,12 +47,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // upper bound larger than lower bound by swapping upper and lower
       assert(
         await didContractThrow(
-          rangeBondLSPFPL.setLongShortPairParameters(
-            lspMock.address,
-
-            lowPriceRange,
-            highPriceRange
-          )
+          rangeBondLSPFPL.setLongShortPairParameters(lspMock.address, lowPriceRange, highPriceRange)
         )
       );
     });


### PR DESCRIPTION
**Motivation**

There was a small but substantial bug in the `RangeBondLongShortPairFinancialProductLibrary.sol` that enabled the bond's params to be overridden. Clearly, this is undesirable behavior as it could lead to a malicious actor affecting settlement differently from the original contract parameterization. This PR fixes this bug as well as the tests that were showing up false positives on this test case.

**Summary**

Updated the contracts and tests to address a bug in an LSP contract.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

