### PR TITLE
feat(sdk): 1539 add lsp creator client and lsp client

### DIFF
--- a/packages/sdk/src/libs/clients/index.ts
+++ b/packages/sdk/src/libs/clients/index.ts
@@ -2,3 +2,5 @@ export * as registry from "./registry";
 export * as emp from "./emp";
 export * as erc20 from "./erc20";
 export * as multicall from "./multicall";
+export * as lspCreator from "./lsp-creator";
+export * as lsp from "./lsp";

--- a/packages/sdk/src/libs/clients/lsp-creator/README.md
+++ b/packages/sdk/src/libs/clients/lsp-creator/README.md
@@ -1,0 +1,24 @@
+# UMA SDK LSP Creator Client
+
+This contract is a long short pair (LSP) factory. Discover all LSP contracts deployed through the creator.
+
+## Usage
+
+Get the address of a deployed LSP Creator based on your network, and discover LSP contracts by querying events.
+
+```js
+import { ethers } from "ethers"
+import uma from "@uma/sdk"
+
+// assume you have a url injected from env
+const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL)
+
+// get the contract instance, address lookup happens based on network (1)
+const address = uma.clients.lspCreator.getAddress("1")
+const client: uma.clients.lspCreator.Instance = uma.clients.lspCreator.connect(address, provider)
+// get all contract registered events, using standard ethers API, empty object gets all events for all time.
+const events = await client.queryFilter({})
+
+// returns EventState, defined in the lsp-creator client
+const state: uma.clients.lspCreator.EventState = uma.clients.lspCreator.getEventState(events)
+```

--- a/packages/sdk/src/libs/clients/lsp-creator/client.e2e.ts
+++ b/packages/sdk/src/libs/clients/lsp-creator/client.e2e.ts
@@ -1,0 +1,22 @@
+require("dotenv").config();
+import assert from "assert";
+import * as Client from "./client";
+import { ethers } from "ethers";
+
+// these require integration testing, skip for ci
+describe("lsp creator", function () {
+  let client: Client.Instance;
+  test("inits", function () {
+    const provider = ethers.providers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+    const address = Client.getAddress("1");
+    console.log(address);
+    client = Client.connect(address, provider);
+    assert.ok(client);
+  });
+  test("getEventState", async function () {
+    const events = await client.queryFilter({});
+    const state = await Client.getEventState(events);
+    assert.ok(state.contracts);
+    assert.ok(Object.keys(state.contracts).length > 0);
+  });
+});

--- a/packages/sdk/src/libs/clients/lsp-creator/client.ts
+++ b/packages/sdk/src/libs/clients/lsp-creator/client.ts
@@ -1,0 +1,48 @@
+import assert from "assert";
+import { LongShortPairCreator__factory, LongShortPairCreator } from "@uma/core/contract-types/ethers";
+import Artifacts from "@uma/core/build/contracts/LongShortPairCreator.json";
+import type { SignerOrProvider, GetEventType } from "../..";
+import { Event } from "ethers";
+
+// exporting Registry type in case its needed
+export type Instance = LongShortPairCreator;
+
+export type Network = keyof typeof Artifacts.networks;
+
+export type CreatedLongShortPair = GetEventType<Instance, "CreatedLongShortPair">;
+
+export interface EventState {
+  contracts?: {
+    [lspAddress: string]: CreatedLongShortPair["args"];
+  };
+}
+
+export function getAddress(network: Network): string {
+  const address = Artifacts?.networks?.[network]?.address;
+  assert(address, "no address found for network: " + network);
+  return address;
+}
+
+export function connect(address: string, provider: SignerOrProvider): Instance {
+  return LongShortPairCreator__factory.connect(address, provider);
+}
+
+export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+  switch (event.event) {
+    case "CreatedLongShortPair": {
+      const typedEvent = event as CreatedLongShortPair;
+      const contracts = state?.contracts || {};
+      return {
+        ...state,
+        contracts: {
+          ...contracts,
+          [typedEvent.args.longShortPair]: typedEvent.args,
+        },
+      };
+    }
+  }
+  return state;
+}
+export function getEventState(events: Event[]): EventState {
+  return events.reduce(reduceEvents, {});
+}

