### PR TITLE
improve(api): add created timestamp for LSPs

### DIFF
--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -103,6 +103,7 @@ export default async (env: ProcessEnv) => {
     registeredEmps: new Set<string>(),
     registeredEmpsMetadata: new Map(),
     registeredLsps: new Set<string>(),
+    registeredLspsMetadata: new Map(),
     collateralAddresses: new Set<string>(),
     syntheticAddresses: new Set<string>(),
     // lsp related props. could be its own state object

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -108,6 +108,7 @@ export type AppState = {
   registeredEmps: Set<string>;
   registeredEmpsMetadata: Map<string, { blockNumber: number }>;
   registeredLsps: Set<string>;
+  registeredLspsMetadata: Map<string, { blockNumber: number }>;
   provider: Provider;
   web3: Web3;
   lastBlockUpdate: number;

--- a/packages/api/src/services/lsp-state.e2e.ts
+++ b/packages/api/src/services/lsp-state.e2e.ts
@@ -11,7 +11,14 @@ import "mocha";
 
 type Dependencies = Pick<
   AppState,
-  "lsps" | "registeredLsps" | "provider" | "collateralAddresses" | "shortAddresses" | "longAddresses" | "multicall"
+  | "lsps"
+  | "registeredLsps"
+  | "provider"
+  | "collateralAddresses"
+  | "shortAddresses"
+  | "longAddresses"
+  | "multicall"
+  | "registeredLspsMetadata"
 >;
 
 // this contract updated to have pairName                                 // does not have pairname
@@ -37,6 +44,7 @@ describe("lsp-state service", function () {
         active: lsps.JsMap("Active LSP"),
         expired: lsps.JsMap("Expired LSP"),
       },
+      registeredLspsMetadata: new Map(),
     };
   });
   it("init", async function () {

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -10,7 +10,7 @@ interface Config extends BaseConfig {
   network?: number;
   debug?: boolean;
 }
-type Dependencies = Pick<AppState, "registeredLsps" | "provider">;
+type Dependencies = Pick<AppState, "registeredLsps" | "provider" | "registeredLspsMetadata">;
 
 export default async (config: Config, appState: Dependencies) => {
   const { addresses = [], network = 1 } = config;

--- a/packages/api/src/tables/lsps/js-map.ts
+++ b/packages/api/src/tables/lsps/js-map.ts
@@ -12,9 +12,14 @@ export const Table = (type = "LSP") => {
     return table.update(id, { sponsors: Array.from(set.values()) });
   }
 
+  async function setCreatedTimestamp(id: string, timestamp: number) {
+    return table.update(id, { createdTimestamp: timestamp });
+  }
+
   return {
     ...table,
     addSponsors,
+    setCreatedTimestamp,
   };
 };
 // want to export the type as the same name

--- a/packages/api/src/tables/lsps/utils.ts
+++ b/packages/api/src/tables/lsps/utils.ts
@@ -32,4 +32,5 @@ export type Data = {
   collateralDecimals?: number | null;
   longTokenDecimals?: number | null;
   shortTokenDecimals?: number | null;
+  createdTimestamp?: number | null;
 };

--- a/packages/sdk/src/clients/lsp-creator/client.ts
+++ b/packages/sdk/src/clients/lsp-creator/client.ts
@@ -29,7 +29,7 @@ export type CreatedLongShortPair = GetEventType<Instance, "CreatedLongShortPair"
 
 export interface EventState {
   contracts?: {
-    [lspAddress: string]: CreatedLongShortPair["args"];
+    [lspAddress: string]: CreatedLongShortPair;
   };
 }
 
@@ -42,7 +42,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         ...state,
         contracts: {
           ...contracts,
-          [typedEvent.args.longShortPair]: typedEvent.args,
+          [typedEvent.args.longShortPair]: typedEvent,
         },
       };
     }


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2281/add-created-timestamp-to-lsp-contracts-in-sdk

**Summary**

The api now holds additional info about the created event for LSPs contract. Based on the event's block number we are now able to serve the created timestamp for this type of financial contract


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


