### PR TITLE
fix(LSP): Add missing rentrancy modifiers

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
@@ -51,7 +51,13 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
+    function computeExpiryTokensForCollateral(int256 expiryPrice)
+        public
+        view
+        override
+        nonReentrantView()
+        returns (uint256)
+    {
         BinaryLongShortPairParameters memory params = longShortPairParameters[msg.sender];
         require(params.isSet, "Params not set for calling LSP");
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
@@ -47,7 +47,13 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
+    function computeExpiryTokensForCollateral(int256 expiryPrice)
+        public
+        view
+        override
+        nonReentrantView()
+        returns (uint256)
+    {
         uint256 contractStrikePrice = longShortPairStrikePrices[msg.sender];
 
         // If the expiry price is less than the strike price then the long options expire worthless (out of the money).

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -65,7 +65,13 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
+    function computeExpiryTokensForCollateral(int256 expiryPrice)
+        public
+        view
+        override
+        nonReentrantView()
+        returns (uint256)
+    {
         LinearLongShortPairParameters memory params = longShortPairParameters[msg.sender];
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -76,7 +76,13 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice) public view override returns (uint256) {
+    function computeExpiryTokensForCollateral(int256 expiryPrice)
+        public
+        view
+        override
+        nonReentrantView()
+        returns (uint256)
+    {
         RangeBondLongShortPairParameters memory params = longShortPairParameters[msg.sender];
 
         // expiryPercentLong=[min(max(1/R2,1/P),1/R1)]/(1/R1)

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -162,7 +162,7 @@ contract LongShortPair is Testable, Lockable {
      * @param tokensToCreate number of long and short synthetic tokens to create.
      * @return collateralUsed total collateral used to mint the synthetics.
      */
-    function create(uint256 tokensToCreate) public preExpiration() returns (uint256 collateralUsed) {
+    function create(uint256 tokensToCreate) public preExpiration() nonReentrant() returns (uint256 collateralUsed) {
         collateralUsed = FixedPoint.Unsigned(tokensToCreate).mul(FixedPoint.Unsigned(collateralPerPair)).rawValue;
 
         collateralToken.safeTransferFrom(msg.sender, address(this), collateralUsed);

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -128,10 +128,6 @@ contract LongShortPairCreator is Testable, Lockable {
         return lspAddress;
     }
 
-    /****************************************
-     *          PRIVATE FUNCTIONS           *
-     ****************************************/
-
     // IERC20Standard.decimals() will revert if the collateral contract has not implemented the decimals() method,
     // which is possible since the method is only an OPTIONAL method in the ERC20 standard:
     // https://eips.ethereum.org/EIPS/eip-20#methods.


### PR DESCRIPTION
**Motivation**

As a general rule, all public methods in the `core` package's smart contracts should include `nonReentrant` and  `nonReetrantView` modifiers. the LSP was missing these modifiers in a number of key places, in particular the `create` function in the `LongShortPair` that is used in the minting of LSP tokens. 

**Summary**

Adds `nonReentrant` and  `nonReetrantView` modifieriers to required locations in smart contract code.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested