### PR TITLE
feat(api): 1884 add additional global utility calls

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -75,6 +75,7 @@ Current channels are
 
 - emp - all emp calls
 - lsp - all lsp calls
+- global - custom calls that are not contract type specific
 
 ## Action Client
 
@@ -245,3 +246,51 @@ Lsp calls are on the lsp channel. These calls are the same as the EMP calls, but
 ### lsp/totalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") => Stat[]
 
 ### lsp/totalTvlSlice(start = 0, length = 1, currency: CurrencySymbol = "usd") => Stat[]
+
+## Global
+
+Global calls allow you to make calls without knowing the type of contract you are dealing with
+
+### global/listActive()
+
+List all active contracts, both LSP or EMP
+
+### global/listExpired()
+
+List all expired contracts, both LSP or EMP
+
+### global/getState(address: string)
+
+Get the state of a known contract address.
+
+### global/globalTvl(currency: CurrencySymbol = "usd")
+
+Global tvl, or the sum of tvls of all known contracts.
+
+### global/tvl(address: string, currency: CurrencySymbol = "usd")
+
+Look up tvl for any contract address.
+
+### global/globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd")
+
+Global tvl history between times in seconds.
+
+### global/tvlHistoryBetween(address: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd")
+
+TVL history for a particular address.
+
+### global/globalTvm(currency: CurrencySymbol = "usd")
+
+Global tvm or the sum of all tvms of all known contracts.
+
+### global/tvm(address: string, currency: CurrencySymbol = "usd")
+
+TVM for a particular address.
+
+### global/tvmHistoryBetween(address: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd")
+
+TVM history for a specific address between timestamps in seconds.
+
+### global/tvmHistorySlice(address: string, start = 0, length = 1, currency: CurrencySymbol = "usd")
+
+TVM history slice for a specific address.

--- a/packages/api/src/services/actions/emp.ts
+++ b/packages/api/src/services/actions/emp.ts
@@ -34,9 +34,19 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     lastBlock() {
       return appState.lastBlock;
     },
+    // deprecated
     listActiveEmps: queries.listActive,
+    // deprecated
     listExpiredEmps: queries.listExpired,
