### PR TITLE
feat(api): optimize api for startup speed when testing

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,8 @@
     "eslint": "eslint './src/**/*.ts'",
     "prettier": "prettier './**/*.md' './src/**/*.ts'",
     "lint": "yarn prettier --write && yarn eslint --fix",
-    "api": "node build/start api"
+    "api": "node build/start api",
+    "lsp_api": "node build/start lsp_api"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/packages/api/src/apps/index.ts
+++ b/packages/api/src/apps/index.ts
@@ -1,1 +1,2 @@
 export { default as api } from "./api";
+export { default as lsp_api } from "./lsp_api";

--- a/packages/api/src/apps/lsp_api/README.md
+++ b/packages/api/src/apps/lsp_api/README.md
@@ -1,0 +1,55 @@
+# Uma LSP API App
+
+This is almost identical to the api app, but its been slimmed down and scoped to just LSP contracts. This is mainly
+to faciliate local testing on forked nodes, since inclusion of EMP contract slow down API and startup speed significantly.
+
+## Environment
+
+Add these to a .env file in the root of the `protocol/packages/api` folder.
+
+```
+CUSTOM_NODE_URL=wss://mainnet.infura.io/ws/v3/${your project key}
+EXPRESS_PORT=8282
+
+# Optional, defaults to 60 (1 minute): number of seconds before rechecking contract states
+UPDATE_RATE_S=
+
+# Optional update rate for price updates, defaults to 900 (15 minutes)
+PRICE_UPDATE_RATE_S=
+
+# Optional update rate for detecting new contracts, defaults to 60 (1 minute)
+DETECT_CONTRACTS_UPDATE_RATE_S=
+
+# these configure synthetic price feed. These price feeds may require paid api keys.
+cryptowatchApiKey=
+tradermadeApiKey=
+quandlApiKey=
+defipulseApiKey=
+
+# 0x price feed gets us market prices on tokens
+zrxBaseUrl=https://api.0x.org
+
+# required for lsp and emp state updates. this is a valid multicall2 address on mainnet.
+MULTI_CALL_2_ADDRESS=0x5ba1e12693dc8f9c48aad8770482f4739beed696
+
+# any non null value will turn on debugging. This adds additional logs and time profiles for key calls.
+debug=1
+
+# LSP Creator addresses are used to discover deployed lsp contracts. Currently we have to manually specify old creator addresses
+lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10
+```
+
+## Starting
+
+Assuming all dependencies are installed and `.env` is configured:
+
+from package script:
+`yarn lsp_api`
+
+or directly:
+`npx ts-node src/start.ts lsp_api`
+
+## Usage
+
+This app is almost identical to the regular API but does not fetch EMP or synthetic prices ( the slowest things when starting up).
+See [api docs]('../api/README.md') for detailed usage.

--- a/packages/api/src/apps/lsp_api/app.ts
+++ b/packages/api/src/apps/lsp_api/app.ts
@@ -1,0 +1,286 @@
+import assert from "assert";
+import { ethers } from "ethers";
+import Events from "events";
+
+import { tables, Coingecko, utils, Multicall2 } from "@uma/sdk";
+
+import * as Services from "../../services";
+import Express from "../../services/express-channels";
+import * as Actions from "../../services/actions";
+import { ProcessEnv, AppState, Channels } from "../..";
+import { empStats, empStatsHistory, lsps } from "../../tables";
+import Zrx from "../../libs/zrx";
+import { Profile, parseEnvArray, getWeb3, BlockInterval, expirePromise } from "../../libs/utils";
+
+// This is almost identical to api app, but removes some key services from starting up. Maintains ability to use
+// api for LSP calls only. Express API maintains compatibility with original API but will not populate EMP data.
+// Eventually much of the code in this file could be refactored to deduplicate a lot of the shared code with API
+// but would require more tooling/thought around how to turn this into configuration rather than code.
+export default async (env: ProcessEnv) => {
+  assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
+  assert(env.EXPRESS_PORT, "requires EXPRESS_PORT");
+  assert(env.zrxBaseUrl, "requires zrxBaseUrl");
+  assert(env.MULTI_CALL_2_ADDRESS, "requires MULTI_CALL_2_ADDRESS");
+  const lspCreatorAddresses = parseEnvArray(env.lspCreatorAddresses || "");
+
+  // debug flag for more verbose logs
+  const debug = Boolean(env.debug);
+  const profile = Profile(debug);
+
+  const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL);
+
+  // we need web3 for syth price feeds
+  const web3 = getWeb3(env.CUSTOM_NODE_URL);
+
+  // how often to run expensive state updates, defaults to 1 minutes since EMP updates are gone
+  const updateRateS = Number(env.UPDATE_RATE_S || 60);
+  // Defaults to 60 seconds, since this is i think a pretty cheap call, and we want to see new contracts quickly
+  const detectContractsUpdateRateS = Number(env.DETECT_CONTRACTS_UPDATE_RATE_S || 60);
+  // Defaults to 15 minutes, prices dont update in coingecko or other calls very fast
+  const priceUpdateRateS = Number(env.PRICE_UPDATE_RATE_S || 15 * 60);
+
+  assert(updateRateS >= 1, "UPDATE_RATE_S must be 1 or higher");
+  assert(detectContractsUpdateRateS >= 1, "DETECT_CONTRACTS_UPDATE_RATE_S must be 1 or higher");
+  assert(priceUpdateRateS >= 1, "PRICE_UPDATE_RATE_S must be 1 or higher");
+
+  // services can emit events when necessary, though for now any services that depend on events must be in same process
+  const serviceEvents = new Events();
+
+  // state shared between services
+  const appState: AppState = {
+    provider,
+    web3,
+    coingecko: new Coingecko(),
+    zrx: new Zrx(env.zrxBaseUrl),
+    blocks: tables.blocks.JsMap(),
+    emps: {
+      active: tables.emps.JsMap("Active Emp"),
+      expired: tables.emps.JsMap("Expired Emp"),
+    },
+    prices: {
+      usd: {
+        latest: {},
+        history: {},
+      },
+    },
+    synthPrices: {
+      latest: {},
+      history: {},
+    },
+    marketPrices: {
+      usdc: {
+        latest: {},
+        history: empStatsHistory.SortedJsMap("Market Price"),
+      },
+    },
+    erc20s: tables.erc20s.JsMap(),
+    stats: {
+      emp: {
+        usd: {
+          latest: {
+            tvm: empStats.JsMap("Latest Tvm"),
+            tvl: empStats.JsMap("Latest Tvl"),
+          },
+          history: {
+            tvm: empStatsHistory.SortedJsMap("Tvm History"),
+            tvl: empStatsHistory.SortedJsMap("Tvl History"),
+          },
+        },
+      },
+      lsp: {
+        usd: {
+          latest: {
+            tvl: empStats.JsMap("Latest Tvl"),
+            tvm: empStats.JsMap("Latest Tvm"),
+          },
+          history: {
+            tvl: empStatsHistory.SortedJsMap("Tvl History"),
+          },
+        },
+      },
+      global: {
+        usd: {
+          latest: {
+            tvl: [0, "0"],
+          },
+          history: {
+            tvl: empStatsHistory.SortedJsMap("Tvl Global History"),
+          },
+        },
+      },
+    },
+    lastBlockUpdate: 0,
+    registeredEmps: new Set<string>(),
+    registeredEmpsMetadata: new Map(),
+    registeredLsps: new Set<string>(),
+    registeredLspsMetadata: new Map(),
+    collateralAddresses: new Set<string>(),
+    syntheticAddresses: new Set<string>(),
+    // lsp related props. could be its own state object
+    longAddresses: new Set<string>(),
+    shortAddresses: new Set<string>(),
+    multicall2: new Multicall2(env.MULTI_CALL_2_ADDRESS, provider),
+    lsps: {
+      active: lsps.JsMap("Active LSP"),
+      expired: lsps.JsMap("Expired LSP"),
+    },
+  };
+
+  // services for ingesting data
+  const services = {
+    // these services can optionally be configured with a config object, but currently they are undefined or have defaults
+    blocks: Services.Blocks(undefined, appState),
+    emps: Services.EmpState({ debug }, appState),
+    registry: await Services.Registry({ debug }, appState, (data) => serviceEvents.emit("empRegistry", data)),
+    collateralPrices: Services.CollateralPrices({ debug }, appState),
+    syntheticPrices: Services.SyntheticPrices(
+      {
+        debug,
+        cryptowatchApiKey: env.cryptowatchApiKey,
+        tradermadeApiKey: env.tradermadeApiKey,
+        quandlApiKey: env.quandlApiKey,
+        defipulseApiKey: env.defipulseApiKey,
+      },
+      appState
+    ),
+    erc20s: Services.Erc20s({ debug }, appState),
+    empStats: Services.stats.Emp({ debug }, appState),
+    marketPrices: Services.MarketPrices({ debug }, appState),
+    lspCreator: await Services.MultiLspCreator({ debug, addresses: lspCreatorAddresses }, appState, (data) =>
+      serviceEvents.emit("multiLspCreator", data)
+    ),
+    lsps: Services.LspState({ debug }, appState),
+    lspStats: Services.stats.Lsp({ debug }, appState),
+    globalStats: Services.stats.Global({ debug }, appState),
+  };
+
+  const initBlock = await provider.getBlock("latest");
+
+  await services.lspCreator.update(appState.lastBlockUpdate, initBlock.number);
+  console.log("Got all LSP addresses");
+
+  await services.lsps.update(appState.lastBlockUpdate, initBlock.number);
+  console.log("Updated LSP state");
+
+  // we've update our state based on latest block we queried
+  appState.lastBlockUpdate = initBlock.number;
+
+  await services.erc20s.update();
+  console.log("Updated tokens");
+
+  await services.collateralPrices.update();
+  console.log("Updated Collateral Prices");
+
+  await services.lspStats.update();
+  console.log("Updated LSP Stats");
+
+  await services.globalStats.update();
+  console.log("Updated Global Stats");
+
+  // services consuming data
+  const channels: Channels = [
+    // set this as default channel for backward compatibility. This is deprecated and will eventually be used for global style queries
+    ["", Actions.Emp(undefined, appState)],
+    // Should switch all clients to explicit channels
+    ["emp", Actions.Emp(undefined, appState)],
+    ["lsp", Actions.Lsp(undefined, appState)],
+    // TODO: switch this to root path once frontend is ready to transition
+    ["global", Actions.Global(undefined, appState)],
+  ];
+
+  await Express({ port: Number(env.EXPRESS_PORT), debug }, channels)();
+  console.log("Started Express Server, API accessible");
+
+  async function detectNewContracts(startBlock: number, endBlock: number) {
+    await services.registry(startBlock, endBlock);
+    await services.lspCreator.update(startBlock, endBlock);
+  }
+
+  // break all state updates by block events into a cleaner function
+  async function updateContractState(startBlock: number, endBlock: number) {
+    await services.lsps.update(startBlock, endBlock);
+    await services.erc20s.update();
+    appState.lastBlockUpdate = endBlock;
+  }
+
+  // separate out price updates into a different loop to query every few minutes
+  async function updatePrices() {
+    await services.collateralPrices.update();
+    await services.marketPrices.update();
+    await services.lspStats.update();
+    await services.globalStats.update();
+  }
+
+  // wait update rate before running loops, since all state was just updated on init
+  await new Promise((res) => setTimeout(res, updateRateS * 1000));
+
+  console.log("Starting LSP API update loops");
+
+  // listen for new lsp contracts since after we have started api, and make sure they get state updated asap
+  // These events should only be bound after startup, since initialization above takes care of updating all contracts on startup
+  // Because there is now a event driven dependency, the lsp creator and lsp state updater must be in same process
+  serviceEvents.on("multiLspCreator", (event, data) => {
+    // handle created events
+    if (event === "created") {
+      console.log("LspCreator found a new contract", JSON.stringify(data));
+      services.lsps.updateLsps([data.address], data.startBlock, data.endBlock).catch(console.error);
+    }
+  });
+
+  // listen for new emp contracts since after we start api, make sure they get state updates asap
+  serviceEvents.on("empRegistry", (event, data) => {
+    // handle created events
+    if (event === "created") {
+      console.log("EmpRegistry found a new contract", JSON.stringify(data));
+      services.emps.updateAll([data.address], data.startBlock, data.endBlock).catch(console.error);
+    }
+  });
+
+  async function getLatestBlockNumber() {
+    const block = await provider.getBlock("latest");
+    return block.number;
+  }
+
+  const newContractBlockTick = BlockInterval(detectNewContracts, initBlock.number);
+  const updateContractStateTick = BlockInterval(updateContractState, initBlock.number);
+
+  // detect contract loop
+  utils.loop(async () => {
+    const end = profile("Detecting New Contracts");
+    // adding in a timeout rejection if the update takes too long
+    await expirePromise(
+      async () => {
+        const { startBlock, endBlock } = await newContractBlockTick(await getLatestBlockNumber());
+        console.log("Checked for new contracts between blocks", startBlock, endBlock);
+        // error out if this fails to complete in 5 minutes
+      },
+      5 * 60 * 1000,
+      "Detecting new contracts timed out"
+    )
+      .catch(console.error)
+      .finally(end);
+  }, detectContractsUpdateRateS * 1000);
+
+  // main update loop for all state, executes immediately and waits for updateRateS
+  utils.loop(async () => {
+    const end = profile("Running contract state updates");
+    // adding in a timeout rejection if the update takes too long
+    await expirePromise(
+      async () => {
+        const { startBlock, endBlock } = await updateContractStateTick(await getLatestBlockNumber());
+        console.log("Updated Contract state between blocks", startBlock, endBlock);
+        // throw an error if this fails to process in 15 minutes
+      },
+      15 * 60 * 1000,
+      "Contract state updates timed out"
+    )
+      .catch(console.error)
+      .finally(end);
+  }, updateRateS * 1000);
+
+  // coingeckos prices don't update very fast, so set it on an interval every few minutes
+  utils.loop(async () => {
+    const end = profile("Update all prices");
+    await updatePrices().catch(console.error).finally(end);
+  }, priceUpdateRateS * 1000);
+};

--- a/packages/api/src/apps/lsp_api/index.ts
+++ b/packages/api/src/apps/lsp_api/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./app";


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2329/optimize-api-for-startup-speed-when-testing

**Summary**

This is to support e2e testing against the LSP umaverse UI. Currently the api takes forever to start mainly due to emp and price feed requests. This is stripped out in this version to allow both faster startup and more responsive updates (tighter update loops) for lsp state and discovering new lsp contracts. This will help when developing e2e LSP tests and automation speed. 

**Details**

to run the new version of the app run `yarn lsp_api`


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2329/optimize-api-for-startup-speed-when-testing