### PR TITLE
feat(fpl): add generalized success token FPL with parameterized base percentage

### DIFF
--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./LongShortPairFinancialProductLibrary.sol";
+import "../../../../common/implementation/Lockable.sol";
+
+/**
+ * @title Success Token Long Short Pair Financial Product Library.
+ * @notice Adds settlement logic to create success token LSPs. A success token pays out a fixed amount of
+ * collateral as a floor, with the remaining amount functioning like an embedded option. The embedded
+ * option can use the payout logic of other financial product libraries, and resemble a covered call, a
+ * KPI option, a range bond, a capped yield dollar, or custom payout logic in a new financial library.
+ */
+contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinancialProductLibrary, Lockable {
+    using FixedPoint for FixedPoint.Unsigned;
+
+    struct SuccessTokenLongShortPairParameters {
+        uint256 strikePrice;
+        uint256 basePercentage;
+    }
+
+    mapping(address => SuccessTokenLongShortPairParameters) public longShortPairParameters;
+
+    /**
+     * @notice Enables any address to set the strike price for an associated LSP.
+     * @param longShortPair address of the LSP.
+     * @param strikePrice the strike price for the covered call for the associated LSP.
+     * @param basePercentage the base percentage of collateral per pair paid out to long tokens, expressed
+     * with 1e18 decimals. E.g., a 50% base percentage should be expressed 500000000000000000, or 0.5 with
+     * 1e18 decimals. The base percentage can not be set to 0.
+     * @dev Note: a) Any address can set the initial strike price b) A strike price cannot be 0.
+     * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
+     * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
+     * e) longShortPair must expose an expirationTimestamp method to validate it is correctly deployed.
+     */
+    function setLongShortPairParameters(
+        address longShortPair,
+        uint256 strikePrice,
+        uint256 basePercentage
+    ) public nonReentrant() {
+        require(ExpiringContractInterface(longShortPair).expirationTimestamp() != 0, "Invalid LSP address");
+        SuccessTokenLongShortPairParameters memory params = longShortPairParameters[longShortPair];
+        require(params.strikePrice == 0 && params.basePercentage == 0, "Parameters already set");
+        require(basePercentage != 0, "Base percentage cannot be set to 0");
+
+        longShortPairParameters[longShortPair] = SuccessTokenLongShortPairParameters({
+            strikePrice: strikePrice,
+            basePercentage: basePercentage
+        });
+    }
+
+    /**
+     * @notice Returns a number between 0 and 1e18 to indicate how much collateral each long and short token are entitled
+     * to per collateralPerPair.
+     * @param expiryPrice price from the optimistic oracle for the LSP price identifier.
+     * @return expiryPercentLong to indicate how much collateral should be sent between long and short tokens.
+     */
+    function percentageLongCollateralAtExpiry(int256 expiryPrice)
+        public
+        view
+        override
+        nonReentrantView()
+        returns (uint256)
+    {
+        SuccessTokenLongShortPairParameters memory params = longShortPairParameters[msg.sender];
+        require(params.strikePrice != 0 || params.basePercentage != 0, "Params not set for calling LSP");
+
+        // If the expiry price is less than the strike price then the long options expire worthless (out of the money).
+        // In this case, return of value of the base percentage to the long tokenholders.
+        // Note we do not consider negative expiry prices in this implementation.
+        uint256 positiveExpiryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;
+        if (positiveExpiryPrice == 0 || uint256(positiveExpiryPrice) <= contractStrikePrice) return basePercentage;
+
+        // Else, token expires to be worth basePercentage + (1 - basePercentage) * (expiryPrice - strikePrice).
+        // E.g., if SUSHI is $30 and strike is $20, long token is redeemable for 0.5 + 0.5*(30-20)/30 = 0.6667%
+        // which if the collateralPerPair is 2, is worth 1.3333 $SUSHI, which is worth $40 if 1 $SUSHI is worth $30.
+        // This return value is strictly < 1. The return value tends to 1 as the expiryPrice tends to infinity.
+        return
+            (
+                FixedPoint.Unsigned(basePercentage).add(
+                    FixedPoint
+                        .Unsigned(uint256(1000000000000000000) - basePercentage)
+                        .mul(
+                        FixedPoint.Unsigned(uint256(positiveExpiryPrice)).sub(FixedPoint.Unsigned(contractStrikePrice))
+                    )
+                        .div(FixedPoint.Unsigned(uint256(positiveExpiryPrice)))
+                )
+            )
+                .rawValue;
+    }
+}

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
@@ -69,21 +69,19 @@ contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinanc
         // In this case, return of value of the base percentage to the long tokenholders.
         // Note we do not consider negative expiry prices in this implementation.
         uint256 positiveExpiryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;
