### PR TITLE
feat(df-pf-configs): Update DIGGBTC, DIGGETH and UMAUSD price feed configs

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -536,9 +536,9 @@ const defaultConfigs = {
     expression: `
       mean(DIGG_WBTC_SUSHI, DIGG_WBTC_UNI)
     `,
-    lookback: 7200,
+    lookback: 93600,
     minTimeBetweenUpdates: 60,
-    twapLength: 1800,
+    twapLength: 86400,
     priceFeedDecimals: 8,
     customFeeds: {
       DIGG_WBTC_SUSHI: { type: "uniswap", uniswapAddress: "0x9a13867048e01c663ce8ce2fe0cdae69ff9f35e3" },

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -541,8 +541,16 @@ const defaultConfigs = {
     twapLength: 86400,
     priceFeedDecimals: 8,
     customFeeds: {
-      DIGG_WBTC_SUSHI: { type: "uniswap", uniswapAddress: "0x9a13867048e01c663ce8ce2fe0cdae69ff9f35e3" },
-      DIGG_WBTC_UNI: { type: "uniswap", uniswapAddress: "0xe86204c4eddd2f70ee00ead6805f917671f56c52" },
+      DIGG_WBTC_SUSHI: {
+        type: "uniswap",
+        uniswapAddress: "0x9a13867048e01c663ce8ce2fe0cdae69ff9f35e3",
+        invertPrice: true,
+      },
+      DIGG_WBTC_UNI: {
+        type: "uniswap",
+        uniswapAddress: "0xe86204c4eddd2f70ee00ead6805f917671f56c52",
+        invertPrice: true,
+      },
     },
   },
   DIGGETH: {
@@ -559,6 +567,29 @@ const defaultConfigs = {
     customFeeds: {
       WBTC_ETH_SUSHI: { type: "uniswap", uniswapAddress: "0xCEfF51756c56CeFFCA006cD410B03FFC46dd3a58" },
       WBTC_ETH_UNI: { type: "uniswap", uniswapAddress: "0xBb2b8038a1640196FbE3e38816F3e67Cba72D940" },
+      DIGGBTC: {
+        type: "expression",
+        // Note: lower-case variables are intermediate, upper-case are configured feeds.
+        expression: `
+          mean(DIGG_WBTC_SUSHI, DIGG_WBTC_UNI)
+        `,
+        lookback: 7200,
+        minTimeBetweenUpdates: 60,
+        twapLength: 1800,
+        priceFeedDecimals: 8,
+        customFeeds: {
+          DIGG_WBTC_SUSHI: {
+            type: "uniswap",
+            uniswapAddress: "0x9a13867048e01c663ce8ce2fe0cdae69ff9f35e3",
+            invertPrice: true,
+          },
+          DIGG_WBTC_UNI: {
+            type: "uniswap",
+            uniswapAddress: "0xe86204c4eddd2f70ee00ead6805f917671f56c52",
+            invertPrice: true,
+          },
+        },
+      },
     },
   },
   DIGGUSD: {
@@ -643,6 +674,7 @@ const defaultConfigs = {
   UMAUSD: {
     type: "medianizer",
     minTimeBetweenUpdates: 60,
+    twapLength: 3600,
     medianizedFeeds: [
       { type: "cryptowatch", exchange: "coinbase-pro", pair: "umausd" },
       { type: "cryptowatch", exchange: "binance", pair: "umausdt" },


### PR DESCRIPTION
**Motivation**

UMAUSD and DIGGBTC need to be updated to cater to a couple of specific use cases that will use these price identifiers.
- UMAUSD needs a 1 hr TWAP for UMA Range Tokens
- DIGGBTC needs a 24 hr TWAP to support DIGG rebasing calculations
- DIGGETH was only updated to leave it unchanged, since it referenced DIGGBTC

This pr is accompanied by an [UMIP update](https://github.com/UMAprotocol/UMIPs/pull/365).

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**
NA
