### PR TITLE
fix(LSP): Continuous audit commenting and require modifications

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -55,9 +55,9 @@ contract LongShortPair is Testable, Lockable {
     enum ContractState { Open, ExpiredPriceRequested, ExpiredPriceReceived }
     ContractState public contractState;
 
-    string public pairName;
-
     uint64 public expirationTimestamp;
+
+    string public pairName;
 
     // Amount of collateral a pair of tokens is always redeemable for.
     uint256 public collateralPerPair;
@@ -126,13 +126,14 @@ contract LongShortPair is Testable, Lockable {
      *    financialProductLibrary: Contract providing settlement payout logic.
      *    customAncillaryData: Custom ancillary data to be passed along with the price request to the OO.
      *    prepaidProposerReward: Preloaded reward to incentivize settlement price proposals.
-     *    optimisticOracleLivenessTime: OO liveness timer for price requests.
+     *    optimisticOracleLivenessTime: OO liveness time for price requests.
      *    optimisticOracleProposerBond: OO proposer bond for price requests.
      *    finder: DVM finder to find other UMA ecosystem contracts.
      *    timerAddress: Timer used to synchronize contract time in testing. Set to 0x000... in production.
      */
     constructor(ConstructorParams memory params) Testable(params.timerAddress) {
         finder = params.finder;
+        require(bytes(params.pairName).length > 0, "Pair name cant be empty");
         require(params.expirationTimestamp > getCurrentTime(), "Expiration timestamp in past");
         require(params.collateralPerPair > 0, "Collateral per pair cannot be 0");
         require(_getIdentifierWhitelist().isIdentifierSupported(params.priceIdentifier), "Identifier not registered");

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -46,7 +46,7 @@ contract LongShortPair is Testable, Lockable {
         LongShortPairFinancialProductLibrary financialProductLibrary; // Contract providing settlement payout logic.
         bytes customAncillaryData; // Custom ancillary data to be passed along with the price request to the OO.
         uint256 prepaidProposerReward; // Preloaded reward to incentivize settlement price proposals.
-        uint256 optimisticOracleLivenessTime; // OO liveness timer for price requests.
+        uint256 optimisticOracleLivenessTime; // OO liveness time for price requests.
         uint256 optimisticOracleProposerBond; // OO proposer bond for price requests.
         FinderInterface finder; // DVM finder to find other UMA ecosystem contracts.
         address timerAddress; // Timer used to synchronize contract time in testing. Set to 0x000... in production.

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -53,6 +53,7 @@ contract LongShortPair is Testable, Lockable {
     }
 
     enum ContractState { Open, ExpiredPriceRequested, ExpiredPriceReceived }
+    // @dev note contractState and expirationTimestamp are declared in this order so they use the same storage slot.
     ContractState public contractState;
 
     uint64 public expirationTimestamp;

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -69,6 +69,7 @@ contract LongShortPairCreator is Testable, Lockable {
      * @notice Creates a longShortPair contract and associated long and short tokens.
      * @dev The caller must approve this contract to transfer `prepaidProposerReward` amount of collateral.
      * @param params Constructor params used to initialize the LSP. Key-valued object with the following structure:
+     *    pairName: Name of the long short pair contract.
      *     expirationTimestamp: unix timestamp of when the contract will expire.
      *     collateralPerPair: how many units of collateral are required to mint one pair of synthetic tokens.
      *     priceIdentifier: registered in the DVM for the synthetic.
@@ -81,7 +82,7 @@ contract LongShortPairCreator is Testable, Lockable {
      *     customAncillaryData: Custom ancillary data to be passed along with the price request. If not needed, this
      *                             should be left as a 0-length bytes array.
      *     prepaidProposerReward: Proposal reward forwarded to the created LSP to incentivize price proposals.
-     *     optimisticOracleLivenessTime: Optimistic oracle liveness timer for price requests.
+     *     optimisticOracleLivenessTime: Optimistic oracle liveness time for price requests.
            optimisticOracleProposerBond: optimistic oracle proposer bond for price requests.
      * @return lspAddress the deployed address of the new long short pair contract.
      * @notice Created LSP is not registered within the registry as the LSP uses the Optimistic Oracle for settlement.


### PR DESCRIPTION
**Motivation**

A few small final comments were left on the LSP contracts after the addition of the OO liveness time, OO proposal bond and pair name. In particular, these comments were as follows:

This PR introduces a new `pairName` property of `LongShortPair` financial contracts and allows the creator to set custom values for the optimistic oracle's liveness and bond. It also refactors the `LongShortPair` and `LongShortPairCreator` contracts to use an initialization struct instead of a large number of individual parameters.

Our comments are:

- The `createLongShortPair` [`@param` comment](https://github.com/UMAprotocol/protocol/blob/4eaa2e1c23065503336e61bf16916cefbab046bc/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L71) does not list the `pairName` field.
- The `pairName` is not validated to have non-zero length.
- The `optimisticOracleLivenessTime` is described as a "timer" (instead of a "time"), in its [definition](https://github.com/UMAprotocol/protocol/blob/4eaa2e1c23065503336e61bf16916cefbab046bc/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L49), the [`LongShortPair` constructor comments](https://github.com/UMAprotocol/protocol/blob/4eaa2e1c23065503336e61bf16916cefbab046bc/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L129) and the [`createLongShortPair` function comments](https://github.com/UMAprotocol/protocol/blob/4eaa2e1c23065503336e61bf16916cefbab046bc/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol#L84).
- Our assumption was that the `expirationTimestamp` is [only 64 bits long](https://github.com/UMAprotocol/protocol/blob/4eaa2e1c23065503336e61bf16916cefbab046bc/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L60) so that it can share a storage location with the [`contractState` variable](https://github.com/UMAprotocol/protocol/blob/4eaa2e1c23065503336e61bf16916cefbab046bc/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol#L56). However, the new `pairName` variable splits them into separate storage slots. Consider defining `pairName` after the `expirationTimestamp`, or including a comment explaining why the non-stardard `uint64` type is used.

**Summary**

This PR implements the required changes as required in the audit.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested