### PR TITLE
fix(api): give lsp actions 0 tvm call, and throw errs on tvm history

### DIFF
--- a/packages/api/src/services/actions/global.ts
+++ b/packages/api/src/services/actions/global.ts
@@ -81,7 +81,7 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     async tvlHistoryBetween(address: string, start = 0, end: number = nowS(), currency: CurrencySymbol = "usd") {
       assert(address, "requires contract address");
-      // otherwise look up tvm for contract
+      // otherwise look up tvl for contract
       for (const action of contractActions) {
         if (await action.hasAddress(address)) {
           return await action.tvlHistoryBetween(address, start, end, currency);
@@ -95,7 +95,6 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     async tvlHistorySlice(address: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(address, "requires contract address");
-      // otherwise look up tvm for contract
       for (const action of contractActions) {
         if (await action.hasAddress(address)) {
           return action.tvlHistorySlice(address, start, length, currency);
@@ -105,7 +104,6 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     async tvm(address: string, currency: CurrencySymbol = "usd") {
       assert(address, "requires contract address");
-      // otherwise look up tvm for contract
       for (const action of contractActions) {
         if (await action.hasAddress(address)) {
           return await action.tvm([address], currency);

--- a/packages/api/src/services/actions/lsp.ts
+++ b/packages/api/src/services/actions/lsp.ts
@@ -47,6 +47,10 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       addresses = addresses ? lodash.castArray(addresses) : [];
       return queries.sumTvl(addresses, currency);
     },
+    // lsp does not support tvm at this time, but we want a function here for consistency with emp interface
+    async tvm() {
+      return "0";
+    },
     async tvlHistoryBetween(
       contractAddress: string,
       start = 0,
@@ -55,6 +59,14 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     ) {
       assert(stats.lsp[currency], "Invalid currency type: " + currency);
       return stats.lsp[currency].history.tvl.betweenByAddress(contractAddress, start, end);
+    },
+    // this is not supported
+    async tvmHistoryBetween() {
+      throw new Error("LSP does not support TVM");
+    },
+    // this is not supported
+    async tvmHistorySlice() {
+      throw new Error("LSP does not support TVM");
     },
     async tvlHistorySlice(contractAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(stats.lsp[currency], "Invalid currency type: " + currency);


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.clubhouse.io/uma-project/story/1922/bug-fix-global-tvm


**Summary**

This was erroring when global calls was trying to call tvm for LSP. This simply adds a placeholder that returns 0.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.clubhouse.io/uma-project/story/1922/bug-fix-global-tvm