+    listActive: queries.listActive,
+    listExpired: queries.listExpired,
+    // deprecated
     async getEmpState(address: string) {
+      assert(await registeredEmps.has(address), "Not a valid emp address: " + address);
+      const state = await queries.getAny(address);
+      return queries.getFullState(state);
+    },
+    async getState(address: string) {
       assert(await registeredEmps.has(address), "Not a valid emp address: " + address);
       const state = await queries.getAny(address);
       return queries.getFullState(state);

--- a/packages/api/src/services/actions/emp.ts
+++ b/packages/api/src/services/actions/emp.ts
@@ -34,6 +34,7 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     lastBlock() {
       return appState.lastBlock;
     },
+    hasAddress: queries.hasAddress,
     // deprecated
     listActiveEmps: queries.listActive,
     // deprecated

--- a/packages/api/src/services/actions/global.ts
+++ b/packages/api/src/services/actions/global.ts
@@ -40,10 +40,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     async getState(address: string) {
       assert(address, "requires a contract address");
       for (const action of contractActions) {
-        try {
-          return await action.getState(address);
-        } catch (err) {
-          // do nothing
+        if (await action.hasAddress(address)) {
+          return action.getState(address);
         }
       }
       throw new Error("Unable to find contract address " + address);
@@ -61,10 +59,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     async tvl(address: string, currency: CurrencySymbol = "usd") {
       assert(address, "requires a contract address");
       for (const action of contractActions) {
-        try {
-          return await action.tvl([address], currency);
-        } catch (err) {
-          // do nothing
+        if (await action.hasAddress(address)) {
+          return action.tvl([address], currency);
         }
       }
       throw new Error("Unable to find TVL for address " + address);
@@ -87,10 +83,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(address, "requires contract address");
       // otherwise look up tvm for contract
       for (const action of contractActions) {
-        try {
+        if (await action.hasAddress(address)) {
           return await action.tvlHistoryBetween(address, start, end, currency);
-        } catch (err) {
-          // do nothing
         }
       }
       throw new Error("Unable to find TVL History between for address " + address);
@@ -103,10 +97,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(address, "requires contract address");
       // otherwise look up tvm for contract
       for (const action of contractActions) {
-        try {
-          return await action.tvlHistorySlice(address, start, length, currency);
-        } catch (err) {
-          // do nothing
+        if (await action.hasAddress(address)) {
+          return action.tvlHistorySlice(address, start, length, currency);
         }
       }
       throw new Error("Unable to find TVL History slice for address " + address);
@@ -115,10 +107,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       assert(address, "requires contract address");
       // otherwise look up tvm for contract
       for (const action of contractActions) {
-        try {
+        if (await action.hasAddress(address)) {
           return await action.tvm([address], currency);
-        } catch (err) {
-          // do nothing
         }
       }
       throw new Error("Unable to find TVM for address " + address);
@@ -126,10 +116,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     async tvmHistoryBetween(address: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
       assert(address, "requires contract address");
       for (const action of contractActions) {
-        try {
+        if (await action.hasAddress(address)) {
           return await action.tvmHistoryBetween(address, start, end, currency);
-        } catch (err) {
-          // do nothing
         }
       }
       throw new Error("Unable to find TVM History between for address " + address);
@@ -137,10 +125,8 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     async tvmHistorySlice(address: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(address, "requires contract address");
       for (const action of contractActions) {
-        try {
+        if (await action.hasAddress(address)) {
           return await action.tvmHistorySlice(address, start, length, currency);
-        } catch (err) {
-          // do nothing
         }
       }
       throw new Error("Unable to find TVM History slice for address " + address);

--- a/packages/api/src/services/actions/global.ts
+++ b/packages/api/src/services/actions/global.ts
@@ -1,9 +1,10 @@
 import assert from "assert";
 import { Json, Actions, AppState, CurrencySymbol, AllContractStates } from "../..";
-import * as Queries from "../../libs/queries";
 import bluebird from "bluebird";
 import { BigNumber } from "ethers";
 import { nowS } from "../../libs/utils";
+import { Handlers as EmpActions } from "./emp";
+import { Handlers as LspActions } from "./lsp";
 
 // actions use all the app state
 type Dependencies = AppState;
@@ -11,7 +12,7 @@ type Config = undefined;
 
 export function Handlers(config: Config, appState: Dependencies): Actions {
   const { stats } = appState;
-  const queries = [Queries.Emp(appState), Queries.Lsp(appState)];
+  const contractActions = [EmpActions(config, appState), LspActions(config, appState)];
 
   const actions: Actions = {
     echo(...args: Json[]) {
@@ -19,18 +20,18 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     async listActive() {
       return bluebird.reduce(
-        queries,
-        async (result: AllContractStates[], query) => {
-          return result.concat(await query.listActive());
+        contractActions,
+        async (result: AllContractStates[], actions) => {
+          return result.concat((await actions.listActive()) as AllContractStates[]);
         },
         []
       );
     },
     async listExpired() {
       return bluebird.reduce(
-        queries,
-        async (result: AllContractStates[], query) => {
-          return result.concat(await query.listExpired());
+        contractActions,
+        async (result: AllContractStates[], actions) => {
+          return result.concat((await actions.listExpired()) as AllContractStates[]);
         },
         []
       );
@@ -38,33 +39,111 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     // return the first address found
     async getState(address: string) {
       assert(address, "requires a contract address");
-      for (const query of queries) {
+      for (const action of contractActions) {
         try {
-          const state = await query.getAny(address);
-          return query.getFullState(state);
+          return await action.getState(address);
         } catch (err) {
           // do nothing
         }
       }
       throw new Error("Unable to find contract address " + address);
     },
-    async tvl(currency: CurrencySymbol = "usd") {
+    async globalTvl(currency: CurrencySymbol = "usd") {
       const sum = await bluebird.reduce(
-        queries,
-        async (sum, queries) => {
-          return sum.add((await queries.getTotalTvl(currency)) || "0");
+        contractActions,
+        async (sum, actions) => {
+          return sum.add(((await actions.tvl(undefined, currency)) as string) || "0");
         },
         BigNumber.from("0")
       );
       return sum.toString();
     },
-    async tvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
+    async tvl(address: string, currency: CurrencySymbol = "usd") {
+      assert(address, "requires a contract address");
+      for (const action of contractActions) {
+        try {
+          return await action.tvl([address], currency);
+        } catch (err) {
+          // do nothing
+        }
+      }
+      throw new Error("Unable to find TVL for address " + address);
+    },
+    async globalTvm(currency: CurrencySymbol = "usd") {
+      const sum = await bluebird.reduce(
+        contractActions,
+        async (sum, actions) => {
+          return sum.add(((await actions.tvm(undefined, currency)) as string) || "0");
+        },
+        BigNumber.from("0")
+      );
+      return sum.toString();
+    },
+    async globalTvlHistoryBetween(start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
       assert(stats.global[currency], "Invalid currency type: " + currency);
       return stats.global[currency].history.tvl.betweenByGlobal(start, end);
     },
-    async tvlHistorySlice(start = 0, length = 1, currency: CurrencySymbol = "usd") {
+    async tvlHistoryBetween(address: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
+      assert(address, "requires contract address");
+      // otherwise look up tvm for contract
+      for (const action of contractActions) {
+        try {
+          return await action.tvlHistoryBetween(address, start, end, currency);
+        } catch (err) {
+          // do nothing
+        }
+      }
+      throw new Error("Unable to find TVL History between for address " + address);
+    },
+    async globalTvlHistorySlice(start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(stats.global[currency], "Invalid currency type: " + currency);
       return stats.global[currency].history.tvl.sliceByGlobal(start, length);
+    },
+    async tvlHistorySlice(address: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
+      assert(address, "requires contract address");
+      // otherwise look up tvm for contract
+      for (const action of contractActions) {
+        try {
+          return await action.tvlHistorySlice(address, start, length, currency);
+        } catch (err) {
+          // do nothing
+        }
+      }
+      throw new Error("Unable to find TVL History slice for address " + address);
+    },
+    async tvm(address: string, currency: CurrencySymbol = "usd") {
+      assert(address, "requires contract address");
+      // otherwise look up tvm for contract
+      for (const action of contractActions) {
+        try {
+          return await action.tvm([address], currency);
+        } catch (err) {
+          // do nothing
+        }
+      }
+      throw new Error("Unable to find TVM for address " + address);
+    },
+    async tvmHistoryBetween(address: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
+      assert(address, "requires contract address");
+      for (const action of contractActions) {
+        try {
+          return await action.tvmHistoryBetween(address, start, end, currency);
+        } catch (err) {
+          // do nothing
+        }
+      }
+      throw new Error("Unable to find TVM History between for address " + address);
+    },
+    async tvmHistorySlice(address: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
+      assert(address, "requires contract address");
+      for (const action of contractActions) {
+        try {
+          return await action.tvmHistorySlice(address, start, length, currency);
+        } catch (err) {
+          // do nothing
+        }
+      }
+      throw new Error("Unable to find TVM History slice for address " + address);
     },
   };
 

--- a/packages/api/src/services/actions/lsp.ts
+++ b/packages/api/src/services/actions/lsp.ts
@@ -16,6 +16,7 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     listAddresses() {
       return Array.from(registeredLsps.values());
     },
+    hasAddress: queries.hasAddress,
     listActive: queries.listActive,
     listExpired: queries.listExpired,
     async getState(address: string) {

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -16,7 +16,7 @@ export default (config: Config, appState: Dependencies) => {
 
   // default props we want to query on contract
   const staticProps: [string, (x: any) => any][] = [
-    ["pairName", parseBytes],
+    // ["pairName", parseBytes],
     ["collateralPerPair", toString],
     ["priceIdentifier", parseBytes],
     ["collateralToken", toString],

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -16,8 +16,7 @@ export default (config: Config, appState: Dependencies) => {
 
   // default props we want to query on contract
   const staticProps: [string, (x: any) => any][] = [
-    // TODO: deal with this when early contracts dont have pairName
-    // ["pairName", parseBytes],
+    ["pairName", parseBytes],
     ["collateralPerPair", toString],
     ["priceIdentifier", parseBytes],
     ["collateralToken", toString],


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.clubhouse.io/uma-project/story/1884/add-single-contract-tvl-calls-to-global-channel

**Summary**
There were several calls requested by francesco to be added to facilitate data requests when the type of contract is unknown. These are documented in the readme.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1884/add-single-contract-tvl-calls-to-global-channel
