### PR TITLE
fix(api): better state updating loops and timeouts

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -13,6 +13,12 @@ EXPRESS_PORT=8282
 # Optional, defaults to 600 (10 minutes): number of seconds before rechecking contract states
 UPDATE_RATE_S=600
 
+# Optional update rate for price updates, defaults to 900 (15 minutes)
+PRICE_UPDATE_RATE_S=900
+
+# Optional update rate for detecting new contracts, defaults to 60 (1 minute)
+DETECT_CONTRACTS_UPDATE_RATE_S=60
+
 # defaults to 864,000,000 ( 10 days): represents the max age a block will stay cached
 OLDEST_BLOCK_MS=1
 

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -251,7 +251,7 @@ export default async (env: ProcessEnv) => {
 
   // listen for new lsp contracts since after we have started api, and make sure they get state updated asap
   // These events should only be bound after startup, since initialization above takes care of updating all contracts on startup
-  // Because there is now a event driven depdency, the lsp creator and lsp state updater must be in same process
+  // Because there is now a event driven dependency, the lsp creator and lsp state updater must be in same process
   serviceEvents.on("multiLspCreator", (data) => {
     console.log("LspCreator found a new contract", JSON.stringify(data));
     services.lsps.updateLsp(data.address, data.startBlock, data.endBlock);

--- a/packages/api/src/libs/utils.test.ts
+++ b/packages/api/src/libs/utils.test.ts
@@ -99,4 +99,17 @@ describe("utils", function () {
     });
     assert.equal(plan, 0);
   });
+  it("BlockInterval", async function () {
+    let plan = 1;
+    async function update(start: number, end: number) {
+      plan--;
+      assert.equal(start, 1);
+      assert.equal(end, 10);
+    }
+    const tick = utils.BlockInterval(update, 1);
+    const result = await tick(10);
+    assert.equal(result.startBlock, 1);
+    assert.equal(result.endBlock, 10);
+    assert.equal(plan, 0);
+  });
 });

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -176,3 +176,32 @@ export function getWeb3(url: string, options: Obj = {}) {
   if (url.startsWith("ws")) return getWeb3Websocket(url, options);
   throw new Error("Only supporting websocket provider URLs for Web3");
 }
