### PR TITLE
feat(api): add pairName to lsp state

### DIFF
--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -147,10 +147,10 @@ export default async (env: ProcessEnv) => {
   await services.lspCreator.update();
   console.log("Got all LSP addresses");
 
-  await services.emps();
+  await services.emps(0);
   console.log("Updated EMP state");
 
-  await services.lsps.update();
+  await services.lsps.update(0);
   console.log("Updated LSP state");
 
   await services.erc20s.update();

--- a/packages/api/src/services/lsp-state.e2e.ts
+++ b/packages/api/src/services/lsp-state.e2e.ts
@@ -14,8 +14,8 @@ type Dependencies = Pick<
   "lsps" | "registeredLsps" | "provider" | "collateralAddresses" | "shortAddresses" | "longAddresses" | "multicall"
 >;
 
-// first contract launched, does not have pairName property
-const registeredContracts = ["0x372802d8A2D69bB43872a1AABe2bd403a0FafA1F"];
+// this contract updated to have pairName
+const registeredContracts = ["0x6B435F5C417d1D058683E2B175d8396F09f2186d"];
 
 describe("lsp-state service", function () {
   let appState: Dependencies;
@@ -72,14 +72,16 @@ describe("lsp-state service", function () {
     const result = await service.utils.getStaticProps(instance, address);
     assert.equal(result.address, address);
     assert.ok(result.updated > 0);
-    assert.equal(result.collateralPerPair, "250000000000000000");
-    assert.equal(result.priceIdentifier, "UMAUSD");
-    assert.equal(result.collateralToken, "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828");
-    assert.equal(result.longToken, "0xa1b777a18333A9EC31b4D81f5d08371b6AE1FEb9");
-    assert.equal(result.shortToken, "0xeFA3356e054A035dD91fA25b3F2A61484Bc2CD54");
+    assert.equal(result.pairName, "SUSHIsBOND July 2024");
+    assert.equal(result.collateralPerPair, "200000000000000000000");
+    assert.equal(result.priceIdentifier, "SUSHIUSD");
+    assert.equal(result.collateralToken, "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2");
+    assert.equal(result.longToken, "0x9c728BAD65cCED25B7F03fB47dCB4AB1d3F2b431");
+    assert.equal(result.shortToken, "0x29c71D66De780396677ddEe87af7261e2Ef34306");
     assert.equal(result.finder, "0x40f941E48A552bF496B154Af6bf55725f18D77c3");
-    assert.equal(result.financialProductLibrary, "0x9214454Ff30410a1558b8749Ab3FB0fD6F942539");
+    assert.equal(result.financialProductLibrary, "0x5a116B8bAb914513F710085cAd0f4628Dcc7eeca");
     assert.equal(result.customAncillaryData, "0x747761704c656e6774683a33363030");
+    assert.equal(result.expirationTimestamp, "1722441600");
     assert.equal(result.prepaidProposerReward, "0");
   });
   it("update", async function () {

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -16,7 +16,7 @@ export default (config: Config, appState: Dependencies) => {
 
   // default props we want to query on contract
   const staticProps: [string, (x: any) => any][] = [
-    // ["pairName", parseBytes],
+    ["pairName", toString],
     ["collateralPerPair", toString],
     ["priceIdentifier", parseBytes],
     ["collateralToken", toString],


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1921/add-pairname-to-lsp-state-in-api


**Summary**

Enables pairName for lsps and updates some tests to verify


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1921/add-pairname-to-lsp-state-in-api
