### PR TITLE
feat(LSP): Add LSP pair name, OO liveness and OO bond settings

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -130,6 +130,7 @@ contract LongShortPair is Testable, Lockable {
         require(address(params.financialProductLibrary) != address(0), "Invalid FinancialProductLibrary");
         require(_getCollateralWhitelist().isOnWhitelist(address(params.collateralToken)), "Collateral not whitelisted");
         require(params.optimisticOracleLivenessTime > 0, "OO liveness cannot be 0");
+        require(params.optimisticOracleLivenessTime < 5200 weeks, "OO liveness too large");
 
         pairName = params.pairName;
         expirationTimestamp = params.expirationTimestamp;

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -42,12 +42,12 @@ contract LongShortPair is Testable, Lockable {
         bytes32 priceIdentifier; // Price identifier, registered in the DVM for the long short pair.
         ExpandedIERC20 longToken; // Token used as long in the LSP. Mint and burn rights needed by this contract.
         ExpandedIERC20 shortToken; // Token used as short in the LSP. Mint and burn rights needed by this contract.
-        IERC20 collateralToken;
-        LongShortPairFinancialProductLibrary financialProductLibrary;
-        bytes customAncillaryData;
-        uint256 prepaidProposerReward;
-        uint256 optimisticOracleLivenessTime;
-        uint256 optimisticOracleProposerBond;
+        IERC20 collateralToken; // Collateral token used to back LSP synthetics.
+        LongShortPairFinancialProductLibrary financialProductLibrary; // Contract providing settlement payout logic.
+        bytes customAncillaryData; // Custom ancillary data to be passed along with the price request to the OO.
+        uint256 prepaidProposerReward; // Preloaded reward to incentivize settlement price proposals.
+        uint256 optimisticOracleLivenessTime; // OO liveness timer for price requests.
+        uint256 optimisticOracleProposerBond; // OO proposer bond for price requests.
     }
 
     enum ContractState { Open, ExpiredPriceRequested, ExpiredPriceReceived }

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -65,6 +65,28 @@ contract LongShortPairCreator is Testable, Lockable {
         finder = _finder;
     }
 
+    /**
+     * @notice Creates a longShortPair contract and associated long and short tokens.
+     * @dev The caller must approve this contract to transfer `prepaidProposerReward` amount of collateral.
+     * @param params Constructor params used to initialize the LSP. Key-valued object with the following structure:
+     *     expirationTimestamp: unix timestamp of when the contract will expire.
+     *     collateralPerPair: how many units of collateral are required to mint one pair of synthetic tokens.
+     *     priceIdentifier: registered in the DVM for the synthetic.
+     *     longSynthName: Name of the long synthetic tokens to be created.
+     *     longSynthSymbol: Symbol of the long synthetic tokens to be created.
+     *     shortSynthName: Name of the short synthetic tokens to be created.
+     *     shortSynthSymbol: Symbol of the short synthetic tokens to be created.
+     *     collateralToken: ERC20 token used as collateral in the LSP.
+     *     financialProductLibrary: Contract providing settlement payout logic.
+     *     customAncillaryData: Custom ancillary data to be passed along with the price request. If not needed, this
+     *                             should be left as a 0-length bytes array.
+     *     prepaidProposerReward: Proposal reward forwarded to the created LSP to incentivize price proposals.
+     *     optimisticOracleLivenessTime: Optimistic oracle liveness timer for price requests.
+           optimisticOracleProposerBond: optimistic oracle proposer bond for price requests.
+     * @return lspAddress the deployed address of the new long short pair contract.
+     * @notice Created LSP is not registered within the registry as the LSP uses the Optimistic Oracle for settlement.
+     * @notice The LSP constructor does a number of validations on input params. These are not repeated here.
+     */
     function createLongShortPair(CreatorParams memory params) public nonReentrant() returns (address) {
         // Create a new synthetic token using the params.
         require(bytes(params.longSynthName).length != 0, "Missing long synthetic name");

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -103,7 +103,7 @@ contract LongShortPairCreator is Testable, Lockable {
             tokenFactory.createToken(params.shortSynthName, params.shortSynthSymbol, collateralDecimals);
 
         // Deploy the LPS contract.
-        LongShortPair lsp = new LongShortPair(_convertParams(params, longToken, shortToken), finder, timerAddress);
+        LongShortPair lsp = new LongShortPair(_convertParams(params, longToken, shortToken));
 
         // Move prepaid proposer reward from the deployer to the newly deployed contract.
         if (params.prepaidProposerReward > 0)
@@ -130,7 +130,7 @@ contract LongShortPairCreator is Testable, Lockable {
         CreatorParams memory creatorParams,
         ExpandedIERC20 longToken,
         ExpandedIERC20 shortToken
-    ) private pure returns (LongShortPair.ConstructorParams memory constructorParams) {
+    ) private view returns (LongShortPair.ConstructorParams memory constructorParams) {
         // Input from function call.
         constructorParams.pairName = creatorParams.pairName;
         constructorParams.expirationTimestamp = creatorParams.expirationTimestamp;
@@ -146,6 +146,10 @@ contract LongShortPairCreator is Testable, Lockable {
         // Constructed long & short synthetic tokens.
         constructorParams.longToken = longToken;
         constructorParams.shortToken = shortToken;
+
+        // Finder and timer. Should be the same as that used in this factory contract.
+        constructorParams.finder = finder;
+        constructorParams.timerAddress = timerAddress;
     }
 
     // IERC20Standard.decimals() will revert if the collateral contract has not implemented the decimals() method,

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -22,10 +22,10 @@ contract LongShortPairCreator is Testable, Lockable {
     using SafeERC20 for IERC20Standard;
 
     struct CreatorParams {
-        string pairName; // Name of the long short pair contract.
-        uint64 expirationTimestamp; // Unix timestamp of when the contract will expire.
-        uint256 collateralPerPair; // How many units of collateral are required to mint one pair of synthetic tokens.
-        bytes32 priceIdentifier; // Price identifier, registered in the DVM for the long short pair.
+        string pairName;
+        uint64 expirationTimestamp;
+        uint256 collateralPerPair;
+        bytes32 priceIdentifier;
         string longSynthName;
         string longSynthSymbol;
         string shortSynthName;

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -21,6 +21,23 @@ contract LongShortPairCreator is Testable, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using SafeERC20 for IERC20Standard;
 
+    struct CreatorParams {
+        string pairName; // Name of the long short pair contract.
+        uint64 expirationTimestamp; // Unix timestamp of when the contract will expire.
+        uint256 collateralPerPair; // How many units of collateral are required to mint one pair of synthetic tokens.
+        bytes32 priceIdentifier; // Price identifier, registered in the DVM for the long short pair.
+        string longSynthName;
+        string longSynthSymbol;
+        string shortSynthName;
+        string shortSynthSymbol;
+        IERC20Standard collateralToken;
+        LongShortPairFinancialProductLibrary financialProductLibrary;
+        bytes customAncillaryData;
+        uint256 prepaidProposerReward;
+        uint256 optimisticOracleLivenessTime;
+        uint256 optimisticOracleProposerBond;
+    }
+
     // Address of TokenFactory used to create a new synthetic token.
     TokenFactory public tokenFactory;
 
@@ -48,67 +65,27 @@ contract LongShortPairCreator is Testable, Lockable {
         finder = _finder;
     }
 
-    /**
-     * @notice Creates a longShortPair contract and associated long and short tokens.
-     * @dev The caller must approve this contract to transfer `prepaidProposerReward` amount of collateral.
-     * @param expirationTimestamp unix timestamp of when the contract will expire.
-     * @param collateralPerPair how many units of collateral are required to mint one pair of synthetic tokens.
-     * @param priceIdentifier registered in the DVM for the synthetic.
-     * @param longSynthName Name of the long synthetic tokens to be created.
-     * @param longSynthSymbol Symbol of the long synthetic tokens to be created.
-     * @param shortSynthName Name of the short synthetic tokens to be created.
-     * @param shortSynthSymbol Symbol of the short synthetic tokens to be created.
-     * @param collateralToken ERC20 token used as collateral in the LSP.
-     * @param financialProductLibrary Contract providing settlement payout logic.
-     * @param customAncillaryData Custom ancillary data to be passed along with the price request. If not needed, this
-     *                             should be left as a 0-length bytes array.
-     * @param prepaidProposerReward Proposal reward forwarded to the created LSP to incentivize price proposals.
-     * @return lspAddress the deployed address of the new long short pair contract.
-     * @notice Created LSP is not registered within the registry as the LSP uses the Optimistic Oracle for settlement.
-     * @notice The LSP constructor does a number of validations on input params. These are not repeated here.
-     */
-    function createLongShortPair(
-        uint64 expirationTimestamp,
-        uint256 collateralPerPair,
-        bytes32 priceIdentifier,
-        string memory longSynthName,
-        string memory longSynthSymbol,
-        string memory shortSynthName,
-        string memory shortSynthSymbol,
-        IERC20Standard collateralToken,
-        LongShortPairFinancialProductLibrary financialProductLibrary,
-        bytes memory customAncillaryData,
-        uint256 prepaidProposerReward
-    ) public nonReentrant() returns (address) {
+    function createLongShortPair(CreatorParams memory params) public nonReentrant() returns (address) {
         // Create a new synthetic token using the params.
-        require(bytes(longSynthName).length != 0, "Missing long synthetic name");
-        require(bytes(shortSynthName).length != 0, "Missing short synthetic name");
-        require(bytes(longSynthSymbol).length != 0, "Missing long synthetic symbol");
-        require(bytes(shortSynthSymbol).length != 0, "Missing short synthetic symbol");
+        require(bytes(params.longSynthName).length != 0, "Missing long synthetic name");
+        require(bytes(params.shortSynthName).length != 0, "Missing short synthetic name");
+        require(bytes(params.longSynthSymbol).length != 0, "Missing long synthetic symbol");
+        require(bytes(params.shortSynthSymbol).length != 0, "Missing short synthetic symbol");
 
         // If the collateral token does not have a `decimals()` method, then a default precision of 18 will be
         // applied to the newly created synthetic token.
-        uint8 collateralDecimals = _getSyntheticDecimals(collateralToken);
-        ExpandedIERC20 longToken = tokenFactory.createToken(longSynthName, longSynthSymbol, collateralDecimals);
-        ExpandedIERC20 shortToken = tokenFactory.createToken(shortSynthName, shortSynthSymbol, collateralDecimals);
-        LongShortPair lsp =
-            new LongShortPair(
-                expirationTimestamp,
-                collateralPerPair,
-                priceIdentifier,
-                longToken,
-                shortToken,
-                collateralToken,
-                finder,
-                financialProductLibrary,
-                customAncillaryData,
-                prepaidProposerReward,
-                timerAddress
-            );
+        uint8 collateralDecimals = _getSyntheticDecimals(params.collateralToken);
+        ExpandedIERC20 longToken =
+            tokenFactory.createToken(params.longSynthName, params.longSynthSymbol, collateralDecimals);
+        ExpandedIERC20 shortToken =
+            tokenFactory.createToken(params.shortSynthName, params.shortSynthSymbol, collateralDecimals);
+
+        // Deploy the LPS contract.
+        LongShortPair lsp = new LongShortPair(_convertParams(params, longToken, shortToken), finder, timerAddress);
 
         // Move prepaid proposer reward from the deployer to the newly deployed contract.
-        if (prepaidProposerReward > 0)
-            collateralToken.safeTransferFrom(msg.sender, address(lsp), prepaidProposerReward);
+        if (params.prepaidProposerReward > 0)
+            params.collateralToken.safeTransferFrom(msg.sender, address(lsp), params.prepaidProposerReward);
 
         address lspAddress = address(lsp);
 
@@ -124,6 +101,29 @@ contract LongShortPairCreator is Testable, Lockable {
         emit CreatedLongShortPair(lspAddress, msg.sender, address(longToken), address(shortToken));
 
         return lspAddress;
+    }
+
+    // Converts createLongShortPair creator params to LongShortPair constructor params.
+    function _convertParams(
+        CreatorParams memory creatorParams,
+        ExpandedIERC20 longToken,
+        ExpandedIERC20 shortToken
+    ) private pure returns (LongShortPair.ConstructorParams memory constructorParams) {
+        // Input from function call.
+        constructorParams.pairName = creatorParams.pairName;
+        constructorParams.expirationTimestamp = creatorParams.expirationTimestamp;
+        constructorParams.collateralPerPair = creatorParams.collateralPerPair;
+        constructorParams.priceIdentifier = creatorParams.priceIdentifier;
+        constructorParams.collateralToken = creatorParams.collateralToken;
+        constructorParams.financialProductLibrary = creatorParams.financialProductLibrary;
+        constructorParams.customAncillaryData = creatorParams.customAncillaryData;
+        constructorParams.prepaidProposerReward = creatorParams.prepaidProposerReward;
+        constructorParams.optimisticOracleLivenessTime = creatorParams.optimisticOracleLivenessTime;
+        constructorParams.optimisticOracleProposerBond = creatorParams.optimisticOracleProposerBond;
+
+        // Constructed long & short synthetic tokens.
+        constructorParams.longToken = longToken;
+        constructorParams.shortToken = shortToken;
     }
 
     // IERC20Standard.decimals() will revert if the collateral contract has not implemented the decimals() method,

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -1,4 +1,4 @@
-const { toWei, utf8ToHex, toBN } = web3.utils;
+const { toWei, utf8ToHex, toBN, padRight } = web3.utils;
 const truffleAssert = require("truffle-assertions");
 const { assert } = require("chai");
 
@@ -22,26 +22,29 @@ let collateralToken;
 let longToken;
 let shortToken;
 let longShortPair;
-let longShortPairLibrary;
+let longShortPairTestLibrary;
 let collateralWhitelist;
 let identifierWhitelist;
 let optimisticOracle;
 let finder;
-let ancillaryData = web3.utils.utf8ToHex("some-address-field:0x1234");
+let customAncillaryData = web3.utils.utf8ToHex("some-address-field:0x1234");
 let timer;
 let constructorParams;
 
+let optimisticOracleLivenessTime = 7200;
+let optimisticOracleProposerBond = "0";
+
 const startTimestamp = Math.floor(Date.now() / 1000);
 const expirationTimestamp = startTimestamp + 10000;
-const optimisticOracleLiveness = 7200;
-const priceFeedIdentifier = utf8ToHex("TEST_IDENTIFIER");
+const priceIdentifier = padRight(utf8ToHex("TEST_IDENTIFIER"), 64);
 const collateralPerPair = toWei("1"); // each pair of long and short tokens need 1 unit of collateral to mint.
 const prepaidProposerReward = toWei("100");
+const pairName = "Long Short Pair Test";
 
-const proposeAndSettleOptimisticOraclePrice = async (priceFeedIdentifier, requestTime, price) => {
-  await optimisticOracle.proposePrice(longShortPair.address, priceFeedIdentifier, requestTime, ancillaryData, price);
-  await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()) + optimisticOracleLiveness);
-  await optimisticOracle.settle(longShortPair.address, priceFeedIdentifier, requestTime, ancillaryData);
+const proposeAndSettleOptimisticOraclePrice = async (priceIdentifier, requestTime, price) => {
+  await optimisticOracle.proposePrice(longShortPair.address, priceIdentifier, requestTime, customAncillaryData, price);
+  await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()) + optimisticOracleLivenessTime);
+  await optimisticOracle.settle(longShortPair.address, priceIdentifier, requestTime, customAncillaryData);
 };
 
 contract("LongShortPair", function (accounts) {
@@ -55,7 +58,7 @@ contract("LongShortPair", function (accounts) {
     collateralWhitelist = await AddressWhitelist.deployed();
 
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(priceFeedIdentifier, { from: deployer });
+    await identifierWhitelist.addSupportedIdentifier(priceIdentifier, { from: deployer });
   });
 
   beforeEach(async function () {
@@ -71,29 +74,30 @@ contract("LongShortPair", function (accounts) {
     longToken = await Token.new("Long Token", "lTKN", 18, { from: deployer });
     shortToken = await Token.new("Short Token", "sTKN", 18, { from: deployer });
 
-    optimisticOracle = await OptimisticOracle.new(optimisticOracleLiveness, finder.address, timer.address);
+    optimisticOracle = await OptimisticOracle.new(optimisticOracleLivenessTime, finder.address, timer.address);
     await finder.changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracle), optimisticOracle.address, {
       from: deployer,
     });
 
     // Create LSP library and LSP contract.
-    longShortPairLibrary = await LongShortPairFinancialProjectLibraryTest.new();
+    longShortPairTestLibrary = await LongShortPairFinancialProjectLibraryTest.new();
 
     constructorParams = {
+      pairName,
       expirationTimestamp,
       collateralPerPair,
-      priceFeedIdentifier,
-      longTokenAddress: longToken.address,
-      shortTokenAddress: shortToken.address,
-      collateralTokenAddress: collateralToken.address,
-      finderAddress: finder.address,
-      LongShortPairLibraryAddress: longShortPairLibrary.address,
-      ancillaryData,
+      priceIdentifier,
+      longToken: longToken.address,
+      shortToken: shortToken.address,
+      collateralToken: collateralToken.address,
+      financialProductLibrary: longShortPairTestLibrary.address,
+      customAncillaryData,
       prepaidProposerReward,
-      timerAddress: timer.address,
+      optimisticOracleLivenessTime,
+      optimisticOracleProposerBond,
     };
 
-    longShortPair = await LongShortPair.new(...Object.values(constructorParams));
+    longShortPair = await LongShortPair.new(constructorParams, finder.address, timer.address);
     await collateralToken.mint(longShortPair.address, toWei("100"));
 
     // Add mint and burn roles for the long and short tokens to the long short pair.
@@ -103,40 +107,59 @@ contract("LongShortPair", function (accounts) {
     await shortToken.addMember(2, longShortPair.address, { from: deployer });
   });
   describe("Basic Functionality", () => {
+    it("Constructor params are set correctly", async function () {
+      assert.equal(await longShortPair.pairName(), pairName);
+      assert.equal(await longShortPair.expirationTimestamp(), expirationTimestamp);
+      assert.equal(await longShortPair.collateralPerPair(), collateralPerPair);
+      assert.equal(await longShortPair.priceIdentifier(), priceIdentifier);
+      assert.equal(await longShortPair.collateralToken(), collateralToken.address);
+      assert.equal(await longShortPair.longToken(), longToken.address);
+      assert.equal(await longShortPair.longToken(), longToken.address);
+      assert.equal(await longShortPair.finder(), finder.address);
+      assert.equal(await longShortPair.financialProductLibrary(), longShortPairTestLibrary.address);
+      assert.equal(await longShortPair.customAncillaryData(), customAncillaryData);
+      assert.equal(await longShortPair.prepaidProposerReward(), prepaidProposerReward);
+      assert.equal(await longShortPair.optimisticOracleLivenessTime(), optimisticOracleLivenessTime);
+      assert.equal(await longShortPair.optimisticOracleProposerBond(), optimisticOracleProposerBond);
+    });
     it("Rejects invalid constructor parameters", async function () {
       // Invalid expiration time.
       assert(
         await didContractThrow(
           LongShortPair.new(
-            ...Object.values({ ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 1 })
+            { ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 1 },
+            finder.address,
+            timer.address
           )
         )
       );
 
       // Invalid collateral per pair.
       assert(
-        await didContractThrow(LongShortPair.new(...Object.values({ ...constructorParams, collateralPerPair: "0" })))
+        await didContractThrow(
+          LongShortPair.new({ ...constructorParams, collateralPerPair: "0" }, finder.address, timer.address)
+        )
       );
 
       // Invalid price identifier time.
       assert(
         await didContractThrow(
-          LongShortPair.new(...Object.values({ ...constructorParams, priceFeedIdentifier: "BAD-IDENTIFIER" }))
+          LongShortPair.new({ ...constructorParams, priceIdentifier: "BAD-IDENTIFIER" }, finder.address, timer.address)
         )
       );
       // Invalid LSP library address.
       assert(
         await didContractThrow(
-          LongShortPair.new(...Object.values({ ...constructorParams, longShortPairLibraryAddress: ZERO_ADDRESS }))
+          LongShortPair.new(
+            { ...constructorParams, financialProductLibrary: ZERO_ADDRESS },
+            finder.address,
+            timer.address
+          )
         )
       );
 
       // Invalid Finder address.
-      assert(
-        await didContractThrow(
-          LongShortPair.new(...Object.values({ ...constructorParams, finderAddress: ZERO_ADDRESS }))
-        )
-      );
+      assert(await didContractThrow(LongShortPair.new(constructorParams, ZERO_ADDRESS, timer.address)));
 
       // Test ancillary data limits.
       // Get max length from contract.
@@ -148,7 +171,9 @@ contract("LongShortPair", function (accounts) {
       assert(
         await didContractThrow(
           LongShortPair.new(
-            ...Object.values({ ...constructorParams, ancillaryData: web3.utils.randomHex(remainingLength + 1) })
+            { ...constructorParams, customAncillaryData: web3.utils.randomHex(remainingLength + 1) },
+            finder.address,
+            timer.address
           )
         )
       );
@@ -188,11 +213,11 @@ contract("LongShortPair", function (accounts) {
       await longShortPair.expire();
       assert.equal(await longShortPair.contractState(), 1); // state should be ExpiredPriceRequested before.
 
-      await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
+      await proposeAndSettleOptimisticOraclePrice(priceIdentifier, expirationTimestamp, toWei("0.5"));
 
       // Redemption value scaled between 0 and 1, indicating how much of the collateralPerPair is split between the long and
       // short tokens. Setting to 0.5 makes each long token worth 0.5 collateral and each short token worth 0.5 collateral.
-      await longShortPairLibrary.setValueToReturn(toWei("0.5"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("0.5"));
 
       await longShortPair.settle(toWei("50"), toWei("0"), { from: holder }); // holder redeem their 50 long tokens.
       assert.equal(await longToken.balanceOf(holder), toWei("0")); // they should have no long tokens left.
@@ -231,9 +256,9 @@ contract("LongShortPair", function (accounts) {
         return ev.caller == deployer;
       });
 
-      await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
+      await proposeAndSettleOptimisticOraclePrice(priceIdentifier, expirationTimestamp, toWei("0.5"));
 
-      await longShortPairLibrary.setValueToReturn(toWei("0.5"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("0.5"));
 
       const settleTx = await longShortPair.settle(toWei("75"), toWei("75"), { from: sponsor });
 
@@ -251,9 +276,9 @@ contract("LongShortPair", function (accounts) {
       await longShortPair.expire();
       const request = await optimisticOracle.getRequest(
         longShortPair.address,
-        priceFeedIdentifier,
+        priceIdentifier,
         expirationTimestamp,
-        ancillaryData
+        customAncillaryData
       );
 
       assert.equal(request.currency, collateralToken.address);
@@ -261,18 +286,18 @@ contract("LongShortPair", function (accounts) {
   });
   describe("Settlement Functionality", () => {
     // Create a position, advance time, expire contract and propose price. Manually set different expiryPercentLong values
-    // using the test longShortPairLibrary that bypass the OO return value so we dont need to test the lib here.
+    // using the test longShortPairTestLibrary that bypass the OO return value so we dont need to test the lib here.
     let sponsorCollateralBefore;
     beforeEach(async () => {
       await collateralToken.approve(longShortPair.address, MAX_UINT_VAL, { from: sponsor });
       await longShortPair.create(toWei("100"), { from: sponsor });
       await timer.setCurrentTime(expirationTimestamp + 1);
       await longShortPair.expire();
-      await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
+      await proposeAndSettleOptimisticOraclePrice(priceIdentifier, expirationTimestamp, toWei("0.5"));
       sponsorCollateralBefore = await collateralToken.balanceOf(sponsor);
     });
     it("expiryPercentLong = 1 should give all collateral to long tokens", async function () {
-      await longShortPairLibrary.setValueToReturn(toWei("1"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("1"));
 
       // Redeeming only short tokens should send 0 collateral as the short tokens are worthless.
       await longShortPair.settle(toWei("0"), toWei("100"), { from: sponsor });
@@ -286,7 +311,7 @@ contract("LongShortPair", function (accounts) {
       );
     });
     it("expiryPercentLong = 0 should give all collateral to short tokens", async function () {
-      await longShortPairLibrary.setValueToReturn(toWei("0"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("0"));
       // Redeeming only long tokens should send 0 collateral as the long tokens are worthless.
       await longShortPair.settle(toWei("100"), toWei("0"), { from: sponsor });
       assert.equal((await collateralToken.balanceOf(sponsor)).toString(), sponsorCollateralBefore.toString());
@@ -300,7 +325,7 @@ contract("LongShortPair", function (accounts) {
     });
     it("expiryTokensForCollateral > 1 should ceil to 1", async function () {
       // anything above 1 for the expiryPercentLong is nonsensical and the LSP should act as if it's set to 1.
-      await longShortPairLibrary.setValueToReturn(toWei("1.5"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("1.5"));
 
       // Redeeming long short tokens should send no collateral.
       await longShortPair.settle(toWei("0"), toWei("100"), { from: sponsor });
@@ -314,7 +339,7 @@ contract("LongShortPair", function (accounts) {
       );
     });
     it("expiryPercentLong = 0.25 should give 25% to long and 75% to short", async function () {
-      await longShortPairLibrary.setValueToReturn(toWei("0.25"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("0.25"));
 
       // Redeeming long tokens should send 25% of the collateral.
       await longShortPair.settle(toWei("100"), toWei("0"), { from: sponsor });
@@ -343,9 +368,9 @@ contract("LongShortPair", function (accounts) {
         (
           await optimisticOracle.getRequest(
             longShortPair.address,
-            priceFeedIdentifier,
+            priceIdentifier,
             expirationTimestamp,
-            ancillaryData
+            customAncillaryData
           )
         ).reward.toString(),
         toWei("100")
@@ -372,9 +397,9 @@ contract("LongShortPair", function (accounts) {
       await longShortPair.expire();
       await optimisticOracle.proposePrice(
         longShortPair.address,
-        priceFeedIdentifier,
+        priceIdentifier,
         expirationTimestamp,
-        ancillaryData,
+        customAncillaryData,
         toWei("0.5")
       );
       assert(await didContractThrow(longShortPair.settle(toWei("100"), toWei("100"), { from: sponsor })));
@@ -383,8 +408,6 @@ contract("LongShortPair", function (accounts) {
   describe("Non-standard ERC20 Decimals", () => {
     const convertDecimals = ConvertDecimals(0, 6, this.web3);
     beforeEach(async () => {
-      console.log("convertDecimals", convertDecimals(6).toString());
-
       collateralToken = await Token.new("USD Coin", "USDC", 6, { from: deployer });
       await collateralToken.addMember(1, deployer, { from: deployer });
       await collateralToken.mint(sponsor, convertDecimals("1000"), { from: deployer });
@@ -396,13 +419,13 @@ contract("LongShortPair", function (accounts) {
 
       constructorParams = {
         ...constructorParams,
-        longTokenAddress: longToken.address,
-        shortTokenAddress: shortToken.address,
-        collateralTokenAddress: collateralToken.address,
-        prepaidProposerReward: convertDecimals("100"),
+        longToken: longToken.address,
+        shortToken: shortToken.address,
+        collateralToken: collateralToken.address,
+        prepaidProposerReward: convertDecimals("100").toString(),
       };
 
-      longShortPair = await LongShortPair.new(...Object.values(constructorParams));
+      longShortPair = await LongShortPair.new(constructorParams, finder.address, timer.address);
       await collateralToken.mint(longShortPair.address, convertDecimals("100"));
 
       // Add mint and burn roles for the long and short tokens to the long short pair.
@@ -447,12 +470,12 @@ contract("LongShortPair", function (accounts) {
       assert.equal(await longShortPair.contractState(), 1); // state should be ExpiredPriceRequested before.
 
       // Note that this proposal is scaled by 1e18. Prices returned from the DVM are scaled independently of the contract decimals.
-      await proposeAndSettleOptimisticOraclePrice(priceFeedIdentifier, expirationTimestamp, toWei("0.5"));
+      await proposeAndSettleOptimisticOraclePrice(priceIdentifier, expirationTimestamp, toWei("0.5"));
 
       // Redemption value scaled between 0 and 1, indicating how much of the collateralPerPair is split between the long and
       // short tokens. Setting to 0.5 makes each long token worth 0.5 collateral and each short token worth 0.5 collateral.
       // Note that this value is still scaled by 1e18 as this lib is independent of decimals.
-      await longShortPairLibrary.setValueToReturn(toWei("0.5"));
+      await longShortPairTestLibrary.setValueToReturn(toWei("0.5"));
 
       await longShortPair.settle(convertDecimals("50"), convertDecimals("0"), { from: holder }); // holder redeem their 50 long tokens.
       assert.equal((await longToken.balanceOf(holder)).toString(), convertDecimals("0")); // they should have no long tokens left.
@@ -467,6 +490,116 @@ contract("LongShortPair", function (accounts) {
 
       // long short pair should have no collateral left in it as everything has been redeemed.
       assert.equal((await collateralToken.balanceOf(longShortPair.address)).toString(), convertDecimals("0"));
+    });
+  });
+  describe("Custom OO parameterization", () => {
+    beforeEach(async () => {
+      optimisticOracleLivenessTime = 3600; // set to one hour. the default for the OO is two hours (7200 seconds).
+      optimisticOracleProposerBond = toWei("1"); // the proposer will now need to provide 1e18 collateral as a bond.
+
+      constructorParams = { ...constructorParams, optimisticOracleLivenessTime, optimisticOracleProposerBond };
+
+      longShortPair = await LongShortPair.new(constructorParams, finder.address, timer.address);
+      await collateralToken.mint(longShortPair.address, toWei("100"));
+
+      // Add mint and burn roles for the long and short tokens to the long short pair.
+      await longToken.addMember(1, longShortPair.address, { from: deployer });
+      await shortToken.addMember(1, longShortPair.address, { from: deployer });
+      await longToken.addMember(2, longShortPair.address, { from: deployer });
+      await shortToken.addMember(2, longShortPair.address, { from: deployer });
+    });
+    it("Custom OO settings are correctly set", async function () {
+      assert.equal(await longShortPair.optimisticOracleLivenessTime(), optimisticOracleLivenessTime);
+      assert.equal(await longShortPair.optimisticOracleProposerBond(), optimisticOracleProposerBond);
+
+      // Create some tokens from sponsor wallet.
+      await collateralToken.approve(longShortPair.address, MAX_UINT_VAL, { from: sponsor });
+      await longShortPair.create(toWei("100"), { from: sponsor });
+
+      // Advance past the expiry timestamp and settle the contract.
+      await timer.setCurrentTime(expirationTimestamp + 1);
+
+      assert.equal(await longShortPair.contractState(), 0); // state should be Open before.
+      await longShortPair.expire();
+      assert.equal(await longShortPair.contractState(), 1); // state should be ExpiredPriceRequested before.
+
+      // Ensure the price request was enqueued correctly and the liveness time and bond was set.
+      const request = await optimisticOracle.getRequest(
+        longShortPair.address,
+        priceIdentifier,
+        expirationTimestamp,
+        customAncillaryData
+      );
+
+      assert.equal(request.currency, collateralToken.address);
+      assert.equal(request.settled, false);
+      assert.equal(request.proposedPrice, "0");
+      assert.equal(request.resolvedPrice, "0");
+      assert.equal(request.reward, prepaidProposerReward);
+      assert.equal(request.bond, optimisticOracleProposerBond);
+      assert.equal(request.customLiveness, optimisticOracleLivenessTime);
+
+      // Proposing a price without approving the proposal bond should revert.
+      assert(
+        await didContractThrow(
+          optimisticOracle.proposePrice(
+            longShortPair.address,
+            priceIdentifier,
+            expirationTimestamp,
+            customAncillaryData,
+            toWei("0.5"),
+            { from: deployer }
+          )
+        )
+      );
+
+      // Approve the OO to pull collateral from the deployer. Mint some collateral to the deployer to pay for bond.
+      await collateralToken.approve(optimisticOracle.address, MAX_UINT_VAL, { from: deployer });
+      await collateralToken.mint(deployer, toWei("1"), { from: deployer });
+
+      // Now the proposal should go through without revert.
+      const deployerBalanceBeforeProposal = await collateralToken.balanceOf(deployer);
+      await optimisticOracle.proposePrice(
+        longShortPair.address,
+        priceIdentifier,
+        expirationTimestamp,
+        customAncillaryData,
+        toWei("0.5"),
+        { from: deployer }
+      );
+
+      assert.equal(
+        deployerBalanceBeforeProposal.sub(await collateralToken.balanceOf(deployer)).toString(),
+        optimisticOracleProposerBond
+      );
+
+      // Advance time. Should not be able to settle any time before the OO liveness.
+
+      assert(
+        await didContractThrow(
+          optimisticOracle.settle(longShortPair.address, priceIdentifier, expirationTimestamp, customAncillaryData)
+        )
+      );
+
+      await optimisticOracle.setCurrentTime((await optimisticOracle.getCurrentTime()) + optimisticOracleLivenessTime);
+
+      const sponsorBalanceBefore = await collateralToken.balanceOf(sponsor);
+      const deployerBalanceBeforeSettlement = await collateralToken.balanceOf(deployer);
+      await optimisticOracle.settle(longShortPair.address, priceIdentifier, expirationTimestamp, customAncillaryData);
+
+      await longShortPairTestLibrary.setValueToReturn(toWei("0.5"));
+
+      // settle all tokens.
+      await longShortPair.settle(toWei("100"), toWei("100"), { from: sponsor }); // sponsor redeem their 100 long tokens.
+      assert.equal((await longToken.balanceOf(sponsor)).toString(), toWei("0")); // sponsor should have no long tokens left.
+      assert.equal((await shortToken.balanceOf(sponsor)).toString(), toWei("0")); // sponsor should have no short tokens left.
+      assert.equal((await collateralToken.balanceOf(sponsor)).sub(sponsorBalanceBefore).toString(), toWei("100")); // sponsor should get back all collateral.
+
+      // OO proposer should get back proposal bond + reward at price request settlement.
+      assert.equal(
+        (await collateralToken.balanceOf(deployer)).sub(deployerBalanceBeforeSettlement).toString(),
+        toBN(optimisticOracleProposerBond).add(toBN(prepaidProposerReward)).toString()
+      );
     });
   });
 });

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -95,9 +95,11 @@ contract("LongShortPair", function (accounts) {
       prepaidProposerReward,
       optimisticOracleLivenessTime,
       optimisticOracleProposerBond,
+      finder: finder.address,
+      timerAddress: timer.address,
     };
 
-    longShortPair = await LongShortPair.new(constructorParams, finder.address, timer.address);
+    longShortPair = await LongShortPair.new(constructorParams);
     await collateralToken.mint(longShortPair.address, toWei("100"));
 
     // Add mint and burn roles for the long and short tokens to the long short pair.
@@ -126,40 +128,22 @@ contract("LongShortPair", function (accounts) {
       // Invalid expiration time.
       assert(
         await didContractThrow(
-          LongShortPair.new(
-            { ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 1 },
-            finder.address,
-            timer.address
-          )
+          LongShortPair.new({ ...constructorParams, expirationTimestamp: (await timer.getCurrentTime()) - 1 })
         )
       );
 
       // Invalid collateral per pair.
-      assert(
-        await didContractThrow(
-          LongShortPair.new({ ...constructorParams, collateralPerPair: "0" }, finder.address, timer.address)
-        )
-      );
+      assert(await didContractThrow(LongShortPair.new({ ...constructorParams, collateralPerPair: "0" })));
 
       // Invalid price identifier time.
-      assert(
-        await didContractThrow(
-          LongShortPair.new({ ...constructorParams, priceIdentifier: "BAD-IDENTIFIER" }, finder.address, timer.address)
-        )
-      );
+      assert(await didContractThrow(LongShortPair.new({ ...constructorParams, priceIdentifier: "BAD-IDENTIFIER" })));
       // Invalid LSP library address.
       assert(
-        await didContractThrow(
-          LongShortPair.new(
-            { ...constructorParams, financialProductLibrary: ZERO_ADDRESS },
-            finder.address,
-            timer.address
-          )
-        )
+        await didContractThrow(LongShortPair.new({ ...constructorParams, financialProductLibrary: ZERO_ADDRESS }))
       );
 
       // Invalid Finder address.
-      assert(await didContractThrow(LongShortPair.new(constructorParams, ZERO_ADDRESS, timer.address)));
+      assert(await didContractThrow(LongShortPair.new({ ...constructorParams, finder: ZERO_ADDRESS })));
 
       // Test ancillary data limits.
       // Get max length from contract.
@@ -170,11 +154,7 @@ contract("LongShortPair", function (accounts) {
       const remainingLength = maxLength - (ooAncillary.length - 2) / 2; // Remove the 0x and divide by 2 to get bytes.
       assert(
         await didContractThrow(
-          LongShortPair.new(
-            { ...constructorParams, customAncillaryData: web3.utils.randomHex(remainingLength + 1) },
-            finder.address,
-            timer.address
-          )
+          LongShortPair.new({ ...constructorParams, customAncillaryData: web3.utils.randomHex(remainingLength + 1) })
         )
       );
     });
@@ -425,7 +405,7 @@ contract("LongShortPair", function (accounts) {
         prepaidProposerReward: convertDecimals("100").toString(),
       };
 
-      longShortPair = await LongShortPair.new(constructorParams, finder.address, timer.address);
+      longShortPair = await LongShortPair.new(constructorParams);
       await collateralToken.mint(longShortPair.address, convertDecimals("100"));
 
       // Add mint and burn roles for the long and short tokens to the long short pair.
@@ -499,7 +479,7 @@ contract("LongShortPair", function (accounts) {
 
       constructorParams = { ...constructorParams, optimisticOracleLivenessTime, optimisticOracleProposerBond };
 
-      longShortPair = await LongShortPair.new(constructorParams, finder.address, timer.address);
+      longShortPair = await LongShortPair.new(constructorParams);
       await collateralToken.mint(longShortPair.address, toWei("100"));
 
       // Add mint and burn roles for the long and short tokens to the long short pair.

--- a/packages/core/test/proxy-scripts/lsp-broker/LspUniswapV2Broker.js
+++ b/packages/core/test/proxy-scripts/lsp-broker/LspUniswapV2Broker.js
@@ -6,7 +6,7 @@ const {
   ZERO_ADDRESS,
 } = require("@uma/common");
 const { getTruffleContract } = require("@uma/core");
-const { toWei, toBN, utf8ToHex, fromWei } = web3.utils;
+const { toWei, toBN, utf8ToHex, fromWei, padRight } = web3.utils;
 
 // Tested Contract
 const LspUniswapV2Broker = artifacts.require("LspUniswapV2Broker");
@@ -59,9 +59,10 @@ const ancillaryData = web3.utils.utf8ToHex("some-address-field:0x1234");
 const startTimestamp = Math.floor(Date.now() / 1000);
 const expirationTimestamp = startTimestamp + 10000;
 const optimisticOracleLiveness = 7200;
-const priceFeedIdentifier = utf8ToHex("TEST_IDENTIFIER");
+const priceIdentifier = padRight(utf8ToHex("TEST_IDENTIFIER"), 64);
 const collateralPerPair = toWei("1"); // each pair of long and short tokens need 1 unit of collateral to mint.
 const prepaidProposerReward = toWei("0");
+const pairName = "Long Short Pair Test";
 
 // Returns the current spot price of a uniswap pool, scaled to `precision` # decimal points.
 const getPoolSpotPrice = async (tokenA, tokenB, _pairAddress = pairAddress, precision = 4) => {
@@ -103,7 +104,7 @@ contract("LspUniswapV2Broker", function (accounts) {
     collateralWhitelist = await AddressWhitelist.deployed();
 
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(priceFeedIdentifier, { from: deployer });
+    await identifierWhitelist.addSupportedIdentifier(priceIdentifier, { from: deployer });
   });
   beforeEach(async () => {
     // Force each test to start with a simulated time that's synced to the startTimestamp.
@@ -129,16 +130,21 @@ contract("LspUniswapV2Broker", function (accounts) {
     longShortPairLibrary = await LongShortPairFinancialProjectLibraryTest.new();
 
     longShortPair = await LongShortPair.new(
-      expirationTimestamp,
-      collateralPerPair,
-      priceFeedIdentifier,
-      longToken.address,
-      shortToken.address,
-      collateralToken.address,
+      {
+        pairName,
+        expirationTimestamp,
+        collateralPerPair,
+        priceIdentifier,
+        longToken: longToken.address,
+        shortToken: shortToken.address,
+        collateralToken: collateralToken.address,
+        financialProductLibrary: longShortPairLibrary.address,
+        customAncillaryData: ancillaryData,
+        prepaidProposerReward,
+        optimisticOracleLivenessTime: 7200,
+        optimisticOracleProposerBond: toWei("0"),
+      },
       finder.address,
-      longShortPairLibrary.address,
-      ancillaryData,
-      prepaidProposerReward,
       timer.address
     );
 

--- a/packages/core/test/proxy-scripts/lsp-broker/LspUniswapV2Broker.js
+++ b/packages/core/test/proxy-scripts/lsp-broker/LspUniswapV2Broker.js
@@ -129,24 +129,22 @@ contract("LspUniswapV2Broker", function (accounts) {
     // Create LSP library and LSP contract.
     longShortPairLibrary = await LongShortPairFinancialProjectLibraryTest.new();
 
-    longShortPair = await LongShortPair.new(
-      {
-        pairName,
-        expirationTimestamp,
-        collateralPerPair,
-        priceIdentifier,
-        longToken: longToken.address,
-        shortToken: shortToken.address,
-        collateralToken: collateralToken.address,
-        financialProductLibrary: longShortPairLibrary.address,
-        customAncillaryData: ancillaryData,
-        prepaidProposerReward,
-        optimisticOracleLivenessTime: 7200,
-        optimisticOracleProposerBond: toWei("0"),
-      },
-      finder.address,
-      timer.address
-    );
+    longShortPair = await LongShortPair.new({
+      pairName,
+      expirationTimestamp,
+      collateralPerPair,
+      priceIdentifier,
+      longToken: longToken.address,
+      shortToken: shortToken.address,
+      collateralToken: collateralToken.address,
+      financialProductLibrary: longShortPairLibrary.address,
+      customAncillaryData: ancillaryData,
+      prepaidProposerReward,
+      optimisticOracleLivenessTime: 7200,
+      optimisticOracleProposerBond: toWei("0"),
+      finder: finder.address,
+      timerAddress: timer.address,
+    });
 
     // Add mint and burn roles for the long and short tokens to the long short pair.
     await longToken.addMember(1, longShortPair.address, { from: deployer });


### PR DESCRIPTION
**Motivation**

The LSP contract needs three additional pieces of functionality:
- The notion of a `pairName` to name an LPS contract. This is useful in front ends to display information about the contract.
- The ability for the deployer to set a custom OO liveness via a `optimisticOracleLivenessTime` param. This is important with complex price requests that might need more than the normal 2 hours to facilitate price proposal verification.
- The ability for the deployer to set a custom OO bond via a `optimisticOracleProposerBond` param. This lets the deployer create stronger security guarantees around price proposals as there is now a cost associated with an invalid proposal.

**Summary**

Updated contracts and unit tests to add a) `pairName`, b) `optimisticOracleLivenessTime` and c) `optimisticOracleProposerBond`.


**Details**

The addition of these parameters put the contract constructor stack depth above Solidity limit. To work around this, the constructor and factory methods were refactored to take in a struct. This is the same pattern the EMP and Perp uses to work around these limits.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested