### PR TITLE
feat(api): add usd price conversions to synthetic prices

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -77,22 +77,42 @@ Returns all known expired emps data. Conforms to the EMP type defined in the uma
 
 Returns all known active collateral or synthetic addresses
 
-### allLatestPrices(currency='usd') => {[address:string]:[timestamp:number,price:string]}
+### allLatestPrices(currency='usd') => {[address:string]:[timestamp:number,price:string]
 
-Returns all known latest prices for collateral addresses. Synthetic prices not yet available.
+Returns all known latest prices for synthetic or collateral addresses in wei.
 
-### latestPriceByAddress(address:string,currency:'usd') => [timestamp:number,price:string]}
+### latestPriceByTokenAddress(tokenAddress:string,currency:'usd') => [timestamp:number,price:string]
 
-Returns latest price for a particular collateral address.
+Returns latest price for a particular erc20 token address ( emp collateral or synthetic address) in wei.
 
-### historicalPricesByAddress(address:string,start:number=0,end:number=Math.floor(Date.now() / 1000),currency:"usd"="usd") => PriceSample[]
+### latestCollateralPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
 
-Get a range of historical prices between start and end in seconds, sorted by timestamp ascending from an erc20 token address.
+### latestSyntheticPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
+
+Gets the latest collateral or synthetic price based on the emp contract address in wei.
+
+### historicalPricesByTokenAddress(tokenAddress:string,start:number=0,end:number=Date.now(),currency:"usd"="usd") => PriceSample[]
+
+Get a range of historical prices between start and end in MS, sorted by timestamp ascending from an erc20 token address in wei.
 This is useful for charting betwen two dates.
 
-### sliceHistoricalPricesByAddress(address:string,start:number=0,length:number=1,currency:"usd"="usd") => PriceSample[]
+### sliceHistoricalPricesByTokenAddress(tokenAddress:string,start:number=0,length:number=1,currency:"usd"="usd") => PriceSample[]
 
 Get a range of historical prices between start and count of price samples, sorted by timestamp ascending, from an erc20 token address.
+This is useful for paginating data when you have X elements per page, and you know the last element seen.
+
+### async historicalSynthPrices( empAddress: string, start = 0, end: number = Date.now()) => PriceSample[]
+
+### async historicalCollateralPrices( empAddress: string, start = 0, end: number = Date.now()) => PriceSample[]
+
+Get a range of historical prices between start and end in MS, sorted by timestamp ascending from an emp contract address.
+This is useful for charting betwen two dates.
+
+### async sliceHistoricalSynthPrices(empAddress: string, start = 0, length = 1) => PriceSample[]
+
+### async sliceHistoricalCollateralPrices(empAddress: string, start = 0, length = 1) => PriceSample[]
+
+Get a range of historical prices between start and count of price samples, sorted by timestamp ascending, from an emp contract address.
 This is useful for paginating data when you have X elements per page, and you know the last element seen.
 
 ### getErc20Info(address:string) => Erc20Data
@@ -102,16 +122,6 @@ Get name, decimals of an erc20 by address.
 ### getAllErc20Info() => Erc20Data[]
 
 List all known erc20s, collateral or synthetic and all known information about them
-
-### allLatestSynthPrices => {[empAddress:string]:[timestamp:number,price:string]}
-
-Returns all known latest synthetic prices based on emp address. This differs from collateral price requests, as
-that call uses the collateral address, not the emp address.
-
-### latestSynthPriceByAddress(empAddress:string,currency:'usd') => [timestamp:number,price:string]}
-
-Returns latest synthetic price for an emp address. This differs from collateral price requests, as
-that call uses the collateral address, not the emp address.
 
 ### getEmpStats(address: string, currency: "usd" = "usd") => StatData
 

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -9,7 +9,6 @@ import Express from "../../services/express";
 import Actions from "../../services/actions";
 import { ProcessEnv, AppState } from "../..";
 import { empStats } from "../../tables";
-import { uniqueId } from "lodash";
 
 async function run(env: ProcessEnv) {
   assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
@@ -69,7 +68,7 @@ async function run(env: ProcessEnv) {
     collateralPrices: Services.CollateralPrices({}, appState),
     syntheticPrices: Services.SyntheticPrices(
       {
-        cryptowatchApiKey: env.cryptwatchApiKey,
+        cryptowatchApiKey: env.cryptowatchApiKey,
         tradermadeApiKey: env.tradermadeApiKey,
         quandlApiKey: env.quandlApiKey,
         defipulseApiKey: env.defipulseApiKey,

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import Web3 from "web3";
 import { ethers } from "ethers";
 
-import { tables, Coingecko } from "@uma/sdk";
+import { tables, Coingecko, utils } from "@uma/sdk";
 
 import * as Services from "../../services";
 import Express from "../../services/express";
@@ -128,7 +128,7 @@ async function run(env: ProcessEnv) {
   }
 
   // coingeckos prices don't update very fast, so set it on an interval every few minutes
-  setInterval(() => {
+  utils.loop(async () => {
     updatePrices().catch(console.error);
   }, 5 * 60 * 1000);
 }

--- a/packages/api/src/libs/queries.ts
+++ b/packages/api/src/libs/queries.ts
@@ -30,7 +30,7 @@ export default (appState: Dependencies) => {
     address: string,
     start = 0,
     length = 1,
-    currency: "usd" = "usd"
+    currency: CurrencySymbol = "usd"
   ): Promise<PriceSample[]> {
     assert(start >= 0, "requires a start value >= 0");
     assert(exists(prices[currency]), "invalid currency type: " + currency);

--- a/packages/api/src/libs/utils.test.ts
+++ b/packages/api/src/libs/utils.test.ts
@@ -1,5 +1,8 @@
 import * as utils from "./utils";
 import assert from "assert";
+import { ethers } from "ethers";
+
+const { parseUnits } = ethers.utils;
 
 describe("utils", function () {
   it("asyncValues", async function () {
@@ -60,11 +63,19 @@ describe("utils", function () {
   });
   it("calculateTvl", function () {
     const emp = {
-      totalPositionCollateral: "1000000000",
+      totalPositionCollateral: parseUnits("100", 8).toString(),
       collateralDecimals: 8,
     };
-    const price = "0.25";
+    const price = parseUnits("0.25").toString();
     const result = utils.calcTvl(price, emp).toString();
-    assert.equal(result, "2500000000000000000");
+    assert.equal(result, parseUnits("25").toString());
+  });
+  it("calcSyntheticPrice", function () {
+    // stablecoin emp, minted 100k usd with eth collateral
+    const collateralPrice = parseUnits("2000");
+    const syntheticPrice = parseUnits(".0005");
+
+    const result = utils.calcSyntheticPrice(syntheticPrice, collateralPrice);
+    assert.equal(result.toString(), parseUnits("1").toString());
   });
 });

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -5,6 +5,11 @@ import { utils, BigNumber } from "ethers";
 import assert from "assert";
 const { parseUnits } = utils;
 
+export const ETH = parseUnits("1");
+export type BigNumberish = number | string | BigNumber;
+
+export { parseUnits };
+
 // Takes an object with promises on its values and resolves them concurrently returning result.
 // Will pass through non promise values without a problem.
 export async function asyncValues<R extends Obj>(object: Obj): Promise<R> {
@@ -40,6 +45,7 @@ export function calcGcr(
 }
 
 export function calcTvl(
+  // price needs to be in wei
   price: string,
   emp: Pick<uma.tables.emps.Data, "totalPositionCollateral" | "collateralDecimals">
 ) {
@@ -47,7 +53,11 @@ export function calcTvl(
   assert(uma.utils.exists(totalPositionCollateral), "requires total position collateral");
   assert(uma.utils.exists(collateralDecimals), "requires collateralDecimals");
   const normalizedCollateral = uma.utils.ConvertDecimals(collateralDecimals, 18)(totalPositionCollateral);
-  return parseUnits(price).mul(normalizedCollateral).div(parseUnits("1"));
+  return BigNumber.from(price).mul(normalizedCollateral).div(ETH);
+}
+
+export function calcSyntheticPrice(syntheticPrice: BigNumberish, collateralPrice: BigNumberish) {
+  return BigNumber.from(syntheticPrice).mul(collateralPrice).div(ETH);
 }
 
 export function sToMs(s: number) {

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -5,7 +5,7 @@ import { utils, BigNumber } from "ethers";
 import assert from "assert";
 const { parseUnits } = utils;
 
-export const ETH = parseUnits("1");
+export const SCALING_MULTIPLIER = parseUnits("1");
 export type BigNumberish = number | string | BigNumber;
 
 export { parseUnits };
@@ -53,11 +53,11 @@ export function calcTvl(
   assert(uma.utils.exists(totalPositionCollateral), "requires total position collateral");
   assert(uma.utils.exists(collateralDecimals), "requires collateralDecimals");
   const normalizedCollateral = uma.utils.ConvertDecimals(collateralDecimals, 18)(totalPositionCollateral);
-  return BigNumber.from(price).mul(normalizedCollateral).div(ETH);
+  return BigNumber.from(price).mul(normalizedCollateral).div(SCALING_MULTIPLIER);
 }
 
 export function calcSyntheticPrice(syntheticPrice: BigNumberish, collateralPrice: BigNumberish) {
-  return BigNumber.from(syntheticPrice).mul(collateralPrice).div(ETH);
+  return BigNumber.from(syntheticPrice).mul(collateralPrice).div(SCALING_MULTIPLIER);
 }
 
 export function sToMs(s: number) {

--- a/packages/api/src/services/actions.ts
+++ b/packages/api/src/services/actions.ts
@@ -12,7 +12,7 @@ type Config = undefined;
 
 export function Handlers(config: Config, appState: Dependencies): Actions {
   const queries = Queries(appState);
-  const { registeredEmps, erc20s, collateralAddresses, syntheticAddresses, prices, synthPrices, stats } = appState;
+  const { registeredEmps, erc20s, collateralAddresses, syntheticAddresses, prices, stats } = appState;
 
   const actions: Actions = {
     echo(...args: Json[]) {
@@ -47,48 +47,47 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(exists(prices[currency]), "invalid currency type: " + currency);
       return prices[currency].latest;
     },
-    async latestPriceByAddress(address: string, currency: CurrencySymbol = "usd") {
-      assert(address, "requires an erc20 token address");
-      assert(exists(prices[currency]), "invalid currency type: " + currency);
-      const priceSample = prices[currency].latest[address];
-      assert(exists(priceSample), "No price for address: " + address);
-      return priceSample;
+    // get prices by token address
+    latestPriceByTokenAddress: queries.latestPriceByTokenAddress,
+    // get synthetic price in usd for an emp address
+    async latestSyntheticPrice(empAddress: string, currency: CurrencySymbol = "usd") {
+      assert(empAddress, "requires an empAddress");
+      const emp = await queries.getAnyEmp(empAddress);
+      assert(exists(emp.tokenCurrency), "EMP does not have token currency address");
+      return queries.latestPriceByTokenAddress(emp.tokenCurrency, currency);
     },
-    // synthetic prices are determined by bot pricefeeds
-    async latestSynthPriceByAddress(address: string) {
-      assert(address, "requires an erc20 token address");
-      const priceSample = synthPrices.latest[address];
-      assert(exists(priceSample), "No synthetic price for address: " + address);
-      return priceSample;
+    // get collateral price in usd for an emp address
+    async latestCollateralPrice(empAddress: string, currency: CurrencySymbol = "usd") {
+      assert(empAddress, "requires an empAddress");
+      const emp = await queries.getAnyEmp(empAddress);
+      assert(exists(emp.collateralCurrency), "EMP does not have collateral currency address");
+      return queries.latestPriceByTokenAddress(emp.collateralCurrency, currency);
     },
-    async allLatestSynthPrices() {
-      return synthPrices.latest;
+    historicalPricesByTokenAddress: queries.historicalPricesByTokenAddress,
+    sliceHistoricalPricesByTokenAddress: queries.sliceHistoricalPricesByTokenAddress,
+    async historicalSynthPrices(empAddress: string, start = 0, end: number = Date.now()): Promise<PriceSample[]> {
+      assert(empAddress, "requires an empAddress");
+      const emp = await queries.getAnyEmp(empAddress);
+      assert(exists(emp.tokenCurrency), "EMP does not have token currency address");
+      return queries.historicalPricesByTokenAddress(emp.tokenCurrency, start, end);
     },
-    async historicalPricesByAddress(
-      address: string,
-      start = 0,
-      end: number = nowS(),
-      currency: "usd" = "usd"
-    ): Promise<PriceSample[]> {
-      assert(start >= 0, "requires a start value >= 0");
-      assert(exists(prices[currency]), "invalid currency type: " + currency);
-      assert(exists(prices[currency].history[address]), "no prices for address" + address);
-      const results = await prices[currency].history[address].betweenByTimestamp(start, end);
-      // convert this to tuple to save bytes.
-      return results.map(({ price, timestamp }) => [timestamp, price]);
+    async sliceHistoricalSynthPrices(empAddress: string, start = 0, length = 1): Promise<PriceSample[]> {
+      assert(empAddress, "requires an empAddress");
+      const emp = await queries.getAnyEmp(empAddress);
+      assert(exists(emp.tokenCurrency), "EMP does not have token currency address");
+      return queries.sliceHistoricalPricesByTokenAddress(emp.tokenCurrency, start, length);
     },
-    async sliceHistoricalPricesByAddress(
-      address: string,
-      start = 0,
-      length = 1,
-      currency: "usd" = "usd"
-    ): Promise<PriceSample[]> {
-      assert(start >= 0, "requires a start value >= 0");
-      assert(exists(prices[currency]), "invalid currency type: " + currency);
-      assert(exists(prices[currency].history[address]), "no prices for address" + address);
-      const results = await prices[currency].history[address].sliceByTimestamp(start, length);
-      // convert this to tuple to save bytes.
-      return results.map(({ price, timestamp }) => [timestamp, price]);
+    async historicalCollateralPrices(empAddress: string, start = 0, end: number = Date.now()): Promise<PriceSample[]> {
+      assert(empAddress, "requires an empAddress");
+      const emp = await queries.getAnyEmp(empAddress);
+      assert(exists(emp.collateralCurrency), "EMP does not have token currency address");
+      return queries.historicalPricesByTokenAddress(emp.collateralCurrency, start, end);
+    },
+    async sliceHistoricalCollateralPrices(empAddress: string, start = 0, length = 1): Promise<PriceSample[]> {
+      assert(empAddress, "requires an empAddress");
+      const emp = await queries.getAnyEmp(empAddress);
+      assert(exists(emp.collateralCurrency), "EMP does not have token currency address");
+      return queries.sliceHistoricalPricesByTokenAddress(emp.collateralCurrency, start, length);
     },
     async getEmpStats(address: string, currency: CurrencySymbol = "usd") {
       assert(address, "requires address");
@@ -100,22 +99,6 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(currency, "requires currency");
       assert(stats[currency], "No stats for currency: " + currency);
       return stats[currency].latest.values();
-    },
-    async historicalSynthPricesByAddress(empAddress: string, start = 0, end: number = nowS()): Promise<PriceSample[]> {
-      assert(empAddress, "requires emp address");
-      assert(start >= 0, "requires a start value >= 0");
-      assert(exists(synthPrices.history[empAddress]), "No synthetic prices for emp address: " + empAddress);
-      const results = await synthPrices.history[empAddress].betweenByTimestamp(start, end);
-      // convert this to tuple to save bytes.
-      return results.map(({ price, timestamp }) => [timestamp, price]);
-    },
-    async sliceHistoricalSynthPricesByAddress(empAddress: string, start = 0, length = 1): Promise<PriceSample[]> {
-      assert(empAddress, "requires emp address");
-      assert(start >= 0, "requires a start value >= 0");
-      assert(exists(synthPrices.history[empAddress]), "No synthetic prices for emp address: " + empAddress);
-      const results = await synthPrices.history[empAddress].sliceByTimestamp(start, length);
-      // convert this to tuple to save bytes.
-      return results.map(({ price, timestamp }) => [timestamp, price]);
     },
     async tvl(addresses?: string[], currency: CurrencySymbol = "usd") {
       if (addresses == null || addresses.length == 0) return queries.totalTvl(currency);

--- a/packages/api/src/services/collateral-prices.ts
+++ b/packages/api/src/services/collateral-prices.ts
@@ -4,6 +4,8 @@ import { AppState, CurrencySymbol } from "..";
 type Config = {
   currency?: CurrencySymbol;
 };
+import { parseUnits } from "../libs/utils";
+
 type Dependencies = Pick<AppState, "coingecko" | "prices" | "collateralAddresses">;
 
 export default function (config: Config, appState: Dependencies) {
@@ -47,7 +49,8 @@ export default function (config: Config, appState: Dependencies) {
   // does not do any queries, just a helper to mutate the latest price table
   function updateLatestPrice(params: { address: string; price: number; timestamp: number }) {
     const { address, timestamp, price } = params;
-    prices[currency].latest[address] = [timestamp, price.toString()];
+    // we need to store prices in wei, so use parse units on this price
+    prices[currency].latest[address] = [timestamp, parseUnits(price.toString()).toString()];
     return params;
   }
 

--- a/packages/api/src/services/synthetic-prices.ts
+++ b/packages/api/src/services/synthetic-prices.ts
@@ -1,7 +1,10 @@
 import assert from "assert";
 import SynthPrices from "../libs/synthPrices";
-import { AppState, PriceSample } from "..";
+import { AppState, PriceSample, Currencies } from "..";
 import * as uma from "@uma/sdk";
+import bluebird from "bluebird";
+import Queries from "../libs/queries";
+import { calcSyntheticPrice } from "../libs/utils";
 
 type Config = {
   cryptowatchApiKey?: string;
@@ -9,33 +12,40 @@ type Config = {
   quandlApiKey?: string;
   defipulseApiKey?: string;
   priceFeedDecimals?: number;
+  currency?: Currencies;
 };
 
-type Dependencies = Pick<AppState, "web3" | "emps" | "synthPrices">;
+type Dependencies = Pick<AppState, "web3" | "emps" | "synthPrices" | "erc20s" | "prices" | "stats" | "registeredEmps">;
 
 export default function (config: Config, appState: Dependencies) {
-  const { web3, emps, synthPrices } = appState;
+  const { currency = "usd" } = config;
+  const { web3, emps, synthPrices, prices } = appState;
   const getSynthPrices = SynthPrices(config, web3);
 
-  // if we have a new emp address, this will create a new price table structure to store historical price data
-  function getOrCreateHistoryTable(empAddress: string) {
-    if (synthPrices.history[empAddress] == null) {
-      synthPrices.history[empAddress] = uma.tables.historicalPrices.SortedJsMap();
+  const queries = Queries(appState);
+
+  // get or create a history table by an erc20 token address. this might be a bit confusing because we also have a
+  // synthPrices table which store raw synth price queried from bot. This table stores the currency converted price over time.
+  function getOrCreateHistoryTable(tokenAddress: string) {
+    if (prices[currency].history[tokenAddress] == null) {
+      prices[currency].history[tokenAddress] = uma.tables.historicalPrices.SortedJsMap();
     }
-    return synthPrices.history[empAddress];
+    return prices[currency].history[tokenAddress];
   }
 
   // utility to grab last price based on address
-  function getLatestPriceFromTable(empAddress: string) {
+  function getLatestSynthPriceFromTable(empAddress: string) {
     const result = synthPrices.latest[empAddress];
-    assert(uma.utils.exists(result), "no latest sythetic price found for: " + empAddress);
+    assert(uma.utils.exists(result), "no latest sythetic price found for emp: " + empAddress);
     return result;
   }
 
   // pulls price from latest and stuffs it into historical table.
   async function updatePriceHistory(empAddress: string) {
-    const table = getOrCreateHistoryTable(empAddress);
-    const [timestamp, price] = getLatestPriceFromTable(empAddress);
+    const emp = await getFullEmpState(empAddress);
+    assert(uma.utils.exists(emp.tokenCurrency), "Requires emp.tokenCurrency: " + empAddress);
+    const table = getOrCreateHistoryTable(emp.tokenCurrency);
+    const [timestamp, price] = await getLatestPriceFromTable(empAddress, emp.tokenCurrency);
     // if this timestamp exists in the table, dont bother re-adding it
     assert(uma.utils.exists(price), "No latest price available for: " + empAddress);
     assert(
@@ -49,24 +59,101 @@ export default function (config: Config, appState: Dependencies) {
     return Promise.allSettled(addresses.map(updatePriceHistory));
   }
 
-  async function updateLatestPrice(empAddress: string) {
+  // updates raw synth price, in relation to collateral
+  async function updateLatestSynthPrice(empAddress: string) {
     const result: PriceSample = await getSynthPrices.getCurrentPrice(empAddress);
     synthPrices.latest[empAddress] = result;
     return result;
   }
 
+  async function updateLatestSynthPrices(empAddresses: string[]) {
+    // slow down updates by running them serially to prevent rate limits, conform to Promise.allSettled
+    return bluebird.mapSeries(empAddresses, async (empAddress) => {
+      try {
+        return {
+          status: "fulfilled",
+          value: await updateLatestSynthPrice(empAddress),
+        };
+      } catch (err) {
+        return {
+          status: "rejected",
+          reason: err,
+        };
+      }
+    });
+  }
+
+  async function getFullEmpState(empAddress: string) {
+    const emp = await queries.getAnyEmp(empAddress);
+    // the full state has collateral decimals, pulled from erc20 state
+    return queries.getFullEmpState(emp);
+  }
+
+  // gets any price from table, synthetic or collateral. Synthetics go into this table once converted to usd
+  async function getLatestPriceFromTable(empAddress: string, currencyAddress: string) {
+    // PriceSample is type [ timestamp:number, price:string]
+    const priceSample: PriceSample = prices[currency].latest[currencyAddress];
+    assert(uma.utils.exists(priceSample), "No latest price found for emp: " + empAddress);
+
+    const price = priceSample[1];
+    assert(uma.utils.exists(price), "Invalid latest price found on emp: " + empAddress);
+
+    return priceSample;
+  }
+
+  // convert synth price to {currency} which is typically usd, based on the current collateral price
+  async function updateLatestPrice(empAddress: string) {
+    const emp = await queries.getAnyEmp(empAddress);
+
+    assert(uma.utils.exists(emp.collateralCurrency), "Requires contract collateralCurrency: " + empAddress);
+    assert(uma.utils.exists(emp.tokenCurrency), "Requires contract tokenCurrency: " + empAddress);
+
+    const [synthTimestamp, synthPrice] = await getLatestSynthPriceFromTable(empAddress);
+    const [collateralTimestamp, collateralPrice] = await getLatestPriceFromTable(empAddress, emp.collateralCurrency);
+
+    // converted price from raw synth to currency ( usually usd)
+    const price = calcSyntheticPrice(synthPrice, collateralPrice).toString();
+
+    // use the most recent timestamp to index this price
+    const timestamp = Math.max(collateralTimestamp, synthTimestamp);
+    prices[currency].latest[emp.tokenCurrency] = [timestamp, price.toString()];
+    return [timestamp, price];
+  }
+
   async function updateLatestPrices(empAddresses: string[]) {
-    return Promise.allSettled(empAddresses.map(updateLatestPrice));
+    // slow down updates by running them serially to prevent rate limits, conform to Promise.allSettled
+    return bluebird.mapSeries(empAddresses, async (empAddress) => {
+      try {
+        return {
+          status: "fulfilled",
+          value: await updateLatestPrice(empAddress),
+        };
+      } catch (err) {
+        return {
+          status: "rejected",
+          reason: err,
+        };
+      }
+    });
   }
 
   async function update() {
     // synth prices are looked up by emp address, not synthetic token address
     const empAddresses = Array.from(await emps.active.keys());
-    await updateLatestPrices(empAddresses).then((results) => {
+    // this gets raw synth price without regard to currency, stores them in table. not really useful until converted to usd.
+    await updateLatestSynthPrices(empAddresses).then((results) => {
       results.forEach((result) => {
         if (result.status === "rejected") console.error("Error updating synthetic price: " + result.reason.message);
       });
     });
+    // this converts latest synth prices to a currency price, based on collateral price relationship
+    await updateLatestPrices(empAddresses).then((results) => {
+      results.forEach((result) => {
+        if (result.status === "rejected")
+          console.error(`Error updating synthetic ${currency} price: ${result.reason.message}`);
+      });
+    });
+    // this takes converted prices and creates a historical record
     await updatePriceHistories(empAddresses).then((results) => {
       results.forEach((result) => {
         if (result.status === "rejected")
@@ -79,11 +166,15 @@ export default function (config: Config, appState: Dependencies) {
     update,
     utils: {
       getOrCreateHistoryTable,
-      getLatestPriceFromTable,
+      getLatestSynthPriceFromTable,
       updatePriceHistories,
       updatePriceHistory,
       updateLatestPrice,
       updateLatestPrices,
+      updateLatestSynthPrice,
+      updateLatestSynthPrices,
+      getFullEmpState,
+      getLatestPriceFromTable,
     },
   };
 }

--- a/packages/sdk/src/libs/utils.ts
+++ b/packages/sdk/src/libs/utils.ts
@@ -56,3 +56,16 @@ export const ConvertDecimals = (fromDecimals: number, toDecimals: number) => {
     return amount.mul(BigNumber.from("10").pow(-1 * diff)).toString();
   };
 };
+
+// async sleep
+export const sleep = (delay = 0) => new Promise((res) => setTimeout(res, delay));
+
+// Loop forever but wait until execution is finished before starting next timer. Throw an error to break this
+// or add another utlity function if you need it to end on condition.
+export async function loop(fn: (...args: any[]) => any, delay: number, ...args: any[]) {
+  do {
+    await fn(...args);
+    await sleep(delay);
+    /* eslint-disable-next-line no-constant-condition */
+  } while (true);
+}


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1492/convert-synthetic-prices-to-usd

**Summary**

In order to calculate TVM, we need all synthetics priced in USD.  Previously we only stored the native synthetic value, which may or may not be valued against usd. PR adds the feature as well as refactors some api calls. 

This adds a conversion utility which converts to usd based on synthetic price and collateral price.  USD synthetic prices are stored in the prices table, keyed by token address. API is refactored to make querying this data a bit easier. 


**Details**
This refactors and updates docs for several api endpoints and all prices are returned as USD in wei. The main pattern here is that it allows you to query by erc20 address or emp address when specifying either collateral or synthetic:


**latest prices**
- latestPriceByTokenAddress: price by erc20
- latestCollateralPrice: collateral price by emp
- latestSyntheticPrice: synth price by emp

**historical prices between** 
- historicalPricesByTokenAddress: historical price by erc20 between dates
- historicalSynthPrices: synth historical price by emp between dates
- historicalCollateralPrices: collateral historical price by emp between dates

**historical prices slice**
- sliceHistoricalPricesByTokenAddress: historical price by erc20 by start date and length
- sliceHistoricalSynthPrices: synth historical price by emp by start date and length
- sliceHistoricalCollateralPrices: collateral historical price by emp by start date and length

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
https://app.clubhouse.io/uma-project/story/1492/convert-synthetic-prices-to-usd
