### PR TITLE
feat(pf-configs): Add default pf config for uSTONKS_0921 and add to OO ignore list

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.js
+++ b/packages/common/src/PriceIdentifierUtils.js
@@ -36,6 +36,7 @@ const OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY = [
   "uSTONKS_APR21",
   "GASETH-TWAP-1Mx1M",
   "uSTONKS_JUN21",
+  "uSTONKS_0921",
 ];
 
 // Any identifier on this list

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -1006,6 +1006,12 @@ const defaultConfigs = {
       },
     },
   },
+  uSTONKS_0921: {
+    type: "uniswap",
+    uniswapAddress: "0xb9292B40cab08e5208b863ea9c4c4927a2308eEE",
+    twapLength: 7200,
+    invertPrice: true,
+  },
 };
 
 // Pull in the number of decimals for each identifier from the common getPrecisionForIdentifier. This is used within the


### PR DESCRIPTION
**Motivation**

uSTONKS_0921 needs a default price feed config. This price identifier switches to a manual calculation at expiry, so it also needs to be added to the `OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY` list.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
