### PR TITLE
fix(polygon-tunnel): Response to audit

### DIFF
--- a/packages/core/contracts/common/implementation/AncillaryData.sol
+++ b/packages/core/contracts/common/implementation/AncillaryData.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
  * @title Library for encoding and decoding ancillary data for DVM price requests.
  * @notice  We assume that on-chain ancillary data can be formatted directly from bytes to utf8 encoding via
  * web3.utils.hexToUtf8, and that clients will parse the utf8-encoded ancillary data as a comma-delimitted key-value
- * dictionary. Therefore, this libraries provides internal methods that aid appending to ancillary data from Solidity
+ * dictionary. Therefore, this library provides internal methods that aid appending to ancillary data from Solidity
  * smart contracts. More details on UMA's ancillary data guidelines below:
  * https://docs.google.com/document/d/1zhKKjgY1BupBGPPrY_WOJvui0B6DMcd-xDR8-9-SPDw/edit
  */
@@ -74,7 +74,7 @@ library AncillaryData {
         bytes memory key,
         address value
     ) internal pure returns (bytes memory) {
-        bytes memory prefix = _appendKey(currentAncillaryData, key);
+        bytes memory prefix = constructPrefix(currentAncillaryData, key);
         return abi.encodePacked(currentAncillaryData, prefix, toUtf8BytesAddress(value));
     }
 
@@ -92,15 +92,16 @@ library AncillaryData {
         bytes memory key,
         uint256 value
     ) internal pure returns (bytes memory) {
-        bytes memory prefix = _appendKey(currentAncillaryData, key);
+        bytes memory prefix = constructPrefix(currentAncillaryData, key);
         return abi.encodePacked(currentAncillaryData, prefix, toUtf8BytesUint(value));
     }
 
     /**
-     * @notice Helper method that returns the LHS of a "key:value" pair plus the colon ":" and a leading comma "," if
-     * the ancillary data to append to is not empty.
+     * @notice Helper method that returns the left hand side of a "key:value" pair plus the colon ":" and a leading
+     * comma "," if the `currentAncillaryData` is not empty. The return value is intended to be appended as a prefix to
+     * some utf8 value that is ultimately added to a comma-delimited, key-value dictionary.
      */
-    function _appendKey(bytes memory currentAncillaryData, bytes memory key) internal pure returns (bytes memory) {
+    function constructPrefix(bytes memory currentAncillaryData, bytes memory key) internal pure returns (bytes memory) {
         if (currentAncillaryData.length > 0) {
             return abi.encodePacked(",", key, ":");
         } else {

--- a/packages/core/contracts/common/test/AncillaryDataTest.sol
+++ b/packages/core/contracts/common/test/AncillaryDataTest.sol
@@ -28,7 +28,7 @@ contract AncillaryDataTest {
         return AncillaryData.appendKeyValueUint(currentAncillaryData, key, value);
     }
 
-    function appendKey(bytes memory currentAncillaryData, bytes memory key) external pure returns (bytes memory) {
-        return AncillaryData._appendKey(currentAncillaryData, key);
+    function constructPrefix(bytes memory currentAncillaryData, bytes memory key) external pure returns (bytes memory) {
+        return AncillaryData.constructPrefix(currentAncillaryData, key);
     }
 }

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -482,7 +482,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         bytes32 identifier,
         uint256 timestamp,
         bytes memory ancillaryData
-    ) public view override returns (Request memory) {
+    ) public view override nonReentrantView() returns (Request memory) {
         return _getRequest(requester, identifier, timestamp, ancillaryData);
     }
 
@@ -499,7 +499,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         bytes32 identifier,
         uint256 timestamp,
         bytes memory ancillaryData
-    ) public view override returns (State) {
+    ) public view override nonReentrantView() returns (State) {
         Request storage request = _getRequest(requester, identifier, timestamp, ancillaryData);
 
         if (address(request.currency) == address(0)) {
@@ -537,7 +537,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         bytes32 identifier,
         uint256 timestamp,
         bytes memory ancillaryData
-    ) public view override returns (bool) {
+    ) public view override nonReentrantView() returns (bool) {
         State state = getState(requester, identifier, timestamp, ancillaryData);
         return state == State.Settled || state == State.Resolved || state == State.Expired;
     }

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -163,7 +163,10 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         require(_getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
         require(timestamp <= getCurrentTime(), "Timestamp in future");
-        require(stampAncillaryData(ancillaryData, msg.sender).length <= ancillaryBytesLimit, "Ancillary Data too long");
+        require(
+            _stampAncillaryData(ancillaryData, msg.sender).length <= ancillaryBytesLimit,
+            "Ancillary Data too long"
+        );
         uint256 finalFee = _getStore().computeFinalFee(address(currency)).rawValue;
         requests[_getId(msg.sender, identifier, timestamp, ancillaryData)] = Request({
             proposer: address(0),

--- a/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
@@ -37,7 +37,7 @@ abstract contract OptimisticOracleInterface {
 
     // This value must be <= the Voting contract's `ancillaryBytesLimit` value otherwise it is possible
     // that a price can be requested to this contract successfully, but cannot be disputed because the DVM refuses
-    // to accept a price request made with ancillary data length of a certain size.
+    // to accept a price request made with ancillary data length over a certain size.
     uint256 public constant ancillaryBytesLimit = 8192;
 
     /**

--- a/packages/core/contracts/polygon/GovernorRootTunnel.sol
+++ b/packages/core/contracts/polygon/GovernorRootTunnel.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../external/polygon/tunnel/FxBaseRootTunnel.sol";
+import "../common/implementation/Lockable.sol";
 
 /**
  * @title Governance relayer contract to be deployed on Ethereum that receives messages from the owner (Governor) and
  * sends them to sidechain.
  */
-contract GovernorRootTunnel is Ownable, FxBaseRootTunnel {
+contract GovernorRootTunnel is Ownable, FxBaseRootTunnel, Lockable {
     event RelayedGovernanceRequest(address indexed to, bytes data);
 
     constructor(address _checkpointManager, address _fxRoot) FxBaseRootTunnel(_checkpointManager, _fxRoot) {}
@@ -20,7 +21,7 @@ contract GovernorRootTunnel is Ownable, FxBaseRootTunnel {
      * @dev The transaction submitted to `to` on the sidechain with the calldata `data` is assumed to have 0 `value`
      * in order to avoid the added complexity of sending cross-chain transactions with positive value.
      */
-    function relayGovernance(address to, bytes memory data) external onlyOwner {
+    function relayGovernance(address to, bytes memory data) external nonReentrant() onlyOwner {
         _sendMessageToChild(abi.encode(to, data));
         emit RelayedGovernanceRequest(to, data);
     }

--- a/packages/core/contracts/polygon/OracleRootTunnel.sol
+++ b/packages/core/contracts/polygon/OracleRootTunnel.sol
@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
 import "../external/polygon/tunnel/FxBaseRootTunnel.sol";
 import "./OracleBaseTunnel.sol";
 import "../oracle/interfaces/OracleAncillaryInterface.sol";
+import "../common/implementation/Lockable.sol";
 
 /**
  * @title Adapter deployed on mainnet that validates and sends price requests from sidechain to the DVM on mainnet.
  * @dev This contract must be a registered financial contract in order to make DVM price requests.
  */
-contract OracleRootTunnel is OracleBaseTunnel, FxBaseRootTunnel {
+contract OracleRootTunnel is OracleBaseTunnel, FxBaseRootTunnel, Lockable {
     constructor(
         address _checkpointManager,
         address _fxRoot,
@@ -28,7 +29,7 @@ contract OracleRootTunnel is OracleBaseTunnel, FxBaseRootTunnel {
         bytes32 identifier,
         uint256 time,
         bytes memory ancillaryData
-    ) public {
+    ) public nonReentrant() {
         // `getPrice` will revert if there is no price.
         int256 price = _getOracle().getPrice(identifier, time, ancillaryData);
         // This implementation allows duplicate MessageSent events via _sendMessageToRoot. The child tunnel on the

--- a/packages/core/contracts/polygon/README.md
+++ b/packages/core/contracts/polygon/README.md
@@ -37,6 +37,6 @@ Any message can be relayed between Polygon and Ethereum provided that they are s
 
 # Security Considerations
 
-This system relies on the [Polygon consensus mechanism](https://docs.matic.network/docs/home/architecture/security-models#proof-of-stake-security) secured by validators in a Proof of Stake system. The validator set enforces the integrity of data passed between networks (i.e. downstream users need to trust that the validators are not modifying the arbitrary messages that are beign sent between networks).
+This system relies on the [Polygon consensus mechanism](https://docs.matic.network/docs/home/architecture/security-models#proof-of-stake-security) secured by validators in a Proof of Stake system. The validator set enforces the integrity of data passed between networks (i.e. downstream users need to trust that the validators are not modifying the arbitrary messages that are being sent between networks).
 
-Moreover, downstream users also rely on off-chain actors to relay messages in a timeley fashion. Historically messages are sent once per hour.
+Moreover, downstream users also rely on off-chain actors to relay messages in a timely fashion. Historically messages are sent once per hour.

--- a/packages/core/test/common/AncillaryData.js
+++ b/packages/core/test/common/AncillaryData.js
@@ -23,14 +23,14 @@ contract("AncillaryData", function () {
     assert.equal(utf8EncodedUint, utf8ToHex("31337"));
   });
 
-  it("_appendKey", async function () {
+  it("constructPrefix", async function () {
     const keyName = utf8ToHex("key");
     let originalAncillaryData;
 
     // Test 1: ancillary data is empty
     originalAncillaryData = "0x";
     assert.equal(
-      await ancillaryDataTest.appendKey(originalAncillaryData, keyName),
+      await ancillaryDataTest.constructPrefix(originalAncillaryData, keyName),
       utf8ToHex("key:"),
       "Should return key: with no leading comma"
     );
@@ -38,7 +38,7 @@ contract("AncillaryData", function () {
     // Test 2: ancillary data is not empty
     originalAncillaryData = "0xab";
     assert.equal(
-      await ancillaryDataTest.appendKey(originalAncillaryData, keyName),
+      await ancillaryDataTest.constructPrefix(originalAncillaryData, keyName),
       utf8ToHex(",key:"),
       "Should return key: with leading comma"
     );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->

# Audit feedback specifically addresses in this PR:

### Pull Request [3061](https://github.com/UMAprotocol/protocol/pull/3061/)

This PR introduces the `AncillaryData` library. It also modifies the `_getAncillaryData` function of the `FundingRateApplier` contract and the `_stampAncillaryData` function of the `OptimisticOracle` contract. Further, it removes some revert reasons in the code base to save bytecode. However, as the code is modified again in Pull Request 3054, we will defer the majority of our comments to our [review of that pull request](#3054).

Our only immediate comments are as follows:

- The `requestPrice` function of the `OptimisticOracle` now [calls `stampAncillaryData`](https://github.com/UMAprotocol/protocol/blob/43d569f66af0323813716927ef2dcc8c7f60dd33/packages/core/contracts/oracle/implementation/OptimisticOracle.sol#L166), which is a pass-through function for the internal [`_stampAncillaryData` function](https://github.com/UMAprotocol/protocol/blob/43d569f66af0323813716927ef2dcc8c7f60dd33/packages/core/contracts/oracle/implementation/OptimisticOracle.sol#L669). Consider calling the internal function directly for simplicity and consistency with the rest of the contract.
- In the `OptimisticOracleInterface` there is a comment about how the DVM could refuse to accept a dispute ["...with ancillary data length of a certain size."](https://github.com/UMAprotocol/protocol/blob/43d569f66af0323813716927ef2dcc8c7f60dd33/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol#L40). Something along the lines of: "...with ancillary data length *over* a certain size" may be more closely aligned with the implementation.

<a id="3054"></a>
### Pull Requests [3054](https://github.com/UMAprotocol/protocol/pull/3054/), [3082](https://github.com/UMAprotocol/protocol/pull/3082/) and [3092](https://github.com/UMAprotocol/protocol/pull/3092/)

These PRs includes many changes that were not reviewed. In particular, they move Chainbridge files and introduce new Polygon files to an `external` directory. They also introduce test files that were not reviewed.

Along with [PR 3061](https://github.com/UMAprotocol/protocol/pull/3061/), PR 3054 introduces the `AncillaryData` library to help construct ancillary data strings in a standard format. The `FundingRateApplier` and `OptimisticOracle` contracts now use this library when constructing price requests. Our comments for these contracts are:

- In `AncillaryData.sol` on [line 8](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/common/implementation/AncillaryData.sol#L8) "libraries" should be "library".
- In the inline docs for `AncillaryData`, ["LHS"](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/common/implementation/AncillaryData.sol#L100) should be written out as "left hand side".
- `AncillaryData` employs an inconsistent underscore prefix for internal functions. Example: [`_appendKey`](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/common/implementation/AncillaryData.sol#L103) and [`appendKeyValueUint`](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/common/implementation/AncillaryData.sol#L90).
- The [`_appendKey` function](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/common/implementation/AncillaryData.sol#L103) is confusingly named, because it doesn't append anything. The name `_constructPrefix` or similar would be clearer.
- In the `OptimisticOracle`, `public` `view` functions do not use reentrancy guards. We have not identified a scenario that requires reentrancy protection, but we thought it is worth mentioning because reentrancy guards are used on `public` `view` functions extensively throughout the code base, so this may be an oversight.

The PRs also implement the Polygon Tunnel for Oracle requests. In particular, they introduce the `OracleBaseTunnel`, `OracleChildTunnel` and `OracleRootTunnel`. Our comments are:

- The `OracleBaseTunnel` comment [claims](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/polygon/OracleBaseTunnel.sol#L8) that the contract ensures price request data is not duplicated, but the design explicitly allows duplicate price requests and responses to traverse the tunnel. Consider clarifying the comment.
- The [`OracleBaseTunnel` events](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/polygon/OracleBaseTunnel.sol#L25-L26) do not index the `requestHash` parameter, even though this parameter would naturally be used to track the request.
- The contracts do not use reentrancy guards. We have not identified a scenario that requires reentrancy protection, but we thought it is worth mentioning because reentrancy guards are used extensively throughout the code base, so this may be an oversight.
- The `OracleChildTunnel` contract does not validate that price requests have [sufficiently short](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/oracle/implementation/Voting.sol#L266) ancillary data (after the [context is added](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/polygon/OracleChildTunnel.sol#L121)). This could lead to price requests that cannot be resolved. Consider validating the length of the ancillary data before initiating a price request.
- In `OracleBaseTunnel` on [line 72](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/polygon/OracleBaseTunnel.sol#L72) "dentifier" should be "identifier".
- In `OracleBaseTunnel` on [line 8](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/polygon/OracleBaseTunnel.sol#L8) "lifecyle" should be "lifecycle".
- In `OracleChildTunnel` on [line 117](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/polygon/OracleChildTunnel.sol#L117) and on [line 118](https://github.com/UMAprotocol/protocol/blob/d146d4feddcf99e157a909032a3071e95ca51eb9/packages/core/contracts/polygon/OracleChildTunnel.sol#L118) "translateable" should be "translatable".

The PR also introduces a README file with a brief overview of the Polygon Tunnel architecture. Our comments are:

- On [line 42](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/polygon/README.md#L42) "timeley" should be "timely".
- On [line 40](https://github.com/UMAprotocol/protocol/blob/a3bf46270787cbaae4ed2218f064b1217c153a50/packages/core/contracts/polygon/README.md#L40) "beign" should be "being".