### PR TITLE
improve(api): 1533 refactor emp stats to have a table per stat type

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -71,6 +71,18 @@ Returns all known active emps data. Conforms to the EMP type defined in the uma 
 
 Returns all known expired emps data. Conforms to the EMP type defined in the uma sdk: `uma.tables.emp.Data`.
 
+### getEmpState(address: string) => EmpState
+
+Get all known state of any emp by its address.
+
+### getErc20Info(address:string) => Erc20Data
+
+Get name, decimals of an erc20 by address.
+
+### getAllErc20Info() => Erc20Data[]
+
+List all known erc20s, collateral or synthetic and all known information about them
+
 ### collateralAddresses() => string[]
 
 ### syntheticAddresses() => string[]
@@ -85,9 +97,9 @@ Returns all known latest prices for synthetic or collateral addresses in wei.
 
 Returns latest price for a particular erc20 token address ( emp collateral or synthetic address) in wei.
 
-### latestCollateralPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
-
 ### latestSyntheticPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
+
+### latestCollateralPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
 
 Gets the latest collateral or synthetic price based on the emp contract address in wei.
 
@@ -115,41 +127,26 @@ This is useful for charting betwen two dates.
 Get a range of historical prices between start and count of price samples, sorted by timestamp ascending, from an emp contract address.
 This is useful for paginating data when you have X elements per page, and you know the last element seen.
 
-### getErc20Info(address:string) => Erc20Data
+### tvl(empAddresses?: string[], currency: CurrencySymbol = "usd") => string
 
-Get name, decimals of an erc20 by address.
+### tvm(empAddresses?: string[], currency: CurrencySymbol = "usd") => string
 
-### getAllErc20Info() => Erc20Data[]
+Returns TVL/TVM of all supplied addresses in USD 18 decimals. If no addresses supplied, returns TVL/TVM of all known contracts.
 
-List all known erc20s, collateral or synthetic and all known information about them
+### tvlHistoryBetween(empAddress: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
 
-### getEmpStats(address: string, currency: "usd" = "usd") => StatData
+### tvmHistoryBetween(empAddress: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
 
-Get only tvl (and other future statistics) for a single emp.
+Returns TVL/TVM between timestamps (in seconds) at the highest resolution for a particular emp address.
 
-### listEmpStats(currency: "usd" = "usd") => StatData[]
+### tvlHistorySlice(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
 
-Get all tvl (and other future statistics) for all known emps.
+### tvmHistorySlice(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
 
-### historicalSynthPricesByAddress(empAddress:string,start:number=0,end:number=Math.floor(Date.now() / 1000)) => PriceSample[]
+Returns TVL/TVM for emp starting at timestamp in seconds and a length number of samples after that ascending.
 
-Get a range of historical prices synthetic prices by emp address between start and end in unix seconds, sorted by timestamp
-ascending. This is useful for charting betwen two dates. Note non synth historical prices are specified by erc20 address.
+### listTvls(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
 
-### sliceHistoricalSynthPricesByAddress(address:string,start:number=0,length:number=1) => PriceSample[]
+### listTvms(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
 
-Get a range of historical synthetic prices by emp address between start (in unix seconds) and count of price samples, sorted by timestamp
-ascending. This is useful for paginating data when you have X elements per page, and you know the last element seen.
-Note non synth historical prices are specified by erc20 address.
-
-### tvl(addresses?: string[], currency: CurrencySymbol = "usd") => string
-
-Returns tvl of all supplied addresses in USD 18 decimals. If no addresses supplied, returns TVL of all known contracts.
-
-### getEmpStatsBetween(address: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
-
-Returns all stats between timestamps (in seconds) at the highest resolution for a particular emp address.
-
-### sliceHistoricalEmpStats(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
-
-Returns all stats for emp starting at timestamp in seconds and a length number of samples after that ascending.
+List all tvls/tvms of known contracts.

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -9,7 +9,7 @@ import * as Services from "../../services";
 import Express from "../../services/express";
 import Actions from "../../services/actions";
 import { ProcessEnv, AppState } from "../..";
