### PR TITLE
feat(common): add compiler overrides to allow most contracts to be gas optimized

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   env: {
     node: true,
     mocha: true,
-    es2020: true,
+    es2021: true,
   },
   extends: ["plugin:prettier/recommended", "eslint:recommended"],
   plugins: ["prettier", "mocha"],

--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -53,6 +53,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
         "contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
         "contracts/financial-templates/expiring-multiparty/Liquidatable.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
         "contracts/oracle/implementation/Voting.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/oracle/implementation/test/VotingTest.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       },
     },
     networks: {

--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -20,15 +20,48 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
   // Solc version defined here so etherscan-verification has access to it
   const solcVersion = "0.8.4";
 
+  // This is a list of the contracts too large to compile at runs = 999999.
+  // Compilation settings are overridden for these to allow them to compile without going over the bytecode limit.
+  const bigContracts = [
+    "contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol",
+    "contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol",
+    "contracts/financial-templates/perpetual-multiparty/Perpetual.sol",
+    "contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol",
+    "contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol",
+    "contracts/financial-templates/expiring-multiparty/Liquidatable.sol",
+  ];
+
+  const overrides = Object.fromEntries(
+    bigContracts.map((name) => {
+      return [
+        name,
+        {
+          version: solcVersion,
+          settings: {
+            optimizer: {
+              enabled: true,
+              runs: 199,
+            },
+          },
+        },
+      ];
+    })
+  );
+
   const defaultConfig = {
     solidity: {
-      version: solcVersion,
-      settings: {
-        optimizer: {
-          enabled: true,
-          runs: 199,
+      compilers: [
+        {
+          version: solcVersion,
+          settings: {
+            optimizer: {
+              enabled: true,
+              runs: 999999,
+            },
+          },
         },
-      },
+      ],
+      overrides,
     },
     networks: {
       hardhat: {
@@ -93,6 +126,8 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
       },
     },
   };
+
+  console.log(defaultConfig.solidity.overrides);
   return { ...defaultConfig, ...configOverrides };
 }
 

--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -20,33 +20,17 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
   // Solc version defined here so etherscan-verification has access to it
   const solcVersion = "0.8.4";
 
-  // This is a list of the contracts too large to compile at runs = 999999.
-  // Compilation settings are overridden for these to allow them to compile without going over the bytecode limit.
-  const bigContracts = [
-    "contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol",
-    "contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol",
-    "contracts/financial-templates/perpetual-multiparty/Perpetual.sol",
-    "contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol",
-    "contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol",
-    "contracts/financial-templates/expiring-multiparty/Liquidatable.sol",
-  ];
-
-  const overrides = Object.fromEntries(
-    bigContracts.map((name) => {
-      return [
-        name,
-        {
-          version: solcVersion,
-          settings: {
-            optimizer: {
-              enabled: true,
-              runs: 199,
-            },
-          },
-        },
-      ];
-    })
-  );
+  // Compilation settings are overridden for large contracts to allow them to compile without going over the bytecode
+  // limit.
+  const LARGE_CONTRACT_COMPILER_SETTINGS = {
+    version: solcVersion,
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 199,
+      },
+    },
+  };
 
   const defaultConfig = {
     solidity: {
@@ -61,7 +45,14 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
           },
         },
       ],
-      overrides,
+      overrides: {
+        "contracts/financial-templates/expiring-multiparty/ExpiringMultiParty.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/financial-templates/expiring-multiparty/ExpiringMultiPartyLib.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/financial-templates/perpetual-multiparty/Perpetual.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/financial-templates/expiring-multiparty/Liquidatable.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+      },
     },
     networks: {
       hardhat: {

--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -27,7 +27,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 199,
+        runs: 200,
       },
     },
   };
@@ -40,7 +40,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
           settings: {
             optimizer: {
               enabled: true,
-              runs: 1000000,
+              runs: 1_000_000,
             },
           },
         },
@@ -52,6 +52,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
         "contracts/financial-templates/perpetual-multiparty/PerpetualLib.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
         "contracts/financial-templates/perpetual-multiparty/PerpetualLiquidatable.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
         "contracts/financial-templates/expiring-multiparty/Liquidatable.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+        "contracts/oracle/implementation/Voting.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       },
     },
     networks: {
@@ -118,7 +119,6 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
     },
   };
 
-  console.log(defaultConfig.solidity.overrides);
   return { ...defaultConfig, ...configOverrides };
 }
 

--- a/packages/common/src/HardhatConfig.js
+++ b/packages/common/src/HardhatConfig.js
@@ -40,7 +40,7 @@ function getHardhatConfig(configOverrides, workingDir = "./") {
           settings: {
             optimizer: {
               enabled: true,
-              runs: 999999,
+              runs: 1000000,
             },
           },
         },


### PR DESCRIPTION
**Motivation**

We can't compile with high values for runs (for user gas optimization) because we have a few large contracts that require low runs values to be deployable.

**Summary**

Use hardhat options to compile most contracts with a high runs value, but leave the large contracts with a runs value of 199.

Note: this makes the compilation process take a little longer.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
