### PR TITLE
feat(trader): migrate away from truffle

### DIFF
--- a/packages/common/src/HardhatConfig.ts
+++ b/packages/common/src/HardhatConfig.ts
@@ -1,6 +1,8 @@
 import { HardhatConfig } from "hardhat/types";
 
 const { getNodeUrl, mnemonic } = require("./TruffleConfig");
+import { HRE } from "./hardhat/plugins/ExtendedWeb3";
+export type { HRE };
 
 export function getHardhatConfig(
   configOverrides: any,

--- a/packages/common/src/hardhat/plugins/ExtendedWeb3.ts
+++ b/packages/common/src/hardhat/plugins/ExtendedWeb3.ts
@@ -63,7 +63,7 @@ interface OtherExtensions {
   deployments: DeploymentsExtension;
 }
 
-type HRE = Extension & OtherExtensions & HardhatRuntimeEnvironment;
+export type HRE = Extension & OtherExtensions & HardhatRuntimeEnvironment;
 
 extendEnvironment((_hre) => {
   const hre = _hre as HRE;

--- a/packages/trader/.mocharc.js
+++ b/packages/trader/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  timeout: 100000,
+  timeout: 10000,
   require: "ts-node/register",
   exit: true,
 };

--- a/packages/trader/.mocharc.js
+++ b/packages/trader/.mocharc.js
@@ -1,4 +1,5 @@
 module.exports = {
   timeout: 100000,
   require: "ts-node/register",
+  exit: true,
 };

--- a/packages/trader/.mocharc.js
+++ b/packages/trader/.mocharc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  timeout: 100000,
+  require: "ts-node/register",
+};

--- a/packages/trader/hardhat.config.ts
+++ b/packages/trader/hardhat.config.ts
@@ -17,4 +17,4 @@ const configOverride = {
   },
 };
 
-module.exports = getHardhatConfig(configOverride, coreWkdir);
+module.exports = getHardhatConfig(configOverride, coreWkdir, false);

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -39,7 +39,7 @@
   "main": "dist/src/index.js",
   "scripts": {
     "build": "tsc -b",
-    "test": "hardhat test"
+    "test": "mocha test 'test/**/*.ts'"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@types/sinon": "^10.0.0",
     "@uma/common": "^2.6.0",
-    "@uma/core": "^2.7.0",
+    "@uma/contracts-node": "^0.1.0",
     "@uma/financial-templates-lib": "^2.6.1",
     "@umaprotocol/ynatm": "^0.0.1",
     "async-retry": "^1.3.1",

--- a/packages/trader/src/RangeTrader.ts
+++ b/packages/trader/src/RangeTrader.ts
@@ -141,7 +141,7 @@ export class RangeTrader {
     }
 
     // Wait exactly one block to fetch events. This ensures that the events have been indexed by your node.
-    await blockUntilBlockMined(this.web3, (await this.web3.eth.getBlockNumber()) + 1);
+    await blockUntilBlockMined(this.web3, tradeExecutionTransaction.blockNumber);
 
     // Get the post trade spot price to double check deviation error.
     await this.tokenPriceFeed.update();

--- a/packages/trader/src/RangeTrader.ts
+++ b/packages/trader/src/RangeTrader.ts
@@ -141,7 +141,7 @@ export class RangeTrader {
     }
 
     // Wait exactly one block to fetch events. This ensures that the events have been indexed by your node.
-    await blockUntilBlockMined(this.web3, tradeExecutionTransaction.blockNumber);
+    await blockUntilBlockMined(this.web3, Number(tradeExecutionTransaction.blockNumber) + 1);
 
     // Get the post trade spot price to double check deviation error.
     await this.tokenPriceFeed.update();

--- a/packages/trader/src/exchange-adapters/ExchangeAdapterInterface.ts
+++ b/packages/trader/src/exchange-adapters/ExchangeAdapterInterface.ts
@@ -1,5 +1,7 @@
 import BigNumber from "bignumber.js";
+import type { TransactionReceipt } from "web3-core";
+
 export default interface ExchangeAdapterInterface {
   // Take in a desired price and execute the trades required to move the market from the current price to desiredPrice.
-  tradeMarketToDesiredPrice(desiredPrice: BigNumber): Promise<Error | { transactionHash: string; any: any }>;
+  tradeMarketToDesiredPrice(desiredPrice: BigNumber): Promise<Error | TransactionReceipt>;
 }

--- a/packages/trader/src/exchange-adapters/UniswapV2Trader.ts
+++ b/packages/trader/src/exchange-adapters/UniswapV2Trader.ts
@@ -4,11 +4,13 @@ import BigNumber from "bignumber.js";
 
 import { MAX_UINT_VAL } from "@uma/common";
 import ExchangeAdapterInterface from "./ExchangeAdapterInterface";
-import { getTruffleContract } from "@uma/core";
+import { getAbi, getBytecode } from "@uma/contracts-node";
+import type { DSProxyManager } from "@uma/financial-templates-lib";
+import type { TransactionReceipt } from "web3-core";
 
 export class UniswapV2Trader implements ExchangeAdapterInterface {
   readonly tradeDeadline: number;
-  readonly UniswapV2Broker: any;
+  readonly UniswapV2Broker: { abi: any; bytecode: string };
   uniswapPair: any;
 
   constructor(
@@ -18,13 +20,13 @@ export class UniswapV2Trader implements ExchangeAdapterInterface {
     readonly uniswapFactoryAddress: string,
     readonly tokenAAddress: string,
     readonly tokenBAddress: string,
-    readonly dsProxyManager: any
+    readonly dsProxyManager: DSProxyManager
   ) {
     this.tradeDeadline = 10 * 60 * 60;
 
-    this.UniswapV2Broker = getTruffleContract("UniswapV2Broker", this.web3 as any);
+    this.UniswapV2Broker = { abi: getAbi("UniswapV2Broker"), bytecode: getBytecode("UniswapV2Broker") };
   }
-  async tradeMarketToDesiredPrice(desiredPrice: BigNumber) {
+  async tradeMarketToDesiredPrice(desiredPrice: BigNumber): Promise<Error | TransactionReceipt> {
     const callCode = this.UniswapV2Broker.bytecode;
 
     const contract = new this.web3.eth.Contract(this.UniswapV2Broker.abi);

--- a/packages/trader/src/exchange-adapters/UniswapV3Trader.ts
+++ b/packages/trader/src/exchange-adapters/UniswapV3Trader.ts
@@ -4,23 +4,25 @@ import BigNumber from "bignumber.js";
 
 import { encodePriceSqrt } from "@uma/common";
 import ExchangeAdapterInterface from "./ExchangeAdapterInterface";
-import { getTruffleContract } from "@uma/core";
+import { getAbi, getBytecode } from "@uma/contracts-node";
+import type { TransactionReceipt } from "web3-core";
+import type { DSProxyManager } from "@uma/financial-templates-lib";
 
 export class UniswapV3Trader implements ExchangeAdapterInterface {
   readonly tradeDeadline: number;
-  readonly UniswapV3Broker: any;
+  readonly UniswapV3Broker: { abi: any; bytecode: string };
 
   constructor(
     readonly logger: winston.Logger,
     readonly web3: Web3,
     readonly uniswapPoolAddress: string,
     readonly uniswapRouterAddress: string,
-    readonly dsProxyManager: any
+    readonly dsProxyManager: DSProxyManager
   ) {
     this.tradeDeadline = 10 * 60 * 60;
-    this.UniswapV3Broker = getTruffleContract("UniswapV3Broker", this.web3 as any);
+    this.UniswapV3Broker = { abi: getAbi("UniswapV3Broker"), bytecode: getBytecode("UniswapV3Broker") };
   }
-  async tradeMarketToDesiredPrice(desiredPrice: BigNumber) {
+  async tradeMarketToDesiredPrice(desiredPrice: BigNumber): Promise<Error | TransactionReceipt> {
     const callCode = this.UniswapV3Broker.bytecode;
 
     const contract = new this.web3.eth.Contract(this.UniswapV3Broker.abi);

--- a/packages/trader/test/UniswapV2Trader.ts
+++ b/packages/trader/test/UniswapV2Trader.ts
@@ -246,9 +246,12 @@ describe("UniswapV2Trader.js", function () {
     assert.equal(parseFloat(latestWinstonLog.postTradePriceDeviationError.replace("%", "")).toFixed(0), "5");
     // The default configuration for the range trader bot is to trade the price back to 5% off the current reference price.
     // Seeing the reference price is set to 1000, the pool price should now be set to 1050 exactly after the correcting trade.
+
     assert.equal(Number(await getPoolSpotPrice()).toFixed(0), "1050");
     // Equally, the price in the uniswap feed should report a price of 1050.
+
     mockTime = Number((await web3.eth.getBlock("latest")).timestamp) + 1;
+
     await tokenPriceFeed.update();
     assert.equal(Number(fromWei(tokenPriceFeed.getLastBlockPrice())).toFixed(4), await getPoolSpotPrice());
 

--- a/packages/trader/test/UniswapV2Trader.ts
+++ b/packages/trader/test/UniswapV2Trader.ts
@@ -1,6 +1,9 @@
 import winston from "winston";
 import sinon from "sinon";
-import { web3, assert } from "hardhat";
+import hre from "hardhat";
+import type { HRE } from "@uma/common";
+const { web3, getContract } = hre as HRE;
+import { assert } from "chai";
 const { toWei, toBN, fromWei } = web3.utils;
 
 import {
@@ -11,7 +14,6 @@ import {
   GasEstimator,
   UniswapV2PriceFeed,
 } from "@uma/financial-templates-lib";
-import { getTruffleContract } from "@uma/core";
 import { createContractObjectFromJson } from "@uma/common";
 
 // Script to test
@@ -20,10 +22,10 @@ import { RangeTrader } from "../src/RangeTrader";
 // Helper scripts
 import { createExchangeAdapter } from "../src/exchange-adapters/CreateExchangeAdapter";
 
-const Token = getTruffleContract("ExpandedERC20", web3 as any);
-const WETH9 = getTruffleContract("WETH9", web3 as any);
-const DSProxyFactory = getTruffleContract("DSProxyFactory", web3 as any);
-const DSProxy = getTruffleContract("DSProxy", web3 as any);
+const Token = getContract("ExpandedERC20");
+const WETH9 = getContract("WETH9");
+const DSProxyFactory = getContract("DSProxyFactory");
+const DSProxy = getContract("DSProxy");
 
 // Helper Contracts
 import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
@@ -56,8 +58,8 @@ let dsProxyFactory: any;
 
 // Returns the current spot price of a uniswap pool, scaled to 4 decimal points.
 const getPoolSpotPrice = async () => {
-  const poolTokenABalance = await tokenA.balanceOf(pairAddress);
-  const poolTokenBBalance = await tokenB.balanceOf(pairAddress);
+  const poolTokenABalance = toBN(await tokenA.methods.balanceOf(pairAddress).call());
+  const poolTokenBBalance = toBN(await tokenB.methods.balanceOf(pairAddress).call());
   return Number(fromWei(poolTokenABalance.mul(toBN(toWei("1"))).div(poolTokenBBalance))).toFixed(4);
 };
 
@@ -68,33 +70,37 @@ describe("UniswapV2Trader.js", function () {
     trader = accounts[1];
     externalTrader = accounts[2];
 
-    dsProxyFactory = await DSProxyFactory.new();
+    dsProxyFactory = await DSProxyFactory.new().send({ from: deployer });
 
-    WETH = await WETH9.new();
+    WETH = await WETH9.new().send({ from: deployer });
     // deploy Uniswap V2 Factory & router.
-    uniswapFactory = await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer });
-    uniswapRouter = await createContractObjectFromJson(UniswapV2Router02, web3).new(
-      uniswapFactory.address,
-      WETH.address,
-      {
-        from: deployer,
-      }
-    );
+    uniswapFactory = (await createContractObjectFromJson(UniswapV2Factory, web3).new(deployer, { from: deployer }))
+      .contract;
+    uniswapRouter = (
+      await createContractObjectFromJson(UniswapV2Router02, web3).new(
+        uniswapFactory.options.address,
+        WETH.options.address,
+        {
+          from: deployer,
+        }
+      )
+    ).contract;
   });
 
   beforeEach(async function () {
     // deploy traded tokens
-    tokenA = await Token.new("TokenA", "TA", 18);
-    tokenB = await Token.new("TokenB", "TB", 18);
-    if (tokenA.address.toLowerCase() < tokenB.address.toLowerCase()) [tokenA, tokenB] = [tokenB, tokenA];
+    tokenA = await Token.new("TokenA", "TA", 18).send({ from: deployer });
+    tokenB = await Token.new("TokenB", "TB", 18).send({ from: deployer });
+    if (tokenA.options.address.toLowerCase() < tokenB.options.address.toLowerCase())
+      [tokenA, tokenB] = [tokenB, tokenA];
 
-    await tokenA.addMember(1, deployer, { from: deployer });
-    await tokenB.addMember(1, deployer, { from: deployer });
+    await tokenA.methods.addMember(1, deployer).send({ from: deployer });
+    await tokenB.methods.addMember(1, deployer).send({ from: deployer });
 
     // initialize the Uniswap pair
-    await uniswapFactory.createPair(tokenA.address, tokenB.address, { from: deployer });
-    pairAddress = await uniswapFactory.getPair(tokenA.address, tokenB.address);
-    pair = await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress);
+    await uniswapFactory.methods.createPair(tokenA.options.address, tokenB.options.address).send({ from: deployer });
+    pairAddress = await uniswapFactory.methods.getPair(tokenA.options.address, tokenB.options.address).call();
+    pair = (await createContractObjectFromJson(IUniswapV2Pair, web3).at(pairAddress)).contract;
 
     // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston logs.
     spy = sinon.spy(); // Create a new spy for each test.
@@ -130,7 +136,7 @@ describe("UniswapV2Trader.js", function () {
       web3,
       gasEstimator,
       account: trader,
-      dsProxyFactoryAddress: dsProxyFactory.address,
+      dsProxyFactoryAddress: dsProxyFactory.options.address,
       dsProxyFactoryAbi: DSProxyFactory.abi,
       dsProxyAbi: DSProxy.abi,
     });
@@ -142,10 +148,10 @@ describe("UniswapV2Trader.js", function () {
 
     const exchangeAdapterConfig = {
       type: "uniswap-v2",
-      tokenAAddress: tokenA.address,
-      tokenBAddress: tokenB.address,
-      uniswapRouterAddress: uniswapRouter.address,
-      uniswapFactoryAddress: uniswapFactory.address,
+      tokenAAddress: tokenA.options.address,
+      tokenBAddress: tokenB.options.address,
+      uniswapRouterAddress: uniswapRouter.options.address,
+      uniswapFactoryAddress: uniswapFactory.options.address,
     };
 
     exchangeAdapter = await createExchangeAdapter(spyLogger, web3, dsProxyManager, exchangeAdapterConfig, 0);
@@ -154,24 +160,24 @@ describe("UniswapV2Trader.js", function () {
     rangeTrader = new RangeTrader(spyLogger, web3, tokenPriceFeed, referencePriceFeed, exchangeAdapter, {});
 
     // Seed the dsProxy wallet.
-    await tokenA.mint(traderDSProxyAddress, toWei("100000000000000"));
-    await tokenB.mint(traderDSProxyAddress, toWei("100000000000000"));
+    await tokenA.methods.mint(traderDSProxyAddress, toWei("100000000000000")).send({ from: deployer });
+    await tokenB.methods.mint(traderDSProxyAddress, toWei("100000000000000")).send({ from: deployer });
 
     // Seed the externalTrader who is used to move the market around.
-    await tokenA.mint(externalTrader, toWei("100000000000000"));
-    await tokenB.mint(externalTrader, toWei("100000000000000"));
-    await tokenA.approve(uniswapRouter.address, toWei("100000000000000"), {
+    await tokenA.methods.mint(externalTrader, toWei("100000000000000")).send({ from: deployer });
+    await tokenB.methods.mint(externalTrader, toWei("100000000000000")).send({ from: deployer });
+    await tokenA.methods.approve(uniswapRouter.options.address, toWei("100000000000000")).send({
       from: externalTrader,
     });
-    await tokenB.approve(uniswapRouter.address, toWei("100000000000000"), {
+    await tokenB.methods.approve(uniswapRouter.options.address, toWei("100000000000000")).send({
       from: externalTrader,
     });
 
     // For these test, say the synthetic starts trading at uniswap at 1000 TokenA/TokenB. To set this up we will seed the
     // pair with 1000x units of TokenA, relative to TokenB.
-    await tokenA.mint(pairAddress, toBN(toWei("1000")).muln(10000000));
-    await tokenB.mint(pairAddress, toBN(toWei("1")).muln(10000000));
-    await pair.sync({ from: deployer });
+    await tokenA.methods.mint(pairAddress, toBN(toWei("1000")).muln(10000000)).send({ from: deployer });
+    await tokenB.methods.mint(pairAddress, toBN(toWei("1")).muln(10000000)).send({ from: deployer });
+    await pair.methods.sync().send({ from: deployer });
     mockTime = Number((await web3.eth.getBlock("latest")).timestamp) + 1;
     referencePriceFeed.setCurrentPrice(toWei("1000"));
     await tokenPriceFeed.update();
@@ -199,14 +205,15 @@ describe("UniswapV2Trader.js", function () {
 
     // For this trade, swap a large number of tokenA into the pool for token B. This should push up the price. A trade of
     // 1.5 billion token B should increase the price by ~ 321 USD, resiting in a price of ~1351
-    await uniswapRouter.swapExactTokensForTokens(
-      toBN(toWei("1500000000")), // amountIn. We are selling tokenA for tokenB, therefore tokenA is "in" and tokenB is "out"
-      0, // amountOutMin
-      [tokenA.address, tokenB.address], // path. We are trading from tokenA to tokenB (selling A for B)
-      externalTrader, // recipient of the trade
-      Number((await web3.eth.getBlock("latest")).timestamp) + 10, // deadline
-      { from: externalTrader }
-    );
+    await uniswapRouter.methods
+      .swapExactTokensForTokens(
+        toBN(toWei("1500000000")), // amountIn. We are selling tokenA for tokenB, therefore tokenA is "in" and tokenB is "out"
+        0, // amountOutMin
+        [tokenA.options.address, tokenB.options.address], // path. We are trading from tokenA to tokenB (selling A for B)
+        externalTrader, // recipient of the trade
+        Number((await web3.eth.getBlock("latest")).timestamp) + 10 // deadline
+      )
+      .send({ from: externalTrader });
 
     // Double check the market moved correctly and that the uniswap Price feed correctly reports the price.
     const currentSpotPrice = Number(await getPoolSpotPrice());

--- a/packages/trader/truffle-config.js
+++ b/packages/trader/truffle-config.js
@@ -1,4 +1,0 @@
-const path = require("path");
-const wkdir = path.dirname(require.resolve("@uma/core/package.json"));
-
-module.exports = require("@uma/common").getTruffleConfig(wkdir);


### PR DESCRIPTION
**Motivation**

Migrate trader off of truffle.

**Summary**

Similar to other PRs, this moves off of any direct dependence on truffle. All tests can be run with mocha (which uses pulls in hardhat under the hood).

Note: there were a few minor source code changes required to get this to work.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
