### PR TITLE
fix(api): add retry options to web3 websocket

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,8 @@
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
-    "url-join": "^4.0.1"
+    "url-join": "^4.0.1",
+    "web3": "^1.5.0"
   },
   "files": [
     "/dist/**/*.js"

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import Web3 from "web3";
 import { ethers } from "ethers";
 import moment from "moment";
 
@@ -11,7 +10,7 @@ import * as Actions from "../../services/actions";
 import { ProcessEnv, AppState, Channels } from "../..";
 import { empStats, empStatsHistory, lsps } from "../../tables";
 import Zrx from "../../libs/zrx";
-import { Profile, parseEnvArray } from "../../libs/utils";
+import { Profile, parseEnvArray, getWeb3 } from "../../libs/utils";
 
 export default async (env: ProcessEnv) => {
   assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
@@ -27,7 +26,7 @@ export default async (env: ProcessEnv) => {
   const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL);
 
   // we need web3 for syth price feeds
-  const web3 = new Web3(env.CUSTOM_NODE_URL);
+  const web3 = getWeb3(env.CUSTOM_NODE_URL);
 
   // how often to run expensive state updates, defaults to 10 minutes
   const updateRateS = Number(env.UPDATE_RATE_S || 10 * 60);

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -3,6 +3,7 @@ import { Obj } from "..";
 import * as uma from "@uma/sdk";
 import { utils, BigNumber, Contract } from "ethers";
 import assert from "assert";
+import Web3 from "web3";
 const { parseUnits, parseBytes32String } = utils;
 
 export const SCALING_MULTIPLIER: BigNumber = parseUnits("1");
@@ -147,4 +148,31 @@ export function parseEnvArray(str: string, delimiter = ","): string[] {
   if (str.length == 0) return [];
   if (!str.includes(delimiter)) return [];
   return str.split(delimiter).map((x) => x.trim());
+}
+
+export function getWeb3Websocket(url: string, options: Obj = {}) {
+  // pulled from common/src/ProviderUtils.ts
+  const defaults = {
+    clientConfig: {
+      maxReceivedFrameSize: 100000000, // Useful if requests result are large bytes - default: 1MiB
+      maxReceivedMessageSize: 100000000, // bytes - default: 8MiB
+    },
+    reconnect: {
+      auto: true, // Enable auto reconnection
+      delay: 5000, // ms
+      maxAttempts: 10,
+      onTimeout: false,
+    },
+  };
+  return new Web3(
+    new Web3.providers.WebsocketProvider(url, {
+      ...options,
+      ...defaults,
+    })
+  );
+}
+
+export function getWeb3(url: string, options: Obj = {}) {
+  if (url.startsWith("ws")) return getWeb3Websocket(url, options);
+  throw new Error("Only supporting websocket provider URLs for Web3");
 }


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2260/bug-connection-not-open-on-send

**Summary**

Some research on this error leads me to believe this has to do with web3 websocket disconnecting after being open for some time.  This PR configures the websocket to try to reconnect if this happens. 

**Details**

Config defaults were pulled from other parts of the repo, as this has been done before. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2260/bug-connection-not-open-on-send

