### PR TITLE
fix(api,sdk): allow build to run with node by fixing imports

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,7 @@
     "eslint": "eslint './src/**/*.ts'",
     "prettier": "prettier './**/*.md' './src/**/*.ts'",
     "lint": "yarn prettier --write && yarn eslint --fix",
-    "api": "ts-node src/start api"
+    "api": "node build/start api"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/packages/sdk/src/libs/clients/emp/client.ts
+++ b/packages/sdk/src/libs/clients/emp/client.ts
@@ -1,11 +1,13 @@
-import { ExpiringMultiParty__factory, ExpiringMultiParty } from "@uma/core/contract-types/ethers";
+import { EthersContracts } from "@uma/core";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 import { Balances } from "../../utils";
 
-export type Instance = ExpiringMultiParty;
+export type Instance = EthersContracts.ExpiringMultiParty;
+const Factory = EthersContracts.ExpiringMultiParty__factory;
+
 export function connect(address: string, provider: SignerOrProvider): Instance {
-  return ExpiringMultiParty__factory.connect(address, provider);
+  return Factory.connect(address, provider);
 }
 
 export interface EventState {

--- a/packages/sdk/src/libs/clients/erc20/client.ts
+++ b/packages/sdk/src/libs/clients/erc20/client.ts
@@ -1,13 +1,14 @@
-import { ERC20__factory, ERC20 } from "@uma/core/contract-types/ethers";
+import { EthersContracts } from "@uma/core";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 import { Balances } from "../../utils";
 import { set } from "lodash";
 
-export type Instance = ERC20;
+export type Instance = EthersContracts.ERC20;
+const Factory = EthersContracts.ERC20__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
-  return ERC20__factory.connect(address, provider);
+  return Factory.connect(address, provider);
 }
 
 export interface EventState {

--- a/packages/sdk/src/libs/clients/lsp-creator/client.ts
+++ b/packages/sdk/src/libs/clients/lsp-creator/client.ts
@@ -1,21 +1,14 @@
 import assert from "assert";
-import { LongShortPairCreator__factory, LongShortPairCreator } from "@uma/core/contract-types/ethers";
+import { EthersContracts } from "@uma/core";
 import Artifacts from "@uma/core/build/contracts/LongShortPairCreator.json";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 
 // exporting Registry type in case its needed
-export type Instance = LongShortPairCreator;
+export type Instance = EthersContracts.LongShortPairCreator;
+const Factory = EthersContracts.LongShortPairCreator__factory;
 
 export type Network = keyof typeof Artifacts.networks;
-
-export type CreatedLongShortPair = GetEventType<Instance, "CreatedLongShortPair">;
-
-export interface EventState {
-  contracts?: {
-    [lspAddress: string]: CreatedLongShortPair["args"];
-  };
-}
 
 export function getAddress(network: Network): string {
   const address = Artifacts?.networks?.[network]?.address;
@@ -28,7 +21,15 @@ export function getAbi() {
 }
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
-  return LongShortPairCreator__factory.connect(address, provider);
+  return Factory.connect(address, provider);
+}
+
+export type CreatedLongShortPair = GetEventType<Instance, "CreatedLongShortPair">;
+
+export interface EventState {
+  contracts?: {
+    [lspAddress: string]: CreatedLongShortPair["args"];
+  };
 }
 
 export function reduceEvents(state: EventState, event: Event, index?: number): EventState {

--- a/packages/sdk/src/libs/clients/lsp/client.ts
+++ b/packages/sdk/src/libs/clients/lsp/client.ts
@@ -1,18 +1,19 @@
-import { LongShortPair__factory, LongShortPair } from "@uma/core/contract-types/ethers";
+import { EthersContracts } from "@uma/core";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 import { Balances } from "../../utils";
 
-export type Instance = LongShortPair;
+export type Instance = EthersContracts.LongShortPair;
+const Factory = EthersContracts.LongShortPair__factory;
+
+export function connect(address: string, provider: SignerOrProvider): Instance {
+  return Factory.connect(address, provider);
+}
 
 export type TokensCreated = GetEventType<Instance, "TokensCreated">;
 export type TokensRedeemed = GetEventType<Instance, "TokensRedeemed">;
 export type ContractExpired = GetEventType<Instance, "ContractExpired">;
 export type PositionSettled = GetEventType<Instance, "PositionSettled">;
-
-export function connect(address: string, provider: SignerOrProvider): Instance {
-  return LongShortPair__factory.connect(address, provider);
-}
 
 export interface EventState {
   sponsors?: string[];

--- a/packages/sdk/src/libs/clients/multicall/client.ts
+++ b/packages/sdk/src/libs/clients/multicall/client.ts
@@ -1,8 +1,9 @@
-import { Multicall__factory, Multicall } from "@uma/core/contract-types/ethers";
+import { EthersContracts } from "@uma/core";
 import type { SignerOrProvider } from "../..";
 
-export type Instance = Multicall;
+export type Instance = EthersContracts.Multicall;
+const Factory = EthersContracts.Multicall__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
-  return Multicall__factory.connect(address, provider);
+  return Factory.connect(address, provider);
 }

--- a/packages/sdk/src/libs/clients/registry/client.ts
+++ b/packages/sdk/src/libs/clients/registry/client.ts
@@ -1,17 +1,11 @@
+import { EthersContracts } from "@uma/core";
 import assert from "assert";
-import { Registry__factory, Registry } from "@uma/core/contract-types/ethers";
 import RegistryArtifacts from "@uma/core/build/contracts/Registry.json";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 
-// exporting Registry type in case its needed
-export type Instance = Registry;
-
-export type NewContractRegistered = GetEventType<Instance, "NewContractRegistered">;
-
-export interface EventState {
-  contracts?: { [key: string]: NewContractRegistered };
-}
+export type Instance = EthersContracts.Registry;
+const Factory = EthersContracts.Registry__factory;
 
 export type Network = keyof typeof RegistryArtifacts.networks;
 
@@ -22,20 +16,27 @@ export function getAddress(network: Network): string {
 }
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
-  return Registry__factory.connect(address, provider);
+  return Factory.connect(address, provider);
 }
+
+export interface EventState {
+  contracts?: { [key: string]: NewContractRegistered };
+}
+
+export type NewContractRegistered = GetEventType<Instance, "NewContractRegistered">;
 
 // experimenting with a generalized way of handling events and returning state, inspired from react style reducers
 export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
   switch (event.event) {
     case "NewContractRegistered": {
       const typedEvent = event as NewContractRegistered;
+      const { contractAddress } = typedEvent.args;
       const contracts = state?.contracts || {};
       return {
         ...state,
         contracts: {
           ...contracts,
-          [typedEvent.args.contractAddress]: typedEvent,
+          [contractAddress]: typedEvent,
         },
       };
     }

--- a/packages/sdk/src/libs/index.ts
+++ b/packages/sdk/src/libs/index.ts
@@ -6,7 +6,7 @@ export { default as Coingecko } from "./coingecko";
 export { default as Multicall } from "./multicall";
 
 // types
-import type { TypedEventFilter, TypedEvent } from "@uma/core/contract-types/ethers/commons";
+import type { TypedEventFilter, TypedEvent } from "@uma/core/types/contract-types/ethers/commons";
 import { Contract } from "ethers";
 import { Result } from "@ethersproject/abi";
 import { Signer } from "@ethersproject/abstract-signer";


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1775/bug-replace-ts-node-with-node-when-running-api

**Summary**
This fixes some sdk imports which caused api to crash when running the built version. 


**Details**
Previously we could only run the api with ts-node. This fixes the runtime errors so that it runs from build. The hope is we can remove another possible cause of the API hitting 100% cpu usage intermittently.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1775/bug-replace-ts-node-with-node-when-running-api