+
+// this just maintains the start/endblock given sporadic updates with a latest block number
+export function BlockInterval(update: (startBlock: number, endBlock: number) => Promise<void>, startBlock = 0) {
+  return async (endBlock: number) => {
+    assert(endBlock > startBlock, "End block must be greater than start block");
+    const params = {
+      startBlock,
+      endBlock,
+    };
+    await update(startBlock, endBlock);
+    startBlock = endBlock;
+    return params;
+  };
+}
+
+// rejects after a timeout period
+export function rejectAfterDelay(ms: number, message = "Call timed out") {
+  return new Promise((res, rej) => {
+    const to = setTimeout(() => {
+      clearTimeout(to);
+      rej(message);
+    }, ms);
+  });
+}
+
+// races a promise against a timeout to reject if it takes too long
+export function expirePromise(promise: () => Promise<any>, timeoutms: number, errorMessage?: string) {
+  return Promise.race([promise(), rejectAfterDelay(timeoutms, errorMessage)]);
+}

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -15,7 +15,7 @@ export default async (config: Config, appState: Dependencies) => {
   const address = await registry.getAddress(network);
   const contract = registry.connect(address, provider);
 
-  async function update(startBlock?: number | "latest", endBlock?: number) {
+  async function update(startBlock?: number, endBlock?: number) {
     const events = await contract.queryFilter(
       contract.filters.NewContractRegistered(null, null, null),
       startBlock,

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -16,7 +16,10 @@ export type EmitData = {
   endBlock?: number;
 };
 
-export default async (config: Config, appState: Dependencies, emit: (data: EmitData) => void) => {
+// type of events
+export type Events = "created";
+
+export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
   const { network = 1 } = config;
   const { registeredEmps, provider, registeredEmpsMetadata } = appState;
   const address = await registry.getAddress(network);
@@ -35,7 +38,7 @@ export default async (config: Config, appState: Dependencies, emit: (data: EmitD
       const blockNumber = contracts[address].blockNumber;
       registeredEmpsMetadata.set(address, { blockNumber });
       registeredEmps.add(address);
-      emit({ address, blockNumber, startBlock, endBlock });
+      emit("created", { address, blockNumber, startBlock, endBlock });
     });
   }
 

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -193,5 +193,8 @@ export default (config: Config, appState: Dependencies) => {
     await updateTokenAddresses();
   }
 
-  return update;
+  return {
+    update,
+    updateOne,
+  };
 };

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -195,6 +195,6 @@ export default (config: Config, appState: Dependencies) => {
 
   return {
     update,
-    updateOne,
+    updateAll,
   };
 };

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -92,7 +92,7 @@ export default (config: Config, appState: Dependencies) => {
     return state;
   }
 
-  async function updateOne(address: string, startBlock?: number | "latest", endBlock?: number) {
+  async function updateOne(address: string, startBlock?: number, endBlock?: number) {
     // ignore expired emps
     if (await emps.expired.has(address)) return;
 
@@ -174,7 +174,7 @@ export default (config: Config, appState: Dependencies) => {
     });
   }
 
-  async function updateAll(addresses: string[], startBlock?: number | "latest", endBlock?: number) {
+  async function updateAll(addresses: string[], startBlock?: number, endBlock?: number) {
     await Promise.mapSeries(addresses, async (address: string) => {
       const end = profile(`Update Emp state for ${address}`);
       try {
@@ -187,7 +187,7 @@ export default (config: Config, appState: Dependencies) => {
     });
   }
 
-  async function update(startBlock?: number | "latest", endBlock?: number) {
+  async function update(startBlock?: number, endBlock?: number) {
     const addresses = Array.from(await registeredEmps.values());
     await updateAll(addresses, startBlock, endBlock);
     await updateTokenAddresses();

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -16,7 +16,7 @@ export default async (config: Config, appState: Dependencies) => {
 
   const contract = lspCreator.connect(address, provider);
 
-  async function update(startBlock?: number | "latest", endBlock?: number) {
+  async function update(startBlock?: number, endBlock?: number) {
     const events = await contract.queryFilter(
       contract.filters.CreatedLongShortPair(null, null, null, null),
       startBlock,

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -17,7 +17,9 @@ export type EmitData = {
   endBlock?: number;
 };
 
-export default async (config: Config, appState: Dependencies, emit: (data: EmitData) => void) => {
+export type Events = "created";
+
+export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
   const { network = 1, address = await lspCreator.getAddress(network) } = config;
   const { registeredLsps, provider, registeredLspsMetadata } = appState;
 
@@ -36,7 +38,7 @@ export default async (config: Config, appState: Dependencies, emit: (data: EmitD
       registeredLspsMetadata.set(address, { blockNumber });
       registeredLsps.add(address);
       // emit that a new contract was found. Must be done after saving meta data
-      emit({ address, blockNumber, startBlock, endBlock });
+      emit("created", { address, blockNumber, startBlock, endBlock });
     });
   }
 

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -10,7 +10,14 @@ interface Config extends BaseConfig {
 }
 type Dependencies = Pick<AppState, "registeredLsps" | "provider" | "registeredLspsMetadata">;
 
-export default async (config: Config, appState: Dependencies) => {
+export type EmitData = {
+  blockNumber: number;
+  address: string;
+  startBlock?: number;
+  endBlock?: number;
+};
+
+export default async (config: Config, appState: Dependencies, emit: (data: EmitData) => void) => {
   const { network = 1, address = await lspCreator.getAddress(network) } = config;
   const { registeredLsps, provider, registeredLspsMetadata } = appState;
 
@@ -27,7 +34,9 @@ export default async (config: Config, appState: Dependencies) => {
     await bluebird.map(Object.keys(contracts), (address) => {
       const blockNumber = contracts[address].blockNumber;
       registeredLspsMetadata.set(address, { blockNumber });
-      return registeredLsps.add(address);
+      registeredLsps.add(address);
+      // emit that a new contract was found. Must be done after saving meta data
+      emit({ address, blockNumber, startBlock, endBlock });
     });
   }
 

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -209,10 +209,10 @@ export default (config: Config, appState: Dependencies) => {
 
   return {
     update,
+    updateLsp,
     utils: {
       updateTokenAddresses,
       updateLsps,
-      updateLsp,
       dynamicProps,
       staticProps,
       batchRead,

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -209,10 +209,10 @@ export default (config: Config, appState: Dependencies) => {
 
   return {
     update,
-    updateLsp,
+    updateLsps,
     utils: {
       updateTokenAddresses,
-      updateLsps,
+      updateLsp,
       dynamicProps,
       staticProps,
       batchRead,

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -91,7 +91,7 @@ export default (config: Config, appState: Dependencies) => {
       .catch(() => "0");
   }
 
-  async function updateLsp(address: string, startBlock?: number | "latest", endBlock?: number) {
+  async function updateLsp(address: string, startBlock?: number, endBlock?: number) {
     // ignored expired lsps
     if (await lsps.expired.has(address)) return;
     const instance = uma.clients.lsp.connect(address, provider);
@@ -176,7 +176,7 @@ export default (config: Config, appState: Dependencies) => {
     const block = await provider.getBlock(blockMetadata.blockNumber);
     await table.setCreatedTimestamp(address, block.timestamp);
   }
-  async function updateLsps(addresses: string[], startBlock?: number | "latest", endBlock?: number) {
+  async function updateLsps(addresses: string[], startBlock?: number, endBlock?: number) {
     return Promise.allSettled(
       addresses.map(async (address) => {
         const end = profile(`Update LSP state for ${address}`);
@@ -197,7 +197,7 @@ export default (config: Config, appState: Dependencies) => {
     });
   }
 
-  async function update(startBlock?: number | "latest", endBlock?: number) {
+  async function update(startBlock?: number, endBlock?: number) {
     const addresses = Array.from(await registeredLsps.values());
     await updateLsps(addresses, startBlock, endBlock).then((results) => {
       results.forEach((result) => {

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -1,7 +1,7 @@
 import { clients } from "@uma/sdk";
 import bluebird from "bluebird";
 import { AppState, BaseConfig } from "..";
-import LspCreator, { EmitData } from "./lsp-creator";
+import LspCreator, { EmitData, Events } from "./lsp-creator";
 
 const { lspCreator } = clients;
 
@@ -13,7 +13,9 @@ interface Config extends BaseConfig {
 type Dependencies = Pick<AppState, "registeredLsps" | "provider" | "registeredLspsMetadata">;
 export type { EmitData };
 
-export default async (config: Config, appState: Dependencies, emit: (data: EmitData) => void) => {
+export type { Events };
+
+export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
   const { addresses = [], network = 1 } = config;
 
   // always include latest known address

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -1,7 +1,7 @@
 import { clients } from "@uma/sdk";
 import bluebird from "bluebird";
 import { AppState, BaseConfig } from "..";
-import LspCreator from "./lsp-creator";
+import LspCreator, { EmitData } from "./lsp-creator";
 
 const { lspCreator } = clients;
 
@@ -11,8 +11,9 @@ interface Config extends BaseConfig {
   debug?: boolean;
 }
 type Dependencies = Pick<AppState, "registeredLsps" | "provider" | "registeredLspsMetadata">;
+export type { EmitData };
 
-export default async (config: Config, appState: Dependencies) => {
+export default async (config: Config, appState: Dependencies, emit: (data: EmitData) => void) => {
   const { addresses = [], network = 1 } = config;
 
   // always include latest known address
@@ -22,7 +23,7 @@ export default async (config: Config, appState: Dependencies) => {
   const allAddresses = Array.from(new Set([...addresses, latestAddress]));
 
   // instantiate individual lsp creator services with a single address
-  const creatorServices = allAddresses.map((address) => LspCreator({ address, ...config }, appState));
+  const creatorServices = allAddresses.map((address) => LspCreator({ address, ...config }, appState, emit));
 
   // run update on all creator services
   async function update(startBlock?: number, endBlock?: number) {

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -25,7 +25,7 @@ export default async (config: Config, appState: Dependencies) => {
   const creatorServices = allAddresses.map((address) => LspCreator({ address, ...config }, appState));
 
   // run update on all creator services
-  async function update(startBlock?: number | "latest", endBlock?: number) {
+  async function update(startBlock?: number, endBlock?: number) {
     await bluebird.mapSeries(creatorServices, (service) => service.update(startBlock, endBlock));
   }
 


### PR DESCRIPTION
Signed-off-by: David Adams <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/stories/space/unsaved


**Summary**
This separates asyncronous loops between checking for new contracts and updating contract state. It seems like the contract state update loop stops after some point, so this will now throw an error if it takes too long.  Some utility functions were added to support these changes.

This also adds some event driven updates as we want to get contract state quickly after discovery.  Its important to note that this change introduces process dependencies between services which use events to communicate. The emp registry and emp state services must now always be within the same process, and the lsp-creator and lsp-state services must likewise also be in the same process. This tradeoff imo is acceptable since the services are highly related and this allows more realtime state updates.
**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/stories/space/unsaved