### PR TITLE
feat(df-pf-configs): Add GASETH-0921 default price feed config

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.ts
+++ b/packages/common/src/PriceIdentifierUtils.ts
@@ -41,6 +41,7 @@ export const OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY = [
   "GASETH-TWAP-1Mx1M",
   "uSTONKS_JUN21",
   "uSTONKS_0921",
+  "GASETH-0921",
 ];
 
 // Any identifier on this list

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
@@ -958,6 +958,12 @@ export const defaultConfigs: { [name: string]: { type: string; [key: string]: an
   "BTC/ibBTC": { type: "expression", expression: "1 / ibBTC\\/BTC" },
   "ibBTC/USD": { type: "expression", expression: "ibBTC\\/BTC * BTCUSD" },
   "USD/ibBTC": { type: "expression", expression: "1 / ibBTC\\/USD" },
+  "GASETH-0921": {
+    type: "uniswap",
+    uniswapAddress: "0x5CCD155ad26B74913ed6266A516A085A2343D426",
+    twapLength: 7200,
+    invertPrice: true,
+  },
 };
 
 // Pull in the number of decimals for each identifier from the common getPrecisionForIdentifier. This is used within the


### PR DESCRIPTION
**Motivation**

The GASETH-0921 price identifier needs a default price feed config and also needs to be ignored by OO bots at expiry.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
NA
