### PR TITLE
fix(cross-package): Fixed typo of "ballance"->"balance" in a few packages

### DIFF
--- a/packages/affiliates/liquidity-mining/CalculateUniswapLPRewards.js
+++ b/packages/affiliates/liquidity-mining/CalculateUniswapLPRewards.js
@@ -196,7 +196,7 @@ async function _updatePayoutAtBlock(
   );
 
   // For each balance result, calculate their associated payment addition. The data structures below are used to store
-  // and compute the "effective" ballance. this is the minimum of the token sponsors sponsor position OR redeemable
+  // and compute the "effective" balance. this is the minimum of the token sponsors sponsor position OR redeemable
   // synths from their LP position.
   let shareHolderEffectiveSnapshotBalance = {};
   let cumulativeEffectiveSnapshotBalance = toBN("0");

--- a/packages/affiliates/liquidity-mining/JoinRolledPayouts.js
+++ b/packages/affiliates/liquidity-mining/JoinRolledPayouts.js
@@ -95,12 +95,12 @@ function _joinPayouts(weeklyRewards, rollRewards, rollPool1EqualsWeeklyRewards) 
   Object.entries(rollRewards.shareHolderPayout).forEach((shareHolder) => {
     const rollShareHolderAddr = shareHolder[0];
     const rollShareHolderRewards = toBN(toWei(shareHolder[1]));
-    // If the address was already in the weeklyRewards then add their previous balance to the rolled ballance.
+    // If the address was already in the weeklyRewards then add their previous balance to the rolled balance.
     if (weeklyRewards.shareHolderPayout[rollShareHolderAddr]) {
       const weeklyShareholderRewards = toBN(toWei(weeklyRewards.shareHolderPayout[rollShareHolderAddr]));
       outputData.shareHolderPayout[rollShareHolderAddr] = fromWei(weeklyShareholderRewards.add(rollShareHolderRewards));
     }
-    // Else their balance should simply be the rolled ballance.
+    // Else their balance should simply be the rolled balance.
     else outputData.shareHolderPayout[rollShareHolderAddr] = fromWei(rollShareHolderRewards);
   });
   return outputData;

