### PR TITLE
feat(api): 1490 add lsp tvl calculations, per contract, totals and history

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -212,7 +212,7 @@ Gets the history of global tvl, the sum of all known EMP total value locked, sta
 
 ## LSP
 
-Lsp calls are on the lsp channel
+Lsp calls are on the lsp channel. These calls are the same as the EMP calls, but just scoped to LSP contracts.
 
 ### lsp/actions() => string[]
 
@@ -233,3 +233,15 @@ Lsp calls are on the lsp channel
 ### lsp/longAddresses() => String[]
 
 ### lsp/shortAddresses() => String[]
+
+### lsp/listTvls(currency: CurrencySymbol = "usd") => Stat[]
+
+### lsp/tvl(addresses: string[] = [], currency: CurrencySymbol = "usd") => Stat
+
+### lsp/tvlHistoryBetween contractAddress: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => Stat[]
+
+### lsp/tvlHistorySlice(contractAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") => Stat[]
+
+### lsp/totalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => Stat[]
+
+### lsp/totalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") => Stat[]

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -65,14 +65,36 @@ export default async (env: ProcessEnv) => {
     },
     erc20s: tables.erc20s.JsMap(),
     stats: {
-      usd: {
-        latest: {
-          tvm: empStats.JsMap("Latest Tvm"),
-          tvl: empStats.JsMap("Latest Tvl"),
+      emp: {
+        usd: {
+          latest: {
+            tvm: empStats.JsMap("Latest Tvm"),
+            tvl: empStats.JsMap("Latest Tvl"),
+          },
+          history: {
+            tvm: empStatsHistory.SortedJsMap("Tvm History"),
+            tvl: empStatsHistory.SortedJsMap("Tvl History"),
+          },
         },
-        history: {
-          tvm: empStatsHistory.SortedJsMap("Tvm History"),
-          tvl: empStatsHistory.SortedJsMap("Tvl History"),
+      },
+      lsp: {
+        usd: {
+          latest: {
+            tvl: empStats.JsMap("Latest Tvl"),
+          },
+          history: {
+            tvl: empStatsHistory.SortedJsMap("Tvl History"),
+          },
+        },
+      },
+      global: {
+        usd: {
+          latest: {
+            tvl: empStats.JsMap("Latest Tvl"),
+          },
+          history: {
+            tvl: empStatsHistory.SortedJsMap("Tvl History"),
+          },
         },
       },
     },
@@ -110,10 +132,11 @@ export default async (env: ProcessEnv) => {
       appState
     ),
     erc20s: Services.Erc20s({ debug }, appState),
-    empStats: Services.EmpStats({ debug }, appState),
+    empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, appState),
     lspCreator: Services.MultiLspCreator({ debug, addresses: lspCreatorAddresses }, appState),
     lsps: Services.LspState({ debug }, appState),
+    lspStats: Services.stats.Lsp({ debug }, appState),
   };
 
   // warm caches
@@ -139,6 +162,9 @@ export default async (env: ProcessEnv) => {
     console.log("Updated Collateral Prices Backfill");
     await services.empStats.backfill();
     console.log("Updated EMP Backfill");
+
+    await services.lspStats.backfill();
+    console.log("Updated LSP Backfill");
   }
 
   await services.collateralPrices.update();
@@ -149,6 +175,9 @@ export default async (env: ProcessEnv) => {
 
   await services.empStats.update();
   console.log("Updated EMP Stats");
+
+  await services.lspStats.update();
+  console.log("Updated LSP Stats");
 
   await services.marketPrices.update();
   console.log("Updated Market Prices");
@@ -196,6 +225,7 @@ export default async (env: ProcessEnv) => {
     await services.syntheticPrices.update();
     await services.marketPrices.update();
     await services.empStats.update();
+    await services.lspStats.update();
   }
 
   // coingeckos prices don't update very fast, so set it on an interval every few minutes

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -67,14 +67,36 @@ export type AppState = {
   };
   erc20s: uma.tables.erc20s.JsMap;
   stats: {
-    usd: {
-      latest: {
-        tvl: empStats.JsMap;
-        tvm: empStats.JsMap;
+    emp: {
+      usd: {
+        latest: {
+          tvl: empStats.JsMap;
+          tvm: empStats.JsMap;
+        };
+        history: {
+          tvl: empStatsHistory.SortedJsMap;
+          tvm: empStatsHistory.SortedJsMap;
+        };
       };
-      history: {
-        tvl: empStatsHistory.SortedJsMap;
-        tvm: empStatsHistory.SortedJsMap;
+    };
+    lsp: {
+      usd: {
+        latest: {
+          tvl: empStats.JsMap;
+        };
+        history: {
+          tvl: empStatsHistory.SortedJsMap;
+        };
+      };
+    };
+    global: {
+      usd: {
+        latest: {
+          tvl: empStats.JsMap;
+        };
+        history: {
+          tvl: empStatsHistory.SortedJsMap;
+        };
       };
     };
   };

--- a/packages/api/src/libs/queries/emp.ts
+++ b/packages/api/src/libs/queries/emp.ts
@@ -1,15 +1,12 @@
 import assert from "assert";
 // allow for more complex queries, joins and shared queries between services
-import type { AppState, CurrencySymbol, PriceSample } from "..";
 import * as uma from "@uma/sdk";
-import { calcGcr } from "./utils";
+import { calcGcr } from "../utils";
 import bluebird from "bluebird";
 import { BigNumber } from "ethers";
-import * as tables from "../tables";
+import * as tables from "../../tables";
+import type { AppState, CurrencySymbol, PriceSample } from "../..";
 
-type Config = {
-  globalKey?: string;
-};
 const { exists } = uma.utils;
 type Dependencies = Pick<
   AppState,
@@ -120,6 +117,7 @@ export default (appState: Dependencies) => {
       collateralSymbol: collateral?.symbol,
       identifierPrice: await getLatestIdentifierPrice(empState.address).catch(() => null),
       tokenMarketPrice,
+      type: "emp",
     };
     let gcr = "0";
     try {
@@ -154,7 +152,7 @@ export default (appState: Dependencies) => {
     const tvls = await Promise.all(
       addresses.map(async (address) => {
         try {
-          const stat = await appState.stats[currency].latest.tvl.get(address);
+          const stat = await appState.stats.emp[currency].latest.tvl.get(address);
           return stat.value || "0";
         } catch (err) {
           return "0";
@@ -176,7 +174,7 @@ export default (appState: Dependencies) => {
     const tvms = await Promise.all(
       addresses.map(async (address) => {
         try {
-          const stat = await appState.stats[currency].latest.tvm.get(address);
+          const stat = await appState.stats.emp[currency].latest.tvm.get(address);
           return stat.value || "0";
         } catch (err) {
           return "0";
@@ -195,8 +193,8 @@ export default (appState: Dependencies) => {
     return sumTvm(addresses, currency);
   }
   async function getGlobalTvl(currency: CurrencySymbol = "usd") {
-    assert(appState.stats[currency], "Invalid currency: " + currency);
-    const { value } = await appState.stats[currency].latest.tvl.getGlobal();
+    assert(appState.stats.emp[currency], "Invalid currency: " + currency);
+    const { value } = await appState.stats.emp[currency].latest.tvl.getGlobal();
     return value;
   }
 

--- a/packages/api/src/libs/queries/index.ts
+++ b/packages/api/src/libs/queries/index.ts
@@ -1,0 +1,2 @@
+export { default as Emp } from "./emp";
+export { default as Lsp } from "./lsp";

--- a/packages/api/src/libs/queries/lsp.ts
+++ b/packages/api/src/libs/queries/lsp.ts
@@ -1,0 +1,85 @@
+import assert from "assert";
+import bluebird from "bluebird";
+import { BigNumber } from "ethers";
+
+import * as tables from "../../tables";
+import type { AppState, CurrencySymbol } from "../..";
+
+type Dependencies = Pick<AppState, "erc20s" | "stats" | "lsps" | "registeredLsps">;
+
+export default (appState: Dependencies) => {
+  const { lsps, erc20s } = appState;
+
+  async function getAny(address: string) {
+    if (await lsps.active.has(address)) {
+      return lsps.active.get(address);
+    }
+    if (await lsps.expired.has(address)) {
+      return lsps.expired.get(address);
+    }
+    throw new Error("LSP not found by address: " + address);
+  }
+  async function getFullState(state: tables.lsps.Data) {
+    const collateralState = state.collateralToken ? await erc20s.get(state.collateralToken).catch(() => null) : null;
+    const longTokenState = state.longToken ? await erc20s.get(state.longToken).catch(() => null) : null;
+    const shortTokenState = state.shortToken ? await erc20s.get(state.shortToken).catch(() => null) : null;
+    return {
+      ...state,
+      longTokenDecimals: longTokenState?.decimals,
+      shortTokenDecimals: shortTokenState?.decimals,
+      collateralDecimals: collateralState?.decimals,
+      longTokenName: longTokenState?.name,
+      shortTokenName: shortTokenState?.name,
+      collateralName: collateralState?.name,
+      longTokenSymbol: longTokenState?.symbol,
+      shortTokenSymbol: shortTokenState?.symbol,
+      collateralSymbol: collateralState?.symbol,
+      type: "lsp",
+    };
+  }
+  async function listActive() {
+    const list = await lsps.active.values();
+    return bluebird.map(list, (el) => getFullState(el).catch(() => el));
+  }
+  async function listExpired() {
+    const list = await lsps.expired.values();
+    return bluebird.map(list, (el) => getFullState(el).catch(() => el));
+  }
+  async function sumTvl(addresses: string[], currency: CurrencySymbol = "usd") {
+    const tvls = await Promise.all(
+      addresses.map(async (address) => {
+        try {
+          const stat = await appState.stats.lsp[currency].latest.tvl.get(address);
+          return stat.value || "0";
+        } catch (err) {
+          return "0";
+        }
+      })
+    );
+
+    const tvl = await tvls.reduce((sum, tvl) => {
+      return sum.add(tvl);
+    }, BigNumber.from("0"));
+
+    return tvl.toString();
+  }
+  async function totalTvl(currency: CurrencySymbol = "usd") {
+    const addresses = Array.from(appState.registeredLsps);
+    return sumTvl(addresses, currency);
+  }
+
+  async function getTotalTvl(currency: CurrencySymbol = "usd") {
+    assert(appState.stats.lsp[currency], "Invalid currency: " + currency);
+    const { value } = await appState.stats.lsp[currency].latest.tvl.getGlobal();
+    return value;
+  }
+  return {
+    getFullState,
+    getAny,
+    listExpired,
+    listActive,
+    totalTvl,
+    sumTvl,
+    getTotalTvl,
+  };
+};

--- a/packages/api/src/services/actions/emp.ts
+++ b/packages/api/src/services/actions/emp.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import * as uma from "@uma/sdk";
 import { Json, Actions, AppState, CurrencySymbol, PriceSample } from "../..";
-import Queries from "../../libs/queries";
+import * as Queries from "../../libs/queries";
 import { nowS } from "../../libs/utils";
 import lodash from "lodash";
 
@@ -12,7 +12,7 @@ type Dependencies = AppState;
 type Config = undefined;
 
 export function Handlers(config: Config, appState: Dependencies): Actions {
-  const queries = Queries(appState);
+  const queries = Queries.Emp(appState);
   const {
     registeredEmps,
     erc20s,
@@ -118,35 +118,35 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       return queries.sumTvm(addresses, currency);
     },
     async tvlHistoryBetween(empAddress: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
-      assert(stats[currency], "Invalid currency type: " + currency);
-      return stats[currency].history.tvl.betweenByAddress(empAddress, start, end);
+      assert(stats.emp[currency], "Invalid currency type: " + currency);
+      return stats.emp[currency].history.tvl.betweenByAddress(empAddress, start, end);
     },
     async tvmHistoryBetween(empAddress: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
-      assert(stats[currency], "Invalid currency type: " + currency);
-      return stats[currency].history.tvm.betweenByAddress(empAddress, start, end);
+      assert(stats.emp[currency], "Invalid currency type: " + currency);
+      return stats.emp[currency].history.tvm.betweenByAddress(empAddress, start, end);
     },
     async globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
-      assert(stats[currency], "Invalid currency type: " + currency);
-      return stats[currency].history.tvl.betweenByGlobal(start, end);
+      assert(stats.emp[currency], "Invalid currency type: " + currency);
+      return stats.emp[currency].history.tvl.betweenByGlobal(start, end);
     },
     async tvlHistorySlice(empAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
-      assert(stats[currency], "Invalid currency type: " + currency);
-      return stats[currency].history.tvl.sliceByAddress(empAddress, start, length);
+      assert(stats.emp[currency], "Invalid currency type: " + currency);
+      return stats.emp[currency].history.tvl.sliceByAddress(empAddress, start, length);
     },
     async globalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") {
-      assert(stats[currency], "Invalid currency type: " + currency);
-      return stats[currency].history.tvl.sliceByGlobal(start, length);
+      assert(stats.emp[currency], "Invalid currency type: " + currency);
+      return stats.emp[currency].history.tvl.sliceByGlobal(start, length);
     },
     async tvmHistorySlice(empAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
-      assert(stats[currency], "Invalid currency type: " + currency);
+      assert(stats.emp[currency], "Invalid currency type: " + currency);
       assert(length < 1000, "length must be less than 1000 samples");
-      return stats[currency].history.tvm.sliceByAddress(empAddress, start, length);
+      return stats.emp[currency].history.tvm.sliceByAddress(empAddress, start, length);
     },
     async listTvls(currency: CurrencySymbol = "usd") {
-      return appState.stats[currency].latest.tvl.values();
+      return appState.stats.emp[currency].latest.tvl.values();
     },
     async listTvms(currency: CurrencySymbol = "usd") {
-      return appState.stats[currency].latest.tvm.values();
+      return appState.stats.emp[currency].latest.tvm.values();
     },
     async historicalMarketPricesBetween(tokenAddress: string, start = 0, end: number = nowS()) {
       assert(tokenAddress, "requires token address");

--- a/packages/api/src/services/actions/lsp.ts
+++ b/packages/api/src/services/actions/lsp.ts
@@ -1,25 +1,27 @@
 import assert from "assert";
-import { Json, Actions, AppState } from "../..";
-import Queries from "../../libs/queries";
+import { Json, Actions, AppState, CurrencySymbol } from "../..";
+import lodash from "lodash";
+import * as Queries from "../../libs/queries";
+import { nowS } from "../../libs/utils";
 
 // actions use all the app state
 type Dependencies = AppState;
 type Config = undefined;
 
 export function Handlers(config: Config, appState: Dependencies): Actions {
-  const queries = Queries(appState);
-  const { registeredLsps, erc20s, collateralAddresses, longAddresses, shortAddresses } = appState;
+  const queries = Queries.Lsp(appState);
+  const { registeredLsps, erc20s, collateralAddresses, longAddresses, shortAddresses, stats } = appState;
 
   const actions: Actions = {
     listAddresses() {
       return Array.from(registeredLsps.values());
     },
-    listActive: queries.listActiveLsps,
-    listExpired: queries.listExpiredLsps,
+    listActive: queries.listActive,
+    listExpired: queries.listExpired,
     async getState(address: string) {
       assert(await registeredLsps.has(address), "Not a valid LSP address: " + address);
-      const state = await queries.getAnyLsp(address);
-      return queries.getFullLspState(state);
+      const state = await queries.getAny(address);
+      return queries.getFullState(state);
     },
     async getErc20Info(address: string) {
       return erc20s.get(address);
@@ -35,6 +37,35 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     async shortAddresses() {
       return Array.from(shortAddresses.values());
+    },
+    async listTvls(currency: CurrencySymbol = "usd") {
+      return appState.stats.lsp[currency].latest.tvl.values();
+    },
+    async tvl(addresses: string[] = [], currency: CurrencySymbol = "usd") {
+      if (addresses == null || addresses.length == 0) return queries.getTotalTvl(currency);
+      addresses = addresses ? lodash.castArray(addresses) : [];
+      return queries.sumTvl(addresses, currency);
+    },
+    async tvlHistoryBetween(
+      contractAddress: string,
+      start = 0,
+      end: number = nowS(),
+      currency: CurrencySymbol = "usd"
+    ) {
+      assert(stats.lsp[currency], "Invalid currency type: " + currency);
+      return stats.lsp[currency].history.tvl.betweenByAddress(contractAddress, start, end);
+    },
+    async tvlHistorySlice(contractAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
+      assert(stats.lsp[currency], "Invalid currency type: " + currency);
+      return stats.lsp[currency].history.tvl.sliceByAddress(contractAddress, start, length);
+    },
+    async totalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
+      assert(stats.lsp[currency], "Invalid currency type: " + currency);
+      return stats.lsp[currency].history.tvl.betweenByGlobal(start, end);
+    },
+    async totalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") {
+      assert(stats.lsp[currency], "Invalid currency type: " + currency);
+      return stats.lsp[currency].history.tvl.sliceByGlobal(start, length);
     },
   };
 

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -4,8 +4,11 @@ export { default as Registry } from "./emp-registry";
 export { default as CollateralPrices } from "./collateral-prices";
 export { default as Erc20s } from "./erc20-state";
 export { default as SyntheticPrices } from "./synthetic-prices";
-export { default as EmpStats } from "./emp-stats";
 export { default as MarketPrices } from "./market-prices";
 export { default as LspCreator } from "./lsp-creator";
 export { default as LspState } from "./lsp-state";
 export { default as MultiLspCreator } from "./multi-lsp-creator";
+export { default as Express } from "./express";
+export { default as ExpressChannels } from "./express-channels";
+// this exports a folder with several services inside
+export * as stats from "./stats";

--- a/packages/api/src/services/stats/emp.ts
+++ b/packages/api/src/services/stats/emp.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
 import * as uma from "@uma/sdk";
 import { BigNumber } from "ethers";
-import { Currencies, AppState, PriceSample, BaseConfig } from "..";
-import { calcTvl, calcTvm, nowS } from "../libs/utils";
-import Queries from "../libs/queries";
+import { Currencies, AppState, PriceSample, BaseConfig } from "../..";
+import { calcTvl, calcTvm, nowS } from "../../libs/utils";
+import * as Queries from "../../libs/queries";
 
 interface Config extends BaseConfig {
   currency?: Currencies;
@@ -18,19 +18,19 @@ export default (config: Config, appState: Dependencies) => {
   const { stats, prices, registeredEmps } = appState;
   const { currency = "usd" } = config;
 
-  const queries = Queries(appState);
+  const queries = Queries.Emp(appState);
 
   function getTvmHistoryTable() {
-    return stats[currency].history.tvm;
+    return stats.emp[currency].history.tvm;
   }
   function getTvlHistoryTable() {
-    return stats[currency].history.tvl;
+    return stats.emp[currency].history.tvl;
   }
   function getLatestTvlTable() {
-    return stats[currency].latest.tvl;
+    return stats.emp[currency].latest.tvl;
   }
   function getLatestTvmTable() {
-    return stats[currency].latest.tvm;
+    return stats.emp[currency].latest.tvm;
   }
   async function updateTvlHistory(empAddress: string) {
     const stat = await getLatestTvlTable().get(empAddress);
@@ -84,7 +84,7 @@ export default (config: Config, appState: Dependencies) => {
       value,
       timestamp: priceSample[0],
     };
-    return stats[currency].latest.tvl.upsert(emp.address, update);
+    return stats.emp[currency].latest.tvl.upsert(emp.address, update);
   }
   async function updateTvm(emp: uma.tables.emps.Data) {
     assert(emp.tokenCurrency, "TVM Requires token currency for emp: " + emp.address);
@@ -100,7 +100,7 @@ export default (config: Config, appState: Dependencies) => {
       value,
       timestamp: priceSample[0],
     };
-    return stats[currency].latest.tvm.upsert(emp.address, update);
+    return stats.emp[currency].latest.tvm.upsert(emp.address, update);
   }
   // update all stats based on array of emp addresses
   async function updateAllTvl(addresses: string[]) {
@@ -142,7 +142,7 @@ export default (config: Config, appState: Dependencies) => {
       timestamp: nowS(),
     };
     // normally you would upsert an emp address where "global" is, but we are going to use a custom value to represent tvl across all addresses
-    return stats[currency].latest.tvl.upsertGlobal(update);
+    return stats.emp[currency].latest.tvl.upsertGlobal(update);
   }
 
   async function update() {

--- a/packages/api/src/services/stats/index.ts
+++ b/packages/api/src/services/stats/index.ts
@@ -1,0 +1,2 @@
+export { default as Emp } from "./emp";
+export { default as Lsp } from "./lsp";

--- a/packages/api/src/services/stats/lsp.ts
+++ b/packages/api/src/services/stats/lsp.ts
@@ -1,0 +1,165 @@
+import assert from "assert";
+import * as uma from "@uma/sdk";
+import { Currencies, AppState, PriceSample, BaseConfig } from "../..";
+import { calcTvl, nowS } from "../../libs/utils";
+import * as Queries from "../../libs/queries";
+import * as tables from "../../tables";
+
+interface Config extends BaseConfig {
+  currency?: Currencies;
+}
+type Dependencies = Pick<AppState, "lsps" | "stats" | "prices" | "erc20s" | "registeredLsps">;
+
+// this service is meant to calculate numbers derived from lsp state, things like TVL, TVM and other things
+export default (config: Config, appState: Dependencies) => {
+  const { prices, registeredLsps } = appState;
+  const { currency = "usd" } = config;
+  const stats = appState.stats.lsp;
+
+  const queries = Queries.Lsp(appState);
+
+  function getTvlHistoryTable() {
+    return stats[currency].history.tvl;
+  }
+  function getLatestTvlTable() {
+    return stats[currency].latest.tvl;
+  }
+  async function updateTvlHistory(contractAddress: string) {
+    const stat = await getLatestTvlTable().get(contractAddress);
+    assert(uma.utils.exists(stat.timestamp), "stats require timestamp for LSP: " + contractAddress);
+    assert(uma.utils.exists(stat.value), "No tvl value for LSP: " + contractAddress);
+    if (await getTvlHistoryTable().hasByAddress(contractAddress, stat.timestamp)) return stat;
+    return getTvlHistoryTable().create({
+      address: contractAddress,
+      value: stat.value,
+      timestamp: stat.timestamp,
+    });
+  }
+  async function updateTvlHistories(addresses: string[]) {
+    return Promise.allSettled(addresses.map(updateTvlHistory));
+  }
+
+  async function getPriceFromTable(contractAddress: string, currencyAddress: string) {
+    // PriceSample is type [ timestamp:number, price:string]
+    const priceSample: PriceSample = prices[currency].latest[currencyAddress];
+    assert(uma.utils.exists(priceSample), "No latest price found for LSP: " + contractAddress);
+    return priceSample;
+  }
+
+  async function getFullState(contractAddress: string) {
+    const result = await queries.getAny(contractAddress);
+    // the full state has collateral decimals, pulled from erc20 state
+    return queries.getFullState(result);
+  }
+
+  async function updateTvl(data: tables.lsps.Data) {
+    assert(data.collateralToken, "TVL Requires collateral currency for LSP: " + data.address);
+    const priceSample = await getPriceFromTable(data.address, data.collateralToken);
+    const value = await calcTvl(priceSample[1], data).toString();
+    const update = {
+      value,
+      timestamp: priceSample[0],
+    };
+    return stats[currency].latest.tvl.upsert(data.address, update);
+  }
+  // update all stats based on array of LSP addresses
+  async function updateAllTvl(addresses: string[]) {
+    // this call can easily error, but we dont want that to prevent all LSPs to resolve
+    // also since this is just calling our db or cache we can use promise.allSettled for speed
+    return Promise.allSettled(
+      addresses.map(async (address) => {
+        const data = await getFullState(address);
+        return updateTvl(data);
+      })
+    );
+  }
+
+  async function updateGlobalTvlHistory() {
+    const latest = getLatestTvlTable();
+    const history = getTvlHistoryTable();
+    const stat = await latest.getGlobal();
+    assert(uma.utils.exists(stat.timestamp), "stats require global TVL timestamp");
+    assert(uma.utils.exists(stat.value), "stats require TVL global TVL value");
+    if (await history.hasGlobal(stat.timestamp)) return stat;
+    return history.createGlobal({
+      value: stat.value,
+      timestamp: stat.timestamp,
+    });
+  }
+  async function updateGlobalTvl() {
+    const value = await queries.totalTvl(currency);
+    const update = {
+      value,
+      timestamp: nowS(),
+    };
+    // normally you would upsert an lsp address where "global" is, but we are going to use a custom value to represent tvl across all addresses
+    return stats[currency].latest.tvl.upsertGlobal(update);
+  }
+  async function update() {
+    const addresses = Array.from(registeredLsps.values());
+    await updateAllTvl(addresses).then((results) => {
+      results.forEach((result) => {
+        if (result.status === "rejected") console.error("Error updating tvl: " + result.reason.message);
+      });
+    });
+    await updateGlobalTvl().catch((err) => {
+      console.error("Error updating global TVL: " + err.message);
+    });
+    await updateGlobalTvlHistory().catch((err) => {
+      console.error("Error updating global TVL History: " + err.message);
+    });
+    await updateTvlHistories(addresses).then((results) => {
+      results.forEach((result) => {
+        if (result.status === "rejected") console.error("Error updating LSP TVL history: " + result.reason.message);
+      });
+    });
+  }
+
+  async function backfillTvl(data: tables.lsps.Data, priceSample: PriceSample) {
+    assert(data.collateralToken, "Backfill TVL Requires collateral token for LSP: " + data.address);
+    const value = await calcTvl(priceSample[1], data).toString();
+    return getTvlHistoryTable().create({
+      address: data.address,
+      timestamp: priceSample[0],
+      value,
+    });
+  }
+
+  async function backfillAllTvl(addresses: string[]) {
+    return Promise.allSettled(
+      addresses.map(async (address) => {
+        const data = await getFullState(address);
+        assert(uma.utils.exists(data.collateralToken), "LSP has no collateral currency: " + data.address);
+        const historicalPrices = await prices[currency].history[data.collateralToken].values();
+        return Promise.all(
+          historicalPrices.map((priceSample) => {
+            return backfillTvl(data, [priceSample.timestamp, priceSample.price]);
+          })
+        );
+      })
+    );
+  }
+
+  async function backfill() {
+    const addresses = Array.from(registeredLsps.values());
+    await backfillAllTvl(addresses).then((results) => {
+      results.forEach((result) => {
+        if (result.status === "rejected") console.error("Error updating TVL: " + result.reason.message);
+      });
+    });
+  }
+
+  return {
+    update,
+    backfill,
+    utils: {
+      backfillAllTvl,
+      backfillTvl,
+      updateAllTvl,
+      updateTvl,
+      updateTvlHistory,
+      updateTvlHistories,
+      getFullState,
+    },
+  };
+};

--- a/packages/api/src/services/synthetic-prices.ts
+++ b/packages/api/src/services/synthetic-prices.ts
@@ -3,7 +3,7 @@ import SynthPrices from "../libs/synthPrices";
 import { AppState, PriceSample, Currencies, BaseConfig } from "..";
 import * as uma from "@uma/sdk";
 import bluebird from "bluebird";
-import Queries from "../libs/queries";
+import * as Queries from "../libs/queries";
 import { calcSyntheticPrice, Profile } from "../libs/utils";
 
 interface Config extends BaseConfig {
@@ -25,7 +25,7 @@ export default function (config: Config, appState: Dependencies) {
   const { web3, emps, synthPrices, prices } = appState;
   const getSynthPrices = SynthPrices(config, web3);
 
-  const queries = Queries(appState);
+  const queries = Queries.Emp(appState);
   const profile = Profile(debug);
 
   // get or create a history table by an erc20 token address. this might be a bit confusing because we also have a

--- a/packages/api/src/tables/lsps/utils.ts
+++ b/packages/api/src/tables/lsps/utils.ts
@@ -27,4 +27,9 @@ export type Data = {
   finder?: string | null;
   prepaidProposerReward?: string | null;
   sponsors?: string[] | null;
+  // these are not on the contract but queried from erc20
+  totalPositionCollateral?: string | null;
+  collateralDecimals?: number | null;
+  longTokenDecimals?: number | null;
+  shortTokenDecimals?: number | null;
 };


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1490/ability-to-pull-in-tvl-for-each-lsp

**Summary**

This refactors stats and queries to accommodate LSP TVL stats as well as adds some new API calls on the LSP channel. 

**Details**

This adds several TVL calls, including historical and TVL backfill for LSP. Readme is updated with calls.

With slightly more refactoring, LSP and EMP stats could potentially share a lot of the same code, but I was afraid this would be too many unecessary changes, so instead business logic is copied and scoped to a specific contract type. 

Future work will need to combine both EMP and LSP TVL and expose in global, or unified stats

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
https://app.clubhouse.io/uma-project/story/1490/ability-to-pull-in-tvl-for-each-lsp