--- a/packages/sdk/src/libs/clients/lsp-creator/client.ts
+++ b/packages/sdk/src/libs/clients/lsp-creator/client.ts
@@ -23,11 +23,15 @@ export function getAddress(network: Network): string {
   return address;
 }
 
+export function getAbi() {
+  return Artifacts?.abi;
+}
+
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return LongShortPairCreator__factory.connect(address, provider);
 }
 
-export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState, event: Event, index?: number): EventState {
   switch (event.event) {
     case "CreatedLongShortPair": {
       const typedEvent = event as CreatedLongShortPair;
@@ -43,6 +47,6 @@ export function reduceEvents(state: EventState = {}, event: Event, index?: numbe
   }
   return state;
 }
-export function getEventState(events: Event[]): EventState {
-  return events.reduce(reduceEvents, {});
+export function getEventState(events: Event[], eventState: EventState = {}): EventState {
+  return events.reduce(reduceEvents, eventState);
 }

--- a/packages/sdk/src/libs/clients/lsp-creator/index.ts
+++ b/packages/sdk/src/libs/clients/lsp-creator/index.ts
@@ -1,0 +1,1 @@
+export * from "./client";

--- a/packages/sdk/src/libs/clients/lsp/README.md
+++ b/packages/sdk/src/libs/clients/lsp/README.md
@@ -1,0 +1,25 @@
+# UMA SDK LSP Client
+
+This is an LSP (Long Short Pair) contract client using ethers and typechain generated types.
+
+## Usage
+
+Connect to a typechain contract instance and recreate state from events.
+
+```js
+import {ethers} from 'ethers'
+import uma from '@uma/sdk'
+
+// assume you have a url injected from env
+const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL)
+
+// get the contract instance
+const contractAddress:string = // assume you have an lsp address you want to connect to
+const client:uma.clients.lsp.Instance = uma.clients.lsp.connect(contractAddress,provider)
+// gets all events using etheres query filter api
+const events = await client.queryFilter({})
+
+// returns EventState, defined in the lsp client
+const state:uma.clients.lsp.EventState = uma.clients.lsp.getEventState(events)
+
+```

--- a/packages/sdk/src/libs/clients/lsp/client.e2e.ts
+++ b/packages/sdk/src/libs/clients/lsp/client.e2e.ts
@@ -1,0 +1,22 @@
+require("dotenv").config();
+import assert from "assert";
+import * as Client from "./client";
+import { ethers } from "ethers";
+
+const address = "0x651EcbFc3d03109Bb9B2183A068F61dF6935a15A";
+// these require integration testing, skip for ci
+describe("lsp", function () {
+  let client: Client.Instance;
+  test("inits", function () {
+    const provider = ethers.providers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+    client = Client.connect(address, provider);
+    assert.ok(client);
+  });
+  test("getEventState", async function () {
+    const events = await client.queryFilter({});
+    const state = await Client.getEventState(events);
+    assert.ok(state.collateral);
+    assert.ok(state.shorts);
+    assert.ok(state.longs);
+  });
+});

--- a/packages/sdk/src/libs/clients/lsp/client.ts
+++ b/packages/sdk/src/libs/clients/lsp/client.ts
@@ -1,0 +1,103 @@
+import { LongShortPair__factory, LongShortPair } from "@uma/core/contract-types/ethers";
+import type { SignerOrProvider, GetEventType } from "../..";
+import { Event } from "ethers";
+import { Balances } from "../../utils";
+
+export type Instance = LongShortPair;
+
+export type TokensCreated = GetEventType<Instance, "TokensCreated">;
+export type TokensRedeemed = GetEventType<Instance, "TokensRedeemed">;
+export type ContractExpired = GetEventType<Instance, "ContractExpired">;
+export type PositionSettled = GetEventType<Instance, "PositionSettled">;
+
+export function connect(address: string, provider: SignerOrProvider): Instance {
+  return LongShortPair__factory.connect(address, provider);
+}
+
+export interface EventState {
+  sponsors?: string[];
+  longs?: Balances;
+  shorts?: Balances;
+  collateral?: Balances;
+  expired?: boolean;
+  expiredBy?: string;
+}
+
+export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+  switch (event.event) {
+    case "TokensCreated": {
+      const typedEvent = event as TokensCreated;
+      const { sponsor, collateralUsed, tokensMinted } = typedEvent.args;
+
+      const sponsors = new Set(state.sponsors || []);
+      const longs = Balances(state.longs || {});
+      const shorts = Balances(state.shorts || {});
+      const collateral = Balances(state.collateral || {});
+
+      sponsors.add(sponsor);
+      longs.add(sponsor, tokensMinted);
+      shorts.add(sponsor, tokensMinted);
+      collateral.add(sponsor, collateralUsed);
+
+      return {
+        ...state,
+        collateral: collateral.balances,
+        shorts: shorts.balances,
+        longs: longs.balances,
+        sponsors: Array.from(sponsors.values()),
+      };
+    }
+    case "TokensRedeemed": {
+      const typedEvent = event as TokensRedeemed;
+      const { sponsor, collateralReturned, tokensRedeemed } = typedEvent.args;
+
+      const longs = Balances(state.longs || {});
+      const shorts = Balances(state.shorts || {});
+      const collateral = Balances(state.collateral || {});
+
+      longs.sub(sponsor, tokensRedeemed);
+      shorts.sub(sponsor, tokensRedeemed);
+      collateral.sub(sponsor, collateralReturned);
+
+      return {
+        ...state,
+        collateral: collateral.balances,
+        shorts: shorts.balances,
+        longs: longs.balances,
+      };
+    }
+    case "ContractExpired": {
+      const typedEvent = event as ContractExpired;
+      const { caller } = typedEvent.args;
+
+      return {
+        ...state,
+        expired: true,
+        expiredBy: caller,
+      };
+    }
+    case "PositionSettled": {
+      const typedEvent = event as PositionSettled;
+      const { sponsor, collateralReturned, longTokens, shortTokens } = typedEvent.args;
+
+      const longs = Balances(state.longs || {});
+      const shorts = Balances(state.shorts || {});
+      const collateral = Balances(state.collateral || {});
+
+      longs.sub(sponsor, longTokens);
+      shorts.sub(sponsor, shortTokens);
+      collateral.sub(sponsor, collateralReturned);
+
+      return {
+        ...state,
+        collateral: collateral.balances,
+        shorts: shorts.balances,
+        longs: longs.balances,
+      };
+    }
+  }
+  return state;
+}
+export function getEventState(events: Event[]): EventState {
+  return events.reduce(reduceEvents, {});
+}

--- a/packages/sdk/src/libs/clients/lsp/client.ts
+++ b/packages/sdk/src/libs/clients/lsp/client.ts
@@ -23,7 +23,7 @@ export interface EventState {
   expiredBy?: string;
 }
 
-export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState, event: Event, index?: number): EventState {
   switch (event.event) {
     case "TokensCreated": {
       const typedEvent = event as TokensCreated;
@@ -98,6 +98,6 @@ export function reduceEvents(state: EventState = {}, event: Event, index?: numbe
   }
   return state;
 }
-export function getEventState(events: Event[]): EventState {
-  return events.reduce(reduceEvents, {});
+export function getEventState(events: Event[], eventState: EventState = {}): EventState {
+  return events.reduce(reduceEvents, eventState);
 }

--- a/packages/sdk/src/libs/clients/lsp/index.ts
+++ b/packages/sdk/src/libs/clients/lsp/index.ts
@@ -1,0 +1,1 @@
+export * from "./client";


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1539/create-lsp-client-in-sdk

**Summary**

Adds 2 clients and some basic tests:
- lsp creator client - allows us to search for address based on network, get a typechain client and deduce deployed lsps by events
- lsp client - allows us to get a typechain client as well as deduce balances based on lsp events

This is a part of a larger task to get lsp state into the api.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1539/create-lsp-client-in-sdk
