### PR TITLE
feat(monitors): remove all truffle dependencies

### DIFF
--- a/packages/core/scripts/BuildContractVersionHashes.js
+++ b/packages/core/scripts/BuildContractVersionHashes.js
@@ -1,3 +1,4 @@
+const { getContract, web3 } = require("hardhat");
 const assert = require("assert");
 const path = require("path");
 const fs = require("fs");
@@ -9,8 +10,11 @@ const { getTruffleContract } = require("../dist/index.js");
 
 const buildVersion = "2.0.1"; // this is the version that will be built and appended to the FindContractVersion util.
 
-async function buildHashes(contractType) {
+async function buildHashes(contractType, hardhat = false) {
   assert(contractType == "Perpetual" || contractType == "ExpiringMultiParty", "Invalid contract type defined!");
+
+  // We can drop the rest of this script once we no longer have truffle-hardhat fusion tests.
+  if (hardhat) return soliditySha3(getContract(contractType).deployedBytecode);
 
   const contractCreator = (await web3.eth.getAccounts())[0];
 
@@ -117,8 +121,10 @@ async function main() {
   const contractHashesToGenerate = ["Perpetual", "ExpiringMultiParty"];
   let versionMap = {};
   for (const contractType of contractHashesToGenerate) {
-    const contractHash = await buildHashes(contractType);
-    versionMap[contractHash] = { contractType, contractVersion: buildVersion };
+    const truffleContractHash = await buildHashes(contractType);
+    versionMap[truffleContractHash] = { contractType, contractVersion: buildVersion };
+    const hardhatContractHash = await buildHashes(contractType, true);
+    versionMap[hardhatContractHash] = { contractType, contractVersion: buildVersion };
   }
   console.log("versionMap", versionMap);
   saveContractHashArtifacts(versionMap);

--- a/packages/monitors/.mocharc.js
+++ b/packages/monitors/.mocharc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  timeout: 10000,
+};

--- a/packages/monitors/hardhat.config.js
+++ b/packages/monitors/hardhat.config.js
@@ -14,4 +14,4 @@ const configOverride = {
   },
 };
 
-module.exports = getHardhatConfig(configOverride, coreWkdir);
+module.exports = getHardhatConfig(configOverride, coreWkdir, false);

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -26,7 +26,8 @@ const { CRMonitor } = require("./src/CRMonitor");
 const { SyntheticPegMonitor } = require("./src/SyntheticPegMonitor");
 
 // Contract ABIs and network Addresses.
-const { getAbi, getAddress, findContractVersion } = require("@uma/core");
+const { findContractVersion } = require("@uma/core");
+const { getAbi, getAddress } = require("@uma/contracts-node");
 const { getWeb3, SUPPORTED_CONTRACT_VERSIONS, PublicNetworks } = require("@uma/common");
 
 /**
@@ -130,7 +131,7 @@ async function run({
         );
 
       // Setup contract instances.
-      const voting = new web3.eth.Contract(getAbi("Voting", "1.2.2"), getAddress("Voting", networkId));
+      const voting = new web3.eth.Contract(getAbi("Voting"), getAddress("Voting", networkId));
       const financialContract = new web3.eth.Contract(
         getAbi(monitorConfig.contractType, monitorConfig.contractVersion),
         financialContractAddress

--- a/packages/monitors/package.json
+++ b/packages/monitors/package.json
@@ -8,11 +8,13 @@
   "dependencies": {
     "@uma/common": "^2.6.0",
     "@uma/core": "^2.7.0",
+    "@uma/contracts-node": "^0.1.0",
     "@uma/financial-templates-lib": "^2.6.1",
     "async-retry": "^1.3.1",
     "dotenv": "^6.2.0"
   },
   "devDependencies": {
+    "@uma/contracts-node-0-1-0": "npm:@uma/contracts-node@0.1.0",
     "sinon": "^9.0.2",
     "truffle": "^5.2.3",
     "winston": "^3.2.1"
@@ -30,7 +32,7 @@
   ],
   "bin": "index.js",
   "scripts": {
-    "test": "hardhat test"
+    "test": "mocha 'test/**/*.js'"
   },
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -9,7 +9,7 @@ const {
   createFormatFunction,
   ConvertDecimals,
 } = require("@uma/common");
-const { getAbi } = require("@uma/core");
+const { getAbi } = require("@uma/contracts-node");
 
 class OptimisticOracleContractMonitor {
   /**

--- a/packages/monitors/test/BalanceMonitor.js
+++ b/packages/monitors/test/BalanceMonitor.js
@@ -1,3 +1,5 @@
+const { web3, getContract } = require("hardhat");
+const { assert } = require("chai");
 const { toWei, toBN } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
@@ -17,19 +19,23 @@ const {
   lastSpyLogLevel,
 } = require("@uma/financial-templates-lib");
 
-// Truffle artifacts
-const Token = artifacts.require("ExpandedERC20");
+const Token = getContract("ExpandedERC20");
 
 const Convert = (decimals) => (number) => parseFixed(number.toString(), decimals).toString();
 
-contract("BalanceMonitor.js", function (accounts) {
+describe("BalanceMonitor.js", function () {
+  let accounts;
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+  });
+
   for (const [index, testConfig] of TEST_DECIMAL_COMBOS.entries()) {
     describe(`${testConfig.collateralDecimals} collateral & ${testConfig.syntheticDecimals} synthetic decimals`, function () {
       // Note that we offset the accounts used in each test so they start with a full ether balance at the start.
       // This ensures the tests are decoupled.
-      const tokenCreator = accounts[0 + index];
-      const liquidatorBot = accounts[1 + index];
-      const disputerBot = accounts[2 + index];
+      let tokenCreator;
+      let liquidatorBot;
+      let disputerBot;
 
       // Contracts
       let collateralToken;
@@ -45,18 +51,24 @@ contract("BalanceMonitor.js", function (accounts) {
 
       let convertDecimals;
 
+      before(function () {
+        tokenCreator = accounts[0 + index];
+        liquidatorBot = accounts[1 + index];
+        disputerBot = accounts[2 + index];
+      });
+
       beforeEach(async function () {
         convertDecimals = Convert(testConfig.collateralDecimals);
 
         // Create new tokens for every test to reset balances of all accounts
-        collateralToken = await Token.new("Wrapped Ether", "WETH", testConfig.collateralDecimals, {
+        collateralToken = await Token.new("Wrapped Ether", "WETH", testConfig.collateralDecimals).send({
           from: tokenCreator,
         });
-        await collateralToken.addMember(1, tokenCreator, { from: tokenCreator });
-        syntheticToken = await Token.new("Test Synthetic Token", "SYNTH", testConfig.syntheticDecimals, {
+        await collateralToken.methods.addMember(1, tokenCreator).send({ from: tokenCreator });
+        syntheticToken = await Token.new("Test Synthetic Token", "SYNTH", testConfig.syntheticDecimals).send({
           from: tokenCreator,
         });
-        await syntheticToken.addMember(1, tokenCreator, { from: tokenCreator });
+        await syntheticToken.methods.addMember(1, tokenCreator).send({ from: tokenCreator });
 
         // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston
         // logs the correct text based on interactions with the financialContract. Note that only `info` level messages are captured.
@@ -69,8 +81,8 @@ contract("BalanceMonitor.js", function (accounts) {
           spyLogger,
           Token.abi,
           web3,
-          collateralToken.address,
-          syntheticToken.address
+          collateralToken.options.address,
+          syntheticToken.options.address
         );
 
         // Create two bot objects to monitor a liquidator bot with a lot of tokens and Eth and a disputer with less.
@@ -94,8 +106,8 @@ contract("BalanceMonitor.js", function (accounts) {
         };
 
         financialContractProps = {
-          collateralSymbol: await collateralToken.symbol(),
-          syntheticSymbol: await syntheticToken.symbol(),
+          collateralSymbol: await collateralToken.methods.symbol().call(),
+          syntheticSymbol: await syntheticToken.methods.symbol().call(),
           collateralDecimals: testConfig.collateralDecimals,
           syntheticDecimals: testConfig.syntheticDecimals,
           networkId: await web3.eth.net.getId(),
@@ -110,12 +122,12 @@ contract("BalanceMonitor.js", function (accounts) {
 
         // setup the positions to the initial happy state.
         // Liquidator threshold is 10000 for both collateral and synthetic so mint a bit more to start above this
-        await collateralToken.mint(liquidatorBot, convertDecimals("11000"), { from: tokenCreator });
-        await syntheticToken.mint(liquidatorBot, convertDecimals("11000"), { from: tokenCreator });
+        await collateralToken.methods.mint(liquidatorBot, convertDecimals("11000")).send({ from: tokenCreator });
+        await syntheticToken.methods.mint(liquidatorBot, convertDecimals("11000")).send({ from: tokenCreator });
 
         // Disputer threshold is 500 and 100 for collateral and synthetics. mint collateral above this and synthetic at this
-        await collateralToken.mint(disputerBot, convertDecimals("600"), { from: tokenCreator });
-        await syntheticToken.mint(disputerBot, convertDecimals("100"), { from: tokenCreator });
+        await collateralToken.methods.mint(disputerBot, convertDecimals("600")).send({ from: tokenCreator });
+        await syntheticToken.methods.mint(disputerBot, convertDecimals("100")).send({ from: tokenCreator });
       });
 
       it("Correctly emits messages on token balances threshold", async function () {
@@ -128,8 +140,11 @@ contract("BalanceMonitor.js", function (accounts) {
 
         // Transfer some tokens away from one of the monitored addresses and check that the bot correctly reports this.
         // Transferring 2000 tokens from the liquidatorBot brings its balance to 9000. this is below the 10000 threshold.
-        await collateralToken.transfer(tokenCreator, convertDecimals("2000"), { from: liquidatorBot });
-        assert.equal((await collateralToken.balanceOf(liquidatorBot)).toString(), convertDecimals("9000"));
+        await collateralToken.methods.transfer(tokenCreator, convertDecimals("2000")).send({ from: liquidatorBot });
+        assert.equal(
+          (await collateralToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("9000")
+        );
         await tokenBalanceClient.update();
         await balanceMonitor.checkBotBalances();
 
@@ -151,8 +166,11 @@ contract("BalanceMonitor.js", function (accounts) {
         assert.equal(spy.callCount, 2);
 
         // Likewise a further drop in collateral should emit a new message.
-        await collateralToken.transfer(tokenCreator, convertDecimals("2000"), { from: liquidatorBot });
-        assert.equal((await collateralToken.balanceOf(liquidatorBot)).toString(), convertDecimals("7000"));
+        await collateralToken.methods.transfer(tokenCreator, convertDecimals("2000")).send({ from: liquidatorBot });
+        assert.equal(
+          (await collateralToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("7000")
+        );
         await tokenBalanceClient.update();
         await balanceMonitor.checkBotBalances();
         assert.equal(spy.callCount, 3);
@@ -160,9 +178,9 @@ contract("BalanceMonitor.js", function (accounts) {
         // Dropping the synthetic below the threshold of the disputer should fire a message. The disputerBot's threshold
         // is set to 100e18, with a balance of 100e18 so moving just 1 wei units of synthetic should trigger an alert.
         // The liquidator bot is still below its threshold we should expect two messages to fire (total calls should be 3 + 2).
-        await syntheticToken.transfer(tokenCreator, "1", { from: disputerBot });
+        await syntheticToken.methods.transfer(tokenCreator, "1").send({ from: disputerBot });
         assert.equal(
-          (await syntheticToken.balanceOf(disputerBot)).toString(),
+          (await syntheticToken.methods.balanceOf(disputerBot).call()).toString(),
           toBN(convertDecimals("100")).sub(toBN("1")).toString()
         );
 
@@ -216,8 +234,11 @@ contract("BalanceMonitor.js", function (accounts) {
         assert.equal(spy.callCount, 0);
 
         // Transfer tokens away from the liquidator below the threshold should emit a message
-        await collateralToken.transfer(tokenCreator, convertDecimals("1001"), { from: liquidatorBot });
-        assert.equal((await collateralToken.balanceOf(liquidatorBot)).toString(), convertDecimals("9999"));
+        await collateralToken.methods.transfer(tokenCreator, convertDecimals("1001")).send({ from: liquidatorBot });
+        assert.equal(
+          (await collateralToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("9999")
+        );
         await tokenBalanceClient.update();
         await balanceMonitor.checkBotBalances();
         assert.equal(spy.callCount, 1);
@@ -236,14 +257,20 @@ contract("BalanceMonitor.js", function (accounts) {
 
         // Transferring tokens back to the bot such that it's balance is above the threshold, updating the client and
         // transferring tokens away again should initiate a new message.
-        await collateralToken.transfer(liquidatorBot, convertDecimals("11"), { from: tokenCreator });
-        assert.equal((await collateralToken.balanceOf(liquidatorBot)).toString(), convertDecimals("10010")); // balance above threshold
+        await collateralToken.methods.transfer(liquidatorBot, convertDecimals("11")).send({ from: tokenCreator });
+        assert.equal(
+          (await collateralToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("10010")
+        ); // balance above threshold
         await tokenBalanceClient.update();
         await balanceMonitor.checkBotBalances();
         assert.equal(spy.callCount, 2); // No new event as balance above threshold
 
-        await collateralToken.transfer(tokenCreator, convertDecimals("15"), { from: liquidatorBot });
-        assert.equal((await collateralToken.balanceOf(liquidatorBot)).toString(), convertDecimals("9995")); // balance below threshold
+        await collateralToken.methods.transfer(tokenCreator, convertDecimals("15")).send({ from: liquidatorBot });
+        assert.equal(
+          (await collateralToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("9995")
+        ); // balance below threshold
 
         await tokenBalanceClient.update();
         await balanceMonitor.checkBotBalances();
@@ -340,8 +367,11 @@ contract("BalanceMonitor.js", function (accounts) {
         });
 
         // Lower the liquidator bot's synthetic balance.
-        await syntheticToken.transfer(tokenCreator, convertDecimals("1001"), { from: liquidatorBot });
-        assert.equal((await syntheticToken.balanceOf(liquidatorBot)).toString(), convertDecimals("9999").toString());
+        await syntheticToken.methods.transfer(tokenCreator, convertDecimals("1001")).send({ from: liquidatorBot });
+        assert.equal(
+          (await syntheticToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("9999").toString()
+        );
 
         // Update monitors.
         await tokenBalanceClient.update();
@@ -362,8 +392,11 @@ contract("BalanceMonitor.js", function (accounts) {
         });
 
         // Lower the liquidator bot's collateral balance.
-        await collateralToken.transfer(tokenCreator, convertDecimals("1001"), { from: liquidatorBot });
-        assert.equal((await collateralToken.balanceOf(liquidatorBot)).toString(), convertDecimals("9999").toString());
+        await collateralToken.methods.transfer(tokenCreator, convertDecimals("1001")).send({ from: liquidatorBot });
+        assert.equal(
+          (await collateralToken.methods.balanceOf(liquidatorBot).call()).toString(),
+          convertDecimals("9999").toString()
+        );
 
         // Update monitors.
         await tokenBalanceClient.update();

--- a/packages/monitors/test/CRMonitor.js
+++ b/packages/monitors/test/CRMonitor.js
@@ -1,3 +1,5 @@
+const { web3, getContract } = require("hardhat");
+const { assert } = require("chai");
 const { toWei, hexToUtf8, utf8ToHex, padRight } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
@@ -8,8 +10,8 @@ const {
   createConstructorParamsForContractVersion,
   TESTED_CONTRACT_VERSIONS,
   TEST_DECIMAL_COMBOS,
+  getContractsNodePackageAliasForVerion,
 } = require("@uma/common");
-const { getTruffleContract } = require("@uma/core");
 
 // Script to test
 const { CRMonitor } = require("../src/CRMonitor");
@@ -56,11 +58,16 @@ let crMonitor;
 
 let convertDecimals;
 
+let accounts;
+let owner;
+let monitoredTrader;
+let monitoredSponsor;
+
 // Set the funding rate and advances time by 10k seconds.
 const _setFundingRateAndAdvanceTime = async (fundingRate) => {
-  currentTime = (await financialContract.getCurrentTime()).toNumber();
-  await financialContract.proposeFundingRate({ rawValue: fundingRate }, currentTime);
-  await financialContract.setCurrentTime(currentTime + 10000);
+  currentTime = parseInt(await financialContract.methods.getCurrentTime().call());
+  await financialContract.methods.proposeFundingRate({ rawValue: fundingRate }, currentTime).send({ from: owner });
+  await financialContract.methods.setCurrentTime(currentTime + 10000).send({ from: owner });
 };
 
 // If the current version being executed is part of the `supportedVersions` array then return `it` to run the test.
@@ -76,29 +83,38 @@ const versionedIt = function (supportedVersions, shouldBeItOnly = false) {
 
 const Convert = (decimals) => (number) => parseFixed(number.toString(), decimals).toString();
 
-contract("CRMonitor.js", function (accounts) {
-  const tokenSponsor = accounts[0];
-  const monitoredTrader = accounts[1];
-  const monitoredSponsor = accounts[2];
+describe("CRMonitor.js", function () {
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+    [owner, monitoredTrader, monitoredSponsor] = accounts;
+  });
 
   TESTED_CONTRACT_VERSIONS.forEach(function (contractVersion) {
     // Store the contractVersion.contractVersion, type and version being tested
     iterationTestVersion = contractVersion;
 
+    const { getAbi, getBytecode } = require(getContractsNodePackageAliasForVerion(contractVersion.contractVersion));
+
+    const createContract = (name) => {
+      const abi = getAbi(name);
+      const bytecode = getBytecode(name);
+      return getContract(name, { abi, bytecode });
+    };
+
     // Import the tested versions of contracts. note that financialContract is either an ExpiringMultiParty or a
     // Perpetual depending on the current iteration version.
-    const FinancialContract = getTruffleContract(contractVersion.contractType, web3, contractVersion.contractVersion);
-    const Finder = getTruffleContract("Finder", web3, contractVersion.contractVersion);
-    const IdentifierWhitelist = getTruffleContract("IdentifierWhitelist", web3, contractVersion.contractVersion);
-    const AddressWhitelist = getTruffleContract("AddressWhitelist", web3, contractVersion.contractVersion);
-    const MockOracle = getTruffleContract("MockOracle", web3, contractVersion.contractVersion);
-    const Token = getTruffleContract("ExpandedERC20", web3, contractVersion.contractVersion);
-    const SyntheticToken = getTruffleContract("SyntheticToken", web3, contractVersion.contractVersion);
-    const Timer = getTruffleContract("Timer", web3, contractVersion.contractVersion);
-    const Store = getTruffleContract("Store", web3, contractVersion.contractVersion);
-    const ConfigStore = getTruffleContract("ConfigStore", web3);
-    const OptimisticOracle = getTruffleContract("OptimisticOracle", web3);
-    const MulticallMock = getTruffleContract("MulticallMock", web3);
+    const FinancialContract = createContract(contractVersion.contractType);
+    const Finder = createContract("Finder");
+    const IdentifierWhitelist = createContract("IdentifierWhitelist");
+    const AddressWhitelist = createContract("AddressWhitelist");
+    const MockOracle = createContract("MockOracle");
+    const Token = createContract("ExpandedERC20");
+    const SyntheticToken = createContract("SyntheticToken");
+    const Timer = createContract("Timer");
+    const Store = createContract("Store");
+    const ConfigStore = createContract("ConfigStore");
+    const OptimisticOracle = createContract("OptimisticOracle");
+    const MulticallMock = createContract("MulticallMock");
 
     for (let testConfig of TEST_DECIMAL_COMBOS) {
       describe(`${testConfig.collateralDecimals} collateral, ${testConfig.syntheticDecimals} synthetic & ${testConfig.priceFeedDecimals} pricefeed decimals, for smart contract version ${contractVersion.contractType} @ ${contractVersion.contractVersion}`, function () {
@@ -109,47 +125,58 @@ contract("CRMonitor.js", function (accounts) {
           collateralToken = await Token.new(
             testConfig.tokenSymbol + " Token",
             testConfig.tokenSymbol,
-            testConfig.collateralDecimals,
-            { from: tokenSponsor }
-          );
+            testConfig.collateralDecimals
+          ).send({ from: owner });
 
-          identifierWhitelist = await IdentifierWhitelist.new();
-          await identifierWhitelist.addSupportedIdentifier(utf8ToHex(identifier));
+          identifierWhitelist = await IdentifierWhitelist.new().send({ from: owner });
+          await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex(identifier)).send({ from: owner });
 
-          finder = await Finder.new();
-          timer = await Timer.new();
-          store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.address);
-          await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
+          finder = await Finder.new().send({ from: owner });
+          timer = await Timer.new().send({ from: owner });
+          store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.options.address).send({ from: owner });
+          await finder.methods
+            .changeImplementationAddress(utf8ToHex(interfaceName.Store), store.options.address)
+            .send({ from: owner });
 
-          await finder.changeImplementationAddress(
-            utf8ToHex(interfaceName.IdentifierWhitelist),
-            identifierWhitelist.address
-          );
-          await identifierWhitelist.addSupportedIdentifier(utf8ToHex(testConfig.tokenSymbol + " Identifier"));
+          await finder.methods
+            .changeImplementationAddress(
+              utf8ToHex(interfaceName.IdentifierWhitelist),
+              identifierWhitelist.options.address
+            )
+            .send({ from: owner });
+          await identifierWhitelist.methods
+            .addSupportedIdentifier(utf8ToHex(testConfig.tokenSymbol + " Identifier"))
+            .send({ from: owner });
 
           // Create a mockOracle and finder. Register the mockOracle with the finder.
-          mockOracle = await MockOracle.new(finder.address, timer.address);
+          mockOracle = await MockOracle.new(finder.options.address, timer.options.address).send({ from: owner });
           const mockOracleInterfaceName = utf8ToHex(interfaceName.Oracle);
-          await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
+          await finder.methods
+            .changeImplementationAddress(mockOracleInterfaceName, mockOracle.options.address)
+            .send({ from: owner });
 
-          collateralWhitelist = await AddressWhitelist.new();
-          await finder.changeImplementationAddress(
-            utf8ToHex(interfaceName.CollateralWhitelist),
-            collateralWhitelist.address
-          );
-          await collateralWhitelist.addToWhitelist(collateralToken.address);
+          collateralWhitelist = await AddressWhitelist.new().send({ from: owner });
+          await finder.methods
+            .changeImplementationAddress(
+              utf8ToHex(interfaceName.CollateralWhitelist),
+              collateralWhitelist.options.address
+            )
+            .send({ from: owner });
+          await collateralWhitelist.methods.addToWhitelist(collateralToken.options.address).send({ from: owner });
 
-          multicall = await MulticallMock.new();
+          multicall = await MulticallMock.new().send({ from: owner });
         });
 
         beforeEach(async function () {
-          await timer.setCurrentTime(startTime - 1);
-          currentTime = await mockOracle.getCurrentTime.call();
+          await timer.methods.setCurrentTime(startTime - 1).send({ from: owner });
+          currentTime = await mockOracle.methods.getCurrentTime().call();
 
           // Create a new synthetic token
-          syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", testConfig.syntheticDecimals, {
-            from: tokenSponsor,
-          });
+          syntheticToken = await SyntheticToken.new(
+            "Test Synthetic Token",
+            "SYNTH",
+            testConfig.syntheticDecimals
+          ).send({ from: owner });
 
           // If we are testing a perpetual then we need to also deploy a config store, an optimistic oracle and set the funding rate identifier.
           if (contractVersion.contractType == "Perpetual") {
@@ -162,15 +189,18 @@ contract("CRMonitor.js", function (accounts) {
                 minFundingRate: { rawValue: toWei("-0.00001") },
                 proposalTimePastLimit: 0,
               },
-              timer.address
-            );
+              timer.options.address
+            ).send({ from: owner });
 
-            await identifierWhitelist.addSupportedIdentifier(padRight(utf8ToHex(fundingRateIdentifier)));
-            optimisticOracle = await OptimisticOracle.new(7200, finder.address, timer.address);
-            await finder.changeImplementationAddress(
-              utf8ToHex(interfaceName.OptimisticOracle),
-              optimisticOracle.address
-            );
+            await identifierWhitelist.methods
+              .addSupportedIdentifier(padRight(utf8ToHex(fundingRateIdentifier)))
+              .send({ from: owner });
+            optimisticOracle = await OptimisticOracle.new(7200, finder.options.address, timer.options.address).send({
+              from: owner,
+            });
+            await finder.methods
+              .changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracle), optimisticOracle.options.address)
+              .send({ from: owner });
           }
 
           const constructorParams = await createConstructorParamsForContractVersion(
@@ -194,10 +224,10 @@ contract("CRMonitor.js", function (accounts) {
             }
           );
           // Deploy a new expiring multi party OR perpetual, depending on the test version.
-          financialContract = await FinancialContract.new(constructorParams);
+          financialContract = await FinancialContract.new(constructorParams).send({ from: owner });
 
           // If we are testing a perpetual then we need to apply the initial funding rate to start the timer.
-          await financialContract.setCurrentTime(startTime);
+          await financialContract.methods.setCurrentTime(startTime).send({ from: owner });
 
           // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston
           // logs the correct text based on interactions with the financialContract. Note that only `info` level messages are captured.
@@ -207,14 +237,14 @@ contract("CRMonitor.js", function (accounts) {
             transports: [new SpyTransport({ level: "info" }, { spy: spy })],
           });
 
-          await syntheticToken.addMinter(financialContract.address);
-          await syntheticToken.addBurner(financialContract.address);
+          await syntheticToken.methods.addMinter(financialContract.options.address).send({ from: owner });
+          await syntheticToken.methods.addBurner(financialContract.options.address).send({ from: owner });
           financialContractClient = new FinancialContractClient(
             spyLogger,
             FinancialContract.abi,
             web3,
-            financialContract.address,
-            multicall.address,
+            financialContract.options.address,
+            multicall.options.address,
             testConfig.collateralDecimals,
             testConfig.syntheticDecimals,
             testConfig.priceFeedDecimals,
@@ -236,15 +266,15 @@ contract("CRMonitor.js", function (accounts) {
               },
             ],
           };
-          syntheticToken = await Token.at(await financialContract.tokenCurrency());
+          syntheticToken = await Token.at(await financialContract.methods.tokenCurrency().call());
 
           financialContractProps = {
-            collateralSymbol: await collateralToken.symbol(),
+            collateralSymbol: await collateralToken.methods.symbol().call(),
             collateralDecimals: testConfig.collateralDecimals,
             syntheticDecimals: testConfig.syntheticDecimals,
             priceFeedDecimals: testConfig.priceFeedDecimals,
-            syntheticSymbol: await syntheticToken.symbol(),
-            priceIdentifier: hexToUtf8(await financialContract.priceIdentifier()),
+            syntheticSymbol: await syntheticToken.methods.symbol().call(),
+            priceIdentifier: hexToUtf8(await financialContract.methods.priceIdentifier().call()),
             networkId: await web3.eth.net.getId(),
           };
 
@@ -256,30 +286,26 @@ contract("CRMonitor.js", function (accounts) {
             financialContractProps,
           });
 
-          await collateralToken.addMember(1, tokenSponsor, { from: tokenSponsor });
+          await collateralToken.methods.addMember(1, owner).send({ from: owner });
 
           //   Bulk mint and approve for all wallets
           for (let i = 1; i < 3; i++) {
-            await collateralToken.mint(accounts[i], convertDecimals("100000000"), { from: tokenSponsor });
-            await collateralToken.approve(financialContract.address, convertDecimals("100000000"), {
-              from: accounts[i],
-            });
-            await syntheticToken.approve(financialContract.address, convertDecimals("100000000"), {
-              from: accounts[i],
-            });
+            await collateralToken.methods.mint(accounts[i], convertDecimals("100000000")).send({ from: owner });
+            await collateralToken.methods
+              .approve(financialContract.options.address, convertDecimals("100000000"))
+              .send({ from: accounts[i] });
+            await syntheticToken.methods
+              .approve(financialContract.options.address, convertDecimals("100000000"))
+              .send({ from: accounts[i] });
           }
 
           // Create positions for the monitoredTrader and monitoredSponsor accounts
-          await financialContract.create(
-            { rawValue: convertDecimals("250") },
-            { rawValue: convertDecimals("100") },
-            { from: monitoredTrader }
-          );
-          await financialContract.create(
-            { rawValue: convertDecimals("300") },
-            { rawValue: convertDecimals("100") },
-            { from: monitoredSponsor }
-          );
+          await financialContract.methods
+            .create({ rawValue: convertDecimals("250") }, { rawValue: convertDecimals("100") })
+            .send({ from: monitoredTrader });
+          await financialContract.methods
+            .create({ rawValue: convertDecimals("300") }, { rawValue: convertDecimals("100") })
+            .send({ from: monitoredSponsor });
         });
 
         versionedIt([{ contractType: "any", contractVersion: "any" }])(
@@ -304,7 +330,7 @@ contract("CRMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, "192.30%")); // calculated CR ratio for this position
             assert.isTrue(lastSpyLogIncludes(spy, "200%")); // calculated CR ratio threshold for this address
             assert.isTrue(lastSpyLogIncludes(spy, "1.30")); // Current price of the identifer
-            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.priceIdentifier()))); // Synthetic identifier
+            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.methods.priceIdentifier().call()))); // Synthetic identifier
             assert.isTrue(lastSpyLogIncludes(spy, "150.00%")); // Collateralization requirement
             assert.isTrue(lastSpyLogIncludes(spy, "1.66")); // Liquidation price
             assert.equal(lastSpyLogLevel(spy), "warn");
@@ -343,7 +369,9 @@ contract("CRMonitor.js", function (accounts) {
             // withdrawal liveness they can place their position's collateralization under the threshold. Say monitoredTrader
             // withdraws 75 units of collateral. Given price is 1 unit of synthetic for each unit of debt. This would place
             // their position at a collateralization ratio of 175/(100*1)=1.75. monitoredSponsor is at 300/(100*1)=3.00.
-            await financialContract.requestWithdrawal({ rawValue: convertDecimals("75") }, { from: monitoredTrader });
+            await financialContract.methods
+              .requestWithdrawal({ rawValue: convertDecimals("75") })
+              .send({ from: monitoredTrader });
 
             // The wallet CR should reflect the requested withdrawal amount.
             await financialContractClient.update();
@@ -356,12 +384,12 @@ contract("CRMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, "175.00%")); // calculated CR ratio for this position
             assert.isTrue(lastSpyLogIncludes(spy, "200%")); // calculated CR ratio threshold for this address
             assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Current price of the identifer
-            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.priceIdentifier()))); // Synthetic identifier
+            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.methods.priceIdentifier().call()))); // Synthetic identifier
 
             // Advance time after withdrawal liveness. Check that CR detected is the same post withdrawal execution
-            currentTime = await timer.getCurrentTime.call();
-            await timer.setCurrentTime(currentTime.toNumber() + 11);
-            await financialContract.withdrawPassedRequest({ from: monitoredTrader });
+            currentTime = await timer.methods.getCurrentTime().call();
+            await timer.methods.setCurrentTime(parseInt(currentTime) + 11).send({ from: owner });
+            await financialContract.methods.withdrawPassedRequest().send({ from: monitoredTrader });
 
             await financialContractClient.update();
             await crMonitor.checkWalletCrRatio();
@@ -372,7 +400,7 @@ contract("CRMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, "175.00%")); // calculated CR ratio for this position
             assert.isTrue(lastSpyLogIncludes(spy, "200%")); // calculated CR ratio threshold for this address
             assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Current price of the identifer
-            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.priceIdentifier()))); // Synthetic identifier
+            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.methods.priceIdentifier().call()))); // Synthetic identifier
           }
         );
         versionedIt([{ contractType: "Perpetual", contractVersion: "2.0.1" }])(
@@ -415,7 +443,7 @@ contract("CRMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, "196.77%")); // calculated CR ratio for this position
             assert.isTrue(lastSpyLogIncludes(spy, "200%")); // calculated CR ratio threshold for this address
             assert.isTrue(lastSpyLogIncludes(spy, "1.10")); // Current price of the identifer
-            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.priceIdentifier()))); // Synthetic identifier
+            assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(await financialContract.methods.priceIdentifier().call()))); // Synthetic identifier
             assert.isTrue(lastSpyLogIncludes(spy, "150.00%")); // Collateralization requirement
             assert.isTrue(lastSpyLogIncludes(spy, "1.44")); // Liquidation price
             assert.isTrue(lastSpyLogIncludes(spy, "cumulative funding rate multiplier is 1.15")); // correctly reports funding rate multiplier.
@@ -429,7 +457,7 @@ contract("CRMonitor.js", function (accounts) {
             // and `crAlert`.
             const invalidMonitorConfig1 = {
               // Config missing `crAlert`.
-              walletsToMonitor: [{ name: "Sponsor wallet", address: tokenSponsor }],
+              walletsToMonitor: [{ name: "Sponsor wallet", address: owner }],
             };
 
             crMonitor = new CRMonitor({

--- a/packages/monitors/test/ContractMonitor.js
+++ b/packages/monitors/test/ContractMonitor.js
@@ -1,3 +1,5 @@
+const { web3, getContract } = require("hardhat");
+const { assert } = require("chai");
 const { toWei, hexToUtf8, utf8ToHex, padRight } = web3.utils;
 const winston = require("winston");
 const sinon = require("sinon");
@@ -9,8 +11,8 @@ const {
   createConstructorParamsForContractVersion,
   TESTED_CONTRACT_VERSIONS,
   TEST_DECIMAL_COMBOS,
+  getContractsNodePackageAliasForVerion,
 } = require("@uma/common");
-const { getTruffleContract } = require("@uma/core");
 
 // Helpers and custom winston transport module to monitor winston log outputs
 const {
@@ -76,31 +78,38 @@ const versionedIt = function (supportedVersions, shouldBeItOnly = false) {
 
 const Convert = (decimals) => (number) => parseFixed(number.toString(), decimals).toString();
 
-contract("ContractMonitor.js", function (accounts) {
-  const tokenSponsor = accounts[0];
-  const liquidator = accounts[1];
-  const disputer = accounts[2];
-  const sponsor1 = accounts[3];
-  const sponsor2 = accounts[4];
-  const sponsor3 = accounts[5];
+describe("ContractMonitor.js", function () {
+  let accounts, deployer, liquidator, disputer, sponsor1, sponsor2, sponsor3;
 
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+    [deployer, liquidator, disputer, sponsor1, sponsor2, sponsor3] = accounts;
+  });
   TESTED_CONTRACT_VERSIONS.forEach(function (contractVersion) {
     // Store the contractVersion.contractVersion, type and version being tested
     iterationTestVersion = contractVersion;
 
+    const { getAbi, getBytecode } = require(getContractsNodePackageAliasForVerion(contractVersion.contractVersion));
+
+    const createContract = (name) => {
+      const abi = getAbi(name);
+      const bytecode = getBytecode(name);
+      return getContract(name, { abi, bytecode });
+    };
+
     // Import the tested versions of contracts. note that financialContract is either an ExpiringMultiParty or a
     // Perpetual depending on the current iteration version.
-    const FinancialContract = getTruffleContract(contractVersion.contractType, web3, contractVersion.contractVersion);
-    const Finder = getTruffleContract("Finder", web3, contractVersion.contractVersion);
-    const IdentifierWhitelist = getTruffleContract("IdentifierWhitelist", web3, contractVersion.contractVersion);
-    const AddressWhitelist = getTruffleContract("AddressWhitelist", web3, contractVersion.contractVersion);
-    const MockOracle = getTruffleContract("MockOracle", web3, contractVersion.contractVersion);
-    const Token = getTruffleContract("ExpandedERC20", web3, contractVersion.contractVersion);
-    const SyntheticToken = getTruffleContract("SyntheticToken", web3, contractVersion.contractVersion);
-    const Timer = getTruffleContract("Timer", web3, contractVersion.contractVersion);
-    const Store = getTruffleContract("Store", web3, contractVersion.contractVersion);
-    const ConfigStore = getTruffleContract("ConfigStore", web3);
-    const OptimisticOracle = getTruffleContract("OptimisticOracle", web3);
+    const FinancialContract = createContract(contractVersion.contractType);
+    const Finder = createContract("Finder");
+    const IdentifierWhitelist = createContract("IdentifierWhitelist");
+    const AddressWhitelist = createContract("AddressWhitelist");
+    const MockOracle = createContract("MockOracle");
+    const Token = createContract("ExpandedERC20");
+    const SyntheticToken = createContract("SyntheticToken");
+    const Timer = createContract("Timer");
+    const Store = createContract("Store");
+    const ConfigStore = createContract("ConfigStore");
+    const OptimisticOracle = createContract("OptimisticOracle");
 
     for (let testConfig of TEST_DECIMAL_COMBOS) {
       describe(`${testConfig.collateralDecimals} collateral, ${testConfig.syntheticDecimals} synthetic & ${testConfig.priceFeedDecimals} pricefeed decimals, for smart contract version ${contractVersion.contractType} @ ${contractVersion.contractVersion}`, function () {
@@ -111,48 +120,57 @@ contract("ContractMonitor.js", function (accounts) {
           collateralToken = await Token.new(
             testConfig.tokenSymbol + " Token",
             testConfig.tokenSymbol,
-            testConfig.collateralDecimals,
-            { from: tokenSponsor }
-          );
+            testConfig.collateralDecimals
+          ).send({ from: deployer });
 
-          identifierWhitelist = await IdentifierWhitelist.new();
-          await identifierWhitelist.addSupportedIdentifier(utf8ToHex(identifier));
+          identifierWhitelist = await IdentifierWhitelist.new().send({ from: deployer });
+          await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex(identifier)).send({ from: deployer });
 
-          finder = await Finder.new();
-          timer = await Timer.new();
-          store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.address);
-          await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
+          finder = await Finder.new().send({ from: deployer });
+          timer = await Timer.new().send({ from: deployer });
+          store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.options.address).send({ from: deployer });
+          await finder.methods
+            .changeImplementationAddress(utf8ToHex(interfaceName.Store), store.options.address)
+            .send({ from: deployer });
 
-          await finder.changeImplementationAddress(
-            utf8ToHex(interfaceName.IdentifierWhitelist),
-            identifierWhitelist.address
-          );
+          await finder.methods
+            .changeImplementationAddress(
+              utf8ToHex(interfaceName.IdentifierWhitelist),
+              identifierWhitelist.options.address
+            )
+            .send({ from: deployer });
 
-          await identifierWhitelist.addSupportedIdentifier(utf8ToHex(identifier));
+          await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex(identifier)).send({ from: deployer });
 
           // Create a mockOracle and finder. Register the mockOracle with the finder.
-          mockOracle = await MockOracle.new(finder.address, timer.address);
+          mockOracle = await MockOracle.new(finder.options.address, timer.options.address).send({ from: deployer });
           const mockOracleInterfaceName = utf8ToHex(interfaceName.Oracle);
-          await finder.changeImplementationAddress(mockOracleInterfaceName, mockOracle.address);
+          await finder.methods
+            .changeImplementationAddress(mockOracleInterfaceName, mockOracle.options.address)
+            .send({ from: deployer });
 
-          collateralWhitelist = await AddressWhitelist.new();
-          await finder.changeImplementationAddress(
-            utf8ToHex(interfaceName.CollateralWhitelist),
-            collateralWhitelist.address
-          );
-          await collateralWhitelist.addToWhitelist(collateralToken.address);
+          collateralWhitelist = await AddressWhitelist.new().send({ from: deployer });
+          await finder.methods
+            .changeImplementationAddress(
+              utf8ToHex(interfaceName.CollateralWhitelist),
+              collateralWhitelist.options.address
+            )
+            .send({ from: deployer });
+          await collateralWhitelist.methods.addToWhitelist(collateralToken.options.address).send({ from: deployer });
         });
 
         beforeEach(async function () {
-          await timer.setCurrentTime(startTime - 1);
-          const currentTime = await mockOracle.getCurrentTime.call();
+          await timer.methods.setCurrentTime(startTime - 1).send({ from: deployer });
+          const currentTime = await mockOracle.methods.getCurrentTime().call();
 
-          await timer.setCurrentTime(currentTime.toString());
+          await timer.methods.setCurrentTime(currentTime.toString()).send({ from: deployer });
 
           // Create a new synthetic token
-          syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", testConfig.syntheticDecimals, {
-            from: tokenSponsor,
-          });
+          syntheticToken = await SyntheticToken.new(
+            "Test Synthetic Token",
+            "SYNTH",
+            testConfig.syntheticDecimals
+          ).send({ from: deployer });
 
           // If we are testing a perpetual then we need to also deploy a config store, an optimistic oracle and set the funding rate identifier.
           if (contractVersion.contractType == "Perpetual") {
@@ -165,15 +183,20 @@ contract("ContractMonitor.js", function (accounts) {
                 minFundingRate: { rawValue: toWei("-0.00001") },
                 proposalTimePastLimit: 0,
               },
-              timer.address
-            );
+              timer.options.address
+            ).send({ from: deployer });
 
-            await identifierWhitelist.addSupportedIdentifier(padRight(utf8ToHex(fundingRateIdentifier)));
-            optimisticOracle = await OptimisticOracle.new(optimisticOracleLiveness, finder.address, timer.address);
-            await finder.changeImplementationAddress(
-              utf8ToHex(interfaceName.OptimisticOracle),
-              optimisticOracle.address
-            );
+            await identifierWhitelist.methods
+              .addSupportedIdentifier(padRight(utf8ToHex(fundingRateIdentifier)))
+              .send({ from: deployer });
+            optimisticOracle = await OptimisticOracle.new(
+              optimisticOracleLiveness,
+              finder.options.address,
+              timer.options.address
+            ).send({ from: deployer });
+            await finder.methods
+              .changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracle), optimisticOracle.options.address)
+              .send({ from: deployer });
           }
 
           const constructorParams = await createConstructorParamsForContractVersion(
@@ -193,27 +216,28 @@ contract("ContractMonitor.js", function (accounts) {
           );
 
           // Deploy a new expiring multi party OR perpetual, depending on the test version.
-          financialContract = await FinancialContract.new(constructorParams);
+          financialContract = await FinancialContract.new(constructorParams).send({ from: deployer });
 
           // If we are testing a perpetual then we need to apply the initial funding rate to start the timer.
-          await financialContract.setCurrentTime(startTime);
-          if (contractVersion.contractType == "Perpetual") await financialContract.applyFundingRate();
+          await financialContract.methods.setCurrentTime(startTime).send({ from: deployer });
+          if (contractVersion.contractType == "Perpetual")
+            await financialContract.methods.applyFundingRate().send({ from: deployer });
 
           // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston
-          // logs the correct text based on interactions with the financialContract. Note that only `info` level messages are captured.
+          // logs the correct text based on interactions with the financialContract.methods. Note that only `info` level messages are captured.
           spy = sinon.spy();
           spyLogger = winston.createLogger({
             level: "info",
             transports: [new SpyTransport({ level: "info" }, { spy })],
           });
 
-          await syntheticToken.addMinter(financialContract.address);
-          await syntheticToken.addBurner(financialContract.address);
+          await syntheticToken.methods.addMinter(financialContract.options.address).send({ from: deployer });
+          await syntheticToken.methods.addBurner(financialContract.options.address).send({ from: deployer });
           eventClient = new FinancialContractEventClient(
             spyLogger,
             FinancialContract.abi,
             web3,
-            financialContract.address,
+            financialContract.options.address,
             0, // startingBlockNumber
             null, // endingBlockNumber
             contractVersion.contractType,
@@ -224,15 +248,15 @@ contract("ContractMonitor.js", function (accounts) {
           // Define a configuration object. In this config only monitor one liquidator and one disputer.
           monitorConfig = { monitoredLiquidators: [liquidator], monitoredDisputers: [disputer] };
 
-          syntheticToken = await Token.at(await financialContract.tokenCurrency());
+          syntheticToken = await Token.at(await financialContract.methods.tokenCurrency().call());
 
           financialContractProps = {
-            collateralSymbol: await collateralToken.symbol(),
+            collateralSymbol: await collateralToken.methods.symbol().call(),
             collateralDecimals: testConfig.collateralDecimals,
             syntheticDecimals: testConfig.syntheticDecimals,
             priceFeedDecimals: testConfig.priceFeedDecimals,
-            syntheticSymbol: await syntheticToken.symbol(),
-            priceIdentifier: hexToUtf8(await financialContract.priceIdentifier()),
+            syntheticSymbol: await syntheticToken.methods.symbol().call(),
+            priceIdentifier: hexToUtf8(await financialContract.methods.priceIdentifier().call()),
             networkId: await web3.eth.net.getId(),
           };
 
@@ -245,35 +269,29 @@ contract("ContractMonitor.js", function (accounts) {
             votingContract: mockOracle,
           });
 
-          await collateralToken.addMember(1, tokenSponsor, { from: tokenSponsor });
+          await collateralToken.methods.addMember(1, deployer).send({ from: deployer });
 
           //   Bulk mint and approve for all wallets
           for (let i = 1; i < 6; i++) {
-            await collateralToken.mint(accounts[i], convertDecimals("100000000"), { from: tokenSponsor });
-            await collateralToken.approve(financialContract.address, convertDecimals("100000000"), {
-              from: accounts[i],
-            });
-            await syntheticToken.approve(financialContract.address, convertDecimals("100000000"), {
-              from: accounts[i],
-            });
+            await collateralToken.methods.mint(accounts[i], convertDecimals("100000000")).send({ from: deployer });
+            await collateralToken.methods
+              .approve(financialContract.options.address, convertDecimals("100000000"))
+              .send({ from: accounts[i] });
+            await syntheticToken.methods
+              .approve(financialContract.options.address, convertDecimals("100000000"))
+              .send({ from: accounts[i] });
           }
 
           // Create positions for the sponsors, liquidator and disputer
-          await financialContract.create(
-            { rawValue: convertDecimals("150") },
-            { rawValue: convertDecimals("50") },
-            { from: sponsor1 }
-          );
-          await financialContract.create(
-            { rawValue: convertDecimals("175") },
-            { rawValue: convertDecimals("45") },
-            { from: sponsor2 }
-          );
-          newSponsorTxn = await financialContract.create(
-            { rawValue: convertDecimals("1500") },
-            { rawValue: convertDecimals("400") },
-            { from: liquidator }
-          );
+          await financialContract.methods
+            .create({ rawValue: convertDecimals("150") }, { rawValue: convertDecimals("50") })
+            .send({ from: sponsor1 });
+          await financialContract.methods
+            .create({ rawValue: convertDecimals("175") }, { rawValue: convertDecimals("45") })
+            .send({ from: sponsor2 });
+          newSponsorTxn = await financialContract.methods
+            .create({ rawValue: convertDecimals("1500") }, { rawValue: convertDecimals("400") })
+            .send({ from: liquidator });
         });
 
         versionedIt([{ contractType: "any", contractVersion: "any" }])(
@@ -286,21 +304,21 @@ contract("ContractMonitor.js", function (accounts) {
             await contractMonitor.checkForNewSponsors();
 
             // Ensure that the spy correctly captured the new sponsor events key information.
-            // Should contain etherscan addresses for the sponsor and transaction
+            // Should contain etherscan.options.addresses for the sponsor and transaction
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${liquidator}`));
-            assert.isTrue(lastSpyLogIncludes(spy, "(Monitored liquidator or disputer bot)")); // The address that initiated the liquidation is a monitored address
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newSponsorTxn.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, "(Monitored liquidator or disputer bot)")); // The.options.address that initiated the liquidation is a monitored.options.address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newSponsorTxn.transactionHash}`));
 
             // should contain the correct position information.
             assert.isTrue(lastSpyLogIncludes(spy, "400.00")); // New tokens created
             assert.isTrue(lastSpyLogIncludes(spy, "1,500.00")); // Collateral amount
 
             // Create another position
-            const txObject1 = await financialContract.create(
-              { rawValue: convertDecimals("10") },
-              { rawValue: convertDecimals("1.5") },
-              { from: sponsor3 } // not a monitored address
-            );
+            const txObject1 = await financialContract.methods
+              .create({ rawValue: convertDecimals("10") }, { rawValue: convertDecimals("1.5") })
+              .send(
+                { from: sponsor3 } // not a monitored.options.address
+              );
 
             await eventClient.update();
 
@@ -308,7 +326,7 @@ contract("ContractMonitor.js", function (accounts) {
             await contractMonitor.checkForNewSponsors();
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor3}`));
             assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator or disputer bot bot)"));
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.transactionHash}`));
             assert.isTrue(lastSpyLogIncludes(spy, "1.50")); // New tokens created
             assert.isTrue(lastSpyLogIncludes(spy, "10.00")); // Collateral amount
           }
@@ -317,17 +335,20 @@ contract("ContractMonitor.js", function (accounts) {
           "Winston correctly emits liquidation message",
           async function () {
             // Request a withdrawal from sponsor1 to check if monitor correctly differentiates between liquidated and locked collateral
-            await financialContract.requestWithdrawal({ rawValue: convertDecimals("10") }, { from: sponsor1 });
+            await financialContract.methods
+              .requestWithdrawal({ rawValue: convertDecimals("10") })
+              .send({ from: sponsor1 });
 
             // Create liquidation to liquidate sponsor2 from sponsor1
-            const txObject1 = await financialContract.createLiquidation(
-              sponsor1,
-              { rawValue: "0" },
-              { rawValue: toWei("99999") },
-              { rawValue: convertDecimals("100") },
-              unreachableDeadline,
-              { from: liquidator }
-            );
+            const txObject1 = await financialContract.methods
+              .createLiquidation(
+                sponsor1,
+                { rawValue: "0" },
+                { rawValue: toWei("99999") },
+                { rawValue: convertDecimals("100") },
+                unreachableDeadline
+              )
+              .send({ from: liquidator });
 
             // Update the eventClient and check it has the liquidation event stored correctly
             await eventClient.update();
@@ -351,11 +372,11 @@ contract("ContractMonitor.js", function (accounts) {
             await contractMonitor.checkForNewLiquidations();
 
             // Ensure that the spy correctly captured the liquidation events key information.
-            // Should contain etherscan addresses for the liquidator, sponsor and transaction
+            // Should contain etherscan.options.addresses for the liquidator, sponsor and transaction
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${liquidator}`));
-            assert.isTrue(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // The address that initiated the liquidation is a monitored address
+            assert.isTrue(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // The.options.address that initiated the liquidation is a monitored.options.address
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor1}`));
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.transactionHash}`));
 
             // should contain the correct position information. Collateralization ratio for sponsor with 140 collateral and 50
             // debt with a price feed of 1 should give 140/(50 * 1) = 280%
@@ -369,23 +390,26 @@ contract("ContractMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, "SYNTH")); // should contain token symbol
 
             // Liquidate another position and ensure the Contract monitor emits the correct params
-            const txObject2 = await financialContract.createLiquidation(
-              sponsor2,
-              { rawValue: "0" },
-              { rawValue: toWei("99999") },
-              { rawValue: convertDecimals("100") },
-              unreachableDeadline,
-              { from: sponsor1 } // not the monitored liquidator address
-            );
+            const txObject2 = await financialContract.methods
+              .createLiquidation(
+                sponsor2,
+                { rawValue: "0" },
+                { rawValue: toWei("99999") },
+                { rawValue: convertDecimals("100") },
+                unreachableDeadline
+              )
+              .send(
+                { from: sponsor1 } // not the monitored liquidator.options.address
+              );
 
             await eventClient.update();
 
             // check for new liquidations and check the winston messages sent to the spy
             await contractMonitor.checkForNewLiquidations();
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor1}`)); // liquidator in txObject2
-            assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // not called from a monitored address
+            assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // not called from a monitored.options.address
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor2}`)); // token sponsor
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.transactionHash}`));
             assert.isTrue(lastSpyLogIncludes(spy, "388.88%")); // expected collateralization ratio: 175 / (45 * 1) = 388.88%
             assert.isTrue(lastSpyLogIncludes(spy, "175.00")); // liquidated & locked collateral: 175
             assert.isTrue(lastSpyLogIncludes(spy, "45.00")); // tokens liquidated
@@ -399,16 +423,17 @@ contract("ContractMonitor.js", function (accounts) {
           "Winston correctly emits dispute message",
           async function () {
             // Create liquidation to dispute.
-            await financialContract.createLiquidation(
-              sponsor1,
-              { rawValue: "0" },
-              { rawValue: toWei("99999") },
-              { rawValue: convertDecimals("100") },
-              unreachableDeadline,
-              { from: liquidator }
-            );
+            await financialContract.methods
+              .createLiquidation(
+                sponsor1,
+                { rawValue: "0" },
+                { rawValue: toWei("99999") },
+                { rawValue: convertDecimals("100") },
+                unreachableDeadline
+              )
+              .send({ from: liquidator });
 
-            const txObject1 = await financialContract.dispute("0", sponsor1, { from: disputer });
+            const txObject1 = await financialContract.methods.dispute("0", sponsor1).send({ from: disputer });
 
             // Update the eventClient and check it has the dispute event stored correctly
             await eventClient.clearState();
@@ -417,25 +442,26 @@ contract("ContractMonitor.js", function (accounts) {
 
             await contractMonitor.checkForNewDisputeEvents();
 
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`)); // disputer address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`)); // disputer.options.address
             assert.isTrue(lastSpyLogIncludes(spy, "(Monitored dispute bot)")); // disputer is monitored
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${liquidator}`)); // liquidator address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${liquidator}`)); // liquidator.options.address
             assert.isTrue(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // liquidator is monitored
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.transactionHash}`));
             assert.isTrue(lastSpyLogIncludes(spy, "15.00")); // dispute bond of 10% of sponsor 1's 150 collateral => 15
 
             // Create a second liquidation to dispute from a non-monitored account.
-            await financialContract.createLiquidation(
-              sponsor2,
-              { rawValue: "0" },
-              { rawValue: toWei("99999") },
-              { rawValue: convertDecimals("100") },
-              unreachableDeadline,
-              { from: sponsor1 }
-            );
+            await financialContract.methods
+              .createLiquidation(
+                sponsor2,
+                { rawValue: "0" },
+                { rawValue: toWei("99999") },
+                { rawValue: convertDecimals("100") },
+                unreachableDeadline
+              )
+              .send({ from: sponsor1 });
 
             // the disputer is also not monitored
-            const txObject2 = await financialContract.dispute("0", sponsor2, { from: sponsor2 });
+            const txObject2 = await financialContract.methods.dispute("0", sponsor2).send({ from: sponsor2 });
 
             // Update the eventClient and check it has the dispute event stored correctly
             await eventClient.clearState();
@@ -443,11 +469,11 @@ contract("ContractMonitor.js", function (accounts) {
 
             await contractMonitor.checkForNewDisputeEvents();
 
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor2}`)); // disputer address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor2}`)); // disputer.options.address
             assert.isFalse(lastSpyLogIncludes(spy, "(Monitored dispute bot)")); // disputer is not monitored
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor1}`)); // liquidator address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor1}`)); // liquidator.options.address
             assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // liquidator is not monitored
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.transactionHash}`));
             assert.isTrue(lastSpyLogIncludes(spy, "17.50")); // dispute bond of 10% of sponsor 2's 175 collateral => 17.50
           }
         );
@@ -455,26 +481,31 @@ contract("ContractMonitor.js", function (accounts) {
           "Winston correctly emits dispute settlement message",
           async function () {
             // Create liquidation to liquidate sponsor1 from liquidator
-            let liquidationTime = (await financialContract.getCurrentTime()).toNumber();
-            await financialContract.createLiquidation(
-              sponsor1,
-              { rawValue: "0" },
-              { rawValue: toWei("99999") },
-              { rawValue: convertDecimals("100") },
-              unreachableDeadline,
-              { from: liquidator }
-            );
+            let liquidationTime = parseInt(await financialContract.methods.getCurrentTime().call());
+            await financialContract.methods
+              .createLiquidation(
+                sponsor1,
+                { rawValue: "0" },
+                { rawValue: toWei("99999") },
+                { rawValue: convertDecimals("100") },
+                unreachableDeadline
+              )
+              .send({ from: liquidator });
 
             // Dispute the position from the disputer
-            await financialContract.dispute("0", sponsor1, { from: disputer });
+            await financialContract.methods.dispute("0", sponsor1).send({ from: disputer });
 
             // Push a price such that the dispute fails and ensure the resolution reports correctly. Sponsor1 has 50 units of
             // debt and 150 units of collateral. price of 2.5: 150 / (50 * 2.5) = 120% => undercollateralized
             let disputePrice = toWei("2.5");
-            await mockOracle.pushPrice(utf8ToHex(identifier), liquidationTime, disputePrice);
+            await mockOracle.methods
+              .pushPrice(utf8ToHex(identifier), liquidationTime, disputePrice)
+              .send({ from: deployer });
 
             // Withdraw from liquidation to settle the dispute event.
-            const txObject1 = await financialContract.withdrawLiquidation("0", sponsor1, { from: liquidator });
+            const txObject1 = await financialContract.methods
+              .withdrawLiquidation("0", sponsor1)
+              .send({ from: liquidator });
             await eventClient.clearState();
 
             // Even though the dispute settlement has occurred on-chain, because we haven't updated the event client yet,
@@ -494,33 +525,40 @@ contract("ContractMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
             assert.isTrue(lastSpyLogIncludes(spy, "(Monitored dispute bot)"));
             assert.isTrue(lastSpyLogIncludes(spy, "failed")); // the disputed was not successful based on settlement price
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject1.transactionHash}`));
 
             // Advance time so that price request is for a different timestamp.
             const nextLiquidationTimestamp = liquidationTime + 1;
-            await financialContract.setCurrentTime(nextLiquidationTimestamp.toString());
+            await financialContract.methods
+              .setCurrentTime(nextLiquidationTimestamp.toString())
+              .send({ from: deployer });
 
-            // Create a second liquidation from a non-monitored address (sponsor1).
-            liquidationTime = (await financialContract.getCurrentTime()).toNumber();
-            await financialContract.createLiquidation(
-              sponsor2,
-              { rawValue: "0" },
-              { rawValue: toWei("99999") },
-              { rawValue: convertDecimals("100") },
-              unreachableDeadline,
-              { from: sponsor1 }
-            );
+            // Create a second liquidation from a non-monitored.options.address (sponsor1).
+            liquidationTime = parseInt(await financialContract.methods.getCurrentTime().call());
+            await financialContract.methods
+              .createLiquidation(
+                sponsor2,
+                { rawValue: "0" },
+                { rawValue: toWei("99999") },
+                { rawValue: convertDecimals("100") },
+                unreachableDeadline
+              )
+              .send({ from: sponsor1 });
 
-            // Dispute the liquidator from a non-monitor address (sponsor2)
-            await financialContract.dispute("0", sponsor2, { from: sponsor2 });
+            // Dispute the liquidator from a non-monitor.options.address (sponsor2)
+            await financialContract.methods.dispute("0", sponsor2).send({ from: sponsor2 });
 
             // Push a price such that the dispute succeeds and ensure the resolution reports correctly. Sponsor2 has 45 units of
             // debt and 175 units of collateral. price of 2.0: 175 / (45 * 2) = 194% => sufficiently collateralized
             disputePrice = convertDecimals("2.0");
-            await mockOracle.pushPrice(utf8ToHex(identifier), liquidationTime, disputePrice);
+            await mockOracle.methods
+              .pushPrice(utf8ToHex(identifier), liquidationTime, disputePrice)
+              .send({ from: deployer });
 
             // Withdraw from liquidation to settle the dispute event.
-            const txObject2 = await financialContract.withdrawLiquidation("0", sponsor2, { from: sponsor2 });
+            const txObject2 = await financialContract.methods
+              .withdrawLiquidation("0", sponsor2)
+              .send({ from: sponsor2 });
             await eventClient.clearState();
 
             // Update the eventClient and check it has the dispute event stored correctly
@@ -528,12 +566,12 @@ contract("ContractMonitor.js", function (accounts) {
 
             await contractMonitor.checkForNewDisputeSettlementEvents();
 
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor1}`)); // liquidator address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor1}`)); // liquidator.options.address
             assert.isFalse(lastSpyLogIncludes(spy, "(Monitored liquidator bot)")); // This liquidator is not monitored
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor2}`)); // disputer address
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${sponsor2}`)); // disputer.options.address
             assert.isFalse(lastSpyLogIncludes(spy, "(Monitored dispute bot)")); // This disputer is not monitored
             assert.isTrue(lastSpyLogIncludes(spy, "succeeded")); // the disputed was successful based on settlement price
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject2.transactionHash}`));
           }
         );
         versionedIt([{ contractType: "Perpetual", contractVersion: "2.0.1" }])(
@@ -542,15 +580,20 @@ contract("ContractMonitor.js", function (accounts) {
             // Propose new funding rate.
             const proposeAndPublishNewRate = async (newRateWei) => {
               // Advance time forward by 1 to guarantee that proposal time > last update time.
-              let currentTime = await timer.getCurrentTime();
-              await timer.setCurrentTime(currentTime.toNumber() + 1);
-              let proposalTime = currentTime.toNumber() + 1;
-              await financialContract.proposeFundingRate({ rawValue: newRateWei }, proposalTime);
+              let currentTime = await timer.methods.getCurrentTime().call();
+              await timer.methods.setCurrentTime(parseInt(currentTime) + 1).send({ from: deployer });
+              let proposalTime = parseInt(currentTime) + 1;
+              await financialContract.methods
+                .proposeFundingRate({ rawValue: newRateWei }, proposalTime)
+                .send({ from: deployer });
               // Advance timer far enough such that funding rate proposal can be published,
               // and publish it.
               const proposalExpiry = proposalTime + optimisticOracleLiveness;
-              await timer.setCurrentTime(proposalExpiry);
-              return { txObject: await financialContract.applyFundingRate(), proposalTime };
+              await timer.methods.setCurrentTime(proposalExpiry).send({ from: deployer });
+              return {
+                txObject: await financialContract.methods.applyFundingRate().send({ from: deployer }),
+                proposalTime,
+              };
             };
 
             await eventClient.clearState();
@@ -569,7 +612,7 @@ contract("ContractMonitor.js", function (accounts) {
             assert.isTrue(lastSpyLogIncludes(spy, "New funding rate published: 0.00001/second"));
             assert.isTrue(lastSpyLogIncludes(spy, `proposal time was ${proposalTime}`));
             assert.isTrue(lastSpyLogIncludes(spy, "reward of 0"));
-            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject.tx}`));
+            assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${txObject.transactionHash}`));
           }
         );
         versionedIt([{ contractType: "any", contractVersion: "any" }])(
@@ -577,7 +620,7 @@ contract("ContractMonitor.js", function (accounts) {
           async function () {
             let errorThrown1;
             try {
-              // Create an invalid config. A valid config expects two arrays of addresses.
+              // Create an invalid config. A valid config expects two arrays of.options.addresses.
               const invalidConfig1 = { monitoredLiquidators: liquidator, monitoredDisputers: [disputer] };
               contractMonitor = new ContractMonitor({
                 logger: spyLogger,
@@ -594,7 +637,7 @@ contract("ContractMonitor.js", function (accounts) {
 
             let errorThrown2;
             try {
-              // Create an invalid config. A valid config expects two arrays of addresses.
+              // Create an invalid config. A valid config expects two arrays of.options.addresses.
               const invalidConfig2 = { monitoredLiquidators: "NOT AN ADDRESS" };
               contractMonitor = new ContractMonitor({
                 logger: spyLogger,
@@ -633,7 +676,7 @@ contract("ContractMonitor.js", function (accounts) {
           async function () {
             let errorThrown;
             try {
-              // Create an invalid config. A valid config expects two arrays of addresses.
+              // Create an invalid config. A valid config expects two arrays of.options.addresses.
               const emptyConfig = {};
               contractMonitor = new ContractMonitor({
                 logger: spyLogger,

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -1,3 +1,6 @@
+const { getContract, web3 } = require("hardhat");
+const { assert } = require("chai");
+
 const winston = require("winston");
 const sinon = require("sinon");
 
@@ -5,7 +8,6 @@ const { toWei, hexToUtf8, utf8ToHex } = web3.utils;
 
 const { OptimisticOracleContractMonitor } = require("../src/OptimisticOracleContractMonitor");
 const { interfaceName, MAX_UINT_VAL } = require("@uma/common");
-const { getTruffleContract } = require("@uma/core");
 
 const {
   OptimisticOracleEventClient,
@@ -14,21 +16,22 @@ const {
   lastSpyLogLevel,
 } = require("@uma/financial-templates-lib");
 
-const OptimisticOracle = getTruffleContract("OptimisticOracle", web3);
-const OptimisticRequesterTest = getTruffleContract("OptimisticRequesterTest", web3);
-const Finder = getTruffleContract("Finder", web3);
-const IdentifierWhitelist = getTruffleContract("IdentifierWhitelist", web3);
-const Token = getTruffleContract("ExpandedERC20", web3);
-const AddressWhitelist = getTruffleContract("AddressWhitelist", web3);
-const Timer = getTruffleContract("Timer", web3);
-const Store = getTruffleContract("Store", web3);
-const MockOracle = getTruffleContract("MockOracleAncillary", web3);
+const OptimisticOracle = getContract("OptimisticOracle");
+const OptimisticRequesterTest = getContract("OptimisticRequesterTest");
+const Finder = getContract("Finder");
+const IdentifierWhitelist = getContract("IdentifierWhitelist");
+const Token = getContract("ExpandedERC20");
+const AddressWhitelist = getContract("AddressWhitelist");
+const Timer = getContract("Timer");
+const Store = getContract("Store");
+const MockOracle = getContract("MockOracleAncillary");
 
-contract("OptimisticOracleContractMonitor.js", function (accounts) {
-  const owner = accounts[0];
-  const requester = accounts[1];
-  const proposer = accounts[2];
-  const disputer = accounts[3];
+describe("OptimisticOracleContractMonitor.js", function () {
+  let accounts;
+  let owner;
+  let requester;
+  let proposer;
+  let disputer;
 
   let optimisticRequester;
   let optimisticOracle;
@@ -63,50 +66,64 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
   const alternativeAncillaryData = "0x1234";
 
   const pushPrice = async (price) => {
-    const [lastQuery] = (await mockOracle.getPendingQueries()).slice(-1);
-    await mockOracle.pushPrice(lastQuery.identifier, lastQuery.time, lastQuery.ancillaryData, price);
+    const [lastQuery] = (await mockOracle.methods.getPendingQueries().call()).slice(-1);
+    await mockOracle.methods
+      .pushPrice(lastQuery.identifier, lastQuery.time, lastQuery.ancillaryData, price)
+      .send({ from: owner });
   };
 
   before(async function () {
-    finder = await Finder.new();
-    timer = await Timer.new();
+    accounts = await web3.eth.getAccounts();
+    [owner, requester, proposer, disputer] = accounts;
+    finder = await Finder.new().send({ from: owner });
+    timer = await Timer.new().send({ from: owner });
 
     // Whitelist an initial identifier we can use to make default price requests.
-    identifierWhitelist = await IdentifierWhitelist.new();
-    await identifierWhitelist.addSupportedIdentifier(identifier);
-    await finder.changeImplementationAddress(utf8ToHex(interfaceName.IdentifierWhitelist), identifierWhitelist.address);
+    identifierWhitelist = await IdentifierWhitelist.new().send({ from: owner });
+    await identifierWhitelist.methods.addSupportedIdentifier(identifier).send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.IdentifierWhitelist), identifierWhitelist.options.address)
+      .send({ from: owner });
 
-    collateralWhitelist = await AddressWhitelist.new();
-    await finder.changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.address);
+    collateralWhitelist = await AddressWhitelist.new().send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.options.address)
+      .send({ from: owner });
 
-    store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.address);
-    await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
+    store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.options.address).send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.Store), store.options.address)
+      .send({ from: owner });
 
-    mockOracle = await MockOracle.new(finder.address, timer.address);
-    await finder.changeImplementationAddress(utf8ToHex(interfaceName.Oracle), mockOracle.address);
+    mockOracle = await MockOracle.new(finder.options.address, timer.options.address).send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.Oracle), mockOracle.options.address)
+      .send({ from: owner });
   });
 
   let requestTxn, proposalTxn, disputeTxn, settlementTxn;
   beforeEach(async function () {
     // Deploy and whitelist a new collateral currency that we will use to pay oracle fees.
-    collateral = await Token.new("Wrapped Ether", "WETH", 18);
-    await collateral.addMember(1, owner);
-    await collateral.mint(owner, initialUserBalance);
-    await collateral.mint(proposer, initialUserBalance);
-    await collateral.mint(requester, initialUserBalance);
-    await collateral.mint(disputer, initialUserBalance);
-    await collateralWhitelist.addToWhitelist(collateral.address);
+    collateral = await Token.new("Wrapped Ether", "WETH", 18).send({ from: owner });
+    await collateral.methods.addMember(1, owner).send({ from: owner });
+    await collateral.methods.mint(owner, initialUserBalance).send({ from: owner });
+    await collateral.methods.mint(proposer, initialUserBalance).send({ from: owner });
+    await collateral.methods.mint(requester, initialUserBalance).send({ from: owner });
+    await collateral.methods.mint(disputer, initialUserBalance).send({ from: owner });
+    await collateralWhitelist.methods.addToWhitelist(collateral.options.address).send({ from: owner });
 
     // Set a non-0 final fee for the collateral currency.
-    await store.setFinalFee(collateral.address, { rawValue: finalFee });
+    await store.methods.setFinalFee(collateral.options.address, { rawValue: finalFee }).send({ from: owner });
 
-    optimisticOracle = await OptimisticOracle.new(liveness, finder.address, timer.address);
+    optimisticOracle = await OptimisticOracle.new(liveness, finder.options.address, timer.options.address).send({
+      from: owner,
+    });
 
     // Contract used to make price requests. Mint it some collateral to pay rewards with.
-    optimisticRequester = await OptimisticRequesterTest.new(optimisticOracle.address);
-    await collateral.mint(optimisticRequester.address, initialUserBalance);
+    optimisticRequester = await OptimisticRequesterTest.new(optimisticOracle.options.address).send({ from: owner });
+    await collateral.methods.mint(optimisticRequester.options.address, initialUserBalance).send({ from: owner });
 
-    startTime = (await optimisticOracle.getCurrentTime()).toNumber();
+    startTime = parseInt(await optimisticOracle.methods.getCurrentTime().call());
     requestTime = startTime - 10;
 
     // Create a sinon spy and give it to the SpyTransport as the winston logger. Use this to check all winston
@@ -118,7 +135,7 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
       spyLogger,
       OptimisticOracle.abi,
       web3,
-      optimisticOracle.address,
+      optimisticOracle.options.address,
       0, // startingBlockNumber
       null // endingBlockNumber
     );
@@ -134,44 +151,28 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
     });
 
     // Make price requests
-    requestTxn = await optimisticRequester.requestPrice(
-      identifier,
-      requestTime,
-      defaultAncillaryData,
-      collateral.address,
-      reward
-    );
+    requestTxn = await optimisticRequester.methods
+      .requestPrice(identifier, requestTime, defaultAncillaryData, collateral.options.address, reward)
+      .send({ from: owner });
 
     // Make proposals
-    await collateral.approve(optimisticOracle.address, MAX_UINT_VAL, { from: proposer });
-    proposalTime = await optimisticOracle.getCurrentTime();
-    proposalTxn = await optimisticOracle.proposePrice(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      defaultAncillaryData,
-      correctPrice,
-      { from: proposer }
-    );
+    await collateral.methods.approve(optimisticOracle.options.address, MAX_UINT_VAL).send({ from: proposer });
+    proposalTime = await optimisticOracle.methods.getCurrentTime().call();
+    proposalTxn = await optimisticOracle.methods
+      .proposePrice(optimisticRequester.options.address, identifier, requestTime, defaultAncillaryData, correctPrice)
+      .send({ from: proposer });
 
     // Make disputes and resolve them
-    await collateral.approve(optimisticOracle.address, MAX_UINT_VAL, { from: disputer });
-    disputeTxn = await optimisticOracle.disputePrice(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      defaultAncillaryData,
-      { from: disputer }
-    );
+    await collateral.methods.approve(optimisticOracle.options.address, MAX_UINT_VAL).send({ from: disputer });
+    disputeTxn = await optimisticOracle.methods
+      .disputePrice(optimisticRequester.options.address, identifier, requestTime, defaultAncillaryData)
+      .send({ from: disputer });
     await pushPrice(correctPrice);
 
     // Settle expired proposals and resolved disputes
-    settlementTxn = await optimisticOracle.settle(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      defaultAncillaryData
-    );
+    settlementTxn = await optimisticOracle.methods
+      .settle(optimisticRequester.options.address, identifier, requestTime, defaultAncillaryData)
+      .send({ from: owner });
   });
 
   it("Winston correctly emits price request message", async function () {
@@ -181,29 +182,25 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
     assert.equal(lastSpyLogLevel(spy), "error");
 
     // Should contain etherscan addresses for the requester and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.address}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.options.address}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.transactionHash}`));
 
     // should contain the correct request information.
     assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
     assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
     assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, collateral.address)); // Currency
+    assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
     assert.isTrue(lastSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
     assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Final Fee
     let spyCount = spy.callCount;
 
     // Make another request with different ancillary data.
-    const newTxn = await optimisticRequester.requestPrice(
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      collateral.address,
-      reward
-    );
+    const newTxn = await optimisticRequester.methods
+      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+      .send({ from: owner });
     await eventClient.update();
     await contractMonitor.checkForRequests();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryData)); // Ancillary Data
 
     // Check that only one extra event was emitted since we already "checked" the original events.
@@ -217,37 +214,34 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
 
     // Should contain etherscan addresses for the proposer and transaction
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${proposer}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalTxn.transactionHash}`));
 
     // should contain the correct proposal information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.address)); // Requester
+    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
     assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
     assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
     assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, collateral.address)); // Currency
+    assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
     assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
     assert.isTrue(lastSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
     let spyCount = spy.callCount;
 
     // Make another proposal with different ancillary data.
-    await optimisticRequester.requestPrice(
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      collateral.address,
-      reward
-    );
-    const newTxn = await optimisticOracle.proposePrice(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      correctPrice,
-      { from: proposer }
-    );
+    await optimisticRequester.methods
+      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+      .send({ from: owner });
+    const newTxn = await optimisticOracle.methods
+      .proposePrice(
+        optimisticRequester.options.address,
+        identifier,
+        requestTime,
+        alternativeAncillaryData,
+        correctPrice
+      )
+      .send({ from: proposer });
     await eventClient.update();
     await contractMonitor.checkForProposals();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryData)); // Ancillary Data
 
     // Check that only one extra event was emitted since we already "checked" the original events.
@@ -261,10 +255,10 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
 
     // Should contain etherscan addresses for the disputer and transaction
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeTxn.transactionHash}`));
 
     // should contain the correct dispute information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.address)); // Requester
+    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
     assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
     assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
     assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
@@ -273,31 +267,24 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
     let spyCount = spy.callCount;
 
     // Make another dispute with different ancillary data.
-    await optimisticRequester.requestPrice(
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      collateral.address,
-      reward
-    );
-    await optimisticOracle.proposePrice(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      correctPrice,
-      { from: proposer }
-    );
-    const newTxn = await optimisticOracle.disputePrice(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      { from: disputer }
-    );
+    await optimisticRequester.methods
+      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+      .send({ from: owner });
+    await optimisticOracle.methods
+      .proposePrice(
+        optimisticRequester.options.address,
+        identifier,
+        requestTime,
+        alternativeAncillaryData,
+        correctPrice
+      )
+      .send({ from: proposer });
+    const newTxn = await optimisticOracle.methods
+      .disputePrice(optimisticRequester.options.address, identifier, requestTime, alternativeAncillaryData)
+      .send({ from: disputer });
     await eventClient.update();
     await contractMonitor.checkForDisputes();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryData)); // Ancillary Data
 
     // Check that only one extra event was emitted since we already "checked" the original events.
@@ -310,10 +297,10 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
     assert.equal(lastSpyLogLevel(spy), "info");
 
     // Should contain etherscan addresses for the transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementTxn.transactionHash}`));
 
     // should contain the correct settlement information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.address)); // Requester
+    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
     assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
     assert.isTrue(lastSpyLogIncludes(spy, disputer)); // Disputer
     assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
@@ -327,32 +314,28 @@ contract("OptimisticOracleContractMonitor.js", function (accounts) {
     let spyCount = spy.callCount;
 
     // Make another settlement without a dispute, with different ancillary data.
-    await optimisticRequester.requestPrice(
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      collateral.address,
-      reward
-    );
-    const newProposalTime = await optimisticOracle.getCurrentTime();
-    await optimisticOracle.proposePrice(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      alternativeAncillaryData,
-      correctPrice,
-      { from: proposer }
-    );
-    await optimisticOracle.setCurrentTime((Number(newProposalTime) + liveness).toString());
-    const newTxn = await optimisticOracle.settle(
-      optimisticRequester.address,
-      identifier,
-      requestTime,
-      alternativeAncillaryData
-    );
+    await optimisticRequester.methods
+      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+      .send({ from: owner });
+    const newProposalTime = await optimisticOracle.methods.getCurrentTime().call();
+    await optimisticOracle.methods
+      .proposePrice(
+        optimisticRequester.options.address,
+        identifier,
+        requestTime,
+        alternativeAncillaryData,
+        correctPrice
+      )
+      .send({ from: proposer });
+    await optimisticOracle.methods
+      .setCurrentTime((Number(newProposalTime) + liveness).toString())
+      .send({ from: owner });
+    const newTxn = await optimisticOracle.methods
+      .settle(optimisticRequester.options.address, identifier, requestTime, alternativeAncillaryData)
+      .send({ from: owner });
     await eventClient.update();
     await contractMonitor.checkForSettlements();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.tx}`));
+    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     // Proposal this time was not disputed so payout to the proposer.
     // Proposer reward equals: default bond (2x final fee) + proposal reward
     // = (2 * 1) + 3 = 5

--- a/packages/monitors/test/index.js
+++ b/packages/monitors/test/index.js
@@ -1,12 +1,14 @@
+const { web3, getContract } = require("hardhat");
+const { assert } = require("chai");
+
 const { toWei, utf8ToHex, padRight } = web3.utils;
 const {
   interfaceName,
   addGlobalHardhatTestingAddress,
   createConstructorParamsForContractVersion,
   TESTED_CONTRACT_VERSIONS,
+  getContractsNodePackageAliasForVerion,
 } = require("@uma/common");
-
-const { getTruffleContract } = require("@uma/core");
 
 // Custom winston transport module to monitor winston log outputs
 const winston = require("winston");
@@ -44,49 +46,77 @@ let errorRetriesTimeout = 0.1; // 100 milliseconds between performing retries
 let identifier = "TEST_IDENTIFIER";
 let fundingRateIdentifier = "TEST_FUNDING";
 
-contract("index.js", function (accounts) {
-  const contractCreator = accounts[0];
+describe("index.js", function () {
+  let accounts;
+  let contractCreator;
+
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+    [contractCreator] = accounts;
+  });
 
   TESTED_CONTRACT_VERSIONS.forEach(function (contractVersion) {
+    const { getAbi, getBytecode } = require(getContractsNodePackageAliasForVerion(contractVersion.contractVersion));
+
+    const createContract = (name) => {
+      const abi = getAbi(name);
+      const bytecode = getBytecode(name);
+      return getContract(name, { abi, bytecode });
+    };
+
     // Import the tested versions of contracts. note that FinancialContract is either an ExpiringMultiParty or the perp
     // depending on the current iteration version.
-    const FinancialContract = getTruffleContract(contractVersion.contractType, web3, contractVersion.contractVersion);
-    const Finder = getTruffleContract("Finder", web3, contractVersion.contractVersion);
-    const IdentifierWhitelist = getTruffleContract("IdentifierWhitelist", web3, contractVersion.contractVersion);
-    const AddressWhitelist = getTruffleContract("AddressWhitelist", web3, contractVersion.contractVersion);
-    const MockOracle = getTruffleContract("MockOracle", web3, contractVersion.contractVersion);
-    const Token = getTruffleContract("ExpandedERC20", web3, contractVersion.contractVersion);
-    const SyntheticToken = getTruffleContract("SyntheticToken", web3, contractVersion.contractVersion);
-    const Timer = getTruffleContract("Timer", web3, contractVersion.contractVersion);
-    const Store = getTruffleContract("Store", web3, contractVersion.contractVersion);
-    const ConfigStore = getTruffleContract("ConfigStore", web3, contractVersion.contractVersion);
+    const FinancialContract = createContract(contractVersion.contractType);
+    const Finder = createContract("Finder");
+    const IdentifierWhitelist = createContract("IdentifierWhitelist");
+    const AddressWhitelist = createContract("AddressWhitelist");
+    const MockOracle = createContract("MockOracle");
+    const Token = createContract("ExpandedERC20");
+    const SyntheticToken = createContract("SyntheticToken");
+    const Timer = createContract("Timer");
+    const Store = createContract("Store");
+    const ConfigStore = createContract("ConfigStore");
     // Note: OptimisticOracle always uses "2.0.1"
-    const OptimisticOracle = getTruffleContract("OptimisticOracle", web3);
+    const OptimisticOracle = createContract("OptimisticOracle");
 
     describe(`Tests running on smart contract version ${contractVersion.contractType} @ ${contractVersion.contractVersion}`, function () {
       before(async function () {
-        collateralToken = await Token.new("Wrapped Ether", "WETH", 18, { from: contractCreator });
+        collateralToken = await Token.new("Wrapped Ether", "WETH", 18).send({ from: contractCreator });
 
-        identifierWhitelist = await IdentifierWhitelist.new();
-        await identifierWhitelist.addSupportedIdentifier(utf8ToHex("TEST_IDENTIFIER"));
-        await identifierWhitelist.addSupportedIdentifier(utf8ToHex("ETH/BTC"));
+        identifierWhitelist = await IdentifierWhitelist.new().send({ from: contractCreator });
+        await identifierWhitelist.methods
+          .addSupportedIdentifier(utf8ToHex("TEST_IDENTIFIER"))
+          .send({ from: contractCreator });
+        await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex("ETH/BTC")).send({ from: contractCreator });
 
         // Create identifier whitelist and register the price tracking ticker with it.
-        finder = await Finder.new();
-        timer = await Timer.new();
-        store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.address);
-        await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
+        finder = await Finder.new().send({ from: contractCreator });
+        timer = await Timer.new().send({ from: contractCreator });
+        store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.options.address).send({
+          from: contractCreator,
+        });
+        await finder.methods
+          .changeImplementationAddress(utf8ToHex(interfaceName.Store), store.options.address)
+          .send({ from: contractCreator });
 
-        await finder.changeImplementationAddress(
-          utf8ToHex(interfaceName.IdentifierWhitelist),
-          identifierWhitelist.address
-        );
-        await identifierWhitelist.addSupportedIdentifier(utf8ToHex("TEST_IDENTIFIER"));
+        await finder.methods
+          .changeImplementationAddress(
+            utf8ToHex(interfaceName.IdentifierWhitelist),
+            identifierWhitelist.options.address
+          )
+          .send({ from: contractCreator });
+        await identifierWhitelist.methods
+          .addSupportedIdentifier(utf8ToHex("TEST_IDENTIFIER"))
+          .send({ from: contractCreator });
 
-        mockOracle = await MockOracle.new(finder.address, timer.address, { from: contractCreator });
-        await finder.changeImplementationAddress(utf8ToHex(interfaceName.Oracle), mockOracle.address);
+        mockOracle = await MockOracle.new(finder.options.address, timer.options.address).send({
+          from: contractCreator,
+        });
+        await finder.methods
+          .changeImplementationAddress(utf8ToHex(interfaceName.Oracle), mockOracle.options.address)
+          .send({ from: contractCreator });
         // Set the address in the global name space to enable disputer's index.js to access it.
-        addGlobalHardhatTestingAddress("Voting", mockOracle.address);
+        addGlobalHardhatTestingAddress("Voting", mockOracle.options.address);
       });
 
       beforeEach(async function () {
@@ -98,17 +128,25 @@ contract("index.js", function (accounts) {
         });
 
         // Create a new synthetic token
-        syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18, { from: contractCreator });
+        syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18).send({ from: contractCreator });
 
-        collateralWhitelist = await AddressWhitelist.new();
-        await finder.changeImplementationAddress(
-          web3.utils.utf8ToHex(interfaceName.CollateralWhitelist),
-          collateralWhitelist.address
-        );
-        await collateralWhitelist.addToWhitelist(collateralToken.address);
+        collateralWhitelist = await AddressWhitelist.new().send({ from: contractCreator });
+        await finder.methods
+          .changeImplementationAddress(
+            web3.utils.utf8ToHex(interfaceName.CollateralWhitelist),
+            collateralWhitelist.options.address
+          )
+          .send({ from: contractCreator });
+        await collateralWhitelist.methods
+          .addToWhitelist(collateralToken.options.address)
+          .send({ from: contractCreator });
 
-        optimisticOracle = await OptimisticOracle.new(7200, finder.address, timer.address);
-        await finder.changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracle), optimisticOracle.address);
+        optimisticOracle = await OptimisticOracle.new(7200, finder.options.address, timer.options.address).send({
+          from: contractCreator,
+        });
+        await finder.methods
+          .changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracle), optimisticOracle.options.address)
+          .send({ from: contractCreator });
 
         if (contractVersion.contractType == "Perpetual") {
           configStore = await ConfigStore.new(
@@ -120,9 +158,11 @@ contract("index.js", function (accounts) {
               minFundingRate: { rawValue: toWei("-0.00001") },
               proposalTimePastLimit: 0,
             },
-            timer.address
-          );
-          await identifierWhitelist.addSupportedIdentifier(padRight(utf8ToHex(fundingRateIdentifier)));
+            timer.options.address
+          ).send({ from: contractCreator });
+          await identifierWhitelist.methods
+            .addSupportedIdentifier(padRight(utf8ToHex(fundingRateIdentifier)))
+            .send({ from: contractCreator });
         }
         // Deploy a new expiring multi party OR perpetual.
         constructorParams = await createConstructorParamsForContractVersion(
@@ -141,9 +181,9 @@ contract("index.js", function (accounts) {
           // Note: an identifier which is part of the default config is required for this test.
           { priceFeedIdentifier: padRight(utf8ToHex("ETH/BTC"), 64) }
         );
-        financialContract = await FinancialContract.new(constructorParams);
-        await syntheticToken.addMinter(financialContract.address);
-        await syntheticToken.addBurner(financialContract.address);
+        financialContract = await FinancialContract.new(constructorParams).send({ from: contractCreator });
+        await syntheticToken.methods.addMinter(financialContract.options.address).send({ from: contractCreator });
+        await syntheticToken.methods.addBurner(financialContract.options.address).send({ from: contractCreator });
 
         defaultMonitorConfig = {};
         defaultTokenPricefeedConfig = { type: "test", currentPrice: "1", historicalPrice: "1" };
@@ -156,7 +196,7 @@ contract("index.js", function (accounts) {
         await Poll.run({
           logger: spyLogger,
           web3,
-          financialContractAddress: financialContract.address,
+          financialContractAddress: financialContract.options.address,
           pollingDelay,
           errorRetries,
           errorRetriesTimeout,
@@ -174,7 +214,7 @@ contract("index.js", function (accounts) {
         await Poll.run({
           logger: spyLogger,
           web3,
-          optimisticOracleAddress: optimisticOracle.address,
+          optimisticOracleAddress: optimisticOracle.options.address,
           pollingDelay,
           errorRetries,
           errorRetriesTimeout,
@@ -192,8 +232,8 @@ contract("index.js", function (accounts) {
         await Poll.run({
           logger: spyLogger,
           web3,
-          financialContractAddress: financialContract.address,
-          optimisticOracleAddress: optimisticOracle.address,
+          financialContractAddress: financialContract.options.address,
+          optimisticOracleAddress: optimisticOracle.options.address,
           pollingDelay,
           errorRetries,
           errorRetriesTimeout,
@@ -214,21 +254,21 @@ contract("index.js", function (accounts) {
           transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
         });
 
-        collateralToken = await Token.new("USDC", "USDC", 6, { from: contractCreator });
-        syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 6, { from: contractCreator });
+        collateralToken = await Token.new("USDC", "USDC", 6).send({ from: contractCreator });
+        syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 6).send({ from: contractCreator });
         constructorParams = {
           ...constructorParams,
-          collateralAddress: collateralToken.address,
-          tokenAddress: syntheticToken.address,
+          collateralAddress: collateralToken.options.address,
+          tokenAddress: syntheticToken.options.address,
         };
-        financialContract = await FinancialContract.new(constructorParams);
-        await syntheticToken.addMinter(financialContract.address);
-        await syntheticToken.addBurner(financialContract.address);
+        financialContract = await FinancialContract.new(constructorParams).send({ from: contractCreator });
+        await syntheticToken.methods.addMinter(financialContract.options.address);
+        await syntheticToken.methods.addBurner(financialContract.options.address);
 
         await Poll.run({
           logger: spyLogger,
           web3,
-          financialContractAddress: financialContract.address,
+          financialContractAddress: financialContract.options.address,
           pollingDelay,
           errorRetries,
           errorRetriesTimeout,
@@ -258,7 +298,7 @@ contract("index.js", function (accounts) {
         await Poll.run({
           logger: spyLogger,
           web3,
-          financialContractAddress: financialContract.address,
+          financialContractAddress: financialContract.options.address,
           pollingDelay,
           errorRetries,
           errorRetriesTimeout,
@@ -291,7 +331,7 @@ contract("index.js", function (accounts) {
           await Poll.run({
             logger: spyLogger,
             web3,
-            financialContractAddress: finder.address,
+            financialContractAddress: finder.options.address,
             pollingDelay,
             errorRetries,
             errorRetriesTimeout,
@@ -319,9 +359,9 @@ contract("index.js", function (accounts) {
         // and excludes any liquidation logic. As a result, calling `getLiquidations` in the Financial Contract contract will error out.
 
         // Need to give an unknown identifier to get past the `createReferencePriceFeedForFinancialContract` & `createUniswapPriceFeedForFinancialContract`
-        await identifierWhitelist.addSupportedIdentifier(utf8ToHex("UNKNOWN"));
+        await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex("UNKNOWN")).send({ from: contractCreator });
 
-        const PricelessPositionManager = getTruffleContract("PricelessPositionManager", web3, "1.2.2");
+        const PricelessPositionManager = getContract("PricelessPositionManager");
         const invalidFinancialContract = await PricelessPositionManager.new(
           constructorParams.expirationTimestamp,
           constructorParams.withdrawalLiveness,
@@ -331,9 +371,8 @@ contract("index.js", function (accounts) {
           utf8ToHex("UNKNOWN"),
           constructorParams.minSponsorTokens,
           constructorParams.timerAddress,
-          constructorParams.excessTokenBeneficiary,
           constructorParams.excessTokenBeneficiary
-        );
+        ).send({ from: contractCreator });
 
         // Create a spy logger to catch all log messages to validate re-try attempts.
         spyLogger = winston.createLogger({
@@ -353,7 +392,7 @@ contract("index.js", function (accounts) {
           await Poll.run({
             logger: spyLogger,
             web3,
-            financialContractAddress: invalidFinancialContract.address,
+            financialContractAddress: invalidFinancialContract.options.address,
             pollingDelay,
             errorRetries: errorRetries,
             errorRetriesTimeout,

--- a/packages/monitors/truffle-config.js
+++ b/packages/monitors/truffle-config.js
@@ -1,4 +1,0 @@
-const path = require("path");
-const wkdir = path.dirname(require.resolve("@uma/core/package.json"));
-
-module.exports = require("@uma/common").getTruffleConfig(wkdir);


### PR DESCRIPTION
**Motivation**

We'd like to drop truffle entirely.

**Summary**

This drops truffle and the majority of the core methods from monitors. The only exception is the contract version finder -- we'll need to decide what to do with that down the line to allow our bots to no longer depend on core.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
