### PR TITLE
fix(LSP): Address audit commenting issues

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -87,17 +87,16 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
         RangeBondLongShortPairParameters memory params = longShortPairParameters[msg.sender];
         require(params.highPriceRange != 0 || params.lowPriceRange != 0, "Params not set for calling LSP");
 
-        // This function's returns a value between 0 and 1e18 to be used in conjunction with the LSP collateralPerPair
+        // This function returns a value between 0 and 1e18 to be used in conjunction with the LSP collateralPerPair
         // that allocates collateral between the short and long tokens on expiry. This can be simplified by considering
-        // the price in three discreet ranges: 1) below the low price range, 2) between low and high range
-        // and 3) above the high price range.
+        // the price in three discrete ranges: 1) below the low price range, 2) between low and high range and 3) above
+        // the high price range.
         uint256 positiveExpiryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;
 
-        // 1) The long position is entitled to the full position in this range. (collateralTokens * lowPriceRange) is
-        // the notional value of the bond below the range.
+        // 1) The long position is entitled to the full position in this range. The short token is worth 0.
         if (positiveExpiryPrice <= params.lowPriceRange) return FixedPoint.fromUnscaledUint(1).rawValue;
-        // 2) Within the range, the long position is entitled to the bond notional value, which is equal to a fixed
-        // fraction of the collateral. In this range it acts like a yield dollar.
+        // 2) Within the range, the long position is entitled to the bond notional value which is equal to
+        // (collateral tokens * lowPriceRange).
         if (positiveExpiryPrice <= params.highPriceRange)
             return FixedPoint.Unsigned(params.lowPriceRange).div(FixedPoint.Unsigned(positiveExpiryPrice)).rawValue;
         // 3) Above the range, the long position is entitled to a fixed number of tokens.

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/RangeBondLongShortPairFinancialProductLibrary.sol
@@ -72,8 +72,8 @@ contract RangeBondLongShortPairFinancialProductLibrary is LongShortPairFinancial
     }
 
     /**
-     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token are entitled
-     * to per collateralPerPair.
+     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token are
+     * entitled to per collateralPerPair.
      * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
      * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
      */

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -65,8 +65,8 @@ contract LongShortPair is Testable, Lockable {
     // Price returned from the Optimistic oracle at settlement time.
     int256 public expiryPrice;
 
-    // number between 0 and 1e18 representing how much collateral long & short tokens are redeemable for. 0 makes each
-    // short token worth collateralPerPair and long tokens worth 0. 1 makes each long token worth collateralPerPair and short 0.
+    // Number between 0 and 1e18 to allocate collateral between long & short tokens at redemption. 0 entitles each short
+    // to collateralPerPair and long worth 0. 1e18 makes each long worth collateralPerPair and short 0.
     uint256 public expiryPercentLong;
 
     bytes32 public priceIdentifier;
@@ -280,7 +280,7 @@ contract LongShortPair is Testable, Lockable {
      * @param sponsor address of the sponsor to query.
      * @return [uint256, uint256]. First is long tokens held by sponsor and second is short tokens held by sponsor.
      */
-    function getPositionTokens(address sponsor) public view returns (uint256, uint256) {
+    function getPositionTokens(address sponsor) public view nonReentrantView() returns (uint256, uint256) {
         return (longToken.balanceOf(sponsor), shortToken.balanceOf(sponsor));
     }
 


### PR DESCRIPTION
**Motivation**

OZ left a number of additional feedback points on commenting after the most recent audit fixes. This PR addresses these issues. Additionally, `getPositionTokens` was found to be missing a reentrant modifier which was added.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
