### PR TITLE
improve(sdk): remove @uma/core references from sdk package

### DIFF
--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -119,7 +119,7 @@ export default async (env: ProcessEnv) => {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     blocks: Services.Blocks(undefined, appState),
     emps: Services.EmpState({ debug }, appState),
-    registry: Services.Registry({ debug }, appState),
+    registry: await Services.Registry({ debug }, appState),
     collateralPrices: Services.CollateralPrices({ debug }, appState),
     syntheticPrices: Services.SyntheticPrices(
       {
@@ -134,7 +134,7 @@ export default async (env: ProcessEnv) => {
     erc20s: Services.Erc20s({ debug }, appState),
     empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, appState),
-    lspCreator: Services.MultiLspCreator({ debug, addresses: lspCreatorAddresses }, appState),
+    lspCreator: await Services.MultiLspCreator({ debug, addresses: lspCreatorAddresses }, appState),
     lsps: Services.LspState({ debug }, appState),
     lspStats: Services.stats.Lsp({ debug }, appState),
     globalStats: Services.stats.Global({ debug }, appState),

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -9,10 +9,10 @@ interface Config extends BaseConfig {
 }
 type Dependencies = Pick<AppState, "registeredEmps" | "provider">;
 
-export default (config: Config, appState: Dependencies) => {
+export default async (config: Config, appState: Dependencies) => {
   const { network = 1 } = config;
   const { registeredEmps, provider } = appState;
-  const address = registry.getAddress(network);
+  const address = await registry.getAddress(network);
   const contract = registry.connect(address, provider);
 
   async function update(startBlock?: number | "latest", endBlock?: number) {

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -10,8 +10,8 @@ interface Config extends BaseConfig {
 }
 type Dependencies = Pick<AppState, "registeredLsps" | "provider">;
 
-export default (config: Config, appState: Dependencies) => {
-  const { network = 1, address = lspCreator.getAddress(network) } = config;
+export default async (config: Config, appState: Dependencies) => {
+  const { network = 1, address = await lspCreator.getAddress(network) } = config;
   const { registeredLsps, provider } = appState;
 
   const contract = lspCreator.connect(address, provider);

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -12,11 +12,11 @@ interface Config extends BaseConfig {
 }
 type Dependencies = Pick<AppState, "registeredLsps" | "provider">;
 
-export default (config: Config, appState: Dependencies) => {
+export default async (config: Config, appState: Dependencies) => {
   const { addresses = [], network = 1 } = config;
 
   // always include latest known address
-  const latestAddress = lspCreator.getAddress(network);
+  const latestAddress = await lspCreator.getAddress(network);
 
   // make sure we dont have duplicate addresses ( case sensitive)
   const allAddresses = Array.from(new Set([...addresses, latestAddress]));

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,7 +37,7 @@
     }
   ],
   "dependencies": {
-    "@uma/core": "^2.7.0",
+    "@uma/contracts-node": "^0.1.0",
     "ethers": "^5.4.2",
     "highland": "^2.13.5"
   },

--- a/packages/sdk/src/clients/emp/client.ts
+++ b/packages/sdk/src/clients/emp/client.ts
@@ -1,10 +1,10 @@
-import { EthersContracts } from "@uma/core";
+import { ExpiringMultiPartyEthers, ExpiringMultiPartyEthers__factory } from "@uma/contracts-node";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 import { Balances } from "../../utils";
 
-export type Instance = EthersContracts.ExpiringMultiParty;
-const Factory = EthersContracts.ExpiringMultiParty__factory;
+export type Instance = ExpiringMultiPartyEthers;
+const Factory = ExpiringMultiPartyEthers__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return Factory.connect(address, provider);

--- a/packages/sdk/src/clients/erc20/client.ts
+++ b/packages/sdk/src/clients/erc20/client.ts
@@ -1,11 +1,11 @@
-import { EthersContracts } from "@uma/core";
+import { ERC20Ethers, ERC20Ethers__factory } from "@uma/contracts-node";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 import { Balances } from "../../utils";
 import { set } from "lodash";
 
-export type Instance = EthersContracts.ERC20;
-const Factory = EthersContracts.ERC20__factory;
+export type Instance = ERC20Ethers;
+const Factory = ERC20Ethers__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return Factory.connect(address, provider);

--- a/packages/sdk/src/clients/lsp-creator/client.e2e.ts
+++ b/packages/sdk/src/clients/lsp-creator/client.e2e.ts
@@ -6,9 +6,9 @@ import { ethers } from "ethers";
 // these require integration testing, skip for ci
 describe("lsp creator", function () {
   let client: Client.Instance;
-  test("inits", function () {
+  test("inits", async function () {
     const provider = ethers.providers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
-    const address = Client.getAddress("1");
+    const address = await Client.getAddress("1");
     client = Client.connect(address, provider);
     assert.ok(client);
   });

--- a/packages/sdk/src/clients/lsp-creator/client.ts
+++ b/packages/sdk/src/clients/lsp-creator/client.ts
@@ -1,23 +1,24 @@
-import assert from "assert";
-import { EthersContracts } from "@uma/core";
-import Artifacts from "@uma/core/build/contracts/LongShortPairCreator.json";
+import {
+  LongShortPairCreatorEthers,
+  LongShortPairCreatorEthers__factory,
+  getAbi as getAbiForContract,
+  getAddress as getAddressForContract,
+} from "@uma/contracts-node";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 
 // exporting Registry type in case its needed
-export type Instance = EthersContracts.LongShortPairCreator;
-const Factory = EthersContracts.LongShortPairCreator__factory;
+export type Instance = LongShortPairCreatorEthers;
+const Factory = LongShortPairCreatorEthers__factory;
 
-export type Network = keyof typeof Artifacts.networks;
+export type Network = string | number;
 
-export function getAddress(network: Network): string {
-  const address = Artifacts?.networks?.[network]?.address;
-  assert(address, "no address found for network: " + network);
-  return address;
+export function getAddress(network: Network): Promise<string> {
+  return getAddressForContract("LongShortPairCreator", Number(network));
 }
 
 export function getAbi() {
-  return Artifacts?.abi;
+  return getAbiForContract("LongShortPairCreator");
 }
 
 export function connect(address: string, provider: SignerOrProvider): Instance {

--- a/packages/sdk/src/clients/lsp/client.ts
+++ b/packages/sdk/src/clients/lsp/client.ts
@@ -1,10 +1,10 @@
-import { EthersContracts } from "@uma/core";
+import { LongShortPairEthers, LongShortPairEthers__factory } from "@uma/contracts-node";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 import { Balances } from "../../utils";
 
-export type Instance = EthersContracts.LongShortPair;
-const Factory = EthersContracts.LongShortPair__factory;
+export type Instance = LongShortPairEthers;
+const Factory = LongShortPairEthers__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return Factory.connect(address, provider);

--- a/packages/sdk/src/clients/multicall/client.ts
+++ b/packages/sdk/src/clients/multicall/client.ts
@@ -1,8 +1,8 @@
-import { EthersContracts } from "@uma/core";
+import { MulticallEthers, MulticallEthers__factory } from "@uma/contracts-node";
 import type { SignerOrProvider } from "../..";
 
-export type Instance = EthersContracts.Multicall;
-const Factory = EthersContracts.Multicall__factory;
+export type Instance = MulticallEthers;
+const Factory = MulticallEthers__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return Factory.connect(address, provider);

--- a/packages/sdk/src/clients/multicall2/client.ts
+++ b/packages/sdk/src/clients/multicall2/client.ts
@@ -1,8 +1,8 @@
-import { EthersContracts } from "@uma/core";
+import { Multicall2Ethers, Multicall2Ethers__factory } from "@uma/contracts-node";
 import type { SignerOrProvider } from "../..";
 
-export type Instance = EthersContracts.Multicall2;
-const Factory = EthersContracts.Multicall2__factory;
+export type Instance = Multicall2Ethers;
+const Factory = Multicall2Ethers__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return Factory.connect(address, provider);

--- a/packages/sdk/src/clients/registry/README.md
+++ b/packages/sdk/src/clients/registry/README.md
@@ -12,7 +12,7 @@ import uma from "@uma/sdk"
 const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL)
 
 // get the contract instance, address lookup happens based on network (1)
-const registryAddress = uma.clients.registry.getAddress("1")
+const registryAddress = await uma.clients.registry.getAddress("1")
 const registryInstance: uma.clients.registry.Instance = uma.clients.registry.connect(address, provider)
 // get all contract registered events, using standard ethers API
 const registryEvents = await registryInstance.queryFilter(

--- a/packages/sdk/src/clients/registry/client.e2e.ts
+++ b/packages/sdk/src/clients/registry/client.e2e.ts
@@ -6,9 +6,9 @@ import { ethers } from "ethers";
 // these require integration testing, skip for ci
 describe("emp registry client", function () {
   let client: Client.Instance;
-  test("inits", function () {
+  test("inits", async function () {
     const provider = ethers.providers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
-    const address = Client.getAddress("1");
+    const address = await Client.getAddress("1");
     client = Client.connect(address, provider);
     assert.ok(client);
   });

--- a/packages/sdk/src/clients/registry/client.ts
+++ b/packages/sdk/src/clients/registry/client.ts
@@ -1,18 +1,14 @@
-import { EthersContracts } from "@uma/core";
-import assert from "assert";
-import RegistryArtifacts from "@uma/core/build/contracts/Registry.json";
+import { RegistryEthers, RegistryEthers__factory, getAddress as getAddressForContract } from "@uma/contracts-node";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event } from "ethers";
 
-export type Instance = EthersContracts.Registry;
-const Factory = EthersContracts.Registry__factory;
+export type Instance = RegistryEthers;
+const Factory = RegistryEthers__factory;
 
-export type Network = keyof typeof RegistryArtifacts.networks;
+export type Network = string | number;
 
-export function getAddress(network: Network): string {
-  const address = RegistryArtifacts?.networks?.[network]?.address;
-  assert(address, "no address found for network: " + network);
-  return address;
+export function getAddress(network: Network): Promise<string> {
+  return getAddressForContract("Registry", Number(network));
 }
 
 export function connect(address: string, provider: SignerOrProvider): Instance {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,7 +6,7 @@ export { default as Coingecko } from "./coingecko";
 export { default as Multicall } from "./multicall";
 
 // types
-import type { TypedEventFilter, TypedEvent } from "@uma/core/types/contract-types/ethers/commons";
+import type { TypedEventFilterEthers as TypedEventFilter, TypedEventEthers as TypedEvent } from "@uma/contracts-node";
 import { Contract } from "ethers";
 import { Result } from "@ethersproject/abi";
 import { Signer } from "@ethersproject/abstract-signer";


### PR DESCRIPTION
**Motivation**

We want to remove all uses of the core artifacts directly (or through the old get* methods in core) to allow us to remove the truffle build from core.

**Summary**

This removes all direct references to core in the sdk package.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