-        if (positiveExpiryPrice == 0 || uint256(positiveExpiryPrice) <= contractStrikePrice) return basePercentage;
+        if (positiveExpiryPrice == 0 || positiveExpiryPrice <= contractStrikePrice) return basePercentage;
 
         // Else, token expires to be worth basePercentage + (1 - basePercentage) * (expiryPrice - strikePrice).
-        // E.g., if SUSHI is $30 and strike is $20, long token is redeemable for 0.5 + 0.5*(30-20)/30 = 0.6667%
-        // which if the collateralPerPair is 2, is worth 1.3333 $SUSHI, which is worth $40 if 1 $SUSHI is worth $30.
+        // E.g., if $TOKEN is $30 and strike is $20, long token is redeemable for 0.5 + 0.5*(30-20)/30 = 0.6667%
+        // which if the collateralPerPair is 2, is worth 1.3333 $TOKEN, which is worth $40 if 1 $TOKEN is worth $30.
         // This return value is strictly < 1. The return value tends to 1 as the expiryPrice tends to infinity.
         return
             (
                 FixedPoint.Unsigned(basePercentage).add(
                     FixedPoint
-                        .Unsigned(uint256(1000000000000000000) - basePercentage)
-                        .mul(
-                        FixedPoint.Unsigned(uint256(positiveExpiryPrice)).sub(FixedPoint.Unsigned(contractStrikePrice))
-                    )
-                        .div(FixedPoint.Unsigned(uint256(positiveExpiryPrice)))
+                        .Unsigned(1e18 - basePercentage)
+                        .mul(FixedPoint.Unsigned(positiveExpiryPrice).sub(FixedPoint.Unsigned(contractStrikePrice)))
+                        .div(FixedPoint.Unsigned(positiveExpiryPrice))
                 )
             )
                 .rawValue;

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
@@ -27,7 +27,7 @@ contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinanc
      * @param strikePrice the strike price for the covered call for the associated LSP.
      * @param basePercentage the base percentage of collateral per pair paid out to long tokens, expressed
      * with 1e18 decimals. E.g., a 50% base percentage should be expressed 500000000000000000, or 0.5 with
-     * 1e18 decimals. The base percentage can not be set to 0.
+     * 1e18 decimals. The base percentage cannot be set to 0.
      * @dev Note: a) Any address can set the initial strike price b) A strike price cannot be 0.
      * c) A strike price can only be set once to prevent the deployer from changing the strike after the fact.
      * d) For safety, a strike price should be set before depositing any synthetic tokens in a liquidity pool.
@@ -41,7 +41,7 @@ contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinanc
         require(ExpiringContractInterface(longShortPair).expirationTimestamp() != 0, "Invalid LSP address");
         SuccessTokenLongShortPairParameters memory params = longShortPairParameters[longShortPair];
         require(params.strikePrice == 0 && params.basePercentage == 0, "Parameters already set");
