### PR TITLE
fix: add trace to fatal hub errors

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -226,7 +226,7 @@ hub.post("/", async (req, res) => {
       logger.error({
         at: "ServerlessHub",
         message: "A fatal error occurred in the hub",
-        output: errorOutput.trace,
+        output: errorOutput.stack,
         notificationPath: "infrastructure-error",
       });
     } else {

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -226,7 +226,7 @@ hub.post("/", async (req, res) => {
       logger.error({
         at: "ServerlessHub",
         message: "A fatal error occurred in the hub",
-        output: errorOutput.message,
+        output: errorOutput.trace,
         notificationPath: "infrastructure-error",
       });
     } else {


### PR DESCRIPTION
**Motivation**

Hub doesn't provide a trace when it has internal errors.

**Summary**

Print out the trace as the error message.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
