### PR TITLE
feat(api): add historical market prices and expose in api

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -164,3 +164,13 @@ Returns TVL/TVM for emp starting at timestamp in seconds and a length number of 
 ### listTvms(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
 
 List all tvls/tvms of known contracts.
+
+### historicalMarketPricesBetween(tokenAddress: string, start = 0, end: number = nowS()) StatData[]
+
+Returns historical market prices (based on 0x api) for a token address. Get samples between a start time and end time ( in seconds).
+Currently only usdc prices are supported.
+
+### sliceHistoricalMarketPrices(tokenAddress: string, start = 0, length = 1) StatData[]
+
+Returns historical market prices (based on 0x api) for a token address. Slices from a starting timestamp (in seconds) and a count of samples newer than that.
+Currently only usdc prices are supported.

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -53,6 +53,7 @@ async function run(env: ProcessEnv) {
     marketPrices: {
       usdc: {
         latest: {},
+        history: empStatsHistory.SortedJsMap("Market Price"),
       },
     },
     erc20s: tables.erc20s.JsMap(),

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -53,6 +53,7 @@ export type AppState = {
     // note this is in usdc since these are fetched from amms using usdc as the quote currency
     usdc: {
       latest: { [tokenAddress: string]: PriceSample };
+      history: empStatsHistory.SortedJsMap;
     };
   };
   erc20s: uma.tables.erc20s.JsMap;

--- a/packages/api/src/services/actions.ts
+++ b/packages/api/src/services/actions.ts
@@ -140,6 +140,15 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     async listTvms(currency: CurrencySymbol = "usd") {
       return appState.stats[currency].latest.tvm.values();
     },
+    async historicalMarketPricesBetween(tokenAddress: string, start = 0, end: number = nowS()) {
+      assert(tokenAddress, "requires token address");
+      return marketPrices.usdc.history.betweenByAddress(tokenAddress, start, end);
+    },
+    async sliceHistoricalMarketPrices(tokenAddress: string, start = 0, length = 1) {
+      assert(tokenAddress, "requires token address");
+      assert(length < 1000, "length must be less than 1000 samples");
+      return marketPrices.usdc.history.sliceByAddress(tokenAddress, start, length);
+    },
   };
 
   // list all available actions


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.clubhouse.io/uma-project/story/1673/add-historical-prices-for-market-data


**Summary**

Adds a table to accumualte historical prices for market prices from the time server starts. This will not backfill history, its not clear that its possible with the api we are using. 

**Details**

This exposes 2 new api endpoints:
- historicalMarketPricesBetween
- sliceHistoricalMarketPrices

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1673/add-historical-prices-for-market-data