-        require(basePercentage != 0, "Base percentage cannot be set to 0");
+        require(strikePrice != 0 && basePercentage != 0, "Base percentage and strike price cannot be set to 0");
 
         longShortPairParameters[longShortPair] = SuccessTokenLongShortPairParameters({
             strikePrice: strikePrice,
@@ -75,6 +75,7 @@ contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinanc
         // E.g., if $TOKEN is $30 and strike is $20, long token is redeemable for 0.5 + 0.5*(30-20)/30 = 0.6667%
         // which if the collateralPerPair is 2, is worth 1.3333 $TOKEN, which is worth $40 if 1 $TOKEN is worth $30.
         // This return value is strictly < 1. The return value tends to 1 as the expiryPrice tends to infinity.
+        // Due to rounding down and precision errors, this may return a very slightly smaller value than expected.
         return
             (
                 FixedPoint.Unsigned(params.basePercentage).add(

--- a/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
+++ b/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.sol
@@ -69,7 +69,7 @@ contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinanc
         // In this case, return of value of the base percentage to the long tokenholders.
         // Note we do not consider negative expiry prices in this implementation.
         uint256 positiveExpiryPrice = expiryPrice > 0 ? uint256(expiryPrice) : 0;
-        if (positiveExpiryPrice == 0 || positiveExpiryPrice <= contractStrikePrice) return basePercentage;
+        if (positiveExpiryPrice == 0 || positiveExpiryPrice <= params.strikePrice) return params.basePercentage;
 
         // Else, token expires to be worth basePercentage + (1 - basePercentage) * (expiryPrice - strikePrice).
         // E.g., if $TOKEN is $30 and strike is $20, long token is redeemable for 0.5 + 0.5*(30-20)/30 = 0.6667%
@@ -77,10 +77,10 @@ contract SuccessTokenLongShortPairFinancialProductLibrary is LongShortPairFinanc
         // This return value is strictly < 1. The return value tends to 1 as the expiryPrice tends to infinity.
         return
             (
-                FixedPoint.Unsigned(basePercentage).add(
+                FixedPoint.Unsigned(params.basePercentage).add(
                     FixedPoint
-                        .Unsigned(1e18 - basePercentage)
-                        .mul(FixedPoint.Unsigned(positiveExpiryPrice).sub(FixedPoint.Unsigned(contractStrikePrice)))
+                        .Unsigned(1e18 - params.basePercentage)
+                        .mul(FixedPoint.Unsigned(positiveExpiryPrice).sub(FixedPoint.Unsigned(params.strikePrice)))
                         .div(FixedPoint.Unsigned(positiveExpiryPrice))
                 )
             )

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.js
@@ -37,11 +37,11 @@ describe("SuccessTokenLongShortPairFinancialProductLibrary", function () {
   describe("Long Short Pair Parameterization", () => {
     it("Can set and fetch valid strikes", async () => {
       await successTokenLSPFPL.methods
-        .setLongShortPairParameters(lspMock.options.address, strikePrice)
+        .setLongShortPairParameters(lspMock.options.address, strikePrice, basePercentage1)
         .send({ from: accounts[0] });
 
-      const setStrike = await successTokenLSPFPL.methods.longShortPairStrikePrices(lspMock.options.address).call();
-      assert.equal(setStrike.toString(), strikePrice);
+      const setParams = await successTokenLSPFPL.methods.longShortPairParameters(lspMock.options.address).call();
+      assert.equal(setParams.strikePrice.toString(), strikePrice);
     });
     it("Can not re-use existing LSP contract address", async () => {
       await successTokenLSPFPL.methods

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.js
@@ -14,7 +14,7 @@ const LongShortPairMock = getContract("LongShortPairMock");
 const { toWei, toBN } = web3.utils;
 const strikePrice = toWei("400");
 const basePercentage1 = toBN(toWei("0.5"));
-// const basePercentage2 = toBN(toWei("0.2"));
+const basePercentage2 = toBN(toWei("0.2"));
 const collateralPerPair = toBN(toWei("1"));
 
 describe("SuccessTokenLongShortPairFinancialProductLibrary", function () {
@@ -94,6 +94,41 @@ describe("SuccessTokenLongShortPairFinancialProductLibrary", function () {
         .percentageLongCollateralAtExpiry(toWei("500"))
         .call({ from: lspMock.options.address });
       assert.equal(expiryTokensForCollateral.toString(), toWei("0.6"));
+    });
+    it("Should never return a value greater than 1", async () => {
+      // Create a massive expiry price. 1e18*1e18. Under all conditions should return less than 1.
+      const expiryTokensForCollateral = await successTokenLSPFPL.methods
+        .percentageLongCollateralAtExpiry(toWei(toWei("1")))
+        .call({ from: lspMock.options.address });
+      assert.isTrue(toBN(expiryTokensForCollateral).lt(toBN(toWei("1"))));
+    });
+  });
+  describe("Compute expiry tokens for collateral with base percentage of 0.2", () => {
+    beforeEach(async () => {
+      await successTokenLSPFPL.methods
+        // Set the strike price at 400.
+        .setLongShortPairParameters(lspMock.options.address, strikePrice, basePercentage2)
+        .send({ from: accounts[0] });
+    });
+    it("Lower than strike should return 0.2", async () => {
+      const expiryTokensForCollateral = await successTokenLSPFPL.methods
+        // If the expiry price is below the strike price, the long should be worth 20% of the
+        // collateralPerPair, or 0.2.
+        .percentageLongCollateralAtExpiry(toWei("300"))
+        .call({ from: lspMock.options.address });
+      assert.equal(expiryTokensForCollateral.toString(), toWei("0.2"));
+    });
+    it("Higher than strike correct value", async () => {
+      const expiryTokensForCollateral = await successTokenLSPFPL.methods
+        // If the expiry price is above the strike price, the long should be worth 20% of the
+        // collateralPerPair, plus 80% * ((expiry price - strike price) / expiry price)
+        // With a collateralPerPair of 1, this can be expressed as:
+        // 0.2 + (0.8 * (expiryPrice - strikePrice) / expiryPrice)
+        // With an expiry price of 500 and strike price of 400, this becomes:
+        // 0.2 + (0.8 * (500 - 400) / 500) = 0.36
+        .percentageLongCollateralAtExpiry(toWei("500"))
+        .call({ from: lspMock.options.address });
+      assert.equal(expiryTokensForCollateral.toString(), toWei("0.36"));
     });
     it("Should never return a value greater than 1", async () => {
       // Create a massive expiry price. 1e18*1e18. Under all conditions should return less than 1.

--- a/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.js
+++ b/packages/core/test/financial-templates/common/financial-product-libraries/long-short-pair-libraries/SuccessTokenLongShortPairFinancialProductLibrary.js
@@ -1,0 +1,106 @@
+const hre = require("hardhat");
+const { runDefaultFixture } = require("@uma/common");
+const { getContract } = hre;
+const { didContractThrow, ZERO_ADDRESS } = require("@uma/common");
+const { assert } = require("chai");
+
+// Tested Contract
+const SuccessTokenLongShortPairFinancialProductLibrary = getContract(
+  "SuccessTokenLongShortPairFinancialProductLibrary"
+);
+
+const LongShortPairMock = getContract("LongShortPairMock");
+
+const { toWei, toBN } = web3.utils;
+const strikePrice = toWei("400");
+const basePercentage1 = toBN(toWei("0.5"));
+// const basePercentage2 = toBN(toWei("0.2"));
+const collateralPerPair = toBN(toWei("1"));
+
+describe("SuccessTokenLongShortPairFinancialProductLibrary", function () {
+  let successTokenLSPFPL;
+  let lspMock;
+  let accounts;
+
+  before(async () => {
+    await runDefaultFixture(hre);
+    accounts = await hre.web3.eth.getAccounts();
+  });
+
+  beforeEach(async () => {
+    successTokenLSPFPL = await SuccessTokenLongShortPairFinancialProductLibrary.new().send({ from: accounts[0] });
+    lspMock = await LongShortPairMock.new(
+      "1000000", // _expirationTimestamp
+      collateralPerPair // _collateralPerPair
+    ).send({ from: accounts[0] });
+  });
+  describe("Long Short Pair Parameterization", () => {
+    it("Can set and fetch valid strikes", async () => {
+      await successTokenLSPFPL.methods
+        .setLongShortPairParameters(lspMock.options.address, strikePrice)
+        .send({ from: accounts[0] });
+
+      const setStrike = await successTokenLSPFPL.methods.longShortPairStrikePrices(lspMock.options.address).call();
+      assert.equal(setStrike.toString(), strikePrice);
+    });
+    it("Can not re-use existing LSP contract address", async () => {
+      await successTokenLSPFPL.methods
+        .setLongShortPairParameters(lspMock.options.address, strikePrice, basePercentage1)
+        .send({ from: accounts[0] });
+
+      // Second attempt should revert.
+      assert(
+        await didContractThrow(
+          successTokenLSPFPL.methods
+            .setLongShortPairParameters(lspMock.options.address, strikePrice, basePercentage1)
+            .send({ from: accounts[0] })
+        )
+      );
+    });
+    it("Can not set invalid LSP contract address", async () => {
+      // LSP Address must implement the `expirationTimestamp method.
+      assert(
+        await didContractThrow(
+          successTokenLSPFPL.methods
+            .setLongShortPairParameters(ZERO_ADDRESS, strikePrice, basePercentage1)
+            .send({ from: accounts[0] })
+        )
+      );
+    });
+  });
+  describe("Compute expiry tokens for collateral with base percentage of 0.5", () => {
+    beforeEach(async () => {
+      await successTokenLSPFPL.methods
+        // Set the strike price at 400.
+        .setLongShortPairParameters(lspMock.options.address, strikePrice, basePercentage1)
+        .send({ from: accounts[0] });
+    });
+    it("Lower than strike should return 0.5", async () => {
+      const expiryTokensForCollateral = await successTokenLSPFPL.methods
+        // If the expiry price is below the strike price, the long should be worth 50% of the
+        // collateralPerPair, or 0.5.
+        .percentageLongCollateralAtExpiry(toWei("300"))
+        .call({ from: lspMock.options.address });
+      assert.equal(expiryTokensForCollateral.toString(), toWei("0.5"));
+    });
+    it("Higher than strike correct value", async () => {
+      const expiryTokensForCollateral = await successTokenLSPFPL.methods
+        // If the expiry price is above the strike price, the long should be worth 50% of the
+        // collateralPerPair, plus 50% * ((expiry price - strike price) / expiry price)
+        // With a collateralPerPair of 1, this can be expressed as:
+        // 0.5 + (0.5 * (expiryPrice - strikePrice) / expiryPrice)
+        // With an expiry price of 500 and strike price of 400, this becomes:
+        // 0.5 + (0.5 * (500 - 400) / 500) = 0.6
+        .percentageLongCollateralAtExpiry(toWei("500"))
+        .call({ from: lspMock.options.address });
+      assert.equal(expiryTokensForCollateral.toString(), toWei("0.6"));
+    });
+    it("Should never return a value greater than 1", async () => {
+      // Create a massive expiry price. 1e18*1e18. Under all conditions should return less than 1.
+      const expiryTokensForCollateral = await successTokenLSPFPL.methods
+        .percentageLongCollateralAtExpiry(toWei(toWei("1")))
+        .call({ from: lspMock.options.address });
+      assert.isTrue(toBN(expiryTokensForCollateral).lt(toBN(toWei("1"))));
+    });
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We would like to have a generalized `SuccessToken` financial product library where the base percentage can be set as a parameter, with the remaining percentage acting like an embedded call option.


**Summary**

Using the `SimpleSuccessToken` as a model, this PR adds a generalized `SuccessToken` financial product library and associated tests.


**Details**

* We discussed creating an even more generalized financial product library, where the "option" part of the payout could follow arbitrary logic defined in an external financial product library, which could be a call option, binary option, range token, or something else. It was determined that this was actually harder to reason about as a deployer, in addition to being more difficult to test, so we stuck with the call option logic for the option part of the payout. The ultra-generalized version of this will be brought up in a Discourse thread for further discussion with the community.
* It might make sense to delete the `SimpleSuccessToken` contract and tests from the repo as part of this pull request, since the generalized version makes it redundant. We didn't do so yet, since that contract is still used for a proof-of-concept as part of an active deal pursuit. If we don't use the `SimpleSuccessToken` for a real contract, we should delete it later.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
