### PR TITLE
feat(insured-bridge): clean comments, address some todos and general code hygiene

### DIFF
--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgeAdmin.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgeAdmin.sol
@@ -58,7 +58,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
      * @notice Construct the Bridge Admin
      * @param _finder DVM finder to find other UMA ecosystem contracts.
      * @param _crossDomainMessenger Optimism messenger contract used to send messages to L2.
-     * @param _optimisticOracleLiveness Timeout that all bridging actions from L2->L1 must wait for a OO response.
+     * @param _optimisticOracleLiveness Timeout that all bridging actions from L2->L1 must wait for a OptimisticOracle response.
      * @param _proposerBondPct Percentage of the bridged amount that a relayer must put up as a bond.
      * @param _identifier Identifier used when querying the OO for a cross bridge transfer action.
      */

--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgeAdmin.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgeAdmin.sol
@@ -54,8 +54,14 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
         _;
     }
 
-    // TODO: Consider switching to hardcoded OVM_L1CrossDomainMessenger:
-    // https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/deployments/README.md
+    /**
+     * @notice Construct the Bridge Admin
+     * @param _finder DVM finder to find other UMA ecosystem contracts.
+     * @param _crossDomainMessenger Optimism messenger contract used to send messages to L2.
+     * @param _optimisticOracleLiveness Timeout that all bridging actions from L2->L1 must wait for a OO response.
+     * @param _proposerBondPct Percentage of the bridged amount that a relayer must put up as a bond.
+     * @param _identifier Identifier used when querying the OO for a cross bridge transfer action.
+     */
     constructor(
         address _finder,
         address _crossDomainMessenger,
@@ -75,8 +81,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
      **************************************/
 
     /**
-     * @notice Sets new price identifier to use for relayed deposits. BridgePools will read the identifier from this
-     * contract.
+     * @notice Sets a price identifier to use for relayed deposits. BridgePools reads the identifier from this contract.
      * @dev Can only be called by the current owner.
      * @param _identifier New identifier to set.
      */
@@ -85,8 +90,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
     }
 
     /**
-     * @notice Sets challenge period for relayed deposits. BridgePools will read this value from this
-     * contract.
+     * @notice Sets challenge period for relayed deposits. BridgePools will read this value from this contract.
      * @dev Can only be called by the current owner.
      * @param _liveness New OptimisticOracle liveness period to set for relay price requests.
      */
@@ -95,8 +99,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
     }
 
     /**
-     * @notice Sets challenge pereiod for relayed deposits. BridgePools will read this value from this
-     * contract.
+     * @notice Sets challenge period for relayed deposits. BridgePools will read this value from this contract.
      * @dev Can only be called by the current owner.
      * @param _proposerBondPct New OptimisticOracle proposer bond % to set for relay price requests. 1e18 = 100%.
      */
@@ -105,8 +108,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
     }
 
     /**
-     * @notice Privileged account can set L2 deposit contract that originates deposit orders to be fulfilled by this
-     * contract.
+     * @notice Sets the L2 deposit contract that originates deposit orders to be fulfilled by this bridgePool contracts.
      * @dev Only callable by the current owner.
      * @param _depositContract Address of L2 deposit contract.
      */