--- a/packages/core/test/proxy-scripts/atomic-disputer/ReserveCurrencyDisputer.js
+++ b/packages/core/test/proxy-scripts/atomic-disputer/ReserveCurrencyDisputer.js
@@ -55,9 +55,9 @@ const finalFeeAmount = toBN(toWei("0.5"));
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {
-  const poolTokenABallance = toBN(await reserveToken.methods.balanceOf(pairAddress).call());
-  const poolTokenBBallance = toBN(await collateralToken.methods.balanceOf(pairAddress).call());
-  return Number(fromWei(poolTokenABallance.mul(toBN(toWei("1"))).div(poolTokenBBallance))).toFixed(4);
+  const poolTokenABalance = toBN(await reserveToken.methods.balanceOf(pairAddress).call());
+  const poolTokenBBalance = toBN(await collateralToken.methods.balanceOf(pairAddress).call());
+  return Number(fromWei(poolTokenABalance.mul(toBN(toWei("1"))).div(poolTokenBBalance))).toFixed(4);
 };
 
 describe("ReserveTokenDisputer", function () {

--- a/packages/core/test/proxy-scripts/atomic-liquidator/ReserveCurrencyLiquidator.js
+++ b/packages/core/test/proxy-scripts/atomic-liquidator/ReserveCurrencyLiquidator.js
@@ -59,9 +59,9 @@ const fixedPointAdjustment = toBN(toWei("1"));
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {
-  const poolTokenABallance = toBN(await reserveToken.methods.balanceOf(pairAddress).call());
-  const poolTokenBBallance = toBN(await collateralToken.methods.balanceOf(pairAddress).call());
-  return Number(fromWei(poolTokenABallance.mul(fixedPointAdjustment).div(poolTokenBBallance))).toFixed(4);
+  const poolTokenABalance = toBN(await reserveToken.methods.balanceOf(pairAddress).call());
+  const poolTokenBBalance = toBN(await collateralToken.methods.balanceOf(pairAddress).call());
+  return Number(fromWei(poolTokenABalance.mul(fixedPointAdjustment).div(poolTokenBBalance))).toFixed(4);
 };
 
 // For a given number of tokens to liquidate, calculate the expected number of tokens that the DSProxy will likely buy
@@ -292,7 +292,7 @@ describe("ReserveTokenLiquidator", function () {
       from: liquidator,
     });
 
-    // The DSProxy should not have any collateral after the liquidation as everything was used. The synthetic ballance
+    // The DSProxy should not have any collateral after the liquidation as everything was used. The synthetic balance
     // should be the starting balance minus the amount liquidated as 2000-1000=1000.
     assert.equal((await collateralToken.methods.balanceOf(dsProxy.options.address).call()).toString(), "0");
     assert.equal((await syntheticToken.methods.balanceOf(dsProxy.options.address).call()).toString(), toWei("1000"));

--- a/packages/core/test/proxy-scripts/lsp-broker/LspUniswapV2Broker.js
+++ b/packages/core/test/proxy-scripts/lsp-broker/LspUniswapV2Broker.js
@@ -69,9 +69,9 @@ const pairName = "Long Short Pair Test";
 
 // Returns the current spot price of a uniswap pool, scaled to `precision` # decimal points.
 const getPoolSpotPrice = async (tokenA, tokenB, _pairAddress = pairAddress, precision = 4) => {
-  const poolTokenABallance = toBN(await tokenA.methods.balanceOf(_pairAddress).call());
-  const poolTokenBBallance = toBN(await tokenB.methods.balanceOf(_pairAddress).call());
-  return Number(fromWei(poolTokenABallance.mul(toBN(toWei("1"))).div(poolTokenBBallance))).toFixed(precision);
+  const poolTokenABalance = toBN(await tokenA.methods.balanceOf(_pairAddress).call());
+  const poolTokenBBalance = toBN(await tokenB.methods.balanceOf(_pairAddress).call());
+  return Number(fromWei(poolTokenABalance.mul(toBN(toWei("1"))).div(poolTokenBBalance))).toFixed(precision);
 };
 
 // For a given amountIn, return the amount out expected from a trade. aToB defines the direction of the trade. If aToB

--- a/packages/core/test/proxy-scripts/uniswap-broker/UniswapV2Broker.js
+++ b/packages/core/test/proxy-scripts/uniswap-broker/UniswapV2Broker.js
@@ -25,9 +25,9 @@ let pairAddress;
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {
-  const poolTokenABallance = toBN(await tokenA.methods.balanceOf(pairAddress).call());
-  const poolTokenBBallance = toBN(await tokenB.methods.balanceOf(pairAddress).call());
-  return Number(fromWei(poolTokenABallance.mul(toBN(toWei("1"))).div(poolTokenBBallance))).toFixed(4);
+  const poolTokenABalance = toBN(await tokenA.methods.balanceOf(pairAddress).call());
+  const poolTokenBBalance = toBN(await tokenB.methods.balanceOf(pairAddress).call());
+  return Number(fromWei(poolTokenABalance.mul(toBN(toWei("1"))).div(poolTokenBBalance))).toFixed(4);
 };
 
 // For a given amountIn, return the amount out expected from a trade. aToB defines the direction of the trade. If aToB

--- a/packages/disputer/test/Disputer.js
+++ b/packages/disputer/test/Disputer.js
@@ -1408,7 +1408,7 @@ contract("Disputer.js", function (accounts) {
               const liquidationTime = await financialContract.getCurrentTime();
               await mockOracle.pushPrice(web3.utils.utf8ToHex(identifier), liquidationTime, toWei("1.1"));
 
-              // rewards should be withdrawn and the DSProxy collateral ballance should increase.
+              // rewards should be withdrawn and the DSProxy collateral balance should increase.
 
               const dsProxyCollateralBalanceBefore = await collateralToken.balanceOf(dsProxy.address);
 

--- a/packages/financial-templates-lib/src/clients/TokenBalanceClient.js
+++ b/packages/financial-templates-lib/src/clients/TokenBalanceClient.js
@@ -20,7 +20,7 @@ class TokenBalanceClient {
     this.collateralToken = new web3.eth.Contract(erc20abi, collateralTokenAddress);
     this.syntheticToken = new web3.eth.Contract(erc20abi, syntheticTokenAddress);
 
-    // Token balances to enable synchronous return of the latest token ballance cashed in the client.
+    // Token balances to enable synchronous return of the latest token balance cashed in the client.
     this.tokenBalances = { collateralBalances: {}, syntheticBalances: {}, etherBalances: {} };
 
     // Array of balances to monitor. Updated when a new addresses balance is requested.

--- a/packages/liquidator/test/Liquidator.js
+++ b/packages/liquidator/test/Liquidator.js
@@ -1733,11 +1733,9 @@ contract("Liquidator.js", function (accounts) {
           let dsProxy;
 
           const getPoolSpotPrice = async () => {
-            const poolTokenABallance = await reserveToken.balanceOf(pairAddress);
-            const poolTokenBBallance = await collateralToken.balanceOf(pairAddress);
-            return Number(fromWei(poolTokenABallance.mul(toBN(convertDecimals("1"))).div(poolTokenBBallance))).toFixed(
-              4
-            );
+            const poolTokenABalance = await reserveToken.balanceOf(pairAddress);
+            const poolTokenBBalance = await collateralToken.balanceOf(pairAddress);
+            return Number(fromWei(poolTokenABalance.mul(toBN(convertDecimals("1"))).div(poolTokenBBalance))).toFixed(4);
           };
 
           beforeEach(async () => {

--- a/packages/monitors/src/BalanceMonitor.js
+++ b/packages/monitors/src/BalanceMonitor.js
@@ -119,7 +119,7 @@ class BalanceMonitor {
     this.toBN = this.web3.utils.toBN;
   }
 
-  // Queries all bot ballance for collateral, synthetic and ether against specified thresholds.
+  // Queries all bot balance for collateral, synthetic and ether against specified thresholds.
   async checkBotBalances() {
     this.logger.debug({ at: "BalanceMonitor", message: "Checking bot balances" });
 

--- a/packages/monitors/src/CRMonitor.js
+++ b/packages/monitors/src/CRMonitor.js
@@ -112,7 +112,7 @@ class CRMonitor {
     this.fixedPointAdjustment = this.toBN(this.toWei("1"));
   }
 
-  // Queries all monitored wallet ballance for collateralization ratio against a given threshold.
+  // Queries all monitored wallet balance for collateralization ratio against a given threshold.
   async checkWalletCrRatio() {
     if (this.walletsToMonitor.length == 0) return; // If there are no wallets to monitor exit early
     // yield the price feed at the current time.

--- a/packages/trader/test/UniswapV2Trader.ts
+++ b/packages/trader/test/UniswapV2Trader.ts
@@ -56,9 +56,9 @@ let dsProxyFactory: any;
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {
-  const poolTokenABallance = await tokenA.balanceOf(pairAddress);
-  const poolTokenBBallance = await tokenB.balanceOf(pairAddress);
-  return Number(fromWei(poolTokenABallance.mul(toBN(toWei("1"))).div(poolTokenBBallance))).toFixed(4);
+  const poolTokenABalance = await tokenA.balanceOf(pairAddress);
+  const poolTokenBBalance = await tokenB.balanceOf(pairAddress);
+  return Number(fromWei(poolTokenABalance.mul(toBN(toWei("1"))).div(poolTokenBBalance))).toFixed(4);
 };
 
 describe("UniswapV2Trader.js", function () {


### PR DESCRIPTION
**Motivation**

Due to my general stupidity, I've managed to make the same spelling mistake in a number of places in the repo. This Pr fixes this.

**Summary**

Fixes a `ballance` to `balance` in all the places I've made this mistake :)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested