### PR TITLE
fix(networks file): fix broken LSP creator address

### DIFF
--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -93,7 +93,7 @@
   },
   {
     "contractName": "LongShortPairCreator",
-    "address": "0x5a8d408B7908E4F00A2f5460B621dbF2DDce8042"
+    "address": "0x0b8de441B26E36f461b2748919ed71f50593A67b"
   },
   {
     "contractName": "BinaryOptionLongShortPairFinancialProductLibrary",


### PR DESCRIPTION
**Motivation**

While helping devx with some deployment info, I realized there was a mistake in the mainnet networks file. the LSP creator address does not point to the correct contract and rather points to a `Finder` contract which must have been deployed by mistake when creating the LSP deployment.

**Summary**

Fixes a mistake in the networks file.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

