### PR TITLE
feat(api): expose various lsp state calls and refactor api slightly

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -63,128 +63,170 @@ This is a non exhaustive list of actions, for the full list see [action source](
 The following actions can be called to the server with `curl -X POST localhost:8282/${action}`.
 Parameters are attached as JSON to the request body in the follow format: `"[...arguments]"`. Arguments should be attached to the body as an array.
 
-### actions() => string[]
+## Channels
+
+Channels are a way to group actions into related sets. Currently channels are used to separate queries
+across contract types, but they can theoretically group any action calls together. To call an action on
+a channel, use the channel name as part of the path. `curl -X POST localhost:8282/${channel}/${action}`.
+Current channels are
+
+- emp - all emp calls
+- lsp - all lsp calls
+
+## Action Client
+
+See [../../examples/action-client.ts](Action Client Code) for an example of how to interface with the api from the client side.
+
+## Emp Api
+
+All calls here are on the emp channel.
+
+### emp/actions() => string[]
 
 Returns a list of all actions
 
-### echo(...args:Json[]) => args
+### emp/echo(...args:Json[]) => args
 
 Echos back any parameters you send to the server. For testing connectivity and client correctness.
 
-### listEmpAddresses() => string[]
+### emp/listEmpAddresses() => string[]
 
 Returns all known emp addresses for this servers network, which defaults to mainnet.
 
-### lastBlock() => number
+### emp/lastBlock() => number
 
 Returns the last block number seen.
 
-### listActiveEmps() => Emps[]
+### emp/listActiveEmps() => Emps[]
 
 Returns all known active emps data. Conforms to the EMP type defined in the uma sdk: `uma.tables.emp.Data`.
 
-### listExpiredEmps() => Emps[]
+### emp/listExpiredEmps() => Emps[]
 
 Returns all known expired emps data. Conforms to the EMP type defined in the uma sdk: `uma.tables.emp.Data`.
 
-### getEmpState(address: string) => EmpState
+### emp/getEmpState(address: string) => EmpState
 
 Get all known state of any emp by its address.
 
-### getErc20Info(address:string) => Erc20Data
+### emp/getErc20Info(address:string) => Erc20Data
 
 Get name, decimals of an erc20 by address.
 
-### getAllErc20Info() => Erc20Data[]
+### emp/getAllErc20Info() => Erc20Data[]
 
 List all known erc20s, collateral or synthetic and all known information about them
 
-### collateralAddresses() => string[]
+### emp/collateralAddresses() => string[]
 
-### syntheticAddresses() => string[]
+### emp/syntheticAddresses() => string[]
 
 Returns all known active collateral or synthetic addresses
 
-### allLatestPrices(currency='usd') => {[address:string]:[timestamp:number,price:string]
+### emp/allLatestPrices(currency='usd') => {[address:string]:[timestamp:number,price:string]
 
 Returns all known latest prices for synthetic or collateral addresses in wei.
 
-### allLatestMarketPrices() => {[address:string]:[timestamp:number,price:string]
+### emp/allLatestMarketPrices() => {[address:string]:[timestamp:number,price:string]
 
 Returns all latest known market prices (based on matcha/0x routing) for synthetic or collateral addresses in wei.
 
-### latestPriceByTokenAddress(tokenAddress:string,currency:'usd') => [timestamp:number,price:string]
+### emp/latestPriceByTokenAddress(tokenAddress:string,currency:'usd') => [timestamp:number,price:string]
 
 Returns latest price for a particular erc20 token address ( emp collateral or synthetic address) in wei.
 
-### latestSyntheticPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
+### emp/latestSyntheticPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
 
-### latestCollateralPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
+### emp/latestCollateralPrice(empAddress: string, currency: CurrencySymbol = "usd") => [timestamp:number,price:string]
 
 Gets the latest collateral or synthetic price based on the emp contract address in wei.
 
-### historicalPricesByTokenAddress(tokenAddress:string,start:number=0,end:number=Date.now(),currency:"usd"="usd") => PriceSample[]
+### emp/historicalPricesByTokenAddress(tokenAddress:string,start:number=0,end:number=Date.now(),currency:"usd"="usd") => PriceSample[]
 
 Get a range of historical prices between start and end in MS, sorted by timestamp ascending from an erc20 token address in wei.
 This is useful for charting betwen two dates.
 
-### sliceHistoricalPricesByTokenAddress(tokenAddress:string,start:number=0,length:number=1,currency:"usd"="usd") => PriceSample[]
+### emp/sliceHistoricalPricesByTokenAddress(tokenAddress:string,start:number=0,length:number=1,currency:"usd"="usd") => PriceSample[]
 
 Get a range of historical prices between start and count of price samples, sorted by timestamp ascending, from an erc20 token address.
 This is useful for paginating data when you have X elements per page, and you know the last element seen.
 
-### async historicalSynthPrices( empAddress: string, start = 0, end: number = Date.now()) => PriceSample[]
+### emp/historicalSynthPrices( empAddress: string, start = 0, end: number = Date.now()) => PriceSample[]
 
-### async historicalCollateralPrices( empAddress: string, start = 0, end: number = Date.now()) => PriceSample[]
+### emp/historicalCollateralPrices( empAddress: string, start = 0, end: number = Date.now()) => PriceSample[]
 
 Get a range of historical prices between start and end in MS, sorted by timestamp ascending from an emp contract address.
 This is useful for charting betwen two dates.
 
-### async sliceHistoricalSynthPrices(empAddress: string, start = 0, length = 1) => PriceSample[]
+### emp/sliceHistoricalSynthPrices(empAddress: string, start = 0, length = 1) => PriceSample[]
 
-### async sliceHistoricalCollateralPrices(empAddress: string, start = 0, length = 1) => PriceSample[]
+### emp/sliceHistoricalCollateralPrices(empAddress: string, start = 0, length = 1) => PriceSample[]
 
 Get a range of historical prices between start and count of price samples, sorted by timestamp ascending, from an emp contract address.
 This is useful for paginating data when you have X elements per page, and you know the last element seen.
 
-### tvl(empAddresses?: string[], currency: CurrencySymbol = "usd") => string
+### emp/tvl(empAddresses?: string[], currency: CurrencySymbol = "usd") => string
 
-### tvm(empAddresses?: string[], currency: CurrencySymbol = "usd") => string
+### emp/tvm(empAddresses?: string[], currency: CurrencySymbol = "usd") => string
 
 Returns TVL/TVM of all supplied addresses in USD 18 decimals. If no addresses supplied, returns TVL/TVM of all known contracts.
 
-### tvlHistoryBetween(empAddress: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
+### emp/tvlHistoryBetween(empAddress: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
 
-### tvmHistoryBetween(empAddress: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
+### emp/tvmHistoryBetween(empAddress: string, start = 0, end: number = Math.floor(Date.now() / 1000), currency: CurrencySymbol = "usd") => StatData[]
 
 Returns TVL/TVM between timestamps (in seconds) at the highest resolution for a particular emp address.
 
-### tvlHistorySlice(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
+### emp/tvlHistorySlice(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
 
-### tvmHistorySlice(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
+### emp/tvmHistorySlice(empAddress: string, start = 0, length = 1, currency:CurrencySymbol='usd') => StatData[]
 
 Returns TVL/TVM for emp starting at timestamp in seconds and a length number of samples after that ascending.
 
-### listTvls(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
+### emp/listTvls(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
 
-### listTvms(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
+### emp/listTvms(currency: CurrencySymbol = "usd") => Array<{value:string, timestamp:number}>
 
 List all tvls/tvms of known contracts.
 
-### historicalMarketPricesBetween(tokenAddress: string, start = 0, end: number = nowS()) StatData[]
+### emp/historicalMarketPricesBetween(tokenAddress: string, start = 0, end: number = nowS()) StatData[]
 
 Returns historical market prices (based on 0x api) for a token address. Get samples between a start time and end time ( in seconds).
 Currently only usdc prices are supported.
 
-### sliceHistoricalMarketPrices(tokenAddress: string, start = 0, length = 1) StatData[]
+### emp/sliceHistoricalMarketPrices(tokenAddress: string, start = 0, length = 1) StatData[]
 
 Returns historical market prices (based on 0x api) for a token address. Slices from a starting timestamp (in seconds) and a count of samples newer than that.
 Currently only usdc prices are supported.
 
-### globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => StatData[]
+### emp/globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => StatData[]
 
 Gets the history of global tvl, the sum of all known EMP total value locked, between start and end timestamps in seconds.
 
-### globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") => StatData[]
+### emp/globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") => StatData[]
 
 Gets the history of global tvl, the sum of all known EMP total value locked, starting at start in timestamp seconds and counting length samples after that.
+
+## LSP
+
+Lsp calls are on the lsp channel
+
+### lsp/actions() => string[]
+
+### lsp/listAddresses() => string[]
+
+### lsp/listActive() => LspState[]
+
+### lsp/listExpired() => LspState[]
+
+### lsp/getState(address: string) => LspState
+
+### lsp/getErc20Info(address: string) => Erc20State
+
+### lsp/allErc20Info() => Erc20State[]
+
+### lsp/collateralAddresses() => String[]
+
+### lsp/longAddresses() => String[]
+
+### lsp/shortAddresses() => String[]

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -6,9 +6,9 @@ import moment from "moment";
 import { tables, Coingecko, utils, Multicall } from "@uma/sdk";
 
 import * as Services from "../../services";
-import Express from "../../services/express";
-import Actions from "../../services/actions";
-import { ProcessEnv, AppState } from "../..";
+import Express from "../../services/express-channels";
+import * as Actions from "../../services/actions";
+import { ProcessEnv, AppState, Channels } from "../..";
 import { empStats, empStatsHistory, lsps } from "../../tables";
 import Zrx from "../../libs/zrx";
 import { Profile } from "../../libs/utils";
@@ -95,7 +95,7 @@ async function run(env: ProcessEnv) {
   const services = {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     blocks: Services.Blocks(undefined, appState),
-    emps: Services.Emps({ debug }, appState),
+    emps: Services.EmpState({ debug }, appState),
     registry: Services.Registry({ debug }, appState),
     collateralPrices: Services.CollateralPrices({ debug }, appState),
     syntheticPrices: Services.SyntheticPrices(
@@ -112,11 +112,8 @@ async function run(env: ProcessEnv) {
     empStats: Services.EmpStats({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, appState),
     lspCreator: Services.LspCreator({ debug }, appState),
-    lsps: Services.Lsps({ debug }, appState),
+    lsps: Services.LspState({ debug }, appState),
   };
-
-  // services consuming data
-  const actions = Actions(undefined, appState);
 
   // warm caches
   await services.registry();
@@ -155,8 +152,16 @@ async function run(env: ProcessEnv) {
   await services.marketPrices.update();
   console.log("Updated Market Prices");
 
-  // expose calls through express
-  await Express({ port: Number(env.EXPRESS_PORT), debug }, actions);
+  // services consuming data
+  const channels: Channels = [
+    // set this as default channel for backward compatibility. This is deprecated and will eventually be used for global style queries
+    ["", Actions.Emp(undefined, appState)],
+    // Should switch all clients to explicit channels
+    ["emp", Actions.Emp(undefined, appState)],
+    ["lsp", Actions.Lsp(undefined, appState)],
+  ];
+
+  await Express({ port: Number(env.EXPRESS_PORT), debug }, channels)();
 
   // break all state updates by block events into a cleaner function
   async function updateByBlock(blockNumber: number) {

--- a/packages/api/src/examples/action-client.e2e.ts
+++ b/packages/api/src/examples/action-client.e2e.ts
@@ -4,15 +4,15 @@ import assert from "assert";
 describe("action client", function () {
   let client: ClientType;
   it("init", function () {
-    client = Client("http://localhost:8282");
+    client = Client("http://localhost:8282", "emp");
     assert.ok(client);
   });
   // these test requires integration testing setup with API running. disable for ci
-  it.skip("echo", async function () {
+  it("echo", async function () {
     const result = await client("echo", "test");
     assert.deepEqual(result, ["test"]);
   });
-  it.skip("error", async function () {
+  it("error", async function () {
     let plan = 1;
     try {
       await client("dne", "test");

--- a/packages/api/src/examples/action-client.ts
+++ b/packages/api/src/examples/action-client.ts
@@ -7,7 +7,7 @@ import join from "url-join";
 // This is a basic client to allow you to call into the server in the form of
 // client(action,arg1,arg2,...etc) => Promise<Json>.
 // see tests for usage.
-export default function Client(host: string) {
+export default function Client(host: string, channel = "") {
   assert(host, "requires api host url");
 
   const defaultOptions = {
@@ -20,7 +20,7 @@ export default function Client(host: string) {
   };
 
   async function call(action: string, ...args: Json[]): Promise<Json> {
-    const url = join(host, action);
+    const url = join(host, channel, action);
     const options = {
       ...defaultOptions,
       body: JSON.stringify(args),

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,8 @@ import { ethers } from "ethers";
 import type { empStats, empStatsHistory, lsps } from "./tables";
 import type Zrx from "./libs/zrx";
 
+export { Channels } from "./services/express-channels";
+
 export interface BaseConfig {
   debug?: boolean;
 }

--- a/packages/api/src/services/actions/emp.ts
+++ b/packages/api/src/services/actions/emp.ts
@@ -1,8 +1,8 @@
 import assert from "assert";
 import * as uma from "@uma/sdk";
-import { Json, Actions, AppState, CurrencySymbol, PriceSample } from "..";
-import Queries from "../libs/queries";
-import { nowS } from "../libs/utils";
+import { Json, Actions, AppState, CurrencySymbol, PriceSample } from "../..";
+import Queries from "../../libs/queries";
+import { nowS } from "../../libs/utils";
 import lodash from "lodash";
 
 const { exists } = uma.utils;

--- a/packages/api/src/services/actions/index.ts
+++ b/packages/api/src/services/actions/index.ts
@@ -1,0 +1,2 @@
+export { default as Emp } from "./emp";
+export { default as Lsp } from "./lsp";

--- a/packages/api/src/services/actions/lsp.ts
+++ b/packages/api/src/services/actions/lsp.ts
@@ -1,0 +1,53 @@
+import assert from "assert";
+import { Json, Actions, AppState } from "../..";
+import Queries from "../../libs/queries";
+
+// actions use all the app state
+type Dependencies = AppState;
+type Config = undefined;
+
+export function Handlers(config: Config, appState: Dependencies): Actions {
+  const queries = Queries(appState);
+  const { registeredLsps, erc20s, collateralAddresses, longAddresses, shortAddresses } = appState;
+
+  const actions: Actions = {
+    listAddresses() {
+      return Array.from(registeredLsps.values());
+    },
+    listActive: queries.listActiveLsps,
+    listExpired: queries.listExpiredLsps,
+    async getState(address: string) {
+      assert(await registeredLsps.has(address), "Not a valid LSP address: " + address);
+      const state = await queries.getAnyLsp(address);
+      return queries.getFullLspState(state);
+    },
+    async getErc20Info(address: string) {
+      return erc20s.get(address);
+    },
+    async allErc20Info() {
+      return erc20s.values();
+    },
+    async collateralAddresses() {
+      return Array.from(collateralAddresses.values());
+    },
+    async longAddresses() {
+      return Array.from(longAddresses.values());
+    },
+    async shortAddresses() {
+      return Array.from(shortAddresses.values());
+    },
+  };
+
+  // list all available actions
+  const keys = Object.keys(actions);
+  actions.actions = () => keys;
+
+  return actions;
+}
+export default (config: Config, appState: AppState) => {
+  const actions = Handlers(config, appState);
+  return async (action: string, ...args: Json[]) => {
+    assert(actions[action], `Invalid action: ${action}`);
+    return actions[action](...args);
+  };
+};

--- a/packages/api/src/services/express-channels.ts
+++ b/packages/api/src/services/express-channels.ts
@@ -1,0 +1,67 @@
+import Express from "express";
+import lodash from "lodash";
+import cors from "cors";
+import bodyParser from "body-parser";
+import assert from "assert";
+import type { Request, Response, NextFunction } from "express";
+import { Json, BaseConfig } from "..";
+import { Profile } from "../libs/utils";
+
+interface Config extends BaseConfig {
+  port: number;
+  path?: string;
+}
+// represents the actions service, a single function which maps to different callable functions
+type Actions = (action: string, ...args: Json[]) => Promise<Json>;
+type Channel = [string, Actions];
+export type Channels = Channel[];
+// This is very similar to the original express service, but takes in the idea of channels, basically
+// will create paths to different action instances. In most cases each channel should be completely
+// independent of other channels.
+export default (config: Config, channels: Channels = []) => {
+  assert(config.port, "requires express port");
+  assert(channels.length, "requires a list of action channels");
+
+  const profile = Profile(config.debug);
+  const app = Express();
+
+  app.use(cors());
+  app.use(bodyParser.json({ limit: "1mb" }));
+  app.use(bodyParser.urlencoded({ extended: true }));
+
+  app.get("/", (req: Request, res: Response) => {
+    return res.send("ok");
+  });
+
+  // loops over all channels and adds the channel name to the url path. If no name exists it will put it at the root.
+  channels.forEach(([path, actions]) => {
+    const actionPath = path && path.length ? `/${path}/:action` : "/:action";
+    app.post(actionPath, (req: Request, res: Response, next: NextFunction) => {
+      const action = req?.params?.action;
+
+      const end = profile(`action: ${action}`);
+      actions(action, ...lodash.castArray(req.body))
+        .then(res.json.bind(res))
+        .catch(next)
+        .finally(end);
+    });
+  });
+
+  app.use(cors());
+
+  app.use(function (req: Request, res: Response, next: NextFunction) {
+    next(new Error("Invalid Request"));
+  });
+
+  // this is an error handler, express knows this because the function has 4 parameters rather than 3
+  // cant remove the "next" parameter, even though linting complains
+  app.use(function (err: Error, req: Request, res: Response, next: NextFunction) {
+    res.status(500).send(err.message || err);
+  });
+
+  return () => {
+    return new Promise((res) => {
+      app.listen(config.port, () => res(true));
+    });
+  };
+};

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -1,5 +1,5 @@
 export { default as Blocks } from "./blocks";
-export { default as Emps } from "./emp-state";
+export { default as EmpState } from "./emp-state";
 export { default as Registry } from "./emp-registry";
 export { default as CollateralPrices } from "./collateral-prices";
 export { default as Erc20s } from "./erc20-state";
@@ -7,4 +7,4 @@ export { default as SyntheticPrices } from "./synthetic-prices";
 export { default as EmpStats } from "./emp-stats";
 export { default as MarketPrices } from "./market-prices";
 export { default as LspCreator } from "./lsp-creator";
-export { default as Lsps } from "./lsp-state";
+export { default as LspState } from "./lsp-state";


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1714/expose-lsp-state-through-api

**Summary**

This exposes LSP state queried through ingestion services to the express api.


**Details**
There was some refactoring done to how the API works, but it should remain backward compatible. Specific contract calls to the api are now separated by "channels", so the path prepends `/emp/` or `/lsp/` to the action for instance `localhost:8282/emp/actions` - to list all actions on the channel.  The root channel `/` and `/emp` are identical for backward compatibility to existing clients, but this is deprecated and will probably change in the future.

Several new API calls were added specifically for the LSP which mirror many of the EMP calls. The README summarizes these.

There is a new [postman link ](https://www.getpostman.com/collections/9ce0fe57a483b5163fbf) which can be imported with the updated calls.

The action-client example has also been updated to show how to use the new channel system.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1714/expose-lsp-state-through-api
