### PR TITLE
fix(cryptowatch-pricefeed): Optimistically match price period without buffer first before resorting to buffer

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -115,7 +115,6 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     // historicalPricePeriods are ordered from oldest to newest.
     // This finds the first pricePeriod whose closeTime is after the provided time.
-    // console.log(this.historicalPricePeriods[this.historicalPricePeriods.length-11, this.historicalPricePeriods.length-1])
     const match = this.historicalPricePeriods.find((pricePeriod) => {
       return time <= pricePeriod.closeTime && time >= pricePeriod.openTime;
     });

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -115,59 +115,57 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     // historicalPricePeriods are ordered from oldest to newest.
     // This finds the first pricePeriod whose closeTime is after the provided time.
     const match = this.historicalPricePeriods.find((pricePeriod) => {
-      return (
-        time < pricePeriod.closeTime + this.historicalTimestampBuffer &&
-        time >= pricePeriod.openTime - this.historicalTimestampBuffer
-      );
+      return time < pricePeriod.closeTime && time >= pricePeriod.openTime;
     });
 
+    // If match doesn't succeed, then we can still try to find the nearest price and use it if its within the caller's
+    // allowed margin of error.
+    let returnPrice;
     if (match === undefined) {
-      // If match doesn't succeed, then give caller details about closest price periods.
+      // Reverse sort the historical price periods from newest to oldest. Find the first time period whose open time,
+      // minus the buffer, is before the target time. Use this matched period's close time.
       const before = this.historicalPricePeriods
         .slice()
         .reverse()
         .find((pricePeriod) => time >= pricePeriod.openTime - this.historicalTimestampBuffer);
-      const after = this.historicalPricePeriods.find(
-        (pricePeriod) => time < pricePeriod.closeTime + this.historicalTimestampBuffer
-      );
 
-      const format = (value: BN | null | undefined) => {
-        const unformattedValue = value && (this.invertPrice ? this._invertPriceSafely(value) : value);
-        if (!unformattedValue) return "[no value found]";
-        return formatFixed(unformattedValue.toString(), this.priceFeedDecimals);
-      };
-
-      throw new Error(`
-        Cryptowatch price feed ${this.uuid} didn't return an ohlc for time ${time}.
-        Closest price point before is close time: ${before?.closeTime} (- buffer of ${
-        this.historicalTimestampBuffer
-      } seconds), close price: ${format(before?.closePrice)}.
-        Closest price point after is open time: ${after?.openTime} (+ buffer of ${
-        this.historicalTimestampBuffer
-      } seconds), open price: ${format(after?.openPrice)}.
-        To see these prices, make a GET request to:
-        https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${
-        (before?.openTime || 0) + this.ohlcPeriod
-      }&before=${after?.closeTime}&periods=60
-      `);
+      // If the closest price period before the desired timestamp is within the historical timestamp buffer,
+      // then use its close price.
+      if (before && before.closeTime >= time - this.historicalTimestampBuffer) {
+        returnPrice = this.invertPrice ? this._invertPriceSafely(before.closePrice) : before.closePrice;
+        if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
+        if (verbose) await this._printVerbose(before.closeTime, returnPrice);
+      }
+      // If before is still not within the buffer, then return the user a detailed error message.
+      else {
+        const after = this.historicalPricePeriods.find(
+          (pricePeriod) => time < pricePeriod.closeTime + this.historicalTimestampBuffer
+        );
+        const format = (value: BN | null | undefined) => {
+          const unformattedValue = value && (this.invertPrice ? this._invertPriceSafely(value) : value);
+          if (!unformattedValue) return "[no value found]";
+          return formatFixed(unformattedValue.toString(), this.priceFeedDecimals);
+        };
+        throw new Error(`
+          Cryptowatch price feed ${this.uuid} didn't return an ohlc for time ${time}.
+          Closest price point before is close time: ${before?.closeTime} (- buffer of ${
+          this.historicalTimestampBuffer
+        } seconds), close price: ${format(before?.closePrice)}.
+            Closest price point after is open time: ${after?.openTime} (+ buffer of ${
+          this.historicalTimestampBuffer
+        } seconds), open price: ${format(after?.openPrice)}.
+            To see these prices, make a GET request to:
+            https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${
+          (before?.openTime || 0) + this.ohlcPeriod
+        }&before=${after?.closeTime}&periods=60
+        `);
+      }
+    } else {
+      returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
+      if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
+      if (verbose) await this._printVerbose(match.openTime, returnPrice);
     }
 
