### PR TITLE
feat: add multichain support for price feeds

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -5,6 +5,7 @@ const { getTruffleContract } = require("@uma/core");
 const { BlockFinder } = require("./utils");
 const { getPrecisionForIdentifier, PublicNetworks } = require("@uma/common");
 const { multicallAddressMap } = require("../helpers/multicall");
+const Web3 = require("web3");
 
 // Price feed interfaces (sorted alphabetically)
 const { BalancerPriceFeed } = require("./BalancerPriceFeed");
@@ -40,6 +41,13 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
   const HarvestVaultInterface = getTruffleContract("HarvestVaultInterface", web3);
   const Perpetual = getTruffleContract("Perpetual", web3);
 
+  let providedWeb3 = web3;
+  if (config.nodeEnvVariable) {
+    if (!process.env[config.nodeEnvVariable])
+      throw Error(`Expected node url to be provided in env variable ${config.nodeEnvVariable}`);
+    providedWeb3 = new Web3(process.env[config.nodeEnvVariable]);
+  }
+
   if (config.type === "cryptowatch") {
     const requiredFields = ["exchange", "pair", "lookback", "minTimeBetweenUpdates"];
 
@@ -51,7 +59,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new CryptoWatchPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.cryptowatchApiKey,
       config.exchange,
       config.pair,
@@ -76,7 +84,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new QuandlPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.quandlApiKey,
       config.datasetCode,
       config.databaseCode,
@@ -97,7 +105,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new DominationFinancePriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.pair,
       config.lookback,
       networker,
@@ -125,7 +133,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
       logger,
       uniswapAbi,
       ERC20.abi,
-      web3,
+      providedWeb3,
       config.uniswapAddress,
       config.twapLength,
       config.lookback,
@@ -145,7 +153,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new ForexDailyPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.base,
       config.symbol,
       config.lookback,
@@ -165,7 +173,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new DefiPulsePriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.defipulseApiKey,
       config.lookback,
       networker,
@@ -216,7 +224,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new BalancerPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       getTime,
       Balancer.abi,
       config.balancerAddress,
@@ -245,7 +253,13 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     const denominatorPriceFeed =
       config.denominatorPriceFeed && (await _createMedianizerPriceFeed(config.denominatorPriceFeed));
 
-    return new BasketSpreadPriceFeed(web3, logger, baselinePriceFeeds, experimentalPriceFeeds, denominatorPriceFeed);
+    return new BasketSpreadPriceFeed(
+      providedWeb3,
+      logger,
+      baselinePriceFeeds,
+      experimentalPriceFeeds,
+      denominatorPriceFeed
+    );
   } else if (config.type === "coinmarketcap") {
     const requiredFields = ["cmcApiKey", "symbol", "quoteCurrency", "lookback", "minTimeBetweenUpdates"];
 
@@ -257,7 +271,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new CoinMarketCapPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.cmcApiKey,
       config.symbol,
       config.quoteCurrency,
@@ -279,7 +293,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new CoinGeckoPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.contractAddress,
       config.quoteCurrency,
       config.lookback,
@@ -300,7 +314,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new TraderMadePriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.tradermadeApiKey,
       config.pair,
       config.minuteLookback,
@@ -330,7 +344,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     return new ETHVIXPriceFeed(
       logger,
-      web3,
+      providedWeb3,
       config.inverse,
       networker,
       getTime,
@@ -361,7 +375,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new VaultPriceFeed({
       ...config,
       logger,
-      web3,
+      web3: providedWeb3,
       getTime,
       vaultAbi: VaultInterface.abi,
       erc20Abi: ERC20.abi,
@@ -379,7 +393,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new HarvestVaultPriceFeed({
       ...config,
       logger,
-      web3,
+      web3: providedWeb3,
       getTime,
       vaultAbi: HarvestVaultInterface.abi,
       erc20Abi: ERC20.abi,
@@ -397,7 +411,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new LPPriceFeed({
       ...config,
       logger,
-      web3,
+      web3: providedWeb3,
       getTime,
       erc20Abi: ERC20.abi,
       blockFinder: getSharedBlockFinder(web3),
@@ -412,7 +426,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
 
     let multicallAddress = config.multicallAddress;
     if (!multicallAddress) {
-      const networkId = await web3.eth.net.getId();
+      const networkId = await providedWeb3.eth.net.getId();
       const networkName = PublicNetworks[Number(networkId)]?.name;
       multicallAddress = multicallAddressMap[networkName]?.multicall;
     }
@@ -428,7 +442,7 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
     return new FundingRateMultiplierPriceFeed({
       ...config,
       logger,
-      web3,
+      web3: providedWeb3,
       getTime,
       perpetualAbi: Perpetual.abi,
       multicallAddress: multicallAddress,

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.js
@@ -41,11 +41,13 @@ async function createPriceFeed(logger, web3, networker, getTime, config) {
   const HarvestVaultInterface = getTruffleContract("HarvestVaultInterface", web3);
   const Perpetual = getTruffleContract("Perpetual", web3);
 
-  let providedWeb3 = web3;
-  if (config.nodeEnvVariable) {
-    if (!process.env[config.nodeEnvVariable])
-      throw Error(`Expected node url to be provided in env variable ${config.nodeEnvVariable}`);
-    providedWeb3 = new Web3(process.env[config.nodeEnvVariable]);
+  let providedWeb3;
+  if (config.nodeUrlEnvVar) {
+    if (!process.env[config.nodeUrlEnvVar])
+      throw Error(`Expected node url to be provided in env variable ${config.nodeUrlEnvVar}`);
+    providedWeb3 = new Web3(process.env[config.nodeUrlEnvVar]);
+  } else {
+    providedWeb3 = web3;
   }
 
   if (config.type === "cryptowatch") {


### PR DESCRIPTION
**Motivation**

Price feeds should support querying custom nodes.


**Summary**

Add a parameter to all price feeds that allows the user to specify an env variable that the feed should use to find the node url to pass to web3.

For example:

```
config = {
  nodeUrlEnvVar: "POLYGON_NODE_URL",
  ...
};
```

This configuration would tell the feed to use the environment variable `POLYGON_NODE_URL` to get the node url that it should use. It was done this way so that users aren't forced to hardcode their node urls in the config json.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
