### PR TITLE
liquidator(Proxy-Helper-Scripts): Add DSProxy script to settle an expired position

### DIFF
--- a/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
+++ b/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "../../common/implementation/FixedPoint.sol";
+
+// Simple contract used to Settle expired positions using a DSProxy.
+contract LiquidationWithdrawer {
+    function settleExpired(address financialContractAddress) public returns (FixedPoint.Unsigned memory) {
+        return IFinancialContract(financialContractAddress).settleExpired();
+    }
+}
+
+interface IFinancialContract {
+    function settleExpired() external returns (FixedPoint.Unsigned memory amountWithdrawn);
+}

--- a/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
+++ b/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
@@ -11,5 +11,5 @@ contract PositionSettler {
 }
 
 interface IFinancialContract {
-    function settle() external returns (FixedPoint.Unsigned memory amountWithdrawn);
+    function settleExpired() external returns (FixedPoint.Unsigned memory amountWithdrawn);
 }

--- a/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
+++ b/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
@@ -6,7 +6,7 @@ import "../../common/implementation/FixedPoint.sol";
 // Simple contract used to Settle expired positions using a DSProxy.
 contract PositionSettler {
     function settle(address financialContractAddress) public returns (FixedPoint.Unsigned memory) {
-        return IFinancialContract(financialContractAddress).settle();
+        return IFinancialContract(financialContractAddress).settleExpired();
     }
 }
 

--- a/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
+++ b/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
@@ -5,7 +5,7 @@ import "../../common/implementation/FixedPoint.sol";
 
 // Simple contract used to Settle expired positions using a DSProxy.
 contract PositionSettler {
-    function settle(address financialContractAddress) public returns (FixedPoint.Unsigned memory) {
+    function settleExpired(address financialContractAddress) public returns (FixedPoint.Unsigned memory) {
         return IFinancialContract(financialContractAddress).settleExpired();
     }
 }

--- a/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
+++ b/packages/core/contracts/proxy-scripts/bot-action-wrappers/PositionSettler.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.0;
 import "../../common/implementation/FixedPoint.sol";
 
 // Simple contract used to Settle expired positions using a DSProxy.
-contract LiquidationWithdrawer {
-    function settleExpired(address financialContractAddress) public returns (FixedPoint.Unsigned memory) {
-        return IFinancialContract(financialContractAddress).settleExpired();
+contract PositionSettler {
+    function settle(address financialContractAddress) public returns (FixedPoint.Unsigned memory) {
+        return IFinancialContract(financialContractAddress).settle();
     }
 }
 
 interface IFinancialContract {
-    function settleExpired() external returns (FixedPoint.Unsigned memory amountWithdrawn);
+    function settle() external returns (FixedPoint.Unsigned memory amountWithdrawn);
 }

--- a/packages/trader/scripts/RedeemTokensWithDSProxy.ts
+++ b/packages/trader/scripts/RedeemTokensWithDSProxy.ts
@@ -1,6 +1,6 @@
 // This script enables a DSProxy to redeem tokens from a contract. This should be used after a swap/mint/liquidate transaction
 // to close out a bots position. To execute the script, run:
-// truffle exec ./scripts /RedeemTokensWithDSProxy.ts--financialContractAddress 0x123 --numTokens 100000000000000000000 --dsProxyFactoryAddress 0x123 --network mainnet_mnemonic
+// truffle exec ./scripts/RedeemTokensWithDSProxy.ts--financialContractAddress 0x123 --numTokens 100000000000000000000 --dsProxyFactoryAddress 0x123 --network mainnet_mnemonic
 // Note if you do not provide the dsProxyAddress the script will try find one deployed at the unlocked wallet account.
 
 async function RedeemTokensWithDSProxy() {

--- a/packages/trader/scripts/RedeemTokensWithDSProxy.ts
+++ b/packages/trader/scripts/RedeemTokensWithDSProxy.ts
@@ -1,6 +1,6 @@
 // This script enables a DSProxy to redeem tokens from a contract. This should be used after a swap/mint/liquidate transaction
 // to close out a bots position. To execute the script, run:
-// truffle exec./ scripts / RedeemTokensWithDSProxy.ts--financialContractAddress 0x123 --numTokens 100000000000000000000 --dsProxyFactoryAddress 0x123 --network mainnet_mnemonic
+// truffle exec ./scripts /RedeemTokensWithDSProxy.ts--financialContractAddress 0x123 --numTokens 100000000000000000000 --dsProxyFactoryAddress 0x123 --network mainnet_mnemonic
 // Note if you do not provide the dsProxyAddress the script will try find one deployed at the unlocked wallet account.
 
 async function RedeemTokensWithDSProxy() {

--- a/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
+++ b/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
@@ -52,7 +52,7 @@ async function SettleExpiredPositionWithDSProxy() {
   // Create the callData as the encoded tx against the PositionSettler contract.
   const PositionSettler = getTruffleContract("PositionSettler", web3);
   const PositionSettlerInstance = new web3.eth.Contract(PositionSettler.abi);
-  const callData = PositionSettlerInstance.methods.redeem(argv.financialContractAddress).encodeABI();
+  const callData = PositionSettlerInstance.methods.settle(argv.financialContractAddress).encodeABI();
 
   // The library also needs the code of the contract to deploy.
   const callCode = PositionSettler.bytecode;

--- a/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
+++ b/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
@@ -1,3 +1,6 @@
+// TODO: the location of these scripts is a bit confusing. This script was put here to follow the Redeem and Withdraw
+// scripts but in future they should be moved somewhere more generic.
+
 // This script enables a DSProxy to settle expired positions from an EMP. This should be used after a DSProxy opens a
 // position due to liquidation and needs to settle the position at contract expiration. To execute the script, run:
 // truffle exec./ scripts/SettleExpiredPositionWithDSProxy.ts --financialContractAddress 0x123 --dsProxyAddress 0x456 --network mainnet_mnemonic

--- a/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
+++ b/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
@@ -3,7 +3,7 @@
 
 // This script enables a DSProxy to settle expired positions from an EMP. This should be used after a DSProxy opens a
 // position due to liquidation and needs to settle the position at contract expiration. To execute the script, run:
-// truffle exec./ scripts/SettleExpiredPositionWithDSProxy.ts --financialContractAddress 0x123 --dsProxyAddress 0x456 --network mainnet_mnemonic
+// truffle exec ./scripts/SettleExpiredPositionWithDSProxy.ts --financialContractAddress 0x123 --dsProxyAddress 0x456 --network mainnet_mnemonic
 // Note: if you do not provide the dsProxyAddress the script will try find one deployed at the unlocked wallet account.
 
 async function SettleExpiredPositionWithDSProxy() {

--- a/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
+++ b/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
@@ -52,7 +52,7 @@ async function SettleExpiredPositionWithDSProxy() {
   // Create the callData as the encoded tx against the PositionSettler contract.
   const PositionSettler = getTruffleContract("PositionSettler", web3);
   const PositionSettlerInstance = new web3.eth.Contract(PositionSettler.abi);
-  const callData = PositionSettlerInstance.methods.settle(argv.financialContractAddress).encodeABI();
+  const callData = PositionSettlerInstance.methods.settleExpired(argv.financialContractAddress).encodeABI();
 
   // The library also needs the code of the contract to deploy.
   const callCode = PositionSettler.bytecode;

--- a/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
+++ b/packages/trader/scripts/SettleExpiredPositionWithDSProxy.ts
@@ -1,0 +1,75 @@
+// This script enables a DSProxy to settle expired positions from an EMP. This should be used after a DSProxy opens a
+// position due to liquidation and needs to settle the position at contract expiration. To execute the script, run:
+// truffle exec./ scripts/SettleExpiredPositionWithDSProxy.ts --financialContractAddress 0x123 --dsProxyAddress 0x456 --network mainnet_mnemonic
+// Note: if you do not provide the dsProxyAddress the script will try find one deployed at the unlocked wallet account.
+
+async function SettleExpiredPositionWithDSProxy() {
+  const winston = require("winston");
+  const assert = require("assert");
+  const argv = require("minimist")(process.argv.slice(), {
+    string: ["financialContractAddress", "numTokens", "dsProxyAddress"],
+  });
+
+  const { getWeb3 } = require("@uma/common");
+  const web3 = getWeb3();
+
+  const { getAbi, getAddress, getTruffleContract } = require("@uma/core");
+  const { DSProxyManager, GasEstimator } = require("@uma/financial-templates-lib");
+
+  assert(web3.utils.isAddress(argv.financialContractAddress), "`financialContractAddress` needs to be a valid address");
+  console.log("Running position settler script 💰");
+
+  const [accounts, networkId] = await Promise.all([web3.eth.getAccounts(), web3.eth.net.getId()]);
+  console.log("Connected to network id", await web3.eth.net.getId());
+
+  const logger = winston.createLogger({
+    level: "debug",
+    transports: [new winston.transports.Console()],
+  });
+  const gasEstimator = new GasEstimator(logger);
+  await gasEstimator.update();
+
+  const dsProxyManager = new DSProxyManager({
+    logger,
+    web3,
+    gasEstimator,
+    account: accounts[0],
+    dsProxyFactoryAddress: getAddress("DSProxyFactory", networkId),
+    dsProxyFactoryAbi: getAbi("DSProxyFactory"),
+    dsProxyAbi: getAbi("DSProxy"),
+  });
+
+  // Load in a DSProxy address. If you did not provide one in the args then the script will check against the factory.
+  // False as the second param in this function prevents the DSProxyManager from deploying a DSProxy if you don't have one.
+  await dsProxyManager.initializeDSProxy(argv.dsProxyAddress || null, false);
+
+  const dsProxyAddress = dsProxyManager.getDSProxyAddress();
+  if (!dsProxyAddress) throw new Error("DSProxy Address was not found or not parameterized");
+
+  // Create the callData as the encoded tx against the PositionSettler contract.
+  const PositionSettler = getTruffleContract("PositionSettler", web3);
+  const PositionSettlerInstance = new web3.eth.Contract(PositionSettler.abi);
+  const callData = PositionSettlerInstance.methods.redeem(argv.financialContractAddress).encodeABI();
+
+  // The library also needs the code of the contract to deploy.
+  const callCode = PositionSettler.bytecode;
+
+  // Send the transaction against the DSProxy manager.
+  const dsProxyCallReturn = await dsProxyManager.callFunctionOnNewlyDeployedLibrary(callCode, callData);
+
+  console.log("TX executed!", dsProxyCallReturn.transactionHash);
+}
+
+const run = async function (callback) {
+  try {
+    await SettleExpiredPositionWithDSProxy();
+  } catch (err) {
+    console.error(err);
+    callback(err);
+    return;
+  }
+  callback();
+};
+
+run.SettleExpiredPositionWithDSProxy = SettleExpiredPositionWithDSProxy;
+module.exports = run;


### PR DESCRIPTION
**Motivation**

While running the single reserve liquidator bot, we created a number of positions due to liquidations. As these contracts are now settling, we require a DSProxy helper script to let us settle these positions. This PR adds the smart contract and script to facilitate this settling of positions.

**Note**: I placed this script within the `trader` package so it would be alongside the other DSProxy helper scripts. This is a bad location and should be moved in future.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested