### PR TITLE
feat(financial-templates-lib): improve the way alternative nodes are handled in the price feeds

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -52,7 +52,7 @@ export async function createPriceFeed(
   let providedWeb3: Web3;
   if (config.chainId && Number.isInteger(Number(config.chainId))) {
     const nodeUrl = process.env[`NODE_URL_${config.chainId}`];
-    if (!nodeUrl) throw Error(`Expected node url to be provided in env variable ${config.nodeUrlEnvVar}`);
+    if (!nodeUrl) throw Error(`Expected node url to be provided in env variable NODE_URL_${config.chainId}`);
     providedWeb3 = new Web3(nodeUrl);
   } else {
     providedWeb3 = web3;

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -50,8 +50,8 @@ export async function createPriceFeed(
   config: any
 ): Promise<PriceFeedInterface | null> {
   let providedWeb3: Web3;
-  if (config.nodeUrlEnvVar) {
-    const nodeUrl = process.env[config.nodeUrlEnvVar];
+  if (config.chainId && Number.isInteger(Number(config.chainId))) {
+    const nodeUrl = process.env[`NODE_URL_${config.chainId}`];
     if (!nodeUrl) throw Error(`Expected node url to be provided in env variable ${config.nodeUrlEnvVar}`);
     providedWeb3 = new Web3(nodeUrl);
   } else {

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -67,7 +67,8 @@ contract("CreatePriceFeed.js", function (accounts) {
   const contractAddress = "test-address";
   const forexBase = "EUR";
   const forexSymbol = "USD";
-  const nodeUrlEnvVar = "ALT_NODE_URL";
+  const nodeUrlEnvVar = "NODE_URL_1";
+  const chainId = 1;
 
   before(async function () {
     identifierWhitelist = await IdentifierWhitelist.new();
@@ -297,7 +298,7 @@ contract("CreatePriceFeed.js", function (accounts) {
   });
 
   it("Valid Uniswap config with alternate node", async function () {
-    const config = { type: "uniswap", uniswapAddress, twapLength, lookback, nodeUrlEnvVar };
+    const config = { type: "uniswap", uniswapAddress, twapLength, lookback, chainId };
 
     const validUniswapFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
@@ -431,7 +432,7 @@ contract("CreatePriceFeed.js", function (accounts) {
       balancerTokenOut: accounts[2],
       lookback: 7200,
       twapLength: 7200,
-      nodeUrlEnvVar,
+      chainId,
     };
 
     const balancerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
@@ -448,7 +449,7 @@ contract("CreatePriceFeed.js", function (accounts) {
   });
 
   it("Valid Uniswap v3 config with alternate node", async function () {
-    const config = { type: "uniswap", uniswapAddress, twapLength, lookback, version: "v3", nodeUrlEnvVar };
+    const config = { type: "uniswap", uniswapAddress, twapLength, lookback, version: "v3", chainId };
 
     const validUniswapFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
@@ -599,7 +600,7 @@ contract("CreatePriceFeed.js", function (accounts) {
       uniswapAddress,
       twapLength,
       medianizedFeeds: [{ type: "cryptowatch" }, { type: "uniswap" }],
-      nodeUrlEnvVar,
+      chainId,
     };
 
     const validMedianizerFeed = await createPriceFeed(logger, web3, networker, getTime, config);
@@ -778,7 +779,7 @@ contract("CreatePriceFeed.js", function (accounts) {
       lookback,
       minTimeBetweenUpdates,
       customFeeds: { mysymbol: { type: "cryptowatch" } },
-      nodeUrlEnvVar,
+      chainId,
     };
 
     const expressionPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
@@ -836,7 +837,7 @@ contract("CreatePriceFeed.js", function (accounts) {
   });
 
   it("VaultPriceFeed: valid config with alternate node", async function () {
-    const config = { type: "vault", address: web3.utils.randomHex(20), nodeUrlEnvVar };
+    const config = { type: "vault", address: web3.utils.randomHex(20), chainId };
 
     const vaultPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
 
@@ -885,7 +886,7 @@ contract("CreatePriceFeed.js", function (accounts) {
       type: "lp",
       poolAddress: web3.utils.randomHex(20),
       tokenAddress: web3.utils.randomHex(20),
-      nodeUrlEnvVar,
+      chainId,
     };
 
     const lpPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
@@ -952,7 +953,7 @@ contract("CreatePriceFeed.js", function (accounts) {
   it("FundingRateMultiplierPriceFeed: creation succeeds with alternate node", async function () {
     const perpetualAddress = web3.utils.randomHex(20);
     const multicallAddress = web3.utils.randomHex(20);
-    const config = { type: "frm", perpetualAddress, multicallAddress, nodeUrlEnvVar };
+    const config = { type: "frm", perpetualAddress, multicallAddress, chainId };
 
     const frmPriceFeed = await createPriceFeed(logger, web3, networker, getTime, config);
     assert.notEqual(frmPriceFeed.web3, web3);


### PR DESCRIPTION
**Motivation**

We would like to have a more obvious way for users to specify what node they want a price feed connected to.


**Summary**

This PR modifies how the user specifies this by establishing a standard `NODE_URL_[CHAIN_ID]` env variable that users can use to specify the node for a particular chain id. The price feeds will be parameterized with the chain id (`chainId` field) and this url will automatically be used with that feed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A