@@ -149,7 +151,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
 
     /**
      * @notice Owner can pause/unpause L2 deposits for a tokens.
-     * @dev Only callable by the current owner. Will set the same setting in the L2 Deposit contract via the cross
+     * @dev Only callable by Owner of this contract. Will set the same setting in the L2 Deposit contract via the cross
      * domain messenger.
      * @param _l2Token address of L2 token to enable/disable deposits for.
      * @param _depositsEnabled bool to set if the deposit box should accept/reject deposits.
@@ -175,7 +177,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, OVM_CrossDomainEnabled {
      * whitelist the token mapping.
      * @param _l1Token Address of L1 token that can be used to relay L2 token deposits.
      * @param _l2Token Address of L2 token whose deposits are fulfilled by `_l1Token`.
-     * @param _bridgePool Address of BridgePool which manages liquidity to filfill L2-->L1 relays.
+     * @param _bridgePool Address of BridgePool which manages liquidity to fulfill L2-->L1 relays.
      * @param _l2Gas Gas limit to set for relayed message on L2
      */
     function whitelistToken(

--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
@@ -8,6 +8,7 @@ import "../../../contracts/oracle/interfaces/OptimisticOracleInterface.sol";
 import "../../../contracts/oracle/interfaces/StoreInterface.sol";
 import "../../../contracts/oracle/interfaces/FinderInterface.sol";
 import "../../../contracts/oracle/implementation/Constants.sol";
+
 import "../../../contracts/common/implementation/AncillaryData.sol";
 import "../../../contracts/common/implementation/Testable.sol";
 import "../../../contracts/common/implementation/FixedPoint.sol";
@@ -18,8 +19,8 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @notice Contract deployed on L1 that provides methods for "Relayers" to fulfill deposit orders that originated on L2.
- * The Relayers can either post capital to fulfill the deposit instantly, or request that the funds are taken out of
- * a passive liquidity provider pool following a challenge period. Related, this contract ingests liquidity from
+ * The Relayers can either post capital to fulfill the deposit (instant relay), or request that the funds are taken out
+ * of a passive liquidity provider pool following a challenge period (slow relay). This contract ingests liquidity from
  * passive liquidity providers and returns them claims to withdraw their funds. Liquidity providers are incentivized
  * to post collateral by earning a fee per fulfilled deposit order.
  * @dev A "Deposit" is an order to send capital from L2 to L1, and a "Relay" is a fulfillment attempt of that order.
@@ -37,6 +38,9 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     // Reserves currently utilized due to L2-L1 transactions in flight.
     int256 public utilizedReserves;
 
+    // Reserves that are not yet utilized but are in pre-allocated for a not yet finalized relay.
+    uint256 public pendingReserves;
+
     // Exponential decay exchange rate to accumulate fees to LPs over time.
     uint256 public lpFeeRatePerSecond;
 
@@ -49,8 +53,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     // Administrative contract that deployed this contract and also houses all state variables needed to relay deposits.
     BridgeAdminInterface public bridgeAdmin;
 
-    // A Relay represents a an attempt to finalize a cross-chain transfer that originated on an L2 DepositBox contract
-    // and can be bridged via this contract.
+    // A Relay represents an attempt to finalize a cross-chain transfer that originated on an L2 DepositBox contract.
     enum RelayState { Uninitialized, Pending, Disputed, Finalized }
 
     // Data from L2 deposit transaction.
@@ -75,9 +78,9 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         address instantRelayer;
     }
 
-    // Associate deposits with pending relay data. When RelayState is Uninitialized, new relay attempts can be
-    // made for this deposit. Contains information necessary to pay out relayers on successful relay. Deposits get
-    // reset to the "Uninitialized" state when they are disputed on the OptimisticOracle.
+    // Associate deposits with pending relay data. When RelayState is Uninitialized, new relay attempts can be made for
+    // this deposit. Contains information necessary to pay out relayers on successful relay. Deposits get reset to the
+    // "Uninitialized" state when they are disputed on the OptimisticOracle.
     mapping(bytes32 => RelayData) public relays;
 
     // Associates ancillary data related to relay price request with the deposit hash that the relay is attempting to
@@ -86,6 +89,8 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     // actors (validators, DVM voters, etc.) to verify that a relay is valid.
     mapping(bytes32 => bytes32) public ancillaryDataToDepositHash;
 
+    event LiquidityAdded(address indexed token, uint256 amount, uint256 lpTokensMinted, address liquidityProvider);
+    event LiquidityRemoved(address indexed token, uint256 amount, uint256 lpTokensBurnt, address liquidityProvider);
     event DepositRelayed(
         uint64 depositId,
         address indexed sender,
@@ -108,14 +113,21 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         bytes32 indexed priceRequestAncillaryDataHash,
         address indexed caller
     );
-    event LiquidityAdded(address indexed token, uint256 amount, uint256 lpTokensMinted, address liquidityProvider);
-    event LiquidityRemoved(address indexed token, uint256 amount, uint256 lpTokensBurnt, address liquidityProvider);
 
     modifier onlyFromOptimisticOracle() {
         require(msg.sender == address(_getOptimisticOracle()), "Caller must be OptimisticOracle");
         _;
     }
 
+    /**
+     * @notice Construct the Bridge Pool
+     * @param _lpTokenName Name of the LP token to be deployed by this contract.
+     * @param _lpTokenSymbol Symbol of the LP token to be deployed by this contract.
+     * @param _bridgeAdmin Admin contract deployed alongside on L1. Stores global variables and has owner control.
+     * @param _l1Token Address of the L1 token that this bridgePool holds. This is the token LPs deposit and is bridged.
+     * @param _lpFeeRatePerSecond Interest rate payment that scales the amount of pending fees per second paid to LPs.
+     * @param _timer Timer used to synchronize contract time in testing. Set to 0x000... in production.
+     */
     constructor(
         string memory _lpTokenName,
         string memory _lpTokenSymbol,
@@ -137,6 +149,12 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
      *          LIQUIDITY PROVIDER FUNCTIONS         *
      *************************************************/
 
+    /**
+     * @notice Add liquidity to the bridge pool. Pulls l1tokens from the callers wallet. The caller is sent back a
+     * commensurate number of LP tokens (minted to their address) at the prevailing exchange rate.
+     * @dev The caller must approve this contract to transfer `l1TokenAmount` amount of l1Token.
+     * @param l1TokenAmount Number of l1Token to add as liquidity.
+     */
     function addLiquidity(uint256 l1TokenAmount) public {
         l1Token.safeTransferFrom(msg.sender, address(this), l1TokenAmount);
 
@@ -150,10 +168,18 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         emit LiquidityAdded(address(l1Token), l1TokenAmount, lpTokensToMint, msg.sender);
     }
 
+    /**
+     * @notice Removes liquidity to the bridge pool. Burns lpTokenAmount LP tokens from the callers wallet. The caller
+     * is sent back a commensurate number of l1Tokens at the prevailing exchange rate.
+     * @dev The caller does not need to approve the spending of LP tokens as this method directly uses the burn logic.
+     * @param lpTokenAmount Number of lpTokens to redeem for underlying.
+     */
     function removeLiquidity(uint256 lpTokenAmount) public {
-        //TODO: consider pending utilized funds(slow transfers waiting liveness) in allowing withdraws.
         uint256 l1TokensToReturn =
             FixedPoint.Unsigned(lpTokenAmount).mul(FixedPoint.Unsigned(exchangeRateCurrent())).rawValue;
+
+        // Check that there is enough liquid reserves to withdraw the requested amount.
+        require(liquidReserves >= (pendingReserves + l1TokensToReturn), "Utilization too high to remove");
 
         _burn(msg.sender, lpTokenAmount);
 
@@ -169,12 +195,13 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
      **************************************/
 
     /**
-     * @notice Called by Relayer to execute Slow relay from L2 to L1, fulfilling a corresponding deposit order.
+     * @notice Called by Relayer to execute a slow relay from L2 to L1, fulfilling a corresponding deposit order.
      * @dev There can only be one pending relay for a deposit.
      * @dev Caller must have approved this contract to spend the total bond for `l1Token`.
      * @param depositId Unique ID corresponding to deposit order that caller wants to relay.
      * @param depositTimestamp Timestamp of Deposit emitted by L2 contract when order was initiated.
      * @param recipient Address on this network who should receive the relayed deposit.
+     * @param l2Sender Address on the L2 network of depositor.
      * @param amount Amount deposited on L2 to be brought over to L1.
      * @param slowRelayFeePct Max fraction of `amount` that the depositor is willing to pay as a slow relay fee.
      * @param instantRelayFeePct Fraction of `amount` that the depositor is willing to pay as a instant relay fee.
@@ -193,8 +220,8 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         uint64 quoteTimestamp,
         uint64 realizedLpFeePct
     ) public {
-        // The realizedLPFeePct should never be greater than 0.5e18 and the slow and instant relay fees
-        // should never be more than 0.25e18 each.
+        // The realizedLPFeePct should never be greater than 0.5e18 and the slow and instant relay fees should never be
+        // more than 0.25e18 each. Therefore, the sum of all fee types can never exceed 1e18 (or 100%).
         require(slowRelayFeePct < 0.25e18);
         require(instantRelayFeePct < 0.25e18);
         require(realizedLpFeePct < 0.5e18);
@@ -216,7 +243,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         require(
             (relays[depositHash].relayState == RelayState.Uninitialized ||
                 relays[depositHash].relayState == RelayState.Disputed),
-            "Pending undisputed relay for deposit exists"
+            "Deposit already relayed"
         );
 
         // If no pending relay for this deposit, then associate the caller's relay attempt with it. Copy over the
@@ -238,16 +265,21 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
 
         // Sanity check that pool has enough balance to cover relay amount + proposer reward. Reward amount will be
         // paid on settlement after the OptimisticOracle price request has passed the challenge period.
-        require(l1Token.balanceOf(address(this)) >= amount + _getProposerBond(amount), "Insufficient pool balance");
+        require(
+            l1Token.balanceOf(address(this)) >= amount + _getProposerBond(amount) &&
+                liquidReserves >= amount + _getProposerBond(amount),
+            "Insufficient pool balance"
+        );
 
         // Request a price for the relay identifier and propose "true" optimistically. These methods will pull the
-        // (proposer reward + proposer bond + final fee) from the caller.
-        // Note: We need to set a new price request timestamp instead of default setting to equal to the
-        // `depositTimestamp`, which is dependent on the L2 VM on which the DepositContract is deployed. Imagine if
-        // the timestamps on the L2 have an offset that are always "in the future" relative to L1 blocks, then the
-        // OptimisticOracle would always reject requests.
+        // (proposer reward + proposer bond + final fee) from the caller. We need to set a new price request timestamp
+        // instead of default setting to equal to the `depositTimestamp`, which is dependent on the L2 VM on which the
+        // DepositContract is deployed. Imagine if the timestamps on the L2 have an offset that are always "in the
+        // future" relative to L1 blocks, then the OptimisticOracle would always reject requests.
         _requestOraclePriceRelay(amount, priceRequestTime, getRelayAncillaryData(depositData, relayData));
         _proposeOraclePriceRelay(amount, priceRequestTime, getRelayAncillaryData(depositData, relayData));
+
+        pendingReserves += amount; // Book off maximum liquidity used by this relay in the pending reserves.
 
         // We use an internal method to emit this event to overcome Solidity's "stack too deep" error.
         _emitDepositRelayedEvent(
@@ -294,17 +326,16 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         bytes32 depositHash = _getDepositHash(_depositData);
         RelayData storage relay = relays[depositHash];
 
-        require(relays[depositHash].relayState == RelayState.Pending, "State not pending");
         // Note `hasPrice` will return false if liveness has not been passed in the optimistic oracle.
-
         require(
-            _getOptimisticOracle().hasPrice(
-                address(this),
-                bridgeAdmin.identifier(),
-                relay.priceRequestTime,
-                getRelayAncillaryData(_depositData, relay)
-            ),
-            "Price not yet resolved"
+            relays[depositHash].relayState == RelayState.Pending &&
+                _getOptimisticOracle().hasPrice(
+                    address(this),
+                    bridgeAdmin.identifier(),
+                    relay.priceRequestTime,
+                    getRelayAncillaryData(_depositData, relay)
+                ),
+            "Relay not settleable"
         );
 
         // Note: Why don't we have to check the value of the price?
@@ -342,6 +373,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         uint256 totalAmountSent = instantRelayerOrRecipientAmount + slowRelayerAmount;
 
         // Update reserves by amounts changed and allocated LP fees.
+        pendingReserves -= _depositData.amount;
         liquidReserves -= totalAmountSent;
         utilizedReserves += int256(totalAmountSent);
         updateAccumulatedLpFees();
@@ -353,6 +385,10 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     /**
      * @notice OptimisticOracle will callback to this function after a pending relay is disputed. This function should
      * ensure that another slow relayer can fulfill the disputed relay for an L2 deposit.
+     * @param identifier Price identifier used when requesting OO price. Unused.
+     * @param timestamp Unix timestamp of the price request. Unused.
+     * @param ancillaryData AncillaryData of the price request. Use to find the associated disputed relay action.
+     * @param refund Amound refunded for the dispute. Unused.
      */
     function priceDisputed(
         bytes32 identifier,
@@ -363,8 +399,8 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         bytes32 depositHash = ancillaryDataToDepositHash[keccak256(ancillaryData)];
         RelayData storage relay = relays[depositHash];
 
-        // Mark pending relay as disputed but do not delete instant relayer information which should be copied
-        // over to next slow relay.
+        // Mark pending relay as disputed but do not delete instant relayer information which should be copied over to
+        // next slow relay.
         relay.relayState = RelayState.Disputed;
 
         // We do not need to reset the other state in `relay` aside from `instantRelayer` because all of the state

--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
@@ -38,7 +38,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     // Reserves currently utilized due to L2-L1 transactions in flight.
     int256 public utilizedReserves;
 
-    // Reserves that are not yet utilized but are in pre-allocated for a not yet finalized relay.
+    // Reserves that are not yet utilized but are pre-allocated for a pending relay.
     uint256 public pendingReserves;
 
     // Exponential decay exchange rate to accumulate fees to LPs over time.

--- a/packages/core/contracts-ovm/insured-bridge/implementation/OVM_BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/OVM_BridgeDepositBox.sol
@@ -6,8 +6,8 @@ import "../external/OVM_Testable.sol"; //TODO: replace this with the normal UMA 
 import { OVM_CrossDomainEnabled } from "@eth-optimism/contracts/libraries/bridge/OVM_CrossDomainEnabled.sol";
 import { Lib_PredeployAddresses } from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
 
-// Define some interfaces and helper libraries. This is temporary until we can bump the solidity
-// version in these contracts to 0.8.x and import the rest of these libs from other UMA contracts in the repo.
+// Define some interfaces and helper libraries. This is temporary until we can bump the solidity version in these
+// contracts to 0.8.x and import the rest of these libs from other UMA contracts in the repo.
 library TokenHelper {
     function safeTransferFrom(
         address token,
@@ -40,7 +40,7 @@ interface StandardBridgeLike {
 
 /**
  * @title OVM Bridge Deposit Box.
- * @notice Accepts deposits on Optimism L2 to relay to Ethereum L1 as part of the UMA insured relayer system.
+ * @notice Accepts deposits on Optimism L2 to relay to Ethereum L1 as part of the UMA insured bridge system.
  */
 
 contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
@@ -101,7 +101,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
     /**
      * @notice Construct the OVM Bridge Deposit Box
      * @param _bridgeAdmin Address of the cross-chain administrator on L1. This contract deploys new BridgePool
-     * contracts that facilitate withdrawals, and can call permissioned functions on this contract.
+     *    contracts that facilitate withdrawals, and can call permissioned functions on this contract.
      * @param _minimumBridgingDelay Minimum second that must elapse between L2->L1 token transfer to prevent dos.
      * @param timerAddress Timer used to synchronize contract time in testing. Set to 0x000... in production.
      */
@@ -120,7 +120,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
      **************************************/
 
     /**
-     * @notice Changes the L1 administrator associated with this L2 deposit box.
+     * @notice Changes the L1 administrator associated with this L2 deposit deposit box.
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _bridgeAdmin address of the new L1 admin contract.
      */
@@ -177,7 +177,6 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
     /**
      * @notice Called by L2 user to bridge funds between L2 and L1.
      * @dev Emits the `FundsDeposited` event which relayers listen for as part of the bridging action.
-     * @dev Max fee Pct
      * @dev The caller must first approve this contract to spend `amount` of `l2Token`.
      * @param recipient L1 address that should receive the tokens.
      * @param l2Token L2 token to deposit.
@@ -196,6 +195,8 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
         uint64 quoteTimestamp
     ) public onlyIfDepositsEnabled(l2Token) {
         require(isWhitelistToken(l2Token), "deposit token not whitelisted");
+        // We limit the sum of slow and instant relay fees to 50% to prevent the user spending all their funds on fees.
+        // The realizedLPFeePct on L1 is limited to 50% so the total spent on fees does not ever exceed 100%.
         require(slowRelayFeePct <= 0.25e18, "slowRelayFeePct can not exceed 25%");
         require(instantRelayFeePct <= 0.25e18, "instantRelayFeePct can not exceed 25%");
 


### PR DESCRIPTION

**Motivation**

This PR cleans up some stuff in the insured bridge contracts, addresses some outstanding todos and adds some additional code hygiene.

The main(only) logic change in this PR is the introduction of a new state variable in the bridge pool called `pendingReserves`. This variable acts to track _eserves that are not yet utilized but are pre-allocated for a pending relay_. i.e if a relay action has happened, which has used funds, but it is not yet finalized, an LP should not be able to pull out their funds if it will prevent the relay action from finalizing.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


