### PR TITLE
fix(api): use api.domination.finance endpoint (#3160)

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/DominationFinancePriceFeed.js
@@ -58,7 +58,7 @@ class DominationFinancePriceFeed extends PriceFeedInterface {
   }
 
   get _historicalPricesUrl() {
-    return `https://live.domination.finance/api/v0/history/${this.pair}?tick=${this.tickPeriod}s&range=${this.lookback}s`;
+    return `https://api.domination.finance/api/v0/price/${this.pair}/history?tick=${this.tickPeriod}s&range=${this.lookback}s`;
   }
 
   getCurrentPrice() {


### PR DESCRIPTION
Signed-off-by: Josh Bowden <josbow@gmail.com>

**Motivation**

Uses `api.domination.finance` endpoint exclusively for all API requests. See #3160.

**Summary**

The API URL was changed from `live.domination.finance` to `api.domination.finance` for the historical price feed.

The `api` endpoint does not do any processing of the pricing data and simply returns the raw historical data from CoinGecko. 
The `live` endpoint is primarily used to power our website's chart and has some data preprocessing for grouping by ticks, etc. 
Importantly, at the moment the `api` endpoint is significantly more stable than the `live` endpoint, primarily due to the fact that the `api` endpoint is not stateful.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

**Issue(s)**

Fixes #3160.