-import { empStats } from "../../tables";
+import { empStats, empStatsHistory } from "../../tables";
 
 async function run(env: ProcessEnv) {
   assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
@@ -50,8 +50,14 @@ async function run(env: ProcessEnv) {
     erc20s: tables.erc20s.JsMap(),
     stats: {
       usd: {
-        latest: empStats.JsMap(),
-        history: {},
+        latest: {
+          tvm: empStats.JsMap("Latest Tvm"),
+          tvl: empStats.JsMap("Latest Tvl"),
+        },
+        history: {
+          tvm: empStatsHistory.SortedJsMap("Tvm History"),
+          tvl: empStatsHistory.SortedJsMap("Tvl History"),
+        },
       },
     },
     lastBlock: 0,
@@ -95,6 +101,7 @@ async function run(env: ProcessEnv) {
 
   // backfill price histories
   await services.collateralPrices.backfill(moment().subtract(1, "month").valueOf());
+  console.log("Updated Collateral Prices Backfill");
 
   await services.collateralPrices.update();
   console.log("Updated Collateral Prices");

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -96,8 +96,6 @@ async function run(env: ProcessEnv) {
   console.log("Updated emp state");
   await services.erc20s.update();
   console.log("Updated tokens");
-  await services.syntheticPrices.update();
-  console.log("Updated Synthetic Prices");
 
   // backfill price histories
   await services.collateralPrices.backfill(moment().subtract(1, "month").valueOf());
@@ -105,6 +103,10 @@ async function run(env: ProcessEnv) {
 
   await services.collateralPrices.update();
   console.log("Updated Collateral Prices");
+
+  await services.syntheticPrices.update();
+  console.log("Updated Synthetic Prices");
+
   await services.empStats.update();
   console.log("Updated EMP Stats");
 
@@ -142,7 +144,7 @@ async function run(env: ProcessEnv) {
   // coingeckos prices don't update very fast, so set it on an interval every few minutes
   utils.loop(async () => {
     updatePrices().catch(console.error);
-  }, 5 * 60 * 1000);
+  }, 10 * 60 * 1000);
 }
 
 export default run;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -50,9 +50,13 @@ export type AppState = {
   erc20s: uma.tables.erc20s.JsMap;
   stats: {
     usd: {
-      latest: empStats.JsMap;
+      latest: {
+        tvl: empStats.JsMap;
+        tvm: empStats.JsMap;
+      };
       history: {
-        [address: string]: empStatsHistory.SortedJsMap;
+        tvl: empStatsHistory.SortedJsMap;
+        tvm: empStatsHistory.SortedJsMap;
       };
     };
   };

--- a/packages/api/src/libs/queries.ts
+++ b/packages/api/src/libs/queries.ts
@@ -96,18 +96,21 @@ export default (appState: Dependencies) => {
   }
 
   async function sumTvl(addresses: string[], currency: CurrencySymbol = "usd") {
-    const tvl = await bluebird.reduce(
-      addresses,
-      async (sum, address) => {
+    const tvls = await Promise.all(
+      addresses.map(async (address) => {
         try {
-          const stats = await appState.stats[currency].latest.tvl.get(address);
-          return sum.add(stats.value || "0");
+          const stat = await appState.stats[currency].latest.tvl.get(address);
+          return stat.value || "0";
         } catch (err) {
-          return sum;
+          return "0";
         }
-      },
-      BigNumber.from("0")
+      })
     );
+
+    const tvl = await tvls.reduce((sum, tvl) => {
+      return sum.add(tvl);
+    }, BigNumber.from("0"));
+
     return tvl.toString();
   }
   async function totalTvl(currency: CurrencySymbol = "usd") {
@@ -115,18 +118,21 @@ export default (appState: Dependencies) => {
     return sumTvl(addresses, currency);
   }
   async function sumTvm(addresses: string[], currency: CurrencySymbol = "usd") {
-    const tvm = await bluebird.reduce(
-      addresses,
-      async (sum, address) => {
+    const tvms = await Promise.all(
+      addresses.map(async (address) => {
         try {
-          const stats = await appState.stats[currency].latest.tvm.get(address);
-          return sum.add(stats.value || "0");
+          const stat = await appState.stats[currency].latest.tvm.get(address);
+          return stat.value || "0";
         } catch (err) {
-          return sum;
+          return "0";
         }
-      },
-      BigNumber.from("0")
+      })
     );
+
+    const tvm = await tvms.reduce((sum, tvm) => {
+      return sum.add(tvm);
+    }, BigNumber.from("0"));
+
     return tvm.toString();
   }
   async function totalTvm(currency: CurrencySymbol = "usd") {

--- a/packages/api/src/services/actions.ts
+++ b/packages/api/src/services/actions.ts
@@ -13,7 +13,7 @@ type Config = undefined;
 
 export function Handlers(config: Config, appState: Dependencies): Actions {
   const queries = Queries(appState);
-  const { registeredEmps, erc20s, collateralAddresses, syntheticAddresses, prices, stats } = appState;
+  const { registeredEmps, erc20s, collateralAddresses, syntheticAddresses, prices, stats, synthPrices } = appState;
 
   const actions: Actions = {
     echo(...args: Json[]) {
@@ -47,6 +47,9 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     async allLatestPrices(currency: CurrencySymbol = "usd") {
       assert(exists(prices[currency]), "invalid currency type: " + currency);
       return prices[currency].latest;
+    },
+    async allIdentifierPrices() {
+      return synthPrices.latest;
     },
     // get prices by token address
     latestPriceByTokenAddress: queries.latestPriceByTokenAddress,
@@ -92,13 +95,13 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(exists(emp.collateralCurrency), "EMP does not have token currency address");
       return queries.sliceHistoricalPricesByTokenAddress(emp.collateralCurrency, start, length);
     },
-    async tvl(addresses?: string[], currency: CurrencySymbol = "usd") {
-      addresses = lodash.castArray(addresses);
+    async tvl(addresses: string[] = [], currency: CurrencySymbol = "usd") {
+      addresses = addresses ? lodash.castArray(addresses) : [];
       if (addresses == null || addresses.length == 0) return queries.totalTvl(currency);
       return queries.sumTvl(addresses, currency);
     },
-    async tvm(addresses?: string[], currency: CurrencySymbol = "usd") {
-      addresses = lodash.castArray(addresses);
+    async tvm(addresses: string[] = [], currency: CurrencySymbol = "usd") {
+      addresses = addresses ? lodash.castArray(addresses) : [];
       if (addresses == null || addresses.length == 0) return queries.totalTvm(currency);
       return queries.sumTvm(addresses, currency);
     },

--- a/packages/api/src/services/emp-stats.ts
+++ b/packages/api/src/services/emp-stats.ts
@@ -8,7 +8,7 @@ import Queries from "../libs/queries";
 type Config = {
   currency?: Currencies;
 };
-type Dependencies = Pick<AppState, "emps" | "stats" | "prices" | "erc20s" | "registeredEmps">;
+type Dependencies = Pick<AppState, "emps" | "stats" | "prices" | "erc20s" | "registeredEmps" | "synthPrices">;
 
 // this service is meant to calculate numbers derived from emp state, things like TVL, TVM and other things
 export default (config: Config, appState: Dependencies) => {
@@ -84,7 +84,7 @@ export default (config: Config, appState: Dependencies) => {
     return stats[currency].latest.tvl.upsert(emp.address, update);
   }
   async function updateTvm(emp: uma.tables.emps.Data) {
-    assert(emp.tokenCurrency, "TVL Requires token currency for emp: " + emp.address);
+    assert(emp.tokenCurrency, "TVM Requires token currency for emp: " + emp.address);
     const priceSample = await getPriceFromTable(emp.address, emp.tokenCurrency);
     const value = await calcTvm(priceSample[1], emp).toString();
     const update = {

--- a/packages/api/src/tables/emp-stats-history/sorted-js-map.test.ts
+++ b/packages/api/src/tables/emp-stats-history/sorted-js-map.test.ts
@@ -1,0 +1,55 @@
+import assert from "assert";
+import { Table } from "./sorted-js-map";
+import type { Data } from "./utils";
+
+describe("emp history", function () {
+  let table: ReturnType<typeof Table>;
+  it("should init", function () {
+    table = Table();
+    assert.ok(table);
+  });
+  it("should set initial data", async function () {
+    const data = [
+      { timestamp: 10, address: "a", value: "0" },
+      { timestamp: 9, address: "a", value: "0" },
+      { timestamp: 8, address: "a", value: "0" },
+      { timestamp: 0, address: "a", value: "0" },
+      { timestamp: 1, address: "a", value: "0" },
+      { timestamp: 10, address: "b", value: "0" },
+      { timestamp: 9, address: "b", value: "0" },
+      { timestamp: 8, address: "b", value: "0" },
+      { timestamp: 0, address: "c", value: "0" },
+      { timestamp: 1, address: "c", value: "0" },
+    ];
+    await Promise.all(data.map(table.create));
+    assert.equal(await table.size(), data.length);
+  });
+  it("should get all data for address", async function () {
+    let result = await table.getAllByAddress("a");
+    assert.equal(result.length, 5);
+    result = await table.getAllByAddress("b");
+    assert.equal(result.length, 3);
+    result = await table.getAllByAddress("c");
+    assert.equal(result.length, 2);
+  });
+  it("should get between by address", async function () {
+    const result = await table.betweenByAddress("a", 1, 9);
+    let plan = 2;
+    result.forEach((sample: Data) => {
+      plan--;
+      assert(sample.timestamp >= 1);
+      assert(sample.timestamp < 9);
+      assert.equal(sample.address, "a");
+    });
+    assert.equal(plan, 0);
+  });
+  it("should slice by address", async function () {
+    const result = await table.sliceByAddress("b", 0, 4);
+    let plan = 3;
+    result.forEach((sample: Data) => {
+      plan--;
+      assert.equal(sample.address, "b");
+    });
+    assert.equal(plan, 0);
+  });
+});

--- a/packages/api/src/tables/emp-stats-history/sorted-js-map.ts
+++ b/packages/api/src/tables/emp-stats-history/sorted-js-map.ts
@@ -1,9 +1,36 @@
 import * as uma from "@uma/sdk";
-import { Data, makeId } from "./utils";
+import { Data, makeId, makeEndId } from "./utils";
 const { SortedJsMap } = uma.tables.generic;
 
 export const Table = (type = "Emp Stat History") => {
-  const table = SortedJsMap<number, Data>(type, makeId);
-  return table;
+  const table = SortedJsMap<string, Data>(type, makeId);
+
+  function hasByAddress(address: string, timestamp: number) {
+    return table.has(makeId({ address, timestamp }));
+  }
+  function getAllByAddress(address: string) {
+    const startid = makeId({ address, timestamp: 0 });
+    const endid = makeEndId({ address });
+    return table.between(startid, endid);
+  }
+  function betweenByAddress(address: string, start: number, end: number) {
+    const startid = makeId({ address, timestamp: start });
+    const endid = makeId({ address, timestamp: end });
+    return table.between(startid, endid);
+  }
+  async function sliceByAddress(address: string, start: number, length: number) {
+    const startid = makeId({ address, timestamp: start });
+    const endid = makeEndId({ address });
+    const result = await table.between(startid, endid);
+    return result.slice(0, length);
+  }
+
+  return {
+    ...table,
+    getAllByAddress,
+    hasByAddress,
+    betweenByAddress,
+    sliceByAddress,
+  };
 };
 export type Table = ReturnType<typeof Table>;

--- a/packages/api/src/tables/emp-stats-history/utils.ts
+++ b/packages/api/src/tables/emp-stats-history/utils.ts
@@ -1,10 +1,15 @@
 export type Data = {
   id?: number;
-  address?: string;
+  address: string;
   timestamp: number;
-  tvl?: string;
-  tvm?: string;
+  value: string;
 };
-export function makeId(data: Pick<Data, "timestamp">) {
-  return data.timestamp;
+// this is a funny id, but allows us to maintain time series data for multiple addresses in the same table
+export function makeId(data: Pick<Data, "timestamp" | "address">) {
+  return [data.address, data.timestamp.toString().padStart(16, "0")].join("!");
+}
+// this creates an id which would represents above the maximum value an address + timestamp can represent
+// useful for calculating the end id for a between(start,end) query
+export function makeEndId(data: Pick<Data, "address">) {
+  return [data.address, "~"].join("!");
 }

--- a/packages/api/src/tables/emp-stats/js-map.test.ts
+++ b/packages/api/src/tables/emp-stats/js-map.test.ts
@@ -3,18 +3,18 @@ import { JsMap } from ".";
 
 describe("emp stat table", function () {
   let table: any;
-  test("init", function () {
+  it("init", function () {
     table = JsMap();
     assert.ok(table);
   });
-  test("create", async function () {
+  it("create", async function () {
     const data = {
       address: "a",
     };
     const result = await table.getOrCreate(data.address);
     assert.equal(result.id, data.address);
   });
-  test("upsert", async function () {
+  it("upsert", async function () {
     const address = "b";
     const update = {
       tvl: "100",

--- a/packages/api/src/tables/emp-stats/utils.ts
+++ b/packages/api/src/tables/emp-stats/utils.ts
@@ -2,11 +2,7 @@ export type Data = {
   id?: string;
   address: string;
   timestamp?: number;
-  tvl?: string;
-  tvm?: string;
-  syntheticPrice?: string;
-  collateralPrice?: string;
-  rawSyntheticPrice?: string;
+  value?: string;
 };
 export function makeId(data: Pick<Data, "address">) {
   return data.address;

--- a/packages/sdk/src/libs/coingecko/coingecko.ts
+++ b/packages/sdk/src/libs/coingecko/coingecko.ts
@@ -2,6 +2,10 @@ import axios from "axios";
 import assert from "assert";
 import { get } from "lodash";
 
+export function msToS(ms: number) {
+  return Math.floor(ms / 1000);
+}
+
 class Coingecko {
   private host: string;
   constructor(host = "https://api.coingecko.com/api/v3") {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1533/refactor-emp-stats-to-break-apart-tvl-tvm-and-other-stats-from-the-same-blob

**Summary**

Refactors the emp stats table to take a single value per table. Updates public api calls to reflect this change, stats no longer return a bundle of stats which include tvl and tvm, but rather you must explicitly call for tvl or tvm directly.  


**Details**

This mainly changes the emp-stats service, the emp-stats-history table structure and app state.  This change essentially changes the 1 historical stat table per emp, and now creates a single table per statistic. TVL and TVM get their own tables, and host multiple emp time series data. Queries on these tables are updated to reflect this.  This allows us now to have separate timestamps for each stat.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1533/refactor-emp-stats-to-break-apart-tvl-tvm-and-other-stats-from-the-same-blob
