### PR TITLE
feat(api): add debugging profiling logs to api to determine

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -27,6 +27,12 @@ zrxBaseUrl=https://api.0x.org
 
 # how many days of price history we should query on startup, leave empty to disable, history will start at the time app is started
 backfillDays=
+
+# required for lsp state updates. this is a valid multicall address on mainnet.
+MULTI_CALL_ADDRESS=0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441
+
+# any non null value will turn on debugging. This adds additional logs and time profiles for key calls.
+debug=1
 ```
 
 ## Starting

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,9 @@ import { ethers } from "ethers";
 import type { empStats, empStatsHistory, lsps } from "./tables";
 import type Zrx from "./libs/zrx";
 
+export interface BaseConfig {
+  debug?: boolean;
+}
 export type Currencies = "usd";
 export type { BigNumber } from "ethers";
 export type Provider = ethers.providers.Provider;

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -129,3 +129,15 @@ export const BatchRead = (multicall: uma.Multicall) => async (
     })
   );
 };
+
+export const Profile = (enabled: boolean | undefined) => {
+  return (msg: string) => {
+    // if not enabled, dont do anything
+    if (!enabled) return lodash.noop;
+
+    const id = lodash.uniqueId(msg + "_");
+    console.log(msg);
+    console.time(id);
+    return () => console.timeEnd(id);
+  };
+};

--- a/packages/api/src/services/collateral-prices.ts
+++ b/packages/api/src/services/collateral-prices.ts
@@ -1,10 +1,10 @@
 import * as uma from "@uma/sdk";
 import bluebird from "bluebird";
 import assert from "assert";
-import { AppState, CurrencySymbol } from "..";
-type Config = {
+import { AppState, CurrencySymbol, BaseConfig } from "..";
+interface Config extends BaseConfig {
   currency?: CurrencySymbol;
-};
+}
 import { parseUnits, msToS } from "../libs/utils";
 
 type Dependencies = Pick<AppState, "coingecko" | "prices" | "collateralAddresses">;

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -1,12 +1,12 @@
 import { clients } from "@uma/sdk";
 import Promise from "bluebird";
-import { AppState } from "..";
+import { AppState, BaseConfig } from "..";
 
 const { registry } = clients;
 
-type Config = {
+interface Config extends BaseConfig {
   network?: number;
-};
+}
 type Dependencies = Pick<AppState, "registeredEmps" | "provider">;
 
 export default (config: Config, appState: Dependencies) => {

--- a/packages/api/src/services/emp-stats.ts
+++ b/packages/api/src/services/emp-stats.ts
@@ -1,13 +1,13 @@
 import assert from "assert";
 import * as uma from "@uma/sdk";
 import { BigNumber } from "ethers";
-import { Currencies, AppState, PriceSample } from "..";
+import { Currencies, AppState, PriceSample, BaseConfig } from "..";
 import { calcTvl, calcTvm, nowS } from "../libs/utils";
 import Queries from "../libs/queries";
 
-type Config = {
+interface Config extends BaseConfig {
   currency?: Currencies;
-};
+}
 type Dependencies = Pick<
   AppState,
   "emps" | "stats" | "prices" | "erc20s" | "registeredEmps" | "synthPrices" | "marketPrices" | "lsps"

--- a/packages/api/src/services/erc20-state.ts
+++ b/packages/api/src/services/erc20-state.ts
@@ -1,8 +1,8 @@
 import { clients } from "@uma/sdk";
-import { AppState } from "..";
+import { AppState, BaseConfig } from "..";
 import { asyncValues } from "../libs/utils";
 
-type Config = undefined;
+type Config = BaseConfig;
 // break out this services specific state dependencies
 type Dependencies = Pick<
   AppState,

--- a/packages/api/src/services/express.ts
+++ b/packages/api/src/services/express.ts
@@ -4,16 +4,19 @@ import cors from "cors";
 import bodyParser from "body-parser";
 import assert from "assert";
 import type { Request, Response, NextFunction } from "express";
-import { Json } from "..";
+import { Json, BaseConfig } from "..";
+import { Profile } from "../libs/utils";
 
-type Config = {
+interface Config extends BaseConfig {
   port: number;
-};
+}
 // represents the actions service, a single function which maps to different callable functions
 type Actions = (action: string, ...args: Json[]) => Promise<Json>;
 
 export default async (config: Config, actions: Actions) => {
   assert(config.port, "requires express port");
+
+  const profile = Profile(config.debug);
   const app = Express();
 
   app.use(cors());
@@ -27,9 +30,11 @@ export default async (config: Config, actions: Actions) => {
   app.post("/:action", (req: Request, res: Response, next: NextFunction) => {
     const action = req?.params?.action;
 
+    const end = profile(`action: ${action}`);
     actions(action, ...lodash.castArray(req.body))
       .then(res.json.bind(res))
-      .catch(next);
+      .catch(next)
+      .finally(end);
   });
 
   app.use(cors());

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -1,12 +1,12 @@
 import { clients } from "@uma/sdk";
 import Promise from "bluebird";
-import { AppState } from "..";
+import { AppState, BaseConfig } from "..";
 
 const { lspCreator } = clients;
 
-type Config = {
+interface Config extends BaseConfig {
   network?: number;
-};
+}
 type Dependencies = Pick<AppState, "registeredLsps" | "provider">;
 
 export default (config: Config, appState: Dependencies) => {

--- a/packages/api/src/services/lsp-state.e2e.ts
+++ b/packages/api/src/services/lsp-state.e2e.ts
@@ -37,12 +37,12 @@ describe("lsp-state service", function () {
     };
   });
   it("init", async function () {
-    const service = Service(undefined, appState);
+    const service = Service({}, appState);
     assert.ok(service);
   });
   it("readDynamicState", async function () {
     const [address] = registeredContracts;
-    const service = Service(undefined, appState);
+    const service = Service({}, appState);
     const instance = await uma.clients.lsp.connect(address, appState.provider);
     const result = await service.utils.batchRead(service.utils.dynamicProps, instance, address);
     assert.equal(result.address, address);
@@ -53,7 +53,7 @@ describe("lsp-state service", function () {
   });
   it("readStaticState", async function () {
     const [address] = registeredContracts;
-    const service = Service(undefined, appState);
+    const service = Service({}, appState);
     const instance = await uma.clients.lsp.connect(address, appState.provider);
     const result = await service.utils.batchRead(service.utils.staticProps, instance, address);
     assert.equal(result.address, address);
@@ -70,7 +70,7 @@ describe("lsp-state service", function () {
   });
   it("update", async function () {
     this.timeout(60000);
-    const service = Service(undefined, appState);
+    const service = Service({}, appState);
     await service.update();
 
     assert.ok((await appState.lsps.active.values()).length || (await appState.lsps.expired.values()).length);

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -1,10 +1,10 @@
 import * as uma from "@uma/sdk";
 import { BatchRead, toString, toNumber, parseBytes, nowS } from "../libs/utils";
-import { AppState } from "..";
+import { AppState, BaseConfig } from "..";
 import { lsps } from "../tables";
 
 type Instance = uma.clients.lsp.Instance;
-type Config = undefined;
+type Config = BaseConfig;
 type Dependencies = Pick<
   AppState,
   "lsps" | "registeredLsps" | "provider" | "collateralAddresses" | "shortAddresses" | "longAddresses" | "multicall"

--- a/packages/api/src/services/synthetic-prices.ts
+++ b/packages/api/src/services/synthetic-prices.ts
@@ -1,19 +1,19 @@
 import assert from "assert";
 import SynthPrices from "../libs/synthPrices";
-import { AppState, PriceSample, Currencies } from "..";
+import { AppState, PriceSample, Currencies, BaseConfig } from "..";
 import * as uma from "@uma/sdk";
 import bluebird from "bluebird";
 import Queries from "../libs/queries";
-import { calcSyntheticPrice } from "../libs/utils";
+import { calcSyntheticPrice, Profile } from "../libs/utils";
 
-type Config = {
+interface Config extends BaseConfig {
   cryptowatchApiKey?: string;
   tradermadeApiKey?: string;
   quandlApiKey?: string;
   defipulseApiKey?: string;
   priceFeedDecimals?: number;
   currency?: Currencies;
-};
+}
 
 type Dependencies = Pick<
   AppState,
@@ -21,11 +21,12 @@ type Dependencies = Pick<
 >;
 
 export default function (config: Config, appState: Dependencies) {
-  const { currency = "usd" } = config;
+  const { currency = "usd", debug } = config;
   const { web3, emps, synthPrices, prices } = appState;
   const getSynthPrices = SynthPrices(config, web3);
 
   const queries = Queries(appState);
+  const profile = Profile(debug);
 
   // get or create a history table by an erc20 token address. this might be a bit confusing because we also have a
   // synthPrices table which store raw synth price queried from bot. This table stores the currency converted price over time.
@@ -72,6 +73,7 @@ export default function (config: Config, appState: Dependencies) {
   async function updateLatestSynthPrices(empAddresses: string[]) {
     // slow down updates by running them serially to prevent rate limits, conform to Promise.allSettled
     return bluebird.mapSeries(empAddresses, async (empAddress) => {
+      const end = profile(`Synth price for ${empAddress}`);
       try {
         return {
           status: "fulfilled",
@@ -82,6 +84,8 @@ export default function (config: Config, appState: Dependencies) {
           status: "rejected",
           reason: err,
         };
+      } finally {
+        end();
       }
     });
   }
@@ -126,6 +130,7 @@ export default function (config: Config, appState: Dependencies) {
   async function updateLatestPrices(empAddresses: string[]) {
     // slow down updates by running them serially to prevent rate limits, conform to Promise.allSettled
     return bluebird.mapSeries(empAddresses, async (empAddress) => {
+      const end = profile(`Update Synth to USD for ${empAddress}`);
       try {
         return {
           status: "fulfilled",
@@ -136,6 +141,8 @@ export default function (config: Config, appState: Dependencies) {
           status: "rejected",
           reason: err,
         };
+      } finally {
+        end();
       }
     });
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1728/add-debugging-profiling-logs-to-api-to-determine-what-is-causing-failure


**Summary**

Adds a profiling helper class which can be enabled or disabled with a boolean. Its used around key calls that could possibly be failing.

Requires `debug=1` in env to enable

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1728/add-debugging-profiling-logs-to-api-to-determine-what-is-causing-failure