### PR TITLE
feat(insured-bridge): Refactoring for gas savings

### DIFF
--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
@@ -299,6 +299,9 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
      * if the deposit data is valid, then even if it is falsely disputed, the instant relayer will eventually get
      * reimbursed because someone else will be incentivized to resubmit the relay to earn slow relayer rewards. Once the
      * valid relay is finalized, the instant relayer will be reimbursed.
+     * @dev We also assume that the caller has validated off-chain that the relay data that they are speeding up is
+     * valid. If the relay is disputed (or eventually gets disputed), then the caller has no recourse to recover
+     * their funds. Therefore, the caller has the same responsibility as the disputer in validating the relay data.
      * @dev Caller must have approved this contract to spend the deposit amount of L1 tokens to relay. There can only
      * be one instant relayer per relay attempt.
      * @param _depositData Unique set of L2 deposit data that caller is trying to instantly relay.

--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
@@ -302,21 +302,12 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
      * reimbursed because someone else will be incentivized to resubmit the relay to earn slow relayer rewards. Once the
      * valid relay is finalized, the instant relayer will be reimbursed.
      * @dev Caller must have approved this contract to spend the deposit amount of L1 tokens to relay. There can only
-     * be one instant relayer per relay attempt and disputed relays cannot be sped up.
+     * be one instant relayer per relay attempt.
      * @param _depositData Unique set of L2 deposit data that caller is trying to instantly relay.
      */
     function speedUpRelay(DepositData memory _depositData) public {
         bytes32 depositHash = _getDepositHash(_depositData);
         RelayData storage relay = relays[depositHash];
-        require(
-            _getOptimisticOracle().getState(
-                address(this),
-                bridgeAdmin.identifier(),
-                relay.priceRequestTime,
-                getRelayAncillaryData(_depositData, relay)
-            ) != OptimisticOracleInterface.State.Disputed,
-            "Cannot speed up disputed relay"
-        );
         require(
             relays[depositHash].relayState == RelayState.Pending && relays[depositHash].instantRelayer == address(0),
             "Relay can not be sped up"

--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
@@ -65,7 +65,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         uint64 depositId;
         address l2Sender;
         address l1Recipient;
-        address l1Token; // todo: we can remove this prop. it's not needed as this contract has a unique l1 token.
         uint256 amount;
         uint64 slowRelayFeePct;
         uint64 instantRelayFeePct;
@@ -230,7 +229,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
                 depositId: depositId,
                 l2Sender: l2Sender,
                 l1Recipient: l1Recipient,
-                l1Token: address(l1Token),
                 amount: amount,
                 slowRelayFeePct: slowRelayFeePct,
                 instantRelayFeePct: instantRelayFeePct,
@@ -459,6 +457,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         view
         returns (bytes memory)
     {
+        // TODO: Consider adding BridgePool address to the ancillary data packet.
         // TODO: Consider hashing all of the params that can be compared against the L2 Deposit contract into a single
         // "relay ancillary data hash" to reduce storage costs.
         bytes memory intermediateAncillaryData = "";
@@ -483,11 +482,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
             intermediateAncillaryData,
             "l2Sender",
             _depositData.l2Sender
-        );
-        intermediateAncillaryData = AncillaryData.appendKeyValueAddress(
-            intermediateAncillaryData,
-            "l1Token",
-            _depositData.l1Token
         );
         intermediateAncillaryData = AncillaryData.appendKeyValueUint(
             intermediateAncillaryData,
@@ -523,6 +517,11 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         );
 
         // Add global state data stored by this contract:
+        intermediateAncillaryData = AncillaryData.appendKeyValueAddress(
+            intermediateAncillaryData,
+            "l1Token",
+            address(l1Token)
+        );
         intermediateAncillaryData = AncillaryData.appendKeyValueAddress(
             intermediateAncillaryData,
             "depositContract",
@@ -581,7 +580,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         return _getAmountFromPct(bridgeAdmin.proposerBondPct(), amount);
     }
 
-    function _getDepositHash(DepositData memory _depositData) private pure returns (bytes32) {
+    function _getDepositHash(DepositData memory _depositData) private view returns (bytes32) {
         return
             keccak256(
                 abi.encode(
@@ -589,7 +588,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
                     _depositData.depositId,
                     _depositData.l1Recipient,
                     _depositData.l2Sender,
-                    _depositData.l1Token,
+                    address(l1Token),
                     _depositData.amount,
                     _depositData.slowRelayFeePct,
                     _depositData.instantRelayFeePct,
@@ -672,7 +671,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
             _depositData.l2Sender,
             msg.sender,
             _depositData.l1Recipient,
-            _depositData.l1Token,
+            address(l1Token),
             _depositData.amount,
             _depositData.slowRelayFeePct,
             _depositData.instantRelayFeePct,

--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgePool.sol
@@ -57,7 +57,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     BridgeAdminInterface public bridgeAdmin;
 
     // A Relay represents an attempt to finalize a cross-chain transfer that originated on an L2 DepositBox contract.
-    enum RelayState { Uninitialized, Pending, Disputed, Finalized }
+    enum RelayState { Uninitialized, Pending, Finalized }
 
     // Data from L2 deposit transaction.
     struct DepositData {
@@ -87,14 +87,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
     // "Uninitialized" state when they are disputed on the OptimisticOracle.
     mapping(bytes32 => RelayData) public relays;
 
-    // TODO: Consider removing this reverse lookup in favor of directly checking the dispute status of relay price
-    // requests from the Optimistic Oracle.
-    // Associates ancillary data related to relay price request with the deposit hash that the relay is attempting to
-    // fulfill. We need to key by the ancillary data so that the OptimisticOracle can locate relays on callbacks using
-    // only price requests' ancillary data. The ancillary data should contain all information required by off-chain
-    // actors (validators, DVM voters, etc.) to verify that a relay is valid.
-    mapping(bytes32 => bytes32) public ancillaryDataToDepositHash;
-
     event LiquidityAdded(address indexed token, uint256 amount, uint256 lpTokensMinted, address liquidityProvider);
     event LiquidityRemoved(address indexed token, uint256 amount, uint256 lpTokensBurnt, address liquidityProvider);
     event DepositRelayed(
@@ -114,7 +106,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         address depositContract
     );
     event RelaySpedUp(bytes32 indexed depositHash, address indexed instantRelayer);
-    event RelayDisputed(bytes32 indexed depositHash, bytes32 indexed priceRequestAncillaryDataHash);
     event RelaySettled(
         bytes32 indexed depositHash,
         bytes32 indexed priceRequestAncillaryDataHash,
@@ -232,7 +223,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         require(instantRelayFeePct < 0.25e18);
         require(realizedLpFeePct < 0.5e18);
 
-        // Check if there is a pending undisputed relay for this deposit.
+        // Check if there is a pending relay for this deposit.
         DepositData memory depositData =
             DepositData({
                 chainId: chainId,
@@ -246,10 +237,19 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
                 quoteTimestamp: quoteTimestamp
             });
         bytes32 depositHash = _getDepositHash(depositData);
+
+        // If relay exists for deposit, check if it is disputed. If its disputed, then we can relay again, otherwise
+        // the relay is pending valid and we cannot re-relay.
         require(
-            (relays[depositHash].relayState == RelayState.Uninitialized ||
-                relays[depositHash].relayState == RelayState.Disputed),
-            "Deposit already relayed"
+            relays[depositHash].relayState == RelayState.Uninitialized ||
+                _getOptimisticOracle().getState(
+                    address(this),
+                    bridgeAdmin.identifier(),
+                    relays[depositHash].priceRequestTime,
+                    getRelayAncillaryData(depositData, relays[depositHash])
+                ) ==
+                OptimisticOracleInterface.State.Disputed,
+            "Pending relay exists"
         );
 
         // If no pending relay for this deposit, then associate the caller's relay attempt with it. Copy over the
@@ -266,10 +266,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
                 instantRelayer: relays[depositHash].instantRelayer
             });
         relays[depositHash] = relayData;
-
-        // Construct unique ancillary data for this relay attempt and associate it with the deposit in a reverse lookup
-        // that the OptimisticOracle can use to mark disputed relay attempts.
-        ancillaryDataToDepositHash[keccak256(getRelayAncillaryData(depositData, relayData))] = depositHash;
 
         // Sanity check that pool has enough balance to cover relay amount + proposer reward. Reward amount will be
         // paid on settlement after the OptimisticOracle price request has passed the challenge period.
@@ -313,6 +309,15 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         bytes32 depositHash = _getDepositHash(_depositData);
         RelayData storage relay = relays[depositHash];
         require(
+            _getOptimisticOracle().getState(
+                address(this),
+                bridgeAdmin.identifier(),
+                relay.priceRequestTime,
+                getRelayAncillaryData(_depositData, relay)
+            ) != OptimisticOracleInterface.State.Disputed,
+            "Cannot speed up disputed relay"
+        );
+        require(
             relays[depositHash].relayState == RelayState.Pending && relays[depositHash].instantRelayer == address(0),
             "Relay can not be sped up"
         );
@@ -340,12 +345,14 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         bytes32 depositHash = _getDepositHash(_depositData);
         RelayData storage relay = relays[depositHash];
 
-        // If relay was disputed, then parties in dispute need to go through OptimisticOracle to resolve dispute.
-        require(relays[depositHash].relayState == RelayState.Pending, "Relay not settleable");
+        require(relays[depositHash].relayState == RelayState.Pending, "Relay state must be pending");
 
         // Attempt to settle OptimisticOracle price as a convenience for the slow relayer who will receive their
-        // dispute bond back. If the price is not settleable, then this call will revert. If the price has already
-        // been settled, then this will not revert and still return the price.
+        // dispute bond back if the relay was disputed unsuccessfully (i.e. the dispute resolved to a price of 1).
+        // If the price is not settleable, then this call will revert. If the price has already
+        // been settled, then this will not revert and still return the price. If the dispute was successful (i.e. the
+        // dispute resolved to a price of 0), then the disputer needs to go through OptimisticOracle to settle their
+        // payout.
         require(
             _getOptimisticOracle().settleAndGetPrice(
                 bridgeAdmin.identifier(),
@@ -390,32 +397,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20 {
         allocateLpFees(_getAmountFromPct(relay.realizedLpFeePct, _depositData.amount));
 
         emit RelaySettled(depositHash, keccak256(getRelayAncillaryData(_depositData, relay)), msg.sender);
-    }
-
-    /**
-     * @notice OptimisticOracle will callback to this function after a pending relay is disputed. This function should
-     * ensure that another slow relayer can fulfill the disputed relay for an L2 deposit.
-     * @param identifier Price identifier used when requesting OO price. Unused.
-     * @param timestamp Unix timestamp of the price request. Unused.
-     * @param ancillaryData AncillaryData of the price request. Use to find the associated disputed relay action.
-     * @param refund Amount refunded for the dispute. Unused.
-     */
-    function priceDisputed(
-        bytes32 identifier,
-        uint256 timestamp,
-        bytes memory ancillaryData,
-        uint256 refund
-    ) public onlyFromOptimisticOracle {
-        bytes32 depositHash = ancillaryDataToDepositHash[keccak256(ancillaryData)];
-        RelayData storage relay = relays[depositHash];
-
-        // Mark pending relay as disputed but do not delete instant relayer information which should be copied over to
-        // next slow relay.
-        relay.relayState = RelayState.Disputed;
-
-        // We do not need to reset the other state in `relay` aside from `instantRelayer` because all of the state
-        // params get rewritten from global state in a `relayDeposit()` call.
-        emit RelayDisputed(depositHash, keccak256(ancillaryData));
     }
 
     /**

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -141,7 +141,7 @@ describe("BridgePool", () => {
         depositData.depositId,
         depositData.l1Recipient,
         depositData.l2Sender,
-        depositData.l1Token,
+        l1Token.options.address,
         depositData.amount,
         depositData.slowRelayFeePct,
         depositData.instantRelayFeePct,
@@ -253,7 +253,6 @@ describe("BridgePool", () => {
       depositId: 1,
       l1Recipient: l1Recipient,
       l2Sender: depositor,
-      l1Token: l1Token.options.address,
       amount: relayAmount,
       slowRelayFeePct: defaultSlowRelayFeePct,
       instantRelayFeePct: defaultInstantRelayFeePct,
@@ -323,6 +322,7 @@ describe("BridgePool", () => {
         }
       }
     });
+    expectedAncillaryDataUtf8 += `l1Token:${l1Token.options.address.substr(2).toLowerCase()},`;
     expectedAncillaryDataUtf8 += `depositContract:${depositContractImpersonator.substr(2).toLowerCase()}`;
     assert.equal(hexToUtf8(relayAncillaryData), expectedAncillaryDataUtf8);
   });
@@ -416,7 +416,7 @@ describe("BridgePool", () => {
           ev.l2Sender === depositData.l2Sender &&
           ev.slowRelayer === relayer &&
           ev.l1Recipient === depositData.l1Recipient &&
-          ev.l1Token === depositData.l1Token &&
+          ev.l1Token === l1Token.options.address &&
           ev.amount === depositData.amount &&
           ev.slowRelayFeePct === depositData.slowRelayFeePct &&
           ev.instantRelayFeePct === depositData.instantRelayFeePct &&

--- a/packages/core/test/insured-bridge/e2e/InsuredBridge.e2e.js
+++ b/packages/core/test/insured-bridge/e2e/InsuredBridge.e2e.js
@@ -386,8 +386,8 @@ describe("Insured bridge e2e tests", () => {
           const relayTx = await (await l1BridgePool.deployed())
             .connect(l1LiquidityProvider)
             .relayDeposit(
+              depositReceipt.events[1].args.chainId.toString(),
               depositReceipt.events[1].args.depositId.toString(),
-              depositReceipt.events[1].args.timestamp.toString(),
               depositReceipt.events[1].args.recipient,
               depositReceipt.events[1].args.sender,
               depositReceipt.events[1].args.amount.toString(),
@@ -402,8 +402,8 @@ describe("Insured bridge e2e tests", () => {
           assert.equal((await l1Token.balanceOf(l1Wallet.address)).toString(), "0"); // Should have no tokens before
 
           depositData = {
+            chainId: depositReceipt.events[1].args.chainId.toString(),
             depositId: depositReceipt.events[1].args.depositId.toString(),
-            depositTimestamp: depositReceipt.events[1].args.timestamp.toString(),
             l2Sender: depositReceipt.events[1].args.sender,
             recipient: depositReceipt.events[1].args.recipient,
             l1Token: l1Token.address,

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -145,10 +145,9 @@ export class InsuredBridgeL1Client {
     // Fetch event information
     // TODO: consider optimizing this further. Right now it will make a series of sequential BlueBird calls for each pool.
     for (const [l1Token, bridgePool] of Object.entries(this.bridgePools)) {
-      const [depositRelayedEvents, relaySpedUpEvents, relayDisputedEvents, relaySettledEvents] = await Promise.all([
+      const [depositRelayedEvents, relaySpedUpEvents, relaySettledEvents] = await Promise.all([
         bridgePool.getPastEvents("DepositRelayed", blockSearchConfig),
         bridgePool.getPastEvents("RelaySpedUp", blockSearchConfig),
-        bridgePool.getPastEvents("RelayDisputed", blockSearchConfig),
         bridgePool.getPastEvents("RelaySettled", blockSearchConfig),
       ]);
 
@@ -190,11 +189,6 @@ export class InsuredBridgeL1Client {
         this.relays[l1Token][relaySpedUpEvent.returnValues.depositHash].instantRelayer =
           relaySpedUpEvent.returnValues.instantRelayer;
         this.relays[l1Token][relaySpedUpEvent.returnValues.depositHash].relayState = RelayState.SpedUp;
-      }
-
-      // For all RelayDisputed, set the state of the relay to disputed.
-      for (const relayDisputedEvent of relayDisputedEvents) {
-        this.relays[l1Token][relayDisputedEvent.returnValues.depositHash].relayState = RelayState.Disputed;
       }
 
       for (const relaySettledEvent of relaySettledEvents) {

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -89,7 +89,7 @@ export class InsuredBridgeL1Client {
     return Object.values(this.relays[l1Token]);
   }
 
-  getRelayForDeposit(l1Token: string, deposit: Deposit): Relay {
+  getRelayForDeposit(l1Token: string, deposit: Deposit): Relay | undefined {
     this._throwIfNotInitialized();
     return this.relays[l1Token][deposit.depositHash];
   }

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -89,6 +89,11 @@ export class InsuredBridgeL1Client {
     return Object.values(this.relays[l1Token]);
   }
 
+  getRelayForDeposit(l1Token: string, deposit: Deposit): Relay {
+    this._throwIfNotInitialized();
+    return this.relays[l1Token][deposit.depositHash];
+  }
+
   getPendingRelayedDeposits(): Relay[] {
     return this.getAllRelayedDeposits().filter((relay: Relay) => relay.relayState === RelayState.Pending);
   }

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -17,6 +17,7 @@ export interface Deposit {
   slowRelayFeePct: string;
   instantRelayFeePct: string;
   quoteTimestamp: number;
+  depositContract: string;
 }
 
 export class InsuredBridgeL2Client {
@@ -76,6 +77,7 @@ export class InsuredBridgeL2Client {
         slowRelayFeePct: depositRelayedEvent.returnValues.slowRelayFeePct,
         instantRelayFeePct: depositRelayedEvent.returnValues.instantRelayFeePct,
         quoteTimestamp: Number(depositRelayedEvent.returnValues.quoteTimestamp),
+        depositContract: depositRelayedEvent.address,
       };
       depositData.depositHash = this.generateDepositHash(depositData);
       this.deposits[depositRelayedEvent.returnValues.depositId] = depositData;

--- a/packages/financial-templates-lib/src/price-feed/InsuredBridgePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/InsuredBridgePriceFeed.ts
@@ -82,7 +82,7 @@ export class InsuredBridgePriceFeed extends PriceFeedInterface {
         deposit.slowRelayFeePct === parsedAncillaryData.slowRelayFeePct.toString() &&
         deposit.instantRelayFeePct === parsedAncillaryData.instantRelayFeePct.toString() &&
         deposit.quoteTimestamp === parsedAncillaryData.quoteTimestamp &&
-        this.l2Client.bridgeDepositAddress === toChecksumAddress("0x" + parsedAncillaryData.depositContract)
+        deposit.depositContract === toChecksumAddress("0x" + parsedAncillaryData.depositContract)
     );
     // TODO: Do we need to check the `relayId` at all thats included in ancillary data?
 

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -418,7 +418,7 @@ describe("InsuredBridgeL1Client", function () {
       assert.equal(JSON.stringify(client.getAllRelayedDeposits()), JSON.stringify([expectedRelayedDepositInformation]));
       assert.equal(JSON.stringify(client.getPendingRelayedDeposits()), JSON.stringify([]));
 
-      // Next, dispute the relay. The state should update accordingly in the client.
+      // Next, dispute the relay.
       await timer.methods.setCurrentTime(Number(await timer.methods.getCurrentTime().call()) + 1).send({ from: owner });
       await l1Token.methods.mint(disputer, totalRelayBond).send({ from: owner });
       await l1Token.methods.approve(optimisticOracle.options.address, totalRelayBond).send({ from: disputer });
@@ -430,11 +430,6 @@ describe("InsuredBridgeL1Client", function () {
           relayAncillaryData
         )
         .send({ from: disputer });
-
-      await client.update();
-      expectedRelayedDepositInformation.relayState = 2; // disputed
-      assert.equal(JSON.stringify(client.getAllRelayedDeposits()), JSON.stringify([expectedRelayedDepositInformation]));
-      assert.equal(JSON.stringify(client.getPendingRelayedDeposits()), JSON.stringify([]));
 
       // Can re-relay the deposit.
       await l1Token.methods.mint(rando, totalRelayBond).send({ from: owner });

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -83,7 +83,7 @@ describe("InsuredBridgeL1Client", function () {
     return [...Object.values(params), _relayData.realizedLpFeePct];
   };
 
-  const generateRelayData = async (depositData, relayData, bridgePool) => {
+  const generateRelayData = async (depositData, relayData, bridgePool, l1TokenAddress = l1Token.options.address) => {
     // Save other reused values.
     depositDataAbiEncoded = web3.eth.abi.encodeParameters(
       ["uint8", "uint64", "address", "address", "address", "uint256", "uint64", "uint64", "uint64"],
@@ -92,7 +92,7 @@ describe("InsuredBridgeL1Client", function () {
         depositData.depositId,
         depositData.l1Recipient,
         depositData.l2Sender,
-        depositData.l1Token,
+        l1TokenAddress,
         depositData.amount,
         depositData.slowRelayFeePct,
         depositData.instantRelayFeePct,
@@ -105,7 +105,7 @@ describe("InsuredBridgeL1Client", function () {
     return { depositHash, relayAncillaryData, relayAncillaryDataHash };
   };
 
-  const syncExpectedRelayedDepositInformation = () => {
+  const syncExpectedRelayedDepositInformation = (_l1TokenAddress = l1Token.options.address) => {
     expectedRelayedDepositInformation = {
       relayId: relayData.relayId,
       chainId: depositData.chainId,
@@ -115,7 +115,7 @@ describe("InsuredBridgeL1Client", function () {
       disputedSlowRelayers: [],
       instantRelayer: relayData.instantRelayer, // not sped up so should be 0x000...
       l1Recipient: depositData.l1Recipient,
-      l1Token: depositData.l1Token,
+      l1Token: _l1TokenAddress,
       amount: depositData.amount,
       slowRelayFeePct: depositData.slowRelayFeePct,
       instantRelayFeePct: depositData.instantRelayFeePct,
@@ -237,7 +237,6 @@ describe("InsuredBridgeL1Client", function () {
       depositId: 1,
       l1Recipient: l1Recipient,
       l2Sender: depositor,
-      l1Token: l1Token.options.address,
       amount: relayAmount,
       slowRelayFeePct: defaultSlowRelayFeePct,
       instantRelayFeePct: defaultInstantRelayFeePct,
@@ -541,7 +540,6 @@ describe("InsuredBridgeL1Client", function () {
       depositData.depositId = 3;
       depositData.l1Recipient = l1Recipient;
       depositData.l2Sender = depositor;
-      depositData.l1Token = l1Token2.options.address;
       depositData.amount = toWei("4.21");
       relayData.slowRelayer = relayer;
       relayData.realizedLpFeePct = toWei("0.13");
@@ -556,11 +554,12 @@ describe("InsuredBridgeL1Client", function () {
       await bridgePool2.methods.relayDeposit(...generateRelayParams()).send({ from: relayer });
 
       // Sync the modified deposit and relay data with the expected returned data and store it.
-      syncExpectedRelayedDepositInformation();
+      syncExpectedRelayedDepositInformation(l1Token2.options.address);
       ({ depositHash, relayAncillaryData, relayAncillaryDataHash } = await generateRelayData(
         depositData,
         relayData,
-        bridgePool
+        bridgePool,
+        l1Token2.options.address
       ));
       expectedRelayedDepositInformation.depositHash = depositHash;
       let expectedBridgePool2Relays = [expectedRelayedDepositInformation];

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
@@ -119,6 +119,7 @@ describe("InsuredBridgeL2Client", () => {
         slowRelayFeePct,
         instantRelayFeePct,
         quoteTimestamp,
+        depositContract: depositBox.options.address,
       },
     ];
     expectedDeposits[0].depositHash = generateDepositHash(expectedDeposits[0]);
@@ -151,6 +152,7 @@ describe("InsuredBridgeL2Client", () => {
       slowRelayFeePct,
       instantRelayFeePct,
       quoteTimestamp: quoteTimestamp2,
+      depositContract: depositBox.options.address,
     });
     expectedDeposits[1].depositHash = generateDepositHash(expectedDeposits[1]);
     assert.equal(JSON.stringify(client.getAllDeposits()), JSON.stringify(expectedDeposits));

--- a/packages/financial-templates-lib/test/price-feed/InsuredBridgePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/InsuredBridgePriceFeed.js
@@ -95,7 +95,7 @@ describe("InsuredBridgePriceFeed", function () {
         depositData.depositId,
         depositData.l1Recipient,
         depositData.l2Sender,
-        depositData.l1Token,
+        l1Token.options.address,
         depositData.amount,
         depositData.slowRelayFeePct,
         depositData.instantRelayFeePct,
@@ -233,7 +233,6 @@ describe("InsuredBridgePriceFeed", function () {
       depositId: 0,
       l1Recipient: l1Recipient,
       l2Sender: depositor,
-      l1Token: l1Token.options.address,
       amount: relayAmount,
       slowRelayFeePct: defaultSlowRelayFeePct,
       instantRelayFeePct: defaultInstantRelayFeePct,
@@ -348,13 +347,6 @@ describe("InsuredBridgePriceFeed", function () {
         await pricefeed.getHistoricalPrice(
           1,
           await generateRelayAncillaryData({ ...depositData, l2Sender: ZERO_ADDRESS }, relayData, bridgePool)
-        ),
-        toWei("0")
-      );
-      assert.equal(
-        await pricefeed.getHistoricalPrice(
-          1,
-          await generateRelayAncillaryData({ ...depositData, l1Token: ZERO_ADDRESS }, relayData, bridgePool)
         ),
         toWei("0")
       );

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -69,16 +69,14 @@ export class Relayer {
         // hash). If relay params are invalid, then we should skip it so that we don't speed up an invalid relay.
         // If we cannot find the relay, then we should not skip it because we can still slow/instant relay it.
         const pendingRelay: Relay = this.l1Client.getRelayForDeposit(l1Token, relayableDeposit.deposit);
-        if (pendingRelay !== undefined) {
-          if (!(await this.isRelayValid(pendingRelay, relayableDeposit.deposit))) {
-            this.logger.debug({
-              at: "Relayer",
-              message: "Pending relay is invalid, ignoring",
-              pendingRelay,
-              relayableDeposit,
-            });
-            return;
-          }
+        if (pendingRelay && !(await this.isRelayValid(pendingRelay, relayableDeposit.deposit))) {
+          this.logger.debug({
+            at: "Relayer",
+            message: "Pending relay is invalid, ignoring",
+            pendingRelay,
+            relayableDeposit,
+          });
+          return;
         }
         // If relay is valid, then account for profitability and bot token balance when deciding how to relay.
         const realizedLpFeePct = await this.l1Client.calculateRealizedLpFeePctForDeposit(relayableDeposit.deposit);

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -123,6 +123,10 @@ export class Relayer {
     }
   }
 
+  // Only Relay-specific params need to be validated (i.e. those params in the Relay struct of BridgePool). If any
+  // Deposit params are incorrect, then the BridgePool's computed deposit hash will be different and the relay won't be
+  // found. So, assuming that the relay contains a matching deposit hash, this bot's job is to only consider speeding up
+  // relays that are valid, otherwise the bot might lose money without recourse on the relay.
   private async isRelayValid(relay: Relay, deposit: Deposit): Promise<boolean> {
     return (
       relay.realizedLpFeePct.toString() ===

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -68,7 +68,7 @@ export class Relayer {
         // If deposit has a pending relay, then validate its relay params (i.e. any data not included in the deposit
         // hash). If relay params are invalid, then we should skip it so that we don't speed up an invalid relay.
         // If we cannot find the relay, then we should not skip it because we can still slow/instant relay it.
-        const pendingRelay: Relay = this.l1Client.getRelayForDeposit(l1Token, relayableDeposit.deposit);
+        const pendingRelay: Relay | undefined = this.l1Client.getRelayForDeposit(l1Token, relayableDeposit.deposit);
         if (pendingRelay && !(await this.isRelayValid(pendingRelay, relayableDeposit.deposit))) {
           this.logger.debug({
             at: "Relayer",

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -128,7 +128,8 @@ export class Relayer {
   private async isRelayValid(relay: Relay, deposit: Deposit): Promise<boolean> {
     return (
       relay.realizedLpFeePct.toString() ===
-      (await this.l1Client.calculateRealizedLpFeePctForDeposit(deposit)).toString()
+        (await this.l1Client.calculateRealizedLpFeePctForDeposit(deposit)).toString() &&
+      relay.depositContract === deposit.depositContract
     );
   }
 

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -213,6 +213,7 @@ describe("Relayer.ts", function () {
         slowRelayFeePct: defaultSlowRelayFeePct,
         instantRelayFeePct: defaultInstantRelayFeePct,
         quoteTimestamp: 1,
+        depositContract: bridgeDepositBox.options.address,
       };
 
       // Set the relay ability to any. This represents a deposit that has not had any data brought to L1 yet.

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -426,5 +426,48 @@ describe("Relayer.ts", function () {
       await relayer.checkForPendingDepositsAndRelay();
       assert.isTrue(lastSpyLogIncludes(spy, "Relay instantly sped up"));
     });
+    it("Does not speedup relays with invalid relay data", async function () {
+      // Make a deposit on L2 and relay it with invalid relay params. The relayer should detect that the relay params
+      // are invalid and skip it.
+      await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
+      const currentBlockTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      await bridgeDepositBox.methods
+        .deposit(
+          l2Depositor,
+          l2Token.options.address,
+          depositAmount,
+          defaultSlowRelayFeePct,
+          defaultInstantRelayFeePct,
+          currentBlockTime
+        )
+        .send({ from: l2Depositor });
+
+      // Relay it from the tests to mimic someone else doing the slow relay.
+      await l1Token.methods.mint(l1Owner, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await bridgePool.methods
+        .relayDeposit(
+          "10",
+          "0",
+          l2Depositor,
+          l2Depositor,
+          depositAmount,
+          defaultSlowRelayFeePct,
+          defaultInstantRelayFeePct,
+          currentBlockTime,
+          toBN(defaultRealizedLpFeePct)
+            .mul(toBN(toWei("2")))
+            .div(toBN(toWei("1")))
+            .toString() // Invalid relay param
+        )
+        .send({ from: l1Owner });
+
+      // Now, run the relayer and check that it ignores the relay.
+      await Promise.all([l1Client.update(), l2Client.update()]);
+      await l1Token.methods.mint(l1Relayer, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Relayer });
+      await relayer.checkForPendingDepositsAndRelay();
+      assert.isTrue(lastSpyLogIncludes(spy, "Pending relay is invalid, ignoring"));
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The motivation for this PR is gas costs. This reduces the `relayDeposit` average gas cost from 1.2mil to 1mil.


**Summary**

`BridgePool.sol`:
- Removes `priceRequestAncillaryDataHash => depositHash` mapping and instead call the OO directly in `relayDeposit` and `speedupRelay` to determine if a relay was disputed.  
- Remove requirement that you can only speedup undisputed relays
- Remove L1 token from deposit data struct since its stored as contract state variable

`Relayer.ts`:
- Validate that pending relay is valid to avoid speeding up invalid relays

`L2Client`
- Add `depositContract` to deposit struct

`L1Client`
- Add `getRelayForDeposit` helper method that `Relayer` can use to validate relays against deposits.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested