### PR TITLE
improve(serverless-orchestration): migrate to hardhat

### DIFF
--- a/packages/core/deploy/006_deploy_voting.js
+++ b/packages/core/deploy/006_deploy_voting.js
@@ -11,10 +11,10 @@ const func = async function (hre) {
   const Finder = await deployments.get("Finder");
 
   // Set the GAT percentage to 5%
-  const gatPercentage = { rawValue: web3.utils.toWei("0.05", "ether") };
+  const gatPercentage = { rawValue: hre.web3.utils.toWei("0.05", "ether") };
 
   // Set the inflation rate.
-  const inflationRate = { rawValue: web3.utils.toWei("0.0005", "ether") };
+  const inflationRate = { rawValue: hre.web3.utils.toWei("0.0005", "ether") };
 
   // Set the rewards expiration timeout.
   const rewardsExpirationTimeout = 60 * 60 * 24 * 14; // Two weeks.

--- a/packages/serverless-orchestration/.mocharc.js
+++ b/packages/serverless-orchestration/.mocharc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  timeout: 100000,
+  exit: true,
+};

--- a/packages/serverless-orchestration/hardhat.config.js
+++ b/packages/serverless-orchestration/hardhat.config.js
@@ -1,0 +1,17 @@
+const { getHardhatConfig } = require("@uma/common");
+
+const path = require("path");
+const coreWkdir = path.dirname(require.resolve("@uma/core/package.json"));
+const packageWkdir = path.dirname(require.resolve("@uma/financial-templates-lib/package.json"));
+
+const configOverride = {
+  paths: {
+    root: coreWkdir,
+    sources: `${coreWkdir}/contracts`,
+    artifacts: `${coreWkdir}/artifacts`,
+    cache: `${coreWkdir}/cache`,
+    tests: `${packageWkdir}/test`,
+  },
+};
+
+module.exports = getHardhatConfig(configOverride, coreWkdir);

--- a/packages/serverless-orchestration/hardhat.config.js
+++ b/packages/serverless-orchestration/hardhat.config.js
@@ -14,4 +14,4 @@ const configOverride = {
   },
 };
 
-module.exports = getHardhatConfig(configOverride, coreWkdir);
+module.exports = getHardhatConfig(configOverride, coreWkdir, false);

--- a/packages/serverless-orchestration/package.json
+++ b/packages/serverless-orchestration/package.json
@@ -43,7 +43,7 @@
     "/src/**/*.js"
   ],
   "scripts": {
-    "test": "yarn truffle test test/*.js"
+    "test": "HARDHAT_NETWORK=localhost yarn mocha 'test/**/*.js'"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -1,4 +1,8 @@
-const { toWei, utf8ToHex, padRight } = web3.utils;
+const hre = require("hardhat");
+const { getContract, web3, network } = hre;
+const { assert } = require("chai");
+const Web3 = require("web3");
+const { toWei, utf8ToHex, padRight } = Web3.utils;
 
 // Enables testing http requests to an express server.
 const request = require("supertest");
@@ -11,27 +15,26 @@ const spoke = require("../src/ServerlessSpoke");
 const timeoutSpoke = require("../test-helpers/TimeoutSpokeMock.js");
 
 // Contracts and helpers
-const ExpiringMultiParty = artifacts.require("ExpiringMultiParty");
-const Finder = artifacts.require("Finder");
-const IdentifierWhitelist = artifacts.require("IdentifierWhitelist");
-const TokenFactory = artifacts.require("TokenFactory");
-const Token = artifacts.require("ExpandedERC20");
-const Timer = artifacts.require("Timer");
-const UniswapV2Mock = artifacts.require("UniswapV2Mock");
-const SyntheticToken = artifacts.require("SyntheticToken");
+const ExpiringMultiParty = getContract("ExpiringMultiParty");
+const Finder = getContract("Finder");
+const IdentifierWhitelist = getContract("IdentifierWhitelist");
+const TokenFactory = getContract("TokenFactory");
+const Token = getContract("ExpandedERC20");
+const Timer = getContract("Timer");
+const UniswapV2Mock = getContract("UniswapV2Mock");
+const SyntheticToken = getContract("SyntheticToken");
 
 // Custom winston transport module to monitor winston log outputs
 const winston = require("winston");
 const sinon = require("sinon");
 const { SpyTransport, lastSpyLogIncludes, spyLogIncludes, lastSpyLogLevel } = require("@uma/financial-templates-lib");
-const { ZERO_ADDRESS } = require("@uma/common");
+const { ZERO_ADDRESS, runDefaultFixture } = require("@uma/common");
 
 // Use Ganache to create additional web3 providers with different chain ID's
 const ganache = require("ganache-core");
-const Web3 = require("web3");
 
-contract("ServerlessHub.js", function (accounts) {
-  const contractDeployer = accounts[0];
+describe("ServerlessHub.js", function () {
+  let contractDeployer, accounts;
 
   let collateralToken;
   let syntheticToken;
@@ -69,15 +72,24 @@ contract("ServerlessHub.js", function (accounts) {
     return request(`http://localhost:${port}`).post("/").send(body).set("Accept", "application/json");
   };
 
-  before(async function () {
-    defaultChainId = await web3.eth.getChainId();
+  const startGanacheServer = (chainId, port) => {
+    const node = ganache.server({ _chainIdRpc: chainId });
+    node.listen(port);
+    return new Web3("http://127.0.0.1:" + port);
+  };
 
-    collateralToken = await Token.new("Wrapped Ether", "WETH", 18, { from: contractDeployer });
-    syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18, { from: contractDeployer });
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+    [contractDeployer] = accounts;
+    defaultChainId = await web3.eth.getChainId();
+    await runDefaultFixture(hre);
+
+    collateralToken = await Token.new("Wrapped Ether", "WETH", 18).send({ from: contractDeployer });
+    syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18).send({ from: contractDeployer });
 
     // Create identifier whitelist and register the price tracking ticker with it.
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.addSupportedIdentifier(utf8ToHex("ETH/BTC"));
+    await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex("ETH/BTC")).send({ from: contractDeployer });
   });
 
   beforeEach(async function () {
@@ -100,17 +112,17 @@ contract("ServerlessHub.js", function (accounts) {
       hubSpyLogger, // injected spy logger
       hubTestPort, // port to run the hub on
       `http://localhost:${spokeTestPort}`, // URL to execute spokes on
-      web3.currentProvider.host, // custom node URL to enable the hub to query block numbers.
+      network.config.url, // custom node URL to enable the hub to query block numbers.
       { printHubConfig: true } // set hub config to print config before execution.
     );
 
     const constructorParams = {
       expirationTimestamp: "22345678900",
       withdrawalLiveness: "1000",
-      collateralAddress: collateralToken.address,
-      tokenAddress: syntheticToken.address,
-      finderAddress: (await Finder.deployed()).address,
-      tokenFactoryAddress: (await TokenFactory.deployed()).address,
+      collateralAddress: collateralToken.options.address,
+      tokenAddress: syntheticToken.options.address,
+      finderAddress: (await Finder.deployed()).options.address,
+      tokenFactoryAddress: (await TokenFactory.deployed()).options.address,
       priceFeedIdentifier: padRight(utf8ToHex("ETH/BTC"), 64),
       liquidationLiveness: "1000",
       collateralRequirement: { rawValue: toWei("1.2") },
@@ -118,20 +130,20 @@ contract("ServerlessHub.js", function (accounts) {
       sponsorDisputeRewardPercentage: { rawValue: toWei("0.1") },
       disputerDisputeRewardPercentage: { rawValue: toWei("0.1") },
       minSponsorTokens: { rawValue: toWei("1") },
-      timerAddress: (await Timer.deployed()).address,
+      timerAddress: (await Timer.deployed()).options.address,
       financialProductLibraryAddress: ZERO_ADDRESS,
     };
 
     // Deploy a new expiring multi party
-    emp = await ExpiringMultiParty.new(constructorParams);
+    emp = await ExpiringMultiParty.new(constructorParams).send({ from: contractDeployer });
 
-    uniswap = await UniswapV2Mock.new();
+    uniswap = await UniswapV2Mock.new().send({ from: contractDeployer });
 
     defaultPricefeedConfig = { type: "test", currentPrice: "1", historicalPrice: "1" };
 
     // Set two uniswap prices to give it a little history.
-    await uniswap.setPrice(toWei("1"), toWei("1"));
-    await uniswap.setPrice(toWei("1"), toWei("1"));
+    await uniswap.methods.setPrice(toWei("1"), toWei("1")).send({ from: contractDeployer });
+    await uniswap.methods.setPrice(toWei("1"), toWei("1")).send({ from: contractDeployer });
   });
   afterEach(async function () {
     hubInstance.close();
@@ -175,9 +187,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessMonitor: {
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -211,9 +223,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessMonitor: {
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -231,7 +243,7 @@ contract("ServerlessHub.js", function (accounts) {
       hubSpyLogger, // injected spy logger
       testHubPort, // port to run the hub for this test on
       "http://localhost:11111", // URL to execute spokes on
-      web3.currentProvider.host // custom node URL to enable the hub to query block numbers.
+      network.config.url // custom node URL to enable the hub to query block numbers.
     );
 
     // not a port the spoke is running on. will get rejected
@@ -256,9 +268,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessMonitor: {
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -279,7 +291,7 @@ contract("ServerlessHub.js", function (accounts) {
       hubSpyLogger, // injected spy logger
       testHubPort, // port to run the hub for this test on
       "http://localhost:8083", // URL to execute spokes on
-      web3.currentProvider.host, // custom node URL to enable the hub to query block numbers.
+      network.config.url, // custom node URL to enable the hub to query block numbers.
       { rejectSpokeDelay: 1 }
     );
 
@@ -310,9 +322,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessMonitor: {
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -320,9 +332,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessLiquidator: {
         serverlessCommand: "yarn --silent liquidator --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
           LIQUIDATOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -330,9 +342,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessDisputer: {
         serverlessCommand: "yarn --silent disputer --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
           DISPUTER_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -377,9 +389,9 @@ contract("ServerlessHub.js", function (accounts) {
         // Creates no error.
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -388,9 +400,9 @@ contract("ServerlessHub.js", function (accounts) {
         // Create an error in the execution path. Child process spoke will crash.
         serverlessCommand: "yarn --silent INVALID --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
         },
       },
@@ -398,7 +410,7 @@ contract("ServerlessHub.js", function (accounts) {
         // Create an error in the execution path. Child process will run but will throw an error.
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
           EMP_ADDRESS: "0x0000000000000000000000000000000000000000",
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
@@ -470,9 +482,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessMonitor: {
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -480,9 +492,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessLiquidator: {
         serverlessCommand: "yarn --silent liquidator --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
           LIQUIDATOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -490,9 +502,9 @@ contract("ServerlessHub.js", function (accounts) {
       testServerlessDisputer: {
         serverlessCommand: "yarn --silent disputer --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
           DISPUTER_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -544,19 +556,15 @@ contract("ServerlessHub.js", function (accounts) {
     // Temporarily spin up a new web3 provider with an overridden chain ID. The hub should be able to detect the
     // alternative node URL and fetch its chain ID.
     const alternateChainId = 666;
-    const alternateNode = ganache.server({ _chainIdRpc: alternateChainId });
-    const alternateNodePort = 7777;
-    alternateNode.listen(alternateNodePort);
-    // This server should automatically tear down after the test.
-    const alternateWeb3 = new Web3("http://127.0.0.1:" + alternateNodePort);
+    const alternateWeb3 = startGanacheServer(alternateChainId, 7777);
 
     const hubConfig = {
       testServerlessMonitor: {
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -566,7 +574,7 @@ contract("ServerlessHub.js", function (accounts) {
         environmentVariables: {
           CUSTOM_NODE_URL: alternateWeb3.currentProvider.host,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -576,7 +584,7 @@ contract("ServerlessHub.js", function (accounts) {
         environmentVariables: {
           CUSTOM_NODE_URL: alternateWeb3.currentProvider.host,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -611,9 +619,9 @@ contract("ServerlessHub.js", function (accounts) {
         // Creates no error.
         serverlessCommand: "yarn --silent monitors --network test",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
           MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
         },
@@ -622,9 +630,9 @@ contract("ServerlessHub.js", function (accounts) {
         // Create an error in the execution path. Child process spoke will crash.
         serverlessCommand: "echo ''",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
-          EMP_ADDRESS: emp.address,
+          EMP_ADDRESS: emp.options.address,
           PRICE_FEED_CONFIG: defaultPricefeedConfig,
         },
       },
@@ -632,7 +640,7 @@ contract("ServerlessHub.js", function (accounts) {
         // Create an error in the execution path. Child process will run but will throw an error.
         serverlessCommand: "echo 'something random but not the magic bot start key word'",
         environmentVariables: {
-          CUSTOM_NODE_URL: web3.currentProvider.host,
+          CUSTOM_NODE_URL: network.config.url,
           POLLING_DELAY: 0,
           EMP_ADDRESS: "0x0000000000000000000000000000000000000000",
           PRICE_FEED_CONFIG: defaultPricefeedConfig,

--- a/packages/serverless-orchestration/truffle-config.js
+++ b/packages/serverless-orchestration/truffle-config.js
@@ -1,4 +1,0 @@
-const path = require("path");
-const wkdir = path.dirname(require.resolve("@uma/core/package.json"));
-
-module.exports = require("@uma/common").getTruffleConfig(wkdir);


### PR DESCRIPTION
**Motivation**

All packages should be fully migrated to running on hardhat without the truffle plugin.

**Summary**

These packages still require an external node to be run (either hardhat node or ganache), but they now don't require truffle.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
