### PR TITLE
fix(core): fix polygon deployent scripts for test/local environments

### DIFF
--- a/packages/core/deploy/023_deploy_state_sync_mock.js
+++ b/packages/core/deploy/023_deploy_state_sync_mock.js
@@ -1,0 +1,14 @@
+const func = async function (hre) {
+  const { getNamedAccounts, deployments } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+  await deploy("StateSyncMock", {
+    from: deployer,
+    args: [],
+    log: true,
+  });
+};
+module.exports = func;
+func.tags = ["StateSyncMock", "test"];
+module.exports.dependencies = [];

--- a/packages/core/deploy/024_deploy_fx_root_mock.js
+++ b/packages/core/deploy/024_deploy_fx_root_mock.js
@@ -1,0 +1,17 @@
+const func = async function (hre) {
+  const { getNamedAccounts, deployments } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+
+  const StateSyncMock = await deployments.get("StateSyncMock");
+
+  await deploy("FxRootMock", {
+    from: deployer,
+    args: [StateSyncMock.address],
+    log: true,
+  });
+};
+module.exports = func;
+func.tags = ["FxRootMock", "test"];
+module.exports.dependencies = ["StateSyncMock"];

--- a/packages/core/deploy/025_deploy_fx_child_mock.js
+++ b/packages/core/deploy/025_deploy_fx_child_mock.js
@@ -1,0 +1,15 @@
+const func = async function (hre) {
+  const { getNamedAccounts, deployments } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+
+  await deploy("FxChildMock", {
+    from: deployer,
+    args: [deployer], // Set deployer as the systemSuperUser.
+    log: true,
+  });
+};
+module.exports = func;
+func.tags = ["FxChildMock", "test"];
+module.exports.dependencies = [];

--- a/packages/core/deploy/026_deploy_oracle_root_tunnel.js
+++ b/packages/core/deploy/026_deploy_oracle_root_tunnel.js
@@ -19,11 +19,15 @@ const func = async function (hre) {
   const chainId = await getChainId();
   const Finder = await deployments.get("Finder");
 
-  const args = [
-    ADDRESSES_FOR_NETWORK[chainId].checkpointManager,
-    ADDRESSES_FOR_NETWORK[chainId].fxRoot,
-    Finder.address,
-  ];
+  let args;
+  if (ADDRESSES_FOR_NETWORK[chainId]) {
+    args = [ADDRESSES_FOR_NETWORK[chainId].checkpointManager, ADDRESSES_FOR_NETWORK[chainId].fxRoot, Finder.address];
+  } else {
+    // Fall back to mocks if hardhcoded addresses aren't there.
+    const FxRootMock = await deployments.get("FxRootMock");
+    args = [deployer, FxRootMock.address, Finder.address]; // Note: uses deployer as the checkpoint manager.
+  }
+
   await deploy("OracleRootTunnel", {
     from: deployer,
     args,

--- a/packages/core/deploy/027_deploy_oracle_child_tunnel.js
+++ b/packages/core/deploy/027_deploy_oracle_child_tunnel.js
@@ -11,13 +11,22 @@ const func = async function (hre) {
   const { deployer } = await getNamedAccounts();
 
   const chainId = await getChainId();
+  const Finder = await deployments.get("Finder");
 
-  const args = [ADDRESSES_FOR_NETWORK[chainId].fxChild];
-  await deploy("GovernorChildTunnel", {
+  let args;
+  if (ADDRESSES_FOR_NETWORK[chainId]) {
+    args = [ADDRESSES_FOR_NETWORK[chainId].fxChild, Finder.address];
+  } else {
+    // Fall back to mocks if hardhcoded addresses aren't there.
+    const FxChildMock = await deployments.get("FxChildMock");
+    args = [FxChildMock.address, Finder.address];
+  }
+
+  await deploy("OracleChildTunnel", {
     from: deployer,
     args,
     log: true,
   });
 };
 module.exports = func;
-func.tags = ["GovernorChildTunnel", "l2-polygon"];
+func.tags = ["OracleChildTunnel", "l2-polygon"];

--- a/packages/core/deploy/028_deploy_governor_child_tunnel.js
+++ b/packages/core/deploy/028_deploy_governor_child_tunnel.js
@@ -11,14 +11,21 @@ const func = async function (hre) {
   const { deployer } = await getNamedAccounts();
 
   const chainId = await getChainId();
-  const Finder = await deployments.get("Finder");
 
-  const args = [ADDRESSES_FOR_NETWORK[chainId].fxChild, Finder.address];
-  await deploy("OracleChildTunnel", {
+  let args;
+  if (ADDRESSES_FOR_NETWORK[chainId]) {
+    args = [ADDRESSES_FOR_NETWORK[chainId].fxChild];
+  } else {
+    // Fall back to mocks if hardhcoded addresses aren't there.
+    const FxChildMock = await deployments.get("FxChildMock");
+    args = [FxChildMock.address];
+  }
+
+  await deploy("GovernorChildTunnel", {
     from: deployer,
     args,
     log: true,
   });
 };
 module.exports = func;
-func.tags = ["OracleChildTunnel", "l2-polygon"];
+func.tags = ["GovernorChildTunnel", "l2-polygon"];

--- a/packages/core/deploy/029_deploy_governor_root_tunnel.js
+++ b/packages/core/deploy/029_deploy_governor_root_tunnel.js
@@ -18,7 +18,15 @@ const func = async function (hre) {
 
   const chainId = await getChainId();
 
-  const args = [ADDRESSES_FOR_NETWORK[chainId].checkpointManager, ADDRESSES_FOR_NETWORK[chainId].fxRoot];
+  let args;
+  if (ADDRESSES_FOR_NETWORK[chainId]) {
+    args = [ADDRESSES_FOR_NETWORK[chainId].checkpointManager, ADDRESSES_FOR_NETWORK[chainId].fxRoot];
+  } else {
+    // Fall back to mocks if hardhcoded addresses aren't there.
+    const FxRootMock = await deployments.get("FxRootMock");
+    args = [deployer, FxRootMock.address]; // Note: uses deployer as the checkpoint manager.
+  }
+
   await deploy("GovernorRootTunnel", {
     from: deployer,
     args,


### PR DESCRIPTION
**Motivation**

Polygon bridge contracts fail to deploy on networks other than those with hardcoded addresses in the deployment scripts (including local networks needed for testing).

**Summary**

Mocks were added to deployment process as a fallback in case these hardcoded addresses aren't present. These mocks are tagged with `test` and their names so they won't be deployed as a part of a typical l2 polygon deployment unless specifically added.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
