### PR TITLE
feat(api): add global tvl history and api calls

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -174,3 +174,11 @@ Currently only usdc prices are supported.
 
 Returns historical market prices (based on 0x api) for a token address. Slices from a starting timestamp (in seconds) and a count of samples newer than that.
 Currently only usdc prices are supported.
+
+### globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => StatData[]
+
+Gets the history of global tvl, the sum of all known EMP total value locked, between start and end timestamps in seconds.
+
+### globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") => StatData[]
+
+Gets the history of global tvl, the sum of all known EMP tottal value locked, starting at start in timestamp seconds and counting length samples after that.

--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -181,4 +181,4 @@ Gets the history of global tvl, the sum of all known EMP total value locked, bet
 
 ### globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") => StatData[]
 
-Gets the history of global tvl, the sum of all known EMP tottal value locked, starting at start in timestamp seconds and counting length samples after that.
+Gets the history of global tvl, the sum of all known EMP total value locked, starting at start in timestamp seconds and counting length samples after that.

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -140,7 +140,6 @@ async function run(env: ProcessEnv) {
       await services.registry(appState.lastBlock, blockNumber);
       await services.emps(appState.lastBlock, blockNumber);
       await services.erc20s.update();
-      await services.empStats.update();
 
       appState.lastBlockUpdate = blockNumber;
     }
@@ -158,6 +157,7 @@ async function run(env: ProcessEnv) {
     await services.collateralPrices.update();
     await services.syntheticPrices.update();
     await services.marketPrices.update();
+    await services.empStats.update();
   }
 
   // coingeckos prices don't update very fast, so set it on an interval every few minutes

--- a/packages/api/src/libs/queries.ts
+++ b/packages/api/src/libs/queries.ts
@@ -6,6 +6,9 @@ import { calcGcr } from "./utils";
 import bluebird from "bluebird";
 import { BigNumber } from "ethers";
 
+type Config = {
+  globalKey?: string;
+};
 const { exists } = uma.utils;
 type Dependencies = Pick<
   AppState,

--- a/packages/api/src/services/actions.ts
+++ b/packages/api/src/services/actions.ts
@@ -125,9 +125,17 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(stats[currency], "Invalid currency type: " + currency);
       return stats[currency].history.tvm.betweenByAddress(empAddress, start, end);
     },
+    async globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
+      assert(stats[currency], "Invalid currency type: " + currency);
+      return stats[currency].history.tvl.betweenByGlobal(start, end);
+    },
     async tvlHistorySlice(empAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(stats[currency], "Invalid currency type: " + currency);
       return stats[currency].history.tvl.sliceByAddress(empAddress, start, length);
+    },
+    async globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") {
+      assert(stats[currency], "Invalid currency type: " + currency);
+      return stats[currency].history.tvl.sliceByGlobal(start, length);
     },
     async tvmHistorySlice(empAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(stats[currency], "Invalid currency type: " + currency);

--- a/packages/api/src/tables/emp-stats-history/sorted-js-map.ts
+++ b/packages/api/src/tables/emp-stats-history/sorted-js-map.ts
@@ -2,6 +2,7 @@ import * as uma from "@uma/sdk";
 import { Data, makeId, makeEndId } from "./utils";
 const { SortedJsMap } = uma.tables.generic;
 
+const globalId = "global";
 export const Table = (type = "Emp Stat History") => {
   const table = SortedJsMap<string, Data>(type, makeId);
 
@@ -25,12 +26,33 @@ export const Table = (type = "Emp Stat History") => {
     return result.slice(0, length);
   }
 
+  function hasGlobal(timestamp: number) {
+    return hasByAddress(globalId, timestamp);
+  }
+  function getAllGlobal() {
+    return getAllByAddress(globalId);
+  }
+  function betweenByGlobal(start: number, end: number) {
+    return betweenByAddress(globalId, start, end);
+  }
+  function sliceByGlobal(start: number, length: number) {
+    return sliceByAddress(globalId, start, length);
+  }
+  function createGlobal(data: { timestamp: number; value: string }) {
+    return table.create({ ...data, address: globalId });
+  }
+
   return {
     ...table,
     getAllByAddress,
     hasByAddress,
     betweenByAddress,
     sliceByAddress,
+    hasGlobal,
+    getAllGlobal,
+    betweenByGlobal,
+    sliceByGlobal,
+    createGlobal,
   };
 };
 export type Table = ReturnType<typeof Table>;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1674/add-the-global-tvl-history-to-the-api


**Summary**

Adds global historical tvl processing and exposes in api.


**Details**

This adds 2 new api endpoints specifically for global tvl:
- globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => StatData[]
- globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd")  => StatData[]

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1674/add-the-global-tvl-history-to-the-api
