### PR TITLE
fix(chainbridge): Response to audit

### DIFF
--- a/packages/core/contracts/chainbridge/SinkGovernor.sol
+++ b/packages/core/contracts/chainbridge/SinkGovernor.sol
@@ -12,6 +12,10 @@ contract SinkGovernor {
 
     event ExecutedGovernanceTransaction(address indexed to, bytes indexed data);
 
+    /**
+     * @notice Constructor.
+     * @param _finder Address of Finder that this contract uses to locate GenericHandler.
+     */
     constructor(FinderInterface _finder) {
         finder = _finder;
     }
@@ -21,6 +25,8 @@ contract SinkGovernor {
      * to this network via an off-chain relayer. The relayer will call `Bridge.executeProposal` on this local network,
      * which call `GenericHandler.executeProposal()` and ultimately this method.
      * @dev This method should send the arbitrary transaction emitted by the L1 governor on this chain.
+     * @param to Contract on this network to send governance transaction to.
+     * @param data Calldata to include in governance transaction.
      */
     function executeGovernance(address to, bytes memory data) external {
         require(

--- a/packages/core/contracts/chainbridge/SourceGovernor.sol
+++ b/packages/core/contracts/chainbridge/SourceGovernor.sol
@@ -16,6 +16,17 @@ contract SourceGovernor is Ownable {
 
     event RelayedGovernanceRequest(uint8 indexed destinationChainId, address indexed to, bytes indexed data);
 
+    /**
+     * @notice Constructor.
+     * @param _finder Address of Finder that this contract uses to locate Bridge.
+     * @param _currentChainId Chain ID for this network. This is configurable by the deployer, rather than
+     * automatically detected via `block.chainid` because the type of `currentChainId` should match any
+     * `destinationChainId`'s submitted as input to `relayGovernance()`. `relayGovernance()` calls `Bridge.deposit()`
+     * which expects a uint8 chainID passed as the first param, but `block.chainid` returns a uint256 value. Due to
+     * the possibility that a uint256 --> uint28 conversion leads to data loss and the complexity of mapping safely
+     * from uint256 --> uint8 on-chain, we opt to allow the user to specify a unique uint8 ID for this chain. It
+     * follows that the `_currentChainId` may not match with `block.chainid`.
+     */
     constructor(FinderInterface _finder, uint8 _currentChainId) {
         finder = _finder;
         currentChainId = _currentChainId;
@@ -24,9 +35,12 @@ contract SourceGovernor is Ownable {
 
     /**
      * @notice This is the first method that should be called in order to relay a governance request to another network
-     * marked by `sinkChainID`. Note: this can only be called by the owner (presumably the L1 governor).
+     * marked by `destinationChainId`. Note: this can only be called by the owner (presumably the L1 governor).
      * @dev The transaction submitted to `to` on the sidechain with the calldata `data` is assumed to have 0 `value`
      * in order to avoid the added complexity of sending cross-chain transactions with positive value.
+     * @param destinationChainId Chain ID of SinkGovernor that this governance request should ultimately be sent to.
+     * @param to Contract on network with chain ID `destinationChainId` to send governance transaction to.
+     * @param data Calldata to include in governance transaction.
      */
     function relayGovernance(
         uint8 destinationChainId,
@@ -44,6 +58,8 @@ contract SourceGovernor is Ownable {
      * @notice This method will ultimately be called after `relayGovernance` calls `Bridge.deposit()`, which will call
      * `GenericHandler.deposit()` and ultimately this method.
      * @dev This method should basically check that the `Bridge.deposit()` was triggered by a valid relay event.
+     * @param to Contract on network with chain ID `destinationChainId` to send governance transaction to.
+     * @param data Calldata to include in governance transaction.
      */
     function verifyRequest(address to, bytes memory data) external view {
         require(currentRequestHash == _computeRequestHash(to, data), "Invalid Request");
@@ -51,6 +67,8 @@ contract SourceGovernor is Ownable {
 
     /**
      * @notice Gets the resource id to send to the bridge.
+     * @dev More details about Resource ID's here: https://chainbridge.chainsafe.io/spec/#resource-id
+     * @return bytes32 Hash containing this stored chain ID.
      */
     function getResourceId() public view returns (bytes32) {
         return keccak256(abi.encode("Governor", currentChainId));

--- a/packages/core/contracts/chainbridge/SourceOracle.sol
+++ b/packages/core/contracts/chainbridge/SourceOracle.sol
@@ -20,7 +20,13 @@ contract SourceOracle is BeaconOracle {
     /**
      * @notice Constructor.
      * @param _finderAddress Address of Finder that this contract uses to locate Bridge.
-     * @param _chainID Chain ID for this contract.
+     * @param _chainID Chain ID for this contract. This is configurable by the deployer, rather than
+     * automatically detected via `block.chainid` because the type of `currentChainId` should match any
+     * `sinkChainId`'s submitted as input to `publishPrice()`. `publishPrice()` calls `Bridge.deposit()`
+     * which expects a uint8 chainID passed as the first param, but `block.chainid` returns a uint256 value. Due to
+     * the possibility that a uint256 --> uint28 conversion leads to data loss and the complexity of mapping safely
+     * from uint256 --> uint8 on-chain, we opt to allow the user to specify a unique uint8 ID for this chain. It
+     * follows that the `_chainID` may not match with `block.chainid`.
      */
     constructor(address _finderAddress, uint8 _chainID) BeaconOracle(_finderAddress, _chainID) {}
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The following audit comments are addressed unless otherwise noted:

### Pull Request [2969](https://github.com/UMAprotocol/protocol/pull/2969/)

This PR extends the logic from [PR 2903](https://github.com/UMAprotocol/protocol/pull/2903/) to send governance actions from the main chain to another EVM-compatible "sink" chain.

There are a couple of misleading comments that should be corrected:

- ~The [`@title` comment](https://github.com/mrice32/protocol/blob/5e81b20b13a961cab8f54b89d2e145a946cd9619/packages/core/contracts/chainbridge/SourceGovernor.sol#L10) of the `SourceGovernor` actually describes the behavior of the `SinkGovernor`.~ This comment was already resolved by [this PR](https://github.com/UMAprotocol/protocol/commit/73644b1794f89078dd5d185402f92d6b7bd14a92#diff-65ed03a28337581c1f4384ac6554ff092fe47a2c0360006fc27fe7f7d1a261d2)
- The `relayGovernance` [function comment](https://github.com/mrice32/protocol/blob/5e81b20b13a961cab8f54b89d2e145a946cd9619/packages/core/contracts/chainbridge/SourceGovernor.sol#L32) says `sinkChainID` instead of `destinationChainId`.

Additionally, as noted in the pull request, none of the new functions follow the [Ethereum Natural Specification Format (NatSpec)](https://docs.soliditylang.org/en/latest/natspec-format.html) for their arguments. Consider including them.

Lastly, instead of passing the chain ID to the [`SourceGovernor` constructor](https://github.com/mrice32/protocol/blob/5e81b20b13a961cab8f54b89d2e145a946cd9619/packages/core/contracts/chainbridge/SourceGovernor.sol#L24), consider using the assembly `chainid` instruction, to avoid the possibility of mismatches. Note that this suggestion is also applicable to the `BeaconOracle` and its descendant contracts.
