### PR TITLE
feat(api): add ability to specify multiple LSP creator addresses

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -33,6 +33,9 @@ MULTI_CALL_ADDRESS=0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441
 
 # any non null value will turn on debugging. This adds additional logs and time profiles for key calls.
 debug=1
+
+# LSP Creator addresses are used to discover deployed lsp contracts. Currently we have to manually specify old creator addresses
+lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10
 ```
 
 ## Starting

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -11,13 +11,14 @@ import * as Actions from "../../services/actions";
 import { ProcessEnv, AppState, Channels } from "../..";
 import { empStats, empStatsHistory, lsps } from "../../tables";
 import Zrx from "../../libs/zrx";
-import { Profile } from "../../libs/utils";
+import { Profile, parseEnvArray } from "../../libs/utils";
 
 export default async (env: ProcessEnv) => {
   assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
   assert(env.EXPRESS_PORT, "requires EXPRESS_PORT");
   assert(env.zrxBaseUrl, "requires zrxBaseUrl");
   assert(env.MULTI_CALL_ADDRESS, "requires MULTI_CALL_ADDRESS");
+  const lspCreatorAddresses = parseEnvArray(env.lspCreatorAddresses || "");
 
   // debug flag for more verbose logs
   const debug = Boolean(env.debug);
@@ -111,7 +112,7 @@ export default async (env: ProcessEnv) => {
     erc20s: Services.Erc20s({ debug }, appState),
     empStats: Services.EmpStats({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, appState),
-    lspCreator: Services.LspCreator({ debug }, appState),
+    lspCreator: Services.MultiLspCreator({ debug, addresses: lspCreatorAddresses }, appState),
     lsps: Services.LspState({ debug }, appState),
   };
 

--- a/packages/api/src/libs/utils.test.ts
+++ b/packages/api/src/libs/utils.test.ts
@@ -87,4 +87,16 @@ describe("utils", function () {
     const result = utils.calcSyntheticPrice(syntheticPrice, collateralPrice);
     assert.equal(result.toString(), parseUnits("1").toString());
   });
+  it("parseEnvArray", function () {
+    const lspCreatorAddresses =
+      "0x0b8de441B26E36f461b2748919ed71f50593A67b , 0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9 ,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10 ";
+    const result = utils.parseEnvArray(lspCreatorAddresses);
+    assert.equal(result.length, 4);
+    let plan = result.length;
+    result.forEach((address) => {
+      plan--;
+      assert.ok(ethers.utils.isAddress(address));
+    });
+    assert.equal(plan, 0);
+  });
 });

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -141,3 +141,10 @@ export const Profile = (enabled: boolean | undefined) => {
     return () => console.timeEnd(id);
   };
 };
+
+// defines a standard convention to pass arrays through an env.  assumes each element in the string is delimited by a comma
+export function parseEnvArray(str: string, delimiter = ","): string[] {
+  if (str.length == 0) return [];
+  if (!str.includes(delimiter)) return [];
+  return str.split(delimiter).map((x) => x.trim());
+}

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -8,3 +8,4 @@ export { default as EmpStats } from "./emp-stats";
 export { default as MarketPrices } from "./market-prices";
 export { default as LspCreator } from "./lsp-creator";
 export { default as LspState } from "./lsp-state";
+export { default as MultiLspCreator } from "./multi-lsp-creator";

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -1,18 +1,19 @@
 import { clients } from "@uma/sdk";
-import Promise from "bluebird";
+import bluebird from "bluebird";
 import { AppState, BaseConfig } from "..";
 
 const { lspCreator } = clients;
 
 interface Config extends BaseConfig {
   network?: number;
+  address?: string;
 }
 type Dependencies = Pick<AppState, "registeredLsps" | "provider">;
 
 export default (config: Config, appState: Dependencies) => {
-  const { network = 1 } = config;
+  const { network = 1, address = lspCreator.getAddress(network) } = config;
   const { registeredLsps, provider } = appState;
-  const address = lspCreator.getAddress(network);
+
   const contract = lspCreator.connect(address, provider);
 
   async function update(startBlock?: number | "latest", endBlock?: number) {
@@ -22,7 +23,7 @@ export default (config: Config, appState: Dependencies) => {
       endBlock
     );
     const { contracts } = lspCreator.getEventState(events);
-    await Promise.map(Object.keys(contracts || {}), (x) => {
+    await bluebird.map(Object.keys(contracts || {}), (x) => {
       return registeredLsps.add(x);
     });
   }

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -1,0 +1,35 @@
+import { clients } from "@uma/sdk";
+import bluebird from "bluebird";
+import { AppState, BaseConfig } from "..";
+import LspCreator from "./lsp-creator";
+
+const { lspCreator } = clients;
+
+interface Config extends BaseConfig {
+  addresses?: string[];
+  network?: number;
+  debug?: boolean;
+}
+type Dependencies = Pick<AppState, "registeredLsps" | "provider">;
+
+export default (config: Config, appState: Dependencies) => {
+  const { addresses = [], network = 1 } = config;
+
+  // always include latest known address
+  const latestAddress = lspCreator.getAddress(network);
+
+  // make sure we dont have duplicate addresses ( case sensitive)
+  const allAddresses = Array.from(new Set([...addresses, latestAddress]));
+
+  // instantiate individual lsp creator services with a single address
+  const creatorServices = allAddresses.map((address) => LspCreator({ address, ...config }, appState));
+
+  // run update on all creator services
+  async function update(startBlock?: number | "latest", endBlock?: number) {
+    await bluebird.mapSeries(creatorServices, (service) => service.update(startBlock, endBlock));
+  }
+
+  return {
+    update,
+  };
+};

--- a/packages/api/src/tables/lsps/js-map.test.ts
+++ b/packages/api/src/tables/lsps/js-map.test.ts
@@ -3,11 +3,11 @@ import { JsMap } from ".";
 
 describe("emp js-map", function () {
   let table: JsMap;
-  test("init", function () {
+  it("init", function () {
     table = JsMap();
     assert.ok(table);
   });
-  test("create", async function () {
+  it("create", async function () {
     const result = await table.create({
       address: "a",
     });
@@ -17,11 +17,11 @@ describe("emp js-map", function () {
     });
     assert.ok(result.id);
   });
-  test("values", async function () {
+  it("values", async function () {
     const result = await table.values();
     assert.equal(result.length, 2);
   });
-  test("addSponsors", async function () {
+  it("addSponsors", async function () {
     const result = await table.addSponsors("a", ["a", "b", "c", "a"]);
     assert.ok(result.sponsors);
     // one dupe, so 3 total


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.clubhouse.io/uma-project/story/1818/determine-how-to-pull-in-other-factories-for-pulling-in-lsps-in-the-api


**Summary**
Add a multi-lsp-creator service that just takes an array of lsp creator addresses and wraps the interface to a single lsp creator service, which then discovers known lsps.  Environment variable must be specified to manually add these creator addresses. If no address is specified, it will always default to the latest known address.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1818/determine-how-to-pull-in-other-factories-for-pulling-in-lsps-in-the-api