### PR TITLE
fix(LSP): Audit nits and cleanup

### DIFF
--- a/packages/core/contracts/common/implementation/Lockable.sol
+++ b/packages/core/contracts/common/implementation/Lockable.sol
@@ -10,21 +10,18 @@ contract Lockable {
     bool private _notEntered;
 
     constructor() {
-        // Storing an initial non-zero value makes deployment a bit more
-        // expensive, but in exchange the refund on every call to nonReentrant
-        // will be lower in amount. Since refunds are capped to a percetange of
-        // the total transaction's gas, it is best to keep them low in cases
-        // like this one, to increase the likelihood of the full refund coming
-        // into effect.
+        // Storing an initial non-zero value makes deployment a bit more expensive, but in exchange the refund on every
+        // call to nonReentrant will be lower in amount. Since refunds are capped to a percentage of the total
+        // transaction's gas, it is best to keep them low in cases like this one, to increase the likelihood of the full
+        // refund coming into effect.
         _notEntered = true;
     }
 
     /**
      * @dev Prevents a contract from calling itself, directly or indirectly.
-     * Calling a `nonReentrant` function from another `nonReentrant`
-     * function is not supported. It is possible to prevent this from happening
-     * by making the `nonReentrant` function external, and make it call a
-     * `private` function that does the actual work.
+     * Calling a `nonReentrant` function from another `nonReentrant` function is not supported. It is possible to
+     * prevent this from happening by making the `nonReentrant` function external, and making it call a `private`
+     * function that does the actual state modification.
      */
     modifier nonReentrant() {
         _preEntranceCheck();
@@ -42,8 +39,9 @@ contract Lockable {
     }
 
     // Internal methods are used to avoid copying the require statement's bytecode to every `nonReentrant()` method.
-    // On entry into a function, `_preEntranceCheck()` should always be called to check if the function is being re-entered.
-    // Then, if the function modifies state, it should call `_postEntranceSet()`, perform its logic, and then call `_postEntranceReset()`.
+    // On entry into a function, `_preEntranceCheck()` should always be called to check if the function is being
+    // re-entered. Then, if the function modifies state, it should call `_postEntranceSet()`, perform its logic, and
+    // then call `_postEntranceReset()`.
     // View-only methods can simply call `_preEntranceCheck()` to make sure that it is not being re-entered.
     function _preEntranceCheck() internal view {
         // On the first call to nonReentrant, _notEntered will be true

--- a/packages/core/contracts/common/implementation/Testable.sol
+++ b/packages/core/contracts/common/implementation/Testable.sol
@@ -7,7 +7,7 @@ import "./Timer.sol";
  * @title Base class that provides time overrides, but only if being run in test mode.
  */
 abstract contract Testable {
-    // If the contract is being run on the test network, then `timerAddress` will be the 0x0 address.
+    // If the contract is being run in production, then `timerAddress` will be the 0x0 address.
     // Note: this variable should be set on construction and never modified.
     address public timerAddress;
 

--- a/packages/core/contracts/common/implementation/Timer.sol
+++ b/packages/core/contracts/common/implementation/Timer.sol
@@ -21,8 +21,7 @@ contract Timer {
     }
 
     /**
-     * @notice Gets the current time. Will return the last time set in `setCurrentTime` if running in test mode.
-     * Otherwise, it will return the block timestamp.
+     * @notice Gets the currentTime variable set in the Timer.
      * @return uint256 for the current Testable timestamp.
      */
     function getCurrentTime() public view returns (uint256) {

--- a/packages/core/contracts/financial-templates/common/TokenFactory.sol
+++ b/packages/core/contracts/financial-templates/common/TokenFactory.sol
@@ -24,8 +24,6 @@ contract TokenFactory is Lockable {
         uint8 tokenDecimals
     ) external nonReentrant() returns (ExpandedIERC20 newToken) {
         SyntheticToken mintableToken = new SyntheticToken(tokenName, tokenSymbol, tokenDecimals);
-        mintableToken.addMinter(msg.sender);
-        mintableToken.addBurner(msg.sender);
         mintableToken.resetOwner(msg.sender);
         newToken = ExpandedIERC20(address(mintableToken));
     }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol
@@ -28,30 +28,30 @@ contract BinaryOptionLongShortPairFinancialProductLibrary is LongShortPairFinanc
 
     /**
      * @notice Enables any address to set the strike price for an associated binary option.
-     * @param LongShortPair address of the LSP.
+     * @param longShortPair address of the LSP.
      * @param strikePrice the strike price for the binary option.
      * @dev Note: a) Any address can set the initial strike price b) A strike can be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
-     * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
+     * e) longShortPair must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setLongShortPairParameters(address LongShortPair, int256 strikePrice) public nonReentrant() {
-        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
-        require(!longShortPairParameters[LongShortPair].isSet, "Parameters already set");
+    function setLongShortPairParameters(address longShortPair, int256 strikePrice) public nonReentrant() {
+        require(ExpiringContractInterface(longShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        require(!longShortPairParameters[longShortPair].isSet, "Parameters already set");
 
-        longShortPairParameters[LongShortPair] = BinaryLongShortPairParameters({
+        longShortPairParameters[longShortPair] = BinaryLongShortPairParameters({
             isSet: true,
             strikePrice: strikePrice
         });
     }
 
     /**
-     * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
+     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice)
+    function percentageLongCollateralAtExpiry(int256 expiryPrice)
         public
         view
         override

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.sol
@@ -27,27 +27,27 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
 
     /**
      * @notice Enables any address to set the strike price for an associated LSP.
-     * @param LongShortPair address of the LSP.
+     * @param longShortPair address of the LSP.
      * @param strikePrice the strike price for the covered call for the associated LSP.
      * @dev Note: a) Any address can set the initial strike price b) A strike price cannot be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
-     * e) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
+     * e) longShortPair must expose an expirationTimestamp method to validate it is correctly deployed.
      */
-    function setLongShortPairParameters(address LongShortPair, uint256 strikePrice) public nonReentrant() {
-        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
-        require(longShortPairStrikePrices[LongShortPair] == 0, "Parameters already set");
+    function setLongShortPairParameters(address longShortPair, uint256 strikePrice) public nonReentrant() {
+        require(ExpiringContractInterface(longShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        require(longShortPairStrikePrices[longShortPair] == 0, "Parameters already set");
 
-        longShortPairStrikePrices[LongShortPair] = strikePrice;
+        longShortPairStrikePrices[longShortPair] = strikePrice;
     }
 
     /**
-     * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
+     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice)
+    function percentageLongCollateralAtExpiry(int256 expiryPrice)
         public
         view
         override
@@ -55,6 +55,7 @@ contract CoveredCallLongShortPairFinancialProductLibrary is LongShortPairFinanci
         returns (uint256)
     {
         uint256 contractStrikePrice = longShortPairStrikePrices[msg.sender];
+        require(contractStrikePrice != 0, "Params not set for calling LSP");
 
         // If the expiry price is less than the strike price then the long options expire worthless (out of the money).
         // Note we do not consider negative expiry prices in this call option implementation.

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -16,7 +16,7 @@ import "../../../../common/implementation/Lockable.sol";
  * expiryPercentLong = 1. if the price is lower than the lower bound then expiryPercentLong = 0. For example, consider
  * a linear LSP on the price of ETH collateralized in USDC with an upperBound = 4000 and lowerBound = 2000 with a
  * collateralPerPair of 1000 (i.e each pair of long and shorts is worth 1000 USDC). At settlement the expiryPercentLong
- * would equal 1 (each long worth 1000 and short worth 0) if ETH price was > 4000 and it would be equal 0 if < 2000
+ * would equal 1 (each long worth 1000 and short worth 0) if ETH price was > 4000 and it would equal 0 if < 2000
  * (each long is worthless and each short is worth 1000). If between the two (say 3500) then expiryPercentLong
  * = (3500 - 2000) / (4000 - 2000) = 0.75. Therefore each long is worth 750 and each short is worth 250.
  */
@@ -32,40 +32,40 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
     mapping(address => LinearLongShortPairParameters) public longShortPairParameters;
 
     /**
-     * @notice Enables any address to set the parameters price for an associated financial product.
-     * @param LongShortPair address of the LSP contract.
+     * @notice Enables any address to set the parameters for an associated financial product.
+     * @param longShortPair address of the LSP contract.
      * @param upperBound the upper price that the linear LSP will operate within.
      * @param lowerBound the lower price that the linear LSP will operate within.
      * @dev Note: a) Any address can set these parameters b) existing LSP parameters for address not set.
      * c) upperBound > lowerBound.
-     * d) parameters price can only be set once to prevent the deployer from changing the parameters after the fact.
-     * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
-     * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
+     * d) parameters can only be set once to prevent the deployer from changing the parameters after the fact.
+     * e) For safety, parameters should be set before depositing any synthetic tokens in a liquidity pool.
+     * f) longShortPair must expose an expirationTimestamp method to validate it is correctly deployed.
      */
     function setLongShortPairParameters(
-        address LongShortPair,
+        address longShortPair,
         int256 upperBound,
         int256 lowerBound
     ) public nonReentrant() {
-        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        require(ExpiringContractInterface(longShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         require(upperBound > lowerBound, "Invalid bounds");
 
-        LinearLongShortPairParameters memory params = longShortPairParameters[LongShortPair];
+        LinearLongShortPairParameters memory params = longShortPairParameters[longShortPair];
         require(params.upperBound == 0 && params.lowerBound == 0, "Parameters already set");
 
-        longShortPairParameters[LongShortPair] = LinearLongShortPairParameters({
+        longShortPairParameters[longShortPair] = LinearLongShortPairParameters({
             upperBound: upperBound,
             lowerBound: lowerBound
         });
     }
 
     /**
-     * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
+     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token is entitled
      * to per collateralPerPair.
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice)
+    function percentageLongCollateralAtExpiry(int256 expiryPrice)
         public
         view
         override
@@ -73,6 +73,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
         returns (uint256)
     {
         LinearLongShortPairParameters memory params = longShortPairParameters[msg.sender];
+        require(params.upperBound != 0 && params.lowerBound != 0, "Params not set for calling LSP");
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -73,7 +73,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
         returns (uint256)
     {
         LinearLongShortPairParameters memory params = longShortPairParameters[msg.sender];
-        require(params.upperBound != 0 && params.lowerBound != 0, "Params not set for calling LSP");
+        require(!(params.upperBound == 0 && params.lowerBound == 0), "Params not set for calling LSP");
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol
@@ -73,7 +73,7 @@ contract LinearLongShortPairFinancialProductLibrary is LongShortPairFinancialPro
         returns (uint256)
     {
         LinearLongShortPairParameters memory params = longShortPairParameters[msg.sender];
-        require(!(params.upperBound == 0 && params.lowerBound == 0), "Params not set for calling LSP");
+        require(params.upperBound != 0 || params.lowerBound != 0, "Params not set for calling LSP");
 
         if (expiryPrice >= params.upperBound) return FixedPoint.fromUnscaledUint(1).rawValue;
 

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol
@@ -8,5 +8,5 @@ interface ExpiringContractInterface {
 }
 
 abstract contract LongShortPairFinancialProductLibrary {
-    function computeExpiryTokensForCollateral(int256 expiryPrice) public view virtual returns (uint256);
+    function percentageLongCollateralAtExpiry(int256 expiryPrice) public view virtual returns (uint256);
 }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -85,7 +85,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         returns (uint256)
     {
         RangeBondLongShortPairParameters memory params = longShortPairParameters[msg.sender];
-        require(params.highPriceRange != 0 && params.lowPriceRange != 0, "Params not set for calling LSP");
+        require(!(params.highPriceRange == 0 && params.lowPriceRange == 0), "Params not set for calling LSP");
 
         // This function's returns a value between 0 and 1e18 to be used in conjunction with the LSP collateralPerPair
         // that allocates collateral between the short and long tokens on expiry. This can be simplified by considering
@@ -101,6 +101,6 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         if (positiveExpiryPrice <= params.highPriceRange)
             return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(positiveExpiryPrice)).rawValue;
         // 3) above the range, the long position is entitled to a fixed number of tokens.
-        else return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(params.highPriceRange)).rawValue;
+        return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(params.highPriceRange)).rawValue;
     }
 }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -85,7 +85,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         returns (uint256)
     {
         RangeBondLongShortPairParameters memory params = longShortPairParameters[msg.sender];
-        require(!(params.highPriceRange == 0 && params.lowPriceRange == 0), "Params not set for calling LSP");
+        require(params.highPriceRange != 0 || params.lowPriceRange != 0, "Params not set for calling LSP");
 
         // This function's returns a value between 0 and 1e18 to be used in conjunction with the LSP collateralPerPair
         // that allocates collateral between the short and long tokens on expiry. This can be simplified by considering

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -42,7 +42,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
 
     /**
      * @notice Enables any address to set the parameters price for an associated financial product.
-     * @param LongShortPair address of the LSP contract.
+     * @param longShortPair address of the LSP contract.
      * @param highPriceRange high price range after which the payout transforms from a yield dollar to a call option.
      * @param lowPriceRange low price range below which the payout transforms from a yield dollar to a short put option.
      * @dev between highPriceRange and lowPriceRange the contract will payout a fixed amount of
@@ -51,33 +51,33 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
      * c) highPriceRange > lowPriceRange.
      * d) parameters price can only be set once to prevent the deployer from changing the parameters after the fact.
      * e) For safety, a parameters should be set before depositing any synthetic tokens in a liquidity pool.
-     * f) financialProduct must expose an expirationTimestamp method to validate it is correctly deployed.
+     * f) longShortPair must expose an expirationTimestamp method to validate it is correctly deployed.
      */
     function setLongShortPairParameters(
-        address LongShortPair,
+        address longShortPair,
         uint256 highPriceRange,
         uint256 lowPriceRange
     ) public nonReentrant() {
-        require(ExpiringContractInterface(LongShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        require(ExpiringContractInterface(longShortPair).expirationTimestamp() != 0, "Invalid LSP address");
 
         require(highPriceRange > lowPriceRange, "Invalid bounds");
 
-        RangeBondLongShortPairParameters memory params = longShortPairParameters[LongShortPair];
+        RangeBondLongShortPairParameters memory params = longShortPairParameters[longShortPair];
         require(params.highPriceRange == 0 && params.lowPriceRange == 0, "Parameters already set");
 
-        longShortPairParameters[LongShortPair] = RangeBondLongShortPairParameters({
+        longShortPairParameters[longShortPair] = RangeBondLongShortPairParameters({
             highPriceRange: highPriceRange,
             lowPriceRange: lowPriceRange
         });
     }
 
     /**
-     * @notice Returns a number between 0 and 1 to indicate how much collateral each long and short token are entitled
+     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token are entitled
      * to per collateralPerPair.
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */
-    function computeExpiryTokensForCollateral(int256 expiryPrice)
+    function percentageLongCollateralAtExpiry(int256 expiryPrice)
         public
         view
         override
@@ -85,25 +85,22 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         returns (uint256)
     {
         RangeBondLongShortPairParameters memory params = longShortPairParameters[msg.sender];
+        require(params.highPriceRange != 0 && params.lowPriceRange != 0, "Params not set for calling LSP");
 
-        // expiryPercentLong=[min(max(1/R2,1/P),1/R1)]/(1/R1)
-        // This function's method must return a value between 0 and 1 to be used in conjunction with the LSP
-        // collateralPerPair that allocates collateral between the short and long tokens on expiry.
-
+        // This function's returns a value between 0 and 1e18 to be used in conjunction with the LSP collateralPerPair
+        // that allocates collateral between the short and long tokens on expiry. This can be simplified by considering
+        // the price in three discreet ranges: 1) below the low price range, 2) between low and high range
+        // and 3) above the high price range.
         uint256 positiveExpiryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;
 
-        FixedPoint.Unsigned memory expiryPriceInverted =
-            FixedPoint.fromUnscaledUint(1).div(FixedPoint.Unsigned(positiveExpiryPrice));
-
-        FixedPoint.Unsigned memory maxPriceInverted =
-            FixedPoint.fromUnscaledUint(1).div(FixedPoint.Unsigned(params.highPriceRange));
-
-        FixedPoint.Unsigned memory minPriceInverted =
-            FixedPoint.fromUnscaledUint(1).div(FixedPoint.Unsigned(params.lowPriceRange));
-
-        return
-            (FixedPoint.min(FixedPoint.max(maxPriceInverted, expiryPriceInverted), minPriceInverted))
-                .div(minPriceInverted)
-                .rawValue;
+        // 1.) (collateralTokens * lowPriceRange) is the notional value of the bond below the range. The collateral is
+        // worth less than this amount. The long position is entitled to the full position in this range.
+        if (positiveExpiryPrice <= params.lowPriceRange) return FixedPoint.fromUnscaledUint(1).rawValue;
+        // 2) Within the range, the long position is entitled to the bond notional value, which is equal to a fixed
+        // fraction of the collateral. In this range it acts like a yield dollar.
+        if (positiveExpiryPrice <= params.highPriceRange)
+            return FixedPoint.fromUnscaledUint(params.lowPriceRange).div(positiveExpiryPrice).rawValue;
+        // 3) above the range, the long position is entitled to a fixed number of tokens.
+        else return FixedPoint.fromUnscaledUint(params.lowPriceRange).div(params.highPriceRange).rawValue;
     }
 }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -101,6 +101,6 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         if (positiveExpiryPrice <= params.highPriceRange)
             return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(positiveExpiryPrice)).rawValue;
         // 3) above the range, the long position is entitled to a fixed number of tokens.
-        else return FixedPoint.fromUnscaledUint(params.lowPriceRange).div(params.highPriceRange).rawValue;
+        else return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(params.highPriceRange)).rawValue;
     }
 }

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -99,7 +99,7 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         // 2) Within the range, the long position is entitled to the bond notional value, which is equal to a fixed
         // fraction of the collateral. In this range it acts like a yield dollar.
         if (positiveExpiryPrice <= params.highPriceRange)
-            return FixedPoint.fromUnscaledUint(params.lowPriceRange).div(positiveExpiryPrice).rawValue;
+            return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(positiveExpiryPrice)).rawValue;
         // 3) above the range, the long position is entitled to a fixed number of tokens.
         else return FixedPoint.fromUnscaledUint(params.lowPriceRange).div(params.highPriceRange).rawValue;
     }

--- a/packages/core/contracts/financial-templates/test/LongShortPairFinancialProjectLibraryTest.sol
+++ b/packages/core/contracts/financial-templates/test/LongShortPairFinancialProjectLibraryTest.sol
@@ -12,7 +12,7 @@ contract LongShortPairFinancialProjectLibraryTest is LongShortPairFinancialProdu
         valueToReturn = value;
     }
 
-    function computeExpiryTokensForCollateral(
+    function percentageLongCollateralAtExpiry(
         int256 /*expiryPrice*/
     ) public view override returns (uint256) {
         return valueToReturn;

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.js
@@ -52,19 +52,19 @@ contract("BinaryOptionLongShortPairFinancialProductLibrary", function () {
       await binaryLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than lower bound should return 0", async () => {
-      const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("2500"), {
+      const expiraryTokensForCollateral = await binaryLSPFPL.percentageLongCollateralAtExpiry.call(toWei("2500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiraryTokensForCollateral.toString(), toWei("0"));
     });
     it("equal to upper bound should return 1", async () => {
-      const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("3000"), {
+      const expiraryTokensForCollateral = await binaryLSPFPL.percentageLongCollateralAtExpiry.call(toWei("3000"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiraryTokensForCollateral.toString(), toWei("1"));
     });
     it("Higher than upper bound should return 1", async () => {
-      const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(toWei("3500"), {
+      const expiraryTokensForCollateral = await binaryLSPFPL.percentageLongCollateralAtExpiry.call(toWei("3500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiraryTokensForCollateral.toString(), toWei("1"));
@@ -72,7 +72,7 @@ contract("BinaryOptionLongShortPairFinancialProductLibrary", function () {
 
     it("Arbitrary price between bounds should return correctly", async () => {
       for (const price of [toWei("1000"), toWei("2000"), toWei("3000"), toWei("4000"), toWei("5000"), toWei("10000")]) {
-        const expiraryTokensForCollateral = await binaryLSPFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiraryTokensForCollateral = await binaryLSPFPL.percentageLongCollateralAtExpiry.call(price, {
           from: expiringContractMock.address,
         });
         const expectedPrice = toBN(price).gte(toBN(strikePrice)) ? toWei("1") : toWei("0");

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/CoveredCallLongShortPairFinancialProductLibrary.js
@@ -52,20 +52,20 @@ contract("CoveredCallLongShortPairFinancialProductLibrary", function () {
       await callOptionLSPFPL.setLongShortPairParameters(expiringContractMock.address, strikePrice);
     });
     it("Lower than strike should return 0", async () => {
-      const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(toWei("300"), {
+      const expiryTokensForCollateral = await callOptionLSPFPL.percentageLongCollateralAtExpiry.call(toWei("300"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0"));
     });
     it("Higher than strike correct value", async () => {
-      const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(toWei("500"), {
+      const expiryTokensForCollateral = await callOptionLSPFPL.percentageLongCollateralAtExpiry.call(toWei("500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.2"));
     });
     it("Arbitrary expiry price above strike should return correctly", async () => {
       for (const price of [toWei("500"), toWei("600"), toWei("1000"), toWei("1500"), toWei("2000")]) {
-        const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiryTokensForCollateral = await callOptionLSPFPL.percentageLongCollateralAtExpiry.call(price, {
           from: expiringContractMock.address,
         });
         const expectedPrice = toBN(price)
@@ -77,7 +77,7 @@ contract("CoveredCallLongShortPairFinancialProductLibrary", function () {
     });
     it("Should never return a value greater than 1", async () => {
       // create a massive expiry price. 1e18*1e18. Under all conditions should return less than 1.
-      const expiryTokensForCollateral = await callOptionLSPFPL.computeExpiryTokensForCollateral.call(
+      const expiryTokensForCollateral = await callOptionLSPFPL.percentageLongCollateralAtExpiry.call(
         toWei(toWei("1")),
         { from: expiringContractMock.address }
       );

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.js
@@ -62,19 +62,19 @@ contract("LinearLongShortPairFinancialProductLibrary", function () {
       await linearLSPFPL.setLongShortPairParameters(expiringContractMock.address, upperBound, lowerBound);
     });
     it("Lower than lower bound should return 0", async () => {
-      const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("900"), {
+      const expiryTokensForCollateral = await linearLSPFPL.percentageLongCollateralAtExpiry.call(toWei("900"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0"));
     });
     it("Higher than upper bound should return 1", async () => {
-      const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("2100"), {
+      const expiryTokensForCollateral = await linearLSPFPL.percentageLongCollateralAtExpiry.call(toWei("2100"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("1"));
     });
     it("Midway between bounds should return 0.5", async () => {
-      const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(toWei("1500"), {
+      const expiryTokensForCollateral = await linearLSPFPL.percentageLongCollateralAtExpiry.call(toWei("1500"), {
         from: expiringContractMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.5"));
@@ -82,7 +82,7 @@ contract("LinearLongShortPairFinancialProductLibrary", function () {
 
     it("Arbitrary price between bounds should return correctly", async () => {
       for (const price of [toWei("1000"), toWei("1200"), toWei("1400"), toWei("1600"), toWei("1800"), toWei("2000")]) {
-        const expiryTokensForCollateral = await linearLSPFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiryTokensForCollateral = await linearLSPFPL.percentageLongCollateralAtExpiry.call(price, {
           from: expiringContractMock.address,
         });
         const numerator = toBN(price).sub(toBN(lowerBound));

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.js
@@ -65,7 +65,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
     it("Lower than low price range should return 1 (long side is short put option)", async () => {
       // If the price is lower than the low price range then the max payout per each long token is hit at the full
       // collateralPerPair. i.e each short token is worth 0*collateralPerPair and each long token is worth 1*collateralPerPair.
-      const expiryTokensForCollateral = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("9"), {
+      const expiryTokensForCollateral = await rangeBondLSPFPL.percentageLongCollateralAtExpiry.call(toWei("9"), {
         from: lspMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("1"));
@@ -74,7 +74,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // If the price is larger than the high price range then the long tokens are equal fixed amount of notional/highPriceRange
       // Considering the long token to compute the expiryPercentLong (notional/highPriceRange)/collateralPerPair=(100/50)/10=0.2.
       // i.e each short token is worth 0.8* collateralPerPair = 8 tokens and each long token is worth 0.2*collateralPerPair=2.
-      const expiryTokensForCollateral = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("60"), {
+      const expiryTokensForCollateral = await rangeBondLSPFPL.percentageLongCollateralAtExpiry.call(toWei("60"), {
         from: lspMock.address,
       });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.2"));
@@ -84,14 +84,14 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // long token is worth the bond notional of 100. At a price of 20 we are between the bounds. Each long should be worth
       // 100 so there should be 100/20=5 UMA per long token. As each collateralPerPair is worth 10, expiryPercentLong should
       // be 10/5=0.5, thereby allocating half to the long and half to the short.
-      const expiryTokensForCollateral1 = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("20"), {
+      const expiryTokensForCollateral1 = await rangeBondLSPFPL.percentageLongCollateralAtExpiry.call(toWei("20"), {
         from: lspMock.address,
       });
       assert.equal(expiryTokensForCollateral1.toString(), toWei("0.5"));
 
       // Equally, at a price of 40 each long should still be worth 100 so there should be 100/40=2.5 UMA per long. As
       // each collateralPerPair=10 expiryPercentLong should be 10/2.5=0.25, thereby allocating 25% to long and the remaining to short.
-      const expiryTokensForCollateral2 = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(toWei("20"), {
+      const expiryTokensForCollateral2 = await rangeBondLSPFPL.percentageLongCollateralAtExpiry.call(toWei("20"), {
         from: lspMock.address,
       });
       assert.equal(expiryTokensForCollateral2.toString(), toWei("0.5"));
@@ -108,7 +108,7 @@ contract("RangeBondLongShortPairFinancialProductLibrary", function () {
       // form of the range bond equation where as the library uses an algebraic simplification of this equation. This
       // test validates the correct mapping between these two forms.
       for (const price of [toWei("5.555"), toWei("11"), toWei("33"), toWei("55"), toWei("66"), toWei("111")]) {
-        const expiryTokensForCollateral = await rangeBondLSPFPL.computeExpiryTokensForCollateral.call(price, {
+        const expiryTokensForCollateral = await rangeBondLSPFPL.percentageLongCollateralAtExpiry.call(price, {
           from: lspMock.address,
         });
         //

--- a/packages/core/test/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.js
+++ b/packages/core/test/financial-templates/expiring-multiparty/ExpiringMultiPartyCreator.js
@@ -234,6 +234,11 @@ contract("ExpiringMultiPartyCreator", function (accounts) {
     assert.isTrue(await tokenContract.isMinter(expiringMultiPartyAddress));
     assert.isTrue(await tokenContract.isBurner(expiringMultiPartyAddress));
     assert.isTrue(await tokenContract.holdsRole(0, expiringMultiPartyAddress));
+
+    // The creator contract should hold no roles.
+    assert.isFalse(await tokenContract.holdsRole(0, expiringMultiPartyCreator.address));
+    assert.isFalse(await tokenContract.holdsRole(1, expiringMultiPartyCreator.address));
+    assert.isFalse(await tokenContract.holdsRole(2, expiringMultiPartyCreator.address));
   });
 
   it("If collateral currency does not implement the decimals() method then synthetic currency defaults to 18 decimals", async function () {

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -240,7 +240,7 @@ contract("LongShortPair", function (accounts) {
       truffleAssert.eventEmitted(settleTx, "PositionSettled", (ev) => {
         return (
           ev.sponsor == sponsor &&
-          ev.colllateralReturned == toWei("75") &&
+          ev.collateralReturned == toWei("75") &&
           ev.longTokens == toWei("75") &&
           ev.shortTokens == toWei("75")
         );

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
@@ -113,17 +113,25 @@ contract("LongShortPairCreator", function (accounts) {
     assert.equal(await longToken.name(), syntheticName + " Long Token");
     assert.equal(await longToken.symbol(), "l" + syntheticSymbol);
     assert.equal((await longToken.decimals()).toString(), (await collateralToken.decimals()).toString());
-    assert.isTrue(await longToken.holdsRole("0", lspAddress));
-    assert.isTrue(await longToken.holdsRole("1", lspAddress));
-    assert.isTrue(await longToken.holdsRole("2", lspAddress));
+    assert.isTrue(await longToken.holdsRole("0", lspAddress)); // owner
+    assert.isTrue(await longToken.holdsRole("1", lspAddress)); // minter
+    assert.isTrue(await longToken.holdsRole("2", lspAddress)); // burner
 
     const shortToken = await Token.at(await lsp.shortToken());
     assert.equal(await shortToken.name(), syntheticName + " Short Token");
     assert.equal(await shortToken.symbol(), "s" + syntheticSymbol);
     assert.equal((await shortToken.decimals()).toString(), (await collateralToken.decimals()).toString());
-    assert.isTrue(await shortToken.holdsRole("0", lspAddress));
-    assert.isTrue(await shortToken.holdsRole("1", lspAddress));
-    assert.isTrue(await shortToken.holdsRole("2", lspAddress));
+    assert.isTrue(await shortToken.holdsRole("0", lspAddress)); // owner
+    assert.isTrue(await shortToken.holdsRole("1", lspAddress)); // minter
+    assert.isTrue(await shortToken.holdsRole("2", lspAddress)); // burner
+
+    // The creator should not hold any roles on the LSP contract.
+    assert.isFalse(await longToken.holdsRole("0", longShortPairCreator.address)); // owner
+    assert.isFalse(await longToken.holdsRole("1", longShortPairCreator.address)); // minter
+    assert.isFalse(await longToken.holdsRole("2", longShortPairCreator.address)); // burner
+    assert.isFalse(await shortToken.holdsRole("0", longShortPairCreator.address)); // owner
+    assert.isFalse(await shortToken.holdsRole("1", longShortPairCreator.address)); // minter
+    assert.isFalse(await shortToken.holdsRole("2", longShortPairCreator.address)); // burner
   });
   it("Correctly respects non-18 decimal collateral currencies", async function () {
     const non18Collateral = await Token.new("USD Coin", "USDC", 6, { from: deployer });

--- a/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
+++ b/packages/core/test/financial-templates/perpetual-multiparty/PerpetualCreator.js
@@ -259,6 +259,11 @@ contract("PerpetualCreator", function (accounts) {
     assert.isTrue(await tokenContract.isMinter(perpetualAddress));
     assert.isTrue(await tokenContract.isBurner(perpetualAddress));
     assert.isTrue(await tokenContract.holdsRole(0, perpetualAddress));
+
+    // The creator contract should hold no roles.
+    assert.isFalse(await tokenContract.holdsRole(0, perpetualCreator.address));
+    assert.isFalse(await tokenContract.holdsRole(1, perpetualCreator.address));
+    assert.isFalse(await tokenContract.holdsRole(2, perpetualCreator.address));
   });
 
   it("If collateral currency does not implement the decimals() method then synthetic currency defaults to 18 decimals", async function () {


### PR DESCRIPTION
**Motivation**

OZ identified a number of small issues during their audit. Most of these are typographical or semantic with major functionality issues identified. This PR implements the required changes to correct all errors identified in the audit.

**Summary**

Fixes the LSP contract post-OZ audit. All comments rased from OZ (as can be seen below) have been implemented in this PR.

**The OZ feedback on this set of contracts was as follows**:
The Long-Short-Pair template was developed and modified over several pull requests. Instead of reviewing the PRs individually, we reviewed the completed files. In particular, we reviewed the files in the [`long-short-pair` folder](https://github.com/UMAprotocol/protocol/tree/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair) and the [`long-short-pair-libraries` folder](https://github.com/UMAprotocol/protocol/tree/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries) at commit `b508f536ddfd94a79f93f633142bdc868b73461c`.

Our most important observation is that [the `setLongShortPairParameters` function of the `RangeBondLongShortPairFinancialProductLibrary` contract](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol#L56) allows anyone to overwrite the parameters at any point in time to maliciously change the payout structure.

The libraries are also inconsistent about whether the `computeExpiryTokensForCollateral` function should ensure the parameters have been set. In particular, the `BinaryOptionLongShortPairFinancialProductLibrary` [requires the strike](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol#L56) to have been set, but the other libraries do not perform the equivalent check. Consider ensuring the configuration parameters have been set in all libraries before calculating the appropriate collateral distribution.

We understand that the UMA team intend to include `nonReentrant` and `nonReentrantView` modifiers on all external and public functions. However, the modifier is missing from [the `create`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L165) and [the `getPositionTokens`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L264) functions of the `LongShortPair` contract. Moreover, it's missing from the `view` functions on all the libraries. Consider including the modifiers where appropriate.

The [`redeem` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L182) is restricted by the `preExpiration` modifier. However, if a user [settles](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L201) an equal number of long and short tokens, it will have the same effect (with a different event emitted) as token redemption, but it requires the user to wait for the price to resolve. Consider allowing users to call the `redeem` function at all times.

The [`_getSyntheticDecimals` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L138) is described and named as a `private` function, but it is `public`. Consider making it private.

The `createLongShortPair` function of the `LongShortPairCreator` contract [grants Minter and Burner roles](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L118-L124) for the synthetic tokens to the new `LongShortPair` contract. However, the creator contract still retains those roles. Consider renouncing them to reduce the attack surface.

The `create` function of the `LongShortPair` contract discards the return value when [minting synthetic tokens](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L170-L171). Similarly, the `settle` function discards the return value when [burning the tokens](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L221-L222). Consider requiring that the `mint` and `burnFrom` functions returns `true`.

The `computeExpiryTokensForCollateral` function of the `RangeBondLongShortPairFinancialProductLibrary` uses [a complicated closed-form expression](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol#L82) to determine how much collateral to assign to the long position. Instead, consider enumerating the cases explicitly so it is easier to reason about. This would reduce to something like:
```solidity
// (collateral tokens * lowPriceRange) is the notional value of the bond
// below the range, the collateral is worth less than this amount
// the long position is entitled to whatever is left
if(expiryPrice <= lowPriceRange) return 1;
// within the range, the long position is entitled to the notional value, 
// which is equal to the following fraction of collateral
if(expiryPrice <= highPriceRange) return lowPriceRange / expiryPrice;
// above the range, the long position is entitled to a fixed number of tokens
return lowPriceRange / highPriceRange;
```

The [`PositionSettled` event](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L75-L80), contains a typographical error in the second argument's identifier. It is presently `colllateralReturned`, when it should be `collateralReturned`. The subtle error could lead to issues with off-chain systems parsing the event details.

In `LongShortPairCreator.sol` there are no events emitted for the [creation of the `longToken`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L84-L89) or [the `shortToken`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L90-L95), nor are those addresses part of the [emitted `CreatedLongShortPair` event](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L126). Consider emitting events that contain the addresses of the new tokens to facilitate tracking.

The following functions have incomplete or incorrect Natural Specification comments. Consider correcting them:

- The [`createLongShortPair` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L66) of the `LongShortPairCreator` contract is missing its `@return` comment.
- The [`settle` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L201) incorrectly lists `collateralReturned` as a parameter (in addition to the returned value).

Some functions could benefit from renaming. These are our suggestions:

- The [`_getAddressWhitelist` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L299) of the `LongShortPair` contract could be renamed to `_getCollateralWhitelist`.
- The [`computeExpiryTokensForCollateral` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LongShortPairFinancialProductLibrary.sol#L11) of the `LongShortPairFinancialProductLibrary` contract could be renamed to `longPercentageCollateralAtExpiry` or similar.

The [`createLongShortPair` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L113) of the `LongShortPairCreator` contract and the [`create` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L168) of the `LongShortPair` contract both transfer funds on behalf of the message sender. The contracts implicitly assume that they have been granted an appropriate allowance. Consider documenting this in the function comments.

There are some misleading comments in the code base:

- The parameter setters in the library functions, for example the [`setLongShortPairParameters` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol#L36) in `BinaryOptionLongShortPairFinancialProductLibrary.sol`, refer to the non-existent `financialProduct` parameter instead of `LongShortPair`.
- The code base is inconsistent about using `1e18` to represent `100%`. For example, the [`expiryPercentLong` comment](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L50-L51) switches between `1e18` and `1` in the same comment. This is [repeated later in the contract](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L224-L225). Similarly, the `computeExpiryTokensForCollateral` functions in all the libraries [claim the function returns a number between 0 and 1](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/BinaryOptionLongShortPairFinancialProductLibrary.sol#L49), instead of between 0 and 1e18.
- The [`redeem` function's `@notice` comment](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L177) says `tokensToCreate` instead of `tokensToRedeem`. This comment would also be clearer if it started with "Redeem" instead of "Return".
- In the [`Testable` contract](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/common/implementation/Testable.sol) there is an [inline comment that says "If the contract is being run on the test network, then `timerAddress` will be the 0x0 address."](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/common/implementation/Testable.sol#L10) However, it appears that this comment is erroneous. The `onlyIfTest` modifier [requires that `timerAddress != address(0x0)`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/common/implementation/Testable.sol#L27). There are also other comments in the codebase that agree with the modifier: ["_timerAddress ... Set to 0x0 in production."](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L114). The comment in `Testable` should be modified to agree with the implementation to avoid potential confusion around such a critically important value.
- In `Timer.sol` the `@notice` docstring for the [`getCurrentTime` function](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/common/implementation/Timer.sol#L28) is misleading. It states, "Otherwise, it will return the block timestamp." However, the function is only capable of returning the stored value of `currentTime` and has no logic to conditionally return the block timestamp.

There are some unused imports in the code base:

- [`SafeMath.sol`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L4) in `LongShortPair.sol`
- [`IERC20Standard.sol`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L16) in `LongShortPair.sol`
- [`ContractCreator.sol`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L7) in `LongShortPairCreator.sol`
- [`AddressWhitelist.sol`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L9) in `LongShortPairCreator.sol`
- [`SyntheticToken.sol`](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L12) in `LongShortPairCreator.sol`

Lastly, there are some typographical errors in the code base:

- [Line 55](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L55) of `LongShortPairCreator.sol` says "appended" instead of "prepended".
- [Line 57](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L57) of `LongShortPairCreator.sol` repeats the word "as".
- [Line 106](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L106) of `LongShortPair.sol` says "Requires mint and burn needed by this contract", which is ungrammatical.
- [Line 19](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol#L19) of `LinearLongShortPairFinancialProductLibrary.sol` has the extra word "be".
- Lines [35](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol#L35) and [41](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol#L41) of `LinearLongShortPairFinancialProductLibrary.sol` have the extra word "price".
- [Line 42](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol#L42) of `LinearLongShortPairFinancialProductLibrary.sol` has the extra word "a".
- [Line 63](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/LinearLongShortPairFinancialProductLibrary.sol#L63) of `LinearLongShortPairFinancialProductLibrary.sol` says "are" instead of "is".
- [Line 26](https://github.com/UMAprotocol/protocol/blob/b508f536ddfd94a79f93f633142bdc868b73461c/packages/core/contracts/common/implementation/Lockable.sol#L26) of `Lockable.sol` reads "... and make it call a" when it should read "... and **making** it call a".


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested