### PR TITLE
fix(common): fix issues with gckms typescript conversion

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "hardhat test ./test/*",
-    "build": "rm -rf dist && tsc"
+    "build": "rm -rf dist && tsc && (cp src/gckms/.GckmsOverride.js dist/gckms/.GckmsOverride.js || echo 'No override file found, continuing')"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"

--- a/packages/common/src/gckms/GckmsConfig.ts
+++ b/packages/common/src/gckms/GckmsConfig.ts
@@ -49,7 +49,7 @@ export function getGckmsConfig(keys = arrayify(argv.keys), network = argv.networ
     const overrideFname = ".GckmsOverride.js";
     try {
       if (fs.existsSync(`${__dirname}/${overrideFname}`)) {
-        configOverride = JSON.parse(fs.readFileSync(`./${overrideFname}`).toString("utf8"));
+        configOverride = require(`./${overrideFname}`);
       }
     } catch (err) {
       console.error(err);

--- a/packages/common/src/gckms/utils.ts
+++ b/packages/common/src/gckms/utils.ts
@@ -27,8 +27,8 @@ export async function retrieveGckmsKeys(gckmsConfigs: KeyConfig[]): Promise<stri
       const client = new kms.KeyManagementServiceClient();
       const name = client.cryptoKeyPath(config.projectId, config.locationId, config.keyRingId, config.cryptoKeyId);
       const [result] = await client.decrypt({ name, ciphertext });
-      if (!result.plaintext || result.plaintext instanceof Uint8Array) throw new Error("result.plaintext wrong type");
-      return "0x" + Buffer.from(result.plaintext.toString(), "base64").toString().trim();
+      if (!(result.plaintext instanceof Uint8Array)) throw new Error("result.plaintext wrong type");
+      return "0x" + Buffer.from(result.plaintext).toString().trim();
     })
   );
 }


### PR DESCRIPTION
**Motivation**

The gckms system has been broken since the typescript upgrade in common.


**Summary**

This PR fixes three distinct issues:
- The previous implementation imported the gckms file incorrectly, assuming it was a JSON file.
- The previous implementation did not copy the pre-existing js hidden file to dist. It assumed it was a typescript file that was compiled. However, the tsc compiler ignores files preceded by a `.` by default, so making this work as a ts file is tricky.
- The previous implementation did an incorrect type check and string conversion in order to generate the private keys.

Note: this new process _does_ require you to run the build with the gckms override file if you intend to use it. Adding the override file _after_ building will not work.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
