### PR TITLE
fix(serverless-hub) address started keyword-lookup

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -452,12 +452,12 @@ function _processSpokeResponse(botKey, spokeResponse, validOutputs, errorOutputs
   } else if (
     spokeResponse.value &&
     spokeResponse.value.execResponse &&
-    !spokeResponse.value.execResponse.stdout.includes("started")
+    !JSON.stringify(spokeResponse.value.execResponse.stdout).includes("started")
   ) {
     errorOutputs[botKey] = {
       status: spokeResponse.status,
       execResponse: spokeResponse.value && spokeResponse.value.execResponse,
-      reason: "missing `Started` key word",
+      reason: "missing `Started` keyword",
       botIdentifier: botKey,
     };
   } else {

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -680,7 +680,7 @@ contract("ServerlessHub.js", function (accounts) {
     ); // check that the catcher for empty standouts correctly caught the error
     assert.isTrue(
       JSON.stringify(responseObject.output.errorOutputs["testServerlessMonitorError2"]).includes(
-        "missing `Started` key word"
+        "missing `Started` keyword"
       )
     ); // check the catcher for missing `Started` key words, sent at the booting sequency of all bots, is captured correctly.
   });


### PR DESCRIPTION
**Motivation**

After the most recent serverless hub update (see https://github.com/UMAprotocol/protocol/pull/3299) a small bug was introduced that only showed itself while testing in production. While the update presented in #3299 works in tests, it does not work in production due to the nesting of logs when running with the bot strategy runner.

This PR makes a small modification to cast the nested logs to a string before looking for the `Started` keyword.

**Summary**

Fixed serverless hub.

**Note this change has been verified in production on the main serverless hub in GCP**


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