-    const returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
-    if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
-    if (verbose) {
-      console.group(`\n(${this.exchange}:${this.pair}) Historical OHLC @ ${match.closeTime}`);
-      console.log(`- ✅ Open Price: ${formatFixed(returnPrice.toString(), this.priceFeedDecimals)}`);
-      console.log(
-        `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${match.closeTime}&before=${match.closeTime}&periods=60`
-      );
-      console.log(
-        '- This will return an OHLC data packet as "result", which contains in order: \n- [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].'
-      );
-      console.log(
-        "- We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH."
-      );
-      console.groupEnd();
-    }
     return returnPrice;
   }
 
@@ -229,6 +227,22 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     this.currentPrice = newPrice;
     this.historicalPricePeriods = newHistoricalPricePeriods;
     this.lastUpdateTime = currentTime;
+  }
+
+  private async _printVerbose(matchTime: number, returnPrice: BN) {
+    console.group(`\n(${this.exchange}:${this.pair}) Historical OHLC @ ${matchTime}`);
+    console.log(`- ✅ Open Price: ${formatFixed(returnPrice.toString(), this.priceFeedDecimals)}`);
+    console.log(
+      `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${matchTime}&before=${matchTime}&periods=60`
+    );
+    console.log(
+      '- This will return an OHLC data packet as "result", which contains in order: \n- [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].'
+    );
+    console.log(
+      "- We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH."
+    );
+    console.groupEnd();
+    return;
   }
 
   private async _getImmediatePrice(): Promise<BN> {

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -124,10 +124,15 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     let returnPrice;
     if (match === undefined) {
       // Accounting for the buffer, find the price periods before and after the target time. These will be undefined if
-      // not found.
-      const before = this.historicalPricePeriods.find(
-        (pricePeriod) => time <= pricePeriod.closeTime + this.historicalTimestampBuffer && time >= pricePeriod.openTime
-      );
+      // not found. Reverse the search for the period so that we match the latest period that encompasses the target
+      // time.
+      const before = this.historicalPricePeriods
+        .slice()
+        .reverse()
+        .find(
+          (pricePeriod) =>
+            time <= pricePeriod.closeTime + this.historicalTimestampBuffer && time >= pricePeriod.openTime
+        );
       const after = this.historicalPricePeriods.find(
         (pricePeriod) => time >= pricePeriod.openTime - this.historicalTimestampBuffer && time <= pricePeriod.closeTime
       );

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -155,6 +155,8 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
       });
 
       // If there is a `before` period, then use its close time, otherwise use the `after` period's open time.
+      // All things being equal we prefer prices from times before the target time because there are fewer manipulation
+      // opportunities and we are not incorporating information that did not exist at the target time.
       if (before) {
         returnPrice = this.invertPrice ? this._invertPriceSafely(before.closePrice) : before.closePrice;
         if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
@@ -169,7 +171,9 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
         );
       }
     }
-    // If we did find a match, then by default use the matched period's open price.
+    // If we did find a match, then by default use the matched period's open price. See comment in the above block about
+    // why we prefer `before` periods to `after` ones. Similar reasoning is why we default to a period's open price to
+    // its close price. We prefer prices that occurred before the target time.
     else {
       returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
       if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -109,7 +109,7 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     // If the time is before the first piece of data in the set, return null because
     // the price is before the lookback window.
     if (time < firstPricePeriod.openTime - this.historicalTimestampBuffer) {
-      throw new Error(`${this.uuid}: time ${time} is before firstPricePeriod.openTime`);
+      throw new Error(`${this.uuid}: time ${time} is before firstPricePeriod.openTime minus historicalTimestampBuffer`);
     }
 
     // historicalPricePeriods are ordered from oldest to newest.

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -113,19 +113,13 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     }
 
     // historicalPricePeriods are ordered from oldest to newest.
-    // This finds the first pricePeriod whose closeTime is after the provided time. First try to find the match without
-    // resorting to using the historical timestamp buffer, then if there is no match found try using the buffer.
-    let match = this.historicalPricePeriods.find((pricePeriod) => {
-      return time < pricePeriod.closeTime && time >= pricePeriod.openTime;
+    // This finds the first pricePeriod whose closeTime is after the provided time.
+    const match = this.historicalPricePeriods.find((pricePeriod) => {
+      return (
+        time < pricePeriod.closeTime + this.historicalTimestampBuffer &&
+        time >= pricePeriod.openTime - this.historicalTimestampBuffer
+      );
     });
-    if (match === undefined && this.historicalTimestampBuffer > 0) {
-      match = this.historicalPricePeriods.find((pricePeriod) => {
-        return (
-          time < pricePeriod.closeTime + this.historicalTimestampBuffer &&
-          time >= pricePeriod.openTime - this.historicalTimestampBuffer
-        );
-      });
-    }
 
     if (match === undefined) {
       // If match doesn't succeed, then give caller details about closest price periods.

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -6,6 +6,12 @@ import Web3 from "web3";
 import { NetworkerInterface } from "./Networker";
 import { BN } from "../types";
 
+interface PricePeriod {
+  openTime: number;
+  closeTime: number;
+  openPrice: BN;
+  closePrice: BN;
+}
 // An implementation of PriceFeedInterface that uses CryptoWatch to retrieve prices.
 export class CryptoWatchPriceFeed extends PriceFeedInterface {
   private readonly uuid: string;
@@ -13,12 +19,7 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
   private readonly convertPriceFeedDecimals: (number: number | string | BN) => BN;
   private currentPrice: null | BN = null;
   private lastUpdateTime: null | number = null;
-  private historicalPricePeriods: {
-    openTime: number;
-    closeTime: number;
-    openPrice: BN;
-    closePrice: BN;
-  }[] = [];
+  private historicalPricePeriods: PricePeriod[] = [];
 
   /**
    * @notice Constructs the CryptoWatchPriceFeed.
@@ -114,56 +115,61 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     // historicalPricePeriods are ordered from oldest to newest.
     // This finds the first pricePeriod whose closeTime is after the provided time.
+    // console.log(this.historicalPricePeriods[this.historicalPricePeriods.length-11, this.historicalPricePeriods.length-1])
     const match = this.historicalPricePeriods.find((pricePeriod) => {
-      return time < pricePeriod.closeTime && time >= pricePeriod.openTime;
+      return time <= pricePeriod.closeTime && time >= pricePeriod.openTime;
     });
 
     // If match doesn't succeed, then we can still try to find the nearest price and use it if its within the caller's
     // allowed margin of error.
     let returnPrice;
     if (match === undefined) {
-      // Reverse sort the historical price periods from newest to oldest. Find the first time period whose open time,
-      // minus the buffer, is before the target time. Use this matched period's close time.
-      const before = this.historicalPricePeriods
-        .slice()
-        .reverse()
-        .find((pricePeriod) => time >= pricePeriod.openTime - this.historicalTimestampBuffer);
+      // Accounting for the buffer, find the price periods before and after the target time. These will be undefined if
+      // not found.
+      const before = this.historicalPricePeriods.find(
+        (pricePeriod) => time <= pricePeriod.closeTime + this.historicalTimestampBuffer && time >= pricePeriod.openTime
+      );
+      const after = this.historicalPricePeriods.find(
+        (pricePeriod) => time >= pricePeriod.openTime - this.historicalTimestampBuffer && time <= pricePeriod.closeTime
+      );
 
-      // If the closest price period before the desired timestamp is within the historical timestamp buffer,
-      // then use its close price.
-      if (before && before.closeTime >= time - this.historicalTimestampBuffer) {
+      this.logger.debug({
+        at: "CryptoWatchPriceFeed",
+        message: "Using historical timestamp buffer to match time",
+        historicalTimestampBuffer: this.historicalTimestampBuffer,
+        time: time,
+        before: before
+          ? `openTime: ${before?.openTime}, closeTime: ${
+              before?.closeTime
+            }, openPrice: ${before?.openPrice.toString()}, closePrice: ${before?.closePrice.toString()}`
+          : before,
+        after: after
+          ? `openTime: ${after?.openTime}, closeTime: ${
+              after?.closeTime
+            }, openPrice: ${after?.openPrice.toString()}, closePrice: ${after?.closePrice.toString()}`
+          : after,
+      });
+
+      // If there is a `before` period, then use its close time, otherwise use the `after` period's open time.
+      if (before) {
         returnPrice = this.invertPrice ? this._invertPriceSafely(before.closePrice) : before.closePrice;
         if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
-        if (verbose) await this._printVerbose(before.closeTime, returnPrice);
-      }
-      // If before is still not within the buffer, then return the user a detailed error message.
-      else {
-        const after = this.historicalPricePeriods.find(
-          (pricePeriod) => time < pricePeriod.closeTime + this.historicalTimestampBuffer
+        if (verbose) await this._printVerbose(before, returnPrice);
+      } else if (after) {
+        returnPrice = this.invertPrice ? this._invertPriceSafely(after.openPrice) : after.openPrice;
+        if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
+        if (verbose) await this._printVerbose(after, returnPrice);
+      } else {
+        throw new Error(
+          `${this.uuid}: could not match a price period with time ${time} after accounting for the historical timestamp buffer of ${this.historicalTimestampBuffer}`
         );
-        const format = (value: BN | null | undefined) => {
-          const unformattedValue = value && (this.invertPrice ? this._invertPriceSafely(value) : value);
-          if (!unformattedValue) return "[no value found]";
-          return formatFixed(unformattedValue.toString(), this.priceFeedDecimals);
-        };
-        throw new Error(`
-          Cryptowatch price feed ${this.uuid} didn't return an ohlc for time ${time}.
-          Closest price point before is close time: ${before?.closeTime} (- buffer of ${
-          this.historicalTimestampBuffer
-        } seconds), close price: ${format(before?.closePrice)}.
-            Closest price point after is open time: ${after?.openTime} (+ buffer of ${
-          this.historicalTimestampBuffer
-        } seconds), open price: ${format(after?.openPrice)}.
-            To see these prices, make a GET request to:
-            https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${
-          (before?.openTime || 0) + this.ohlcPeriod
-        }&before=${after?.closeTime}&periods=60
-        `);
       }
-    } else {
+    }
+    // If we did find a match, then by default use the matched period's open price.
+    else {
       returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
       if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
-      if (verbose) await this._printVerbose(match.openTime, returnPrice);
+      if (verbose) await this._printVerbose(match, returnPrice);
     }
 
     return returnPrice;
@@ -229,18 +235,22 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     this.lastUpdateTime = currentTime;
   }
 
-  private async _printVerbose(matchTime: number, returnPrice: BN) {
-    console.group(`\n(${this.exchange}:${this.pair}) Historical OHLC @ ${matchTime}`);
-    console.log(`- ✅ Open Price: ${formatFixed(returnPrice.toString(), this.priceFeedDecimals)}`);
+  private async _printVerbose(pricePeriod: PricePeriod, returnPrice: BN) {
+    console.group(`\n(${this.exchange}:${this.pair}) Historical OHLC:`);
     console.log(
-      `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${matchTime}&before=${matchTime}&periods=60`
+      `- openTime: ${pricePeriod.openTime}, closeTime: ${
+        pricePeriod.closeTime
+      }, openPrice: ${pricePeriod.openPrice.toString()}, closePrice: ${pricePeriod.closePrice.toString()}`
+    );
+    console.log(`- historicalTimestampBuffer: ${this.historicalTimestampBuffer}`);
+    console.log(`- ✅ Matched Price: ${formatFixed(returnPrice.toString(), this.priceFeedDecimals)}`);
+    console.log(
+      `- ⚠️  If you want to manually verify the specific exchange prices, you can make a GET request to: \n- https://api.cryptowat.ch/markets/${this.exchange}/${this.pair}/ohlc?after=${pricePeriod.openTime}&before=${pricePeriod.closeTime}&periods=60`
     );
     console.log(
       '- This will return an OHLC data packet as "result", which contains in order: \n- [CloseTime, OpenPrice, HighPrice, LowPrice, ClosePrice, Volume, QuoteVolume].'
     );
-    console.log(
-      "- We use the OpenPrice to compute the median. Note that you might need to invert the prices for certain identifiers like USDETH."
-    );
+    console.log("- Note that you might need to invert the prices for certain identifiers like USDETH.");
     console.groupEnd();
     return;
   }

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -113,13 +113,19 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     }
 
     // historicalPricePeriods are ordered from oldest to newest.
-    // This finds the first pricePeriod whose closeTime is after the provided time.
-    const match = this.historicalPricePeriods.find((pricePeriod) => {
-      return (
-        time < pricePeriod.closeTime + this.historicalTimestampBuffer &&
-        time >= pricePeriod.openTime - this.historicalTimestampBuffer
-      );
+    // This finds the first pricePeriod whose closeTime is after the provided time. First try to find the match without
+    // resorting to using the historical timestamp buffer, then if there is no match found try using the buffer.
+    let match = this.historicalPricePeriods.find((pricePeriod) => {
+      return time < pricePeriod.closeTime && time >= pricePeriod.openTime;
     });
+    if (match === undefined && this.historicalTimestampBuffer > 0) {
+      match = this.historicalPricePeriods.find((pricePeriod) => {
+        return (
+          time < pricePeriod.closeTime + this.historicalTimestampBuffer &&
+          time >= pricePeriod.openTime - this.historicalTimestampBuffer
+        );
+      });
+    }
 
     if (match === undefined) {
       // If match doesn't succeed, then give caller details about closest price periods.

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -28,6 +28,7 @@ describe("CryptoWatchPriceFeed.js", function () {
       result: {
         60: [
           [
+            // 1588376339
             1588376400, // CloseTime
             1.1, // OpenPrice
             1.7, // HighPrice
@@ -194,6 +195,11 @@ describe("CryptoWatchPriceFeed.js", function () {
 
     // After period 3 should succeed for same reason.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.3"));
+
+    // Between period 1 and period 1 should return period 2 price, even if subtracting the historical buffer time would
+    // return period 1. This tests that the CW pricefeed first tries to match a price period without resorting to the
+    // buffer.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376400)).toString(), toWei("1.2"));
   });
 
   it("Missing historical data", async function () {

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -28,7 +28,6 @@ describe("CryptoWatchPriceFeed.js", function () {
       result: {
         60: [
           [
-            // 1588376339
             1588376400, // CloseTime
             1.1, // OpenPrice
             1.7, // HighPrice

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -189,11 +189,18 @@ describe("CryptoWatchPriceFeed.js", function () {
 
     await cryptoWatchPriceFeed.update();
 
-    // Before period 1 should succeed when accounting for historical timestamp buffer.
-    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376339)).toString(), toWei("1.1"));
+    // An input timestamp before period 1 should succeed when accounting for backwards historical timestamp buffer.
+    // This will return the close price of the period that matches the timestamp when accounting for the buffer.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376339)).toString(), toWei("1.2"));
 
-    // After period 3 should succeed for same reason.
-    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.3"));
+    // An input timestamp that falls within period 1 without accounting for the historical timestamp buffer should
+    // return the open price of the period.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376340)).toString(), toWei("1.1"));
+
+    // An input timestamp after period 3 should also succeed when accounting for backwards historical timestamp buffer.
+    // This will return the close price of the last period, which was previously "too early" for the target time, but
+    // when accounting for the buffer now matches the target time.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.4"));
   });
 
   it("Missing historical data", async function () {

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -194,11 +194,6 @@ describe("CryptoWatchPriceFeed.js", function () {
 
     // After period 3 should succeed for same reason.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376521)).toString(), toWei("1.3"));
-
-    // Between period 1 and period 1 should return period 2 price, even if subtracting the historical buffer time would
-    // return period 1. This tests that the CW pricefeed first tries to match a price period without resorting to the
-    // buffer.
-    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376400)).toString(), toWei("1.2"));
   });
 
   it("Missing historical data", async function () {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently when `historicalTimestampBuffer` is set > 0, the CW pricefeed expands the valid price period through which to look for a historical price. It matches the earliest price period, which potentially returns the incorrect price if the exact historical price is available.

**Summary**

This PR changes the CW pricefeed to first match the earliest price period without accounting for the historical timestamp buffer, then if nothing is found, it uses the buffer to expand the period.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
