### PR TITLE
fix(api): use token decimals when looking up market price

### DIFF
--- a/packages/api/src/services/market-prices.ts
+++ b/packages/api/src/services/market-prices.ts
@@ -1,5 +1,6 @@
 import bluebird from "bluebird";
 import assert from "assert";
+import lodash from "lodash";
 import { AppState, BaseConfig } from "..";
 import { parseUnits, nowS, Profile } from "../libs/utils";
 
@@ -73,7 +74,8 @@ export default function (config: Config, appState: Dependencies) {
   // we can try to price all known erc20 addresses. Some will fail. Also this endpoint does not return a timestamp
   // so we will just set one from our query time.
   async function update(timestampS = nowS()) {
-    const addresses = Array.from(new Set(Array.from(collateralAddresses).concat(Array.from(syntheticAddresses))));
+    // want to make sure we dont have any duplicate addresses between collaterals and synthetic
+    const addresses = lodash.uniq(Array.from(collateralAddresses).concat(Array.from(syntheticAddresses)));
     await updateLatestPrices(addresses, timestampS).catch((err) => {
       console.error("Error getting Market Price: " + err.message);
     });


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.clubhouse.io/uma-project/story/1963/bug-adjust-matcha-price-call-to-use-correct-decimals


**Summary**

Some market prices were not showing, this may have been to querying the matcha api with the wrong quantity of synthetic. Small change to use token decimals to set the correct synthetic amount when calling matcha api. 


**Details**

This synthetic token used to not return a market price: 0x2dE7A5157693a895ae8E55b1e935e23451a77cB3, which it now does after this fix 


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.clubhouse.io/uma-project/story/1963/bug-adjust-matcha-price-call-to-use-correct-decimals