### PR TITLE
feat(api): allow pairName optionally if contract supports it

### DIFF
--- a/packages/api/src/services/lsp-state.e2e.ts
+++ b/packages/api/src/services/lsp-state.e2e.ts
@@ -14,8 +14,11 @@ type Dependencies = Pick<
   "lsps" | "registeredLsps" | "provider" | "collateralAddresses" | "shortAddresses" | "longAddresses" | "multicall"
 >;
 
-// this contract updated to have pairName
-const registeredContracts = ["0x6B435F5C417d1D058683E2B175d8396F09f2186d"];
+// this contract updated to have pairName                                 // does not have pairname
+const registeredContracts = [
+  "0x6B435F5C417d1D058683E2B175d8396F09f2186d",
+  "0x372802d8A2D69bB43872a1AABe2bd403a0FafA1F",
+];
 
 describe("lsp-state service", function () {
   let appState: Dependencies;
@@ -65,6 +68,13 @@ describe("lsp-state service", function () {
     assert.ok(result.expiryPercentLong);
     assert.ok(result.contractState >= 0);
   });
+  it("readOptionalState", async function () {
+    const [address] = registeredContracts;
+    const service = Service({}, appState);
+    const instance = await uma.clients.lsp.connect(address, appState.provider);
+    const result = await service.utils.getOptionalProps(instance, address);
+    assert.equal(result.pairName, "SUSHIsBOND July 2024");
+  });
   it("readStaticState", async function () {
     const [address] = registeredContracts;
     const service = Service({}, appState);
@@ -72,7 +82,6 @@ describe("lsp-state service", function () {
     const result = await service.utils.getStaticProps(instance, address);
     assert.equal(result.address, address);
     assert.ok(result.updated > 0);
-    assert.equal(result.pairName, "SUSHIsBOND July 2024");
     assert.equal(result.collateralPerPair, "200000000000000000000");
     assert.equal(result.priceIdentifier, "SUSHIUSD");
     assert.equal(result.collateralToken, "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2");

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -16,7 +16,6 @@ export default (config: Config, appState: Dependencies) => {
 
   // default props we want to query on contract
   const staticProps: [string, (x: any) => any][] = [
-    ["pairName", toString],
     ["collateralPerPair", toString],
     ["priceIdentifier", parseBytes],
     ["collateralToken", toString],
@@ -44,6 +43,16 @@ export default (config: Config, appState: Dependencies) => {
     };
   }
 
+  async function getOptionalProps(instance: Instance, address: string) {
+    return {
+      address,
+      updated: nowS(),
+      pairName: await instance
+        .pairName()
+        .then(toString)
+        .catch(() => null),
+    };
+  }
   async function getStaticProps(instance: Instance, address: string) {
     return batchRead(staticProps, instance, address);
   }
@@ -72,6 +81,7 @@ export default (config: Config, appState: Dependencies) => {
     let currentState: lsps.Data = { address };
     let staticState: lsps.Data = { address };
     let dynamicState: lsps.Data = { address };
+    let optionalState: lsps.Data = { address };
     let eventState: uma.clients.lsp.EventState = { sponsors: [] };
 
     const events = await instance.queryFilter({}, startBlock, endBlock);
@@ -97,8 +107,10 @@ export default (config: Config, appState: Dependencies) => {
       } else {
         // have to make sure we get static state if we have never seen this expired emp before
         staticState = await getStaticProps(instance, address);
+        optionalState = await getOptionalProps(instance, address);
         // if it was never active, just create an expired emp
         await lsps.expired.create({
+          ...optionalState,
           ...staticState,
           ...dynamicState,
           totalPositionCollateral,
@@ -112,8 +124,10 @@ export default (config: Config, appState: Dependencies) => {
       if (!(await lsps.active.has(address))) {
         // get static state once if it does not exist (optimizes network calls)
         staticState = await getStaticProps(instance, address);
+        optionalState = await getOptionalProps(instance, address);
         // create active emp with static/dynamic state
         await lsps.active.create({
+          ...optionalState,
           ...staticState,
           ...dynamicState,
           totalPositionCollateral,
@@ -161,6 +175,7 @@ export default (config: Config, appState: Dependencies) => {
       getErc20BalanceOf,
       getStaticProps,
       getDynamicProps,
+      getOptionalProps,
       getPositionCollateral,
     },
   };


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1923/get-pairname-on-lsp-conditionally-with-fallback-if-unavailable


**Summary**

This seperates out pairName into its own call outside of multicall. if pairname does not exist on the particular contract it will set the state to null, adds a test to make sure it comes in properly.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1923/get-pairname-on-lsp-conditionally-with-fallback-if-unavailable
