### PR TITLE
fix: make unused variables an error in the typescript linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
       ],
-      rules: { "@typescript-eslint/no-var-requires": 0 },
+      rules: { "@typescript-eslint/no-var-requires": 0, "@typescript-eslint/no-unused-vars": "error" },
     },
   ],
   settings: { "mocha/additionalTestFunctions": ["describeModule"] },

--- a/packages/affiliates/libs/uniswap/contracts.ts
+++ b/packages/affiliates/libs/uniswap/contracts.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { ethers } from "ethers";
 import Promise from "bluebird";
 

--- a/packages/api/src/libs/queries/emp.ts
+++ b/packages/api/src/libs/queries/emp.ts
@@ -4,7 +4,6 @@ import * as uma from "@uma/sdk";
 import { calcGcr } from "../utils";
 import bluebird from "bluebird";
 import { BigNumber } from "ethers";
-import * as tables from "../../tables";
 import type { AppState, CurrencySymbol, PriceSample } from "../..";
 
 const { exists } = uma.utils;

--- a/packages/api/src/services/express-channels.ts
+++ b/packages/api/src/services/express-channels.ts
@@ -55,7 +55,7 @@ export default (config: Config, channels: Channels = []) => {
 
   // this is an error handler, express knows this because the function has 4 parameters rather than 3
   // cant remove the "next" parameter, even though linting complains
-  app.use(function (err: Error, req: Request, res: Response, next: NextFunction) {
+  app.use(function (err: Error, req: Request, res: Response) {
     res.status(500).send(err.message || err);
   });
 

--- a/packages/api/src/services/express.ts
+++ b/packages/api/src/services/express.ts
@@ -45,7 +45,7 @@ export default async (config: Config, actions: Actions) => {
 
   // this is an error handler, express knows this because the function has 4 parameters rather than 3
   // cant remove the "next" parameter, even though linting complains
-  app.use(function (err: Error, req: Request, res: Response, next: NextFunction) {
+  app.use(function (err: Error, req: Request, res: Response) {
     res.status(500).send(err.message || err);
   });
 

--- a/packages/api/src/services/lsp-state.e2e.ts
+++ b/packages/api/src/services/lsp-state.e2e.ts
@@ -7,7 +7,7 @@ import type { AppState } from "../";
 import { Multicall } from "@uma/sdk";
 import { lsps } from "../tables";
 // this fixes usage of "this" as any
-import type Mocha from "mocha";
+import "mocha";
 
 type Dependencies = Pick<
   AppState,

--- a/packages/api/src/services/stats/global.ts
+++ b/packages/api/src/services/stats/global.ts
@@ -1,7 +1,6 @@
 import assert from "assert";
 import * as uma from "@uma/sdk";
 import { Currencies, AppState, BaseConfig } from "../..";
-import { nowS } from "../../libs/utils";
 import * as Queries from "../../libs/queries";
 import { BigNumber } from "ethers";
 import bluebird from "bluebird";

--- a/packages/bot-strategy-runner/src/ConfigBuilder.ts
+++ b/packages/bot-strategy-runner/src/ConfigBuilder.ts
@@ -7,7 +7,6 @@ const { toChecksumAddress } = Web3.utils;
 import { getWeb3 } from "@uma/common";
 import { getAbi } from "@uma/core";
 
-import { liquidatorConfig, disputerConfig, monitorConfig } from "./BotEntryWrapper";
 import nodeFetch from "node-fetch";
 import assert from "assert";
 

--- a/packages/bot-strategy-runner/src/index.ts
+++ b/packages/bot-strategy-runner/src/index.ts
@@ -159,7 +159,7 @@ const processExecutionOptions = async () => {
 
 // Returns a promise that is resolved after `seconds` delay. Used to limit how long a spoke can run for.
 const _rejectAfterDelay = (seconds: number | undefined, executionConfig: any) =>
-  new Promise((resolve, _) => {
+  new Promise((resolve) => {
     setTimeout(resolve, (seconds ? seconds : defaultStrategyTimeout) * 1000, {
       error: "timeout",
       message: `The strategy call took longer than ${seconds} seconds to exit`,

--- a/packages/common/src/HardhatConfig.ts
+++ b/packages/common/src/HardhatConfig.ts
@@ -4,6 +4,7 @@ const { getNodeUrl, mnemonic } = require("./TruffleConfig");
 
 export function getHardhatConfig(
   configOverrides: any,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _workingDir = "./",
   includeTruffle = true
 ): Partial<HardhatConfig> {

--- a/packages/common/src/ProviderUtils.ts
+++ b/packages/common/src/ProviderUtils.ts
@@ -3,7 +3,7 @@
 // syntax mimics that of the main UMA Truffle implementation to make this backwards compatible.
 
 import Web3 from "web3";
-import { getTruffleConfig, getNodeUrl, Network } from "./TruffleConfig";
+import { getTruffleConfig, getNodeUrl } from "./TruffleConfig";
 import minimist from "minimist";
 import Url from "url";
 import { RetryProvider, RetryConfig } from "./RetryProvider";

--- a/packages/common/src/SolidityTestUtils.ts
+++ b/packages/common/src/SolidityTestUtils.ts
@@ -76,7 +76,7 @@ async function startMining(web3: Web3): Promise<CallbackResult> {
   });
 }
 
-async function takeSnapshot(web3: Web3): Promise<CallbackResult> {
+export async function takeSnapshot(web3: Web3): Promise<CallbackResult> {
   return new Promise((resolve, reject) => {
     if (!web3.currentProvider || typeof web3?.currentProvider === "string" || !web3.currentProvider.send) {
       reject(new Error("No web3 provider that allows send()"));
@@ -94,7 +94,7 @@ async function takeSnapshot(web3: Web3): Promise<CallbackResult> {
   });
 }
 
-async function revertToSnapshot(web3: Web3, id: number): Promise<CallbackResult> {
+export async function revertToSnapshot(web3: Web3, id: number): Promise<CallbackResult> {
   return new Promise((resolve, reject) => {
     if (!web3.currentProvider || typeof web3?.currentProvider === "string" || !web3.currentProvider.send) {
       reject(new Error("No web3 provider that allows send()"));

--- a/packages/core/scripts/mainnet/WithdrawTokens.ts
+++ b/packages/core/scripts/mainnet/WithdrawTokens.ts
@@ -16,7 +16,7 @@ async function WithdrawTokens() {
   const { getWeb3 } = require("@uma/common");
   const web3 = getWeb3();
 
-  const { getAbi, getTruffleContract } = require("@uma/core");
+  const { getTruffleContract } = require("@uma/core");
   const { GasEstimator } = require("@uma/financial-templates-lib");
 
   assert(

--- a/packages/merkle-distributor/integration-test/MerkleDistributorHelper.ts
+++ b/packages/merkle-distributor/integration-test/MerkleDistributorHelper.ts
@@ -2,7 +2,6 @@
 // they require privileged information(such as cloudflare API keys) and they run against the kovan test network.
 // They are simply meant to showcase the correct behavior of the helpers under a number of different situations and inputs.
 
-const { ethers } = require("ethers");
 const { assert } = require("chai");
 
 import { createLeaf, createMerkleDistributionProofs, getClaimsForAddress } from "../src/MerkleDistributorHelper";

--- a/packages/reporters/liquidation-reporter/liquidation-reporter.ts
+++ b/packages/reporters/liquidation-reporter/liquidation-reporter.ts
@@ -239,7 +239,7 @@ export async function fetchUmaEcosystemData() {
     // expired, having no sponsors or having no graph data.
     const builtUpExistingCollaterals: any = [];
 
-    uniqueCollateralTypes[collateralAddress].activeFinancialContracts.forEach((activeFinancialContractInfo, index) => {
+    uniqueCollateralTypes[collateralAddress].activeFinancialContracts.forEach((activeFinancialContractInfo) => {
       if (activeFinancialContractInfo.contractExpirationTime)
         builtUpExistingCollaterals.push(activeFinancialContractInfo);
     });

--- a/packages/sdk/src/libs/clients/emp/client.ts
+++ b/packages/sdk/src/libs/clients/emp/client.ts
@@ -27,7 +27,7 @@ export type Withdrawal = GetEventType<Instance, "Withdrawal">;
 export type LiquidationCreated = GetEventType<Instance, "LiquidationCreated">;
 
 // experimenting with a generalized way of handling events and returning state, inspired from react style reducers
-export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState = {}, event: Event): EventState {
   switch (event.event) {
     case "RequestTransferPositionExecuted": {
       const typedEvent = event as RequestTransferPositionExecuted;

--- a/packages/sdk/src/libs/clients/erc20/client.ts
+++ b/packages/sdk/src/libs/clients/erc20/client.ts
@@ -35,7 +35,7 @@ export type Transfer = GetEventType<Instance, "Transfer">;
 export type Approval = GetEventType<Instance, "Approval">;
 
 // takes all events and returns user balances and approvals
-export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState = {}, event: Event): EventState {
   switch (event.event) {
     case "Transfer": {
       const typedEvent = event as Transfer;

--- a/packages/sdk/src/libs/clients/lsp-creator/client.ts
+++ b/packages/sdk/src/libs/clients/lsp-creator/client.ts
@@ -32,7 +32,7 @@ export interface EventState {
   };
 }
 
-export function reduceEvents(state: EventState, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState, event: Event): EventState {
   switch (event.event) {
     case "CreatedLongShortPair": {
       const typedEvent = event as CreatedLongShortPair;

--- a/packages/sdk/src/libs/clients/lsp/client.ts
+++ b/packages/sdk/src/libs/clients/lsp/client.ts
@@ -24,7 +24,7 @@ export interface EventState {
   expiredBy?: string;
 }
 
-export function reduceEvents(state: EventState, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState, event: Event): EventState {
   switch (event.event) {
     case "TokensCreated": {
       const typedEvent = event as TokensCreated;

--- a/packages/sdk/src/libs/clients/registry/client.ts
+++ b/packages/sdk/src/libs/clients/registry/client.ts
@@ -26,7 +26,7 @@ export interface EventState {
 export type NewContractRegistered = GetEventType<Instance, "NewContractRegistered">;
 
 // experimenting with a generalized way of handling events and returning state, inspired from react style reducers
-export function reduceEvents(state: EventState = {}, event: Event, index?: number): EventState {
+export function reduceEvents(state: EventState = {}, event: Event): EventState {
   switch (event.event) {
     case "NewContractRegistered": {
       const typedEvent = event as NewContractRegistered;


### PR DESCRIPTION
**Motivation**

The eslint considers an unused variable a warning for typescript.


**Summary**

Added a rule to make this an error rather than warning.

Note: I think this is a warning by default because typescript, itself, can check for this. However, rather than change the tsconfigs, it seems easier to add this to eslint. Long term, we may want to have a standard tsconfig that we inherit from, but that's a slightly larger project.

This also fixes a minor issue with unexported functions in common.

The two other common warnings for ts code are:
- `@typescript-eslint/no-explicit-any` -- we still use any in a lot of places, so we either need to disable it individually or just keep this rule off and just try to avoid any as much as possible.
- `@typescript-eslint/explicit-module-boundary-types` -- I'm not sure we want to add this one to our list of errors. It essentially requires an explicit return type for each exported function in a file. These explicit types get extremely cumbersome and time-consuming to write in certain places. It would be a bigger time sink to enable this.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
