### PR TITLE
feat(pf-configs): Add default pf configs for ibBTC/BTC, BTC/ibBTC, ibBTC/USD and USD/ibBTC

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.js
@@ -940,6 +940,23 @@ const defaultConfigs = {
     twapLength: 7200,
     invertPrice: true,
   },
+  "ibBTC/BTC": {
+    type: "medianizer",
+    lookback: 7200,
+    twapLength: 1800,
+    invertPrice: true,
+    medianizedFeeds: [
+      { type: "uniswap", uniswapAddress: "0x18d98D452072Ac2EB7b74ce3DB723374360539f1" },
+      {
+        type: "uniswap",
+        nodeUrlEnvVar: "POLYGON_NODE_URL",
+        uniswapAddress: "0x8F8e95Ff4B4c5E354ccB005c6B0278492D7B5907",
+      },
+    ],
+  },
+  "BTC/ibBTC": { type: "expression", expression: "1 / ibBTC\\/BTC" },
+  "ibBTC/USD": { type: "expression", expression: "ibBTC\\/BTC * BTCUSD" },
+  "USD/ibBTC": { type: "expression", expression: "1 / ibBTC\\/USD" },
 };
 
 // Pull in the number of decimals for each identifier from the common getPrecisionForIdentifier. This is used within the


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

ibBTC related price identifiers defined in [UMIP-119](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-119.md) needs default price feed configuration.


**Summary**

Default price feed configuration was added for ibBTC/BTC, BTC/ibBTC, ibBTC/USD and USD/ibBTC price identifiers.


**Details**

These price feed configurations utilizes multichain support introduced in #3277.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
NA
