### PR TITLE
feat(api): add lsp tvm by copying in tvl as the source

### DIFF
--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -81,6 +81,7 @@ export default async (env: ProcessEnv) => {
         usd: {
           latest: {
             tvl: empStats.JsMap("Latest Tvl"),
+            tvm: empStats.JsMap("Latest Tvm"),
           },
           history: {
             tvl: empStatsHistory.SortedJsMap("Tvl History"),

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -87,6 +87,7 @@ export type AppState = {
       usd: {
         latest: {
           tvl: empStats.JsMap;
+          tvm: empStats.JsMap;
         };
         history: {
           tvl: empStatsHistory.SortedJsMap;

--- a/packages/api/src/services/actions/lsp.ts
+++ b/packages/api/src/services/actions/lsp.ts
@@ -47,9 +47,10 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
       addresses = addresses ? lodash.castArray(addresses) : [];
       return queries.sumTvl(addresses, currency);
     },
-    // lsp does not support tvm at this time, but we want a function here for consistency with emp interface
-    async tvm() {
-      return "0";
+    async tvm(addresses: string[] = [], currency: CurrencySymbol = "usd") {
+      if (addresses == null || addresses.length == 0) return queries.totalTvm(currency);
+      addresses = addresses ? lodash.castArray(addresses) : [];
+      return queries.sumTvm(addresses, currency);
     },
     async tvlHistoryBetween(
       contractAddress: string,
@@ -62,11 +63,11 @@ export function Handlers(config: Config, appState: Dependencies): Actions {
     },
     // this is not supported
     async tvmHistoryBetween() {
-      throw new Error("LSP does not support TVM");
+      throw new Error("LSP does not support TVM History");
     },
     // this is not supported
     async tvmHistorySlice() {
-      throw new Error("LSP does not support TVM");
+      throw new Error("LSP does not support TVM History");
     },
     async tvlHistorySlice(contractAddress: string, start = 0, length = 1, currency: CurrencySymbol = "usd") {
       assert(stats.lsp[currency], "Invalid currency type: " + currency);


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1953/update-the-global-tvm-to-account-for-lsps


**Summary**

This replicates a lot of the infrastructure from EMP TVM to LSP TVM. The final TVM values for LSPs are just copied from its TVL, so ultimately the user just sees the LSP TVL as TVM.  The global TVM is also updated with the new global TVM values.

Global TVM value goes from 31.6 million -> 45.4 million with this new addition


**Details**

This allows the frontend to call to get an LSPs tvm per address or a group of addresses on the `lsp/tvm` action. Most likely this wont be used. The main change comes from the global tvm value which should now be slightly higher and no changes to FE necessary for this.  Another minor modification is that LSP states now have an additional `tvm` field which will be a mirror of the `tvl`. If we ever change this calculation in the future we can pass through the new tvm value with no further modifications to the api.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
https://app.clubhouse.io/uma-project/story/1953/update-the-global-tvm-to-account-for-lsps
