### PR TITLE
perf(api): perform EMPs calls in batch

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -28,8 +28,8 @@ zrxBaseUrl=https://api.0x.org
 # how many days of price history we should query on startup, leave empty to disable, history will start at the time app is started
 backfillDays=
 
-# required for lsp state updates. this is a valid multicall address on mainnet.
-MULTI_CALL_ADDRESS=0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441
+# required for lsp and emp state updates. this is a valid multicall2 address on mainnet.
+MULTI_CALL_2_ADDRESS=0x5ba1e12693dc8f9c48aad8770482f4739beed696
 
 # any non null value will turn on debugging. This adds additional logs and time profiles for key calls.
 debug=1

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { ethers } from "ethers";
 import moment from "moment";
 
-import { tables, Coingecko, utils, Multicall } from "@uma/sdk";
+import { tables, Coingecko, utils, Multicall, Multicall2 } from "@uma/sdk";
 
 import * as Services from "../../services";
 import Express from "../../services/express-channels";
@@ -17,6 +17,7 @@ export default async (env: ProcessEnv) => {
   assert(env.EXPRESS_PORT, "requires EXPRESS_PORT");
   assert(env.zrxBaseUrl, "requires zrxBaseUrl");
   assert(env.MULTI_CALL_ADDRESS, "requires MULTI_CALL_ADDRESS");
+  assert(env.MULTI_CALL_2_ADDRESS, "requires MULTI_CALL_2_ADDRESS");
   const lspCreatorAddresses = parseEnvArray(env.lspCreatorAddresses || "");
 
   // debug flag for more verbose logs
@@ -109,6 +110,7 @@ export default async (env: ProcessEnv) => {
     longAddresses: new Set<string>(),
     shortAddresses: new Set<string>(),
     multicall: new Multicall(env.MULTI_CALL_ADDRESS, provider),
+    multicall2: new Multicall2(env.MULTI_CALL_2_ADDRESS, provider),
     lsps: {
       active: lsps.JsMap("Active LSP"),
       expired: lsps.JsMap("Expired LSP"),

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { ethers } from "ethers";
 import moment from "moment";
 
-import { tables, Coingecko, utils, Multicall, Multicall2 } from "@uma/sdk";
+import { tables, Coingecko, utils, Multicall2 } from "@uma/sdk";
 
 import * as Services from "../../services";
 import Express from "../../services/express-channels";
@@ -16,7 +16,6 @@ export default async (env: ProcessEnv) => {
   assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
   assert(env.EXPRESS_PORT, "requires EXPRESS_PORT");
   assert(env.zrxBaseUrl, "requires zrxBaseUrl");
-  assert(env.MULTI_CALL_ADDRESS, "requires MULTI_CALL_ADDRESS");
   assert(env.MULTI_CALL_2_ADDRESS, "requires MULTI_CALL_2_ADDRESS");
   const lspCreatorAddresses = parseEnvArray(env.lspCreatorAddresses || "");
 
@@ -109,7 +108,6 @@ export default async (env: ProcessEnv) => {
     // lsp related props. could be its own state object
     longAddresses: new Set<string>(),
     shortAddresses: new Set<string>(),
-    multicall: new Multicall(env.MULTI_CALL_ADDRESS, provider),
     multicall2: new Multicall2(env.MULTI_CALL_2_ADDRESS, provider),
     lsps: {
       active: lsps.JsMap("Active LSP"),

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -116,6 +116,5 @@ export type AppState = {
   syntheticAddresses: Set<string>;
   longAddresses: Set<string>;
   shortAddresses: Set<string>;
-  multicall: uma.Multicall;
   multicall2: uma.Multicall2;
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -117,4 +117,5 @@ export type AppState = {
   longAddresses: Set<string>;
   shortAddresses: Set<string>;
   multicall: uma.Multicall;
+  multicall2: uma.Multicall2;
 };

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -131,6 +131,28 @@ export const BatchRead = (multicall: uma.Multicall) => async (
   );
 };
 
+export const BatchReadWithErrors = (multicall2: uma.Multicall2) => async (
+  calls: [string, (x: any) => any][],
+  contract: Contract
+) => {
+  // multicall batch takes array of {method} objects
+  const results = await multicall2
+    .batch(
+      contract,
+      calls.map(([method]) => ({ method }))
+    )
+    .readWithErrors();
+  // convert results of multicall, an array of responses, into a key value, keyed by contract method
+  return Object.fromEntries(
+    lodash.zip(calls, results).map(([method, result]) => {
+      if (method == null) return [];
+      const [key, map] = method;
+      if (!result?.result) return [key, undefined];
+      return [key, map(result.result)];
+    })
+  );
+};
+
 export const Profile = (enabled: boolean | undefined) => {
   return (msg: string) => {
     // if not enabled, dont do anything

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -107,7 +107,7 @@ export function parseBytes(x: any) {
   return parseBytes32String(x);
 }
 
-export const BatchRead = (multicall: uma.Multicall) => async (
+export const BatchRead = (multicall: uma.Multicall2) => async (
   calls: [string, (x: any) => any][],
   contract: Contract
 ) => {

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -142,13 +142,13 @@ export const BatchReadWithErrors = (multicall2: uma.Multicall2) => async (
       calls.map(([method]) => ({ method }))
     )
     .readWithErrors();
-  // convert results of multicall, an array of responses, into a key value, keyed by contract method
+  // convert results of multicall, an array of responses, into an object keyed by contract method
   return Object.fromEntries(
-    lodash.zip(calls, results).map(([method, result]) => {
-      if (method == null) return [];
-      const [key, map] = method;
-      if (!result?.result) return [key, undefined];
-      return [key, map(result.result)];
+    lodash.zip(calls, results).map(([call, result]) => {
+      if (call == null) return [];
+      const [method, cb] = call;
+      if (!result?.result) return [method, undefined];
+      return [method, cb(result.result)];
     })
   );
 };

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -1,95 +1,72 @@
 import * as uma from "@uma/sdk";
 import Promise from "bluebird";
 const { emp } = uma.clients;
-import { BigNumber, utils } from "ethers";
-const { parseBytes32String } = utils;
-import { asyncValues, Profile } from "../libs/utils";
+import { BatchReadWithErrors, nowS, parseBytes, Profile, toNumber, toString } from "../libs/utils";
 import { AppState, BaseConfig } from "..";
 
 type Instance = uma.clients.emp.Instance;
 type Config = BaseConfig;
 type Dependencies = Pick<
   AppState,
-  "registeredEmps" | "provider" | "emps" | "collateralAddresses" | "syntheticAddresses" | "registeredEmpsMetadata"
+  | "registeredEmps"
+  | "provider"
+  | "emps"
+  | "collateralAddresses"
+  | "syntheticAddresses"
+  | "registeredEmpsMetadata"
+  | "multicall2"
 >;
 
 export default (config: Config, appState: Dependencies) => {
-  const { registeredEmps, registeredEmpsMetadata, provider, emps, collateralAddresses, syntheticAddresses } = appState;
+  const {
+    registeredEmps,
+    registeredEmpsMetadata,
+    provider,
+    emps,
+    collateralAddresses,
+    syntheticAddresses,
+    multicall2,
+  } = appState;
   const profile = Profile(config.debug);
+  // default props we want to query on contract
+  const staticProps: [string, (x: any) => any][] = [
+    ["priceIdentifier", parseBytes],
+    ["expirationTimestamp", toNumber],
+    ["withdrawalLiveness", toNumber],
+    ["tokenCurrency", toString],
+    ["collateralCurrency", toString],
+    ["finder", toString],
+    ["minSponsorTokens", toString],
+    ["liquidationLiveness", toNumber],
+    ["collateralRequirement", toString],
+    ["disputeBondPercentage", toNumber],
+    ["sponsorDisputeRewardPercentage", toNumber],
+    ["disputerDisputeRewardPercentage", toNumber],
+    ["cumulativeFeeMultiplier", toString],
+  ];
+
+  const dynamicProps: [string, (x: any) => any][] = [
+    ["totalTokensOutstanding", toString],
+    ["totalPositionCollateral", toString],
+    ["rawTotalPositionCollateral", toString],
+    ["expiryPrice", toString],
+  ];
+
+  async function batchRead(calls: [string, (x: any) => any][], instance: Instance, address: string) {
+    const result = await BatchReadWithErrors(multicall2)(calls, instance);
+    return {
+      address,
+      updated: nowS(),
+      ...result,
+    };
+  }
 
   async function readEmpDynamicState(instance: Instance, address: string) {
-    return asyncValues<uma.tables.emps.Data>({
-      address,
-      updated: Date.now(),
-      totalTokensOutstanding: instance
-        .totalTokensOutstanding()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      totalPositionCollateral: instance
-        .totalPositionCollateral()
-        .then((x: any) => x.rawValue.toString())
-        .catch(() => null),
-      rawTotalPositionCollateral: instance
-        .rawTotalPositionCollateral()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      expiryPrice: instance
-        .expiryPrice()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-    });
+    return batchRead(dynamicProps, instance, address);
   }
 
   async function readEmpStaticState(instance: Instance, address: string) {
-    const state = await asyncValues<uma.tables.emps.Data>({
-      address,
-      // position manager
-      priceIdentifier: instance
-        .priceIdentifier()
-        .then(parseBytes32String)
-        .catch(() => null),
-      expirationTimestamp: instance
-        .expirationTimestamp()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      withdrawLiveness: instance
-        .withdrawalLiveness()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      tokenCurrency: instance.tokenCurrency().catch(() => null),
-      collateralCurrency: instance.collateralCurrency().catch(() => null),
-      finder: instance.finder().catch(() => null),
-      minSponsorTokens: instance
-        .minSponsorTokens()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      // liquidatable
-      liquidationLiveness: instance
-        .liquidationLiveness()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      collateralRequirement: instance
-        .collateralRequirement()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      disputeBondPercentage: instance
-        .disputeBondPercentage()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      sponsorDisputeRewardPercentage: instance
-        .sponsorDisputeRewardPercentage()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      disputerDisputeRewardPercentage: instance
-        .disputerDisputeRewardPercentage()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-      cumulativeFeeMultiplier: instance
-        .cumulativeFeeMultiplier()
-        .then((x: BigNumber) => x.toString())
-        .catch(() => null),
-    });
-    return state;
+    return batchRead(staticProps, instance, address);
   }
 
   async function updateOne(address: string, startBlock?: number | "latest", endBlock?: number) {

--- a/packages/api/src/services/lsp-state.e2e.ts
+++ b/packages/api/src/services/lsp-state.e2e.ts
@@ -4,7 +4,7 @@ import assert from "assert";
 import { ethers } from "ethers";
 import Service from "./lsp-state";
 import type { AppState } from "../";
-import { Multicall } from "@uma/sdk";
+import { Multicall2 } from "@uma/sdk";
 import { lsps } from "../tables";
 // this fixes usage of "this" as any
 import "mocha";
@@ -17,7 +17,7 @@ type Dependencies = Pick<
   | "collateralAddresses"
   | "shortAddresses"
   | "longAddresses"
-  | "multicall"
+  | "multicall2"
   | "registeredLspsMetadata"
 >;
 
@@ -31,11 +31,11 @@ describe("lsp-state service", function () {
   let appState: Dependencies;
   before(async function () {
     assert(process.env.CUSTOM_NODE_URL);
-    assert(process.env.MULTI_CALL_ADDRESS);
+    assert(process.env.MULTI_CALL_2_ADDRESS);
     const provider = new ethers.providers.WebSocketProvider(process.env.CUSTOM_NODE_URL);
     appState = {
       provider,
-      multicall: new Multicall(process.env.MULTI_CALL_ADDRESS, provider),
+      multicall2: new Multicall2(process.env.MULTI_CALL_2_ADDRESS, provider),
       registeredLsps: new Set<string>(registeredContracts),
       collateralAddresses: new Set<string>(),
       longAddresses: new Set<string>(),

--- a/packages/api/src/services/lsp-state.ts
+++ b/packages/api/src/services/lsp-state.ts
@@ -14,7 +14,7 @@ type Dependencies = Pick<
   | "collateralAddresses"
   | "shortAddresses"
   | "longAddresses"
-  | "multicall"
+  | "multicall2"
   | "registeredLspsMetadata"
 >;
 
@@ -27,7 +27,7 @@ export default (config: Config, appState: Dependencies) => {
     collateralAddresses,
     shortAddresses,
     longAddresses,
-    multicall,
+    multicall2,
   } = appState;
   const profile = Profile(config.debug);
 
@@ -52,7 +52,7 @@ export default (config: Config, appState: Dependencies) => {
   ];
 
   async function batchRead(calls: [string, (x: any) => any][], instance: Instance, address: string) {
-    const result = await BatchRead(multicall)(calls, instance);
+    const result = await BatchRead(multicall2)(calls, instance);
     return {
       address,
       updated: nowS(),

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,6 +4,7 @@ export * as tables from "./tables";
 export * as utils from "./utils";
 export { default as Coingecko } from "./coingecko";
 export { default as Multicall } from "./multicall";
+export { default as Multicall2 } from "./multicall2";
 
 // types
 import type { TypedEventFilterEthers as TypedEventFilter, TypedEventEthers as TypedEvent } from "@uma/contracts-node";

--- a/packages/sdk/src/tables/emps/utils.ts
+++ b/packages/sdk/src/tables/emps/utils.ts
@@ -8,7 +8,7 @@ export type Data = {
   address: string;
   priceIdentifier?: string | null;
   expirationTimestamp?: string | null;
-  withdrawLiveness?: string | null;
+  withdrawalLiveness?: string | null;
   tokenCurrency?: string | null;
   collateralCurrency?: string | null;
   collateralRequirement?: string | null;


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/1502/use-multicall-to-prevent-high-infura-usage-for-api-calls-to-contracts


**Summary**

This PR introduces the Multicall2 contract for getting the state of an EMP contract by wrapping the calls into batches instead of using multiple `asyncValues()` calls.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
