### PR TITLE
feat(common): Ignore Optimistic Oracle requests for identifiers without price feeds

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.ts
+++ b/packages/common/src/PriceIdentifierUtils.ts
@@ -45,4 +45,13 @@ export const OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY = [
 ];
 
 // Any identifier on this list
-export const OPTIMISTIC_ORACLE_IGNORE = ["SPACEXLAUNCH", "uTVL_KPI_UMA"];
+export const OPTIMISTIC_ORACLE_IGNORE = [
+  "SPACEXLAUNCH",
+  "uTVL_KPI_UMA",
+  "DIGG_Positive_Rebases",
+  "uDAO_KPI_UMA",
+  "YES_OR_NO_QUERY",
+  "XSUSHI_APY",
+  "V2migration_KPI_Aragon",
+  "General_KPI",
+];


### PR DESCRIPTION
**Motivation**

Some price identifiers do not have accompanying price feeds and should be ignored by OO bots. 

**Summary**

Adds price identifiers to OPTIMISTIC_ORACLE_IGNORE list.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**

NA
