### PR TITLE
fix: update api package name to be under @uma

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api",
+  "name": "@uma/api",
   "private": true,
   "version": "0.2.0",
   "author": "David Adams",
@@ -43,5 +43,9 @@
     "prettier": "prettier './**/*.md' './src/**/*.ts'",
     "lint": "yarn prettier --write && yarn eslint --fix",
     "api": "ts-node src/start api"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com/",
+    "access": "public"
   }
 }


### PR DESCRIPTION
**Motivation**

api package is being published under the name `api` rather than `@uma/api`.

**Summary**

Updated the package.json.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
