### PR TITLE
feat(api): 1680 cache global tvl rather than compute it for every query

### DIFF
--- a/packages/api/src/libs/queries.ts
+++ b/packages/api/src/libs/queries.ts
@@ -154,6 +154,11 @@ export default (appState: Dependencies) => {
     const addresses = Array.from(appState.registeredEmps.values());
     return sumTvm(addresses, currency);
   }
+  async function getGlobalTvl(currency: CurrencySymbol = "usd") {
+    assert(appState.stats[currency], "Invalid currency: " + currency);
+    const { value } = await appState.stats[currency].latest.tvl.getGlobal();
+    return value;
+  }
 
   return {
     getFullEmpState,
@@ -167,5 +172,6 @@ export default (appState: Dependencies) => {
     latestPriceByTokenAddress,
     historicalPricesByTokenAddress,
     sliceHistoricalPricesByTokenAddress,
+    getGlobalTvl,
   };
 };

--- a/packages/api/src/services/actions.ts
+++ b/packages/api/src/services/actions.ts
@@ -109,7 +109,7 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     async tvl(addresses: string[] = [], currency: CurrencySymbol = "usd") {
       addresses = addresses ? lodash.castArray(addresses) : [];
-      if (addresses == null || addresses.length == 0) return queries.totalTvl(currency);
+      if (addresses == null || addresses.length == 0) queries.getGlobalTvl(currency);
       return queries.sumTvl(addresses, currency);
     },
     async tvm(addresses: string[] = [], currency: CurrencySymbol = "usd") {

--- a/packages/api/src/tables/emp-stats/js-map.ts
+++ b/packages/api/src/tables/emp-stats/js-map.ts
@@ -2,6 +2,7 @@ import * as uma from "@uma/sdk";
 import { Data, makeId } from "./utils";
 const { JsMap } = uma.tables.generic;
 
+const globalId = "global";
 export const Table = (type = "Emp Stat") => {
   const table = JsMap<string, Data>(type, makeId);
   async function getOrCreate(address: string) {
@@ -12,10 +13,22 @@ export const Table = (type = "Emp Stat") => {
     await getOrCreate(address);
     return table.update(address, data);
   }
+  async function upsertGlobal(data: Partial<Data>) {
+    return upsert(globalId, data);
+  }
+  async function getGlobal() {
+    return table.get(globalId);
+  }
+  async function getOrCreateGlobal() {
+    return getOrCreate(globalId);
+  }
   return {
     ...table,
     getOrCreate,
     upsert,
+    upsertGlobal,
+    getOrCreateGlobal,
+    getGlobal,
   };
 };
 export type Table = ReturnType<typeof Table>;


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.clubhouse.io/uma-project/story/1680/add-latest-global-tvl-value-and-expose-in-api


**Summary**

Theres an existing call to calculate tvl based on a number of emp addresses. This just calls it on an interval and caches it in the latest tvl table under the key "global".  This is a prerequisite to adding global tvl history, which we currently do not have, we only have tvl per EMP.


**Details**

No api changes were necessary, but when a user requests global tvl, it returns the cached version now rather than doing the math for the request. 


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1680/add-latest-global-tvl-value-and-expose-in-api