### PR TITLE
feat(contracts-node): export similar functions in contracts-node as contracts-frontend

### DIFF
--- a/packages/common/src/hardhat/tasks/artifacts.ts
+++ b/packages/common/src/hardhat/tasks/artifacts.ts
@@ -246,10 +246,7 @@ export async function getAddress(name: DeploymentName | ContractName, chainId: n
 `
     );
 
-    // Write abi and bytecode for the browser file.
-    // Note: the idea behind writing the functions this way is to make them as optimized as possible for tree-shaking
-    // to remove any unused json files. In modern versions of webpack, this should allow absolutely _no_ artifact
-    // information that isn't needed to be pulled in.
+    // Write abi, bytecode, and address functions to match the contracts-frontend package api.
     artifacts.forEach(({ contractName }) => {
       fs.appendFileSync(
         out,

--- a/packages/common/src/hardhat/tasks/artifacts.ts
+++ b/packages/common/src/hardhat/tasks/artifacts.ts
@@ -203,7 +203,7 @@ export type { ${normalizeClassName(contractName)}Web3Events };\n`
     // Creates get[name]Address(chainId) using switch statements.
     // Note: don't export these functions as they are only used internally.
     for (const [name, addressesByChain] of Object.entries(addresses)) {
-      const declaration = `function get${name}Address(chainId: number): string {\n  switch (chainId.toString()) {\n`;
+      const declaration = `function get${name}StaticAddress(chainId: number): string {\n  switch (chainId.toString()) {\n`;
       const cases = Object.entries(addressesByChain).map(([chainId, address]) => {
         return `    case "${chainId}":\n      return "${address}";\n`;
       });
@@ -213,7 +213,7 @@ export type { ${normalizeClassName(contractName)}Web3Events };\n`
 
     // Constructs a mapping of name to address function for nodejs.
     fs.appendFileSync(out, "const addressFunctions = {\n");
-    Object.keys(addresses).forEach((name) => fs.appendFileSync(out, `  ${name}: get${name}Address,\n`));
+    Object.keys(addresses).forEach((name) => fs.appendFileSync(out, `  ${name}: get${name}StaticAddress,\n`));
     fs.appendFileSync(out, "};\n");
     fs.appendFileSync(out, "type DeploymentName = keyof typeof addressFunctions;\n");
 
@@ -245,6 +245,31 @@ export async function getAddress(name: DeploymentName | ContractName, chainId: n
 }
 `
     );
+
+    // Write abi and bytecode for the browser file.
+    // Note: the idea behind writing the functions this way is to make them as optimized as possible for tree-shaking
+    // to remove any unused json files. In modern versions of webpack, this should allow absolutely _no_ artifact
+    // information that isn't needed to be pulled in.
+    artifacts.forEach(({ contractName }) => {
+      fs.appendFileSync(
+        out,
+        `export function get${contractName}Abi(): any[] { return require(artifactPaths["${contractName}"]).abi; }\n`
+      );
+    });
+    artifacts.forEach(({ contractName }) => {
+      fs.appendFileSync(
+        out,
+        `export function get${contractName}Bytecode(): string { return require(artifactPaths["${contractName}"]).bytecode }\n`
+      );
+    });
+
+    // Creates get[name]Address(chainId) that just calls the getAddress function internally.
+    for (const [name] of Object.entries(addresses)) {
+      fs.appendFileSync(
+        out,
+        `export function get${name}Address(chainId: number): Promise<string> { return getAddress("${name}", chainId); }\n`
+      );
+    }
   });
 
 task("load-addresses", "Load addresses from the networks folder into the hardhat deployments folder").setAction(


### PR DESCRIPTION
**Motivation**

To allow backend packages (like the SDK) to gracefully switch between contracts-node and contracts-frontend depending on the env, we would like the functions in contracts-frontend to be available in contracts-node.


**Summary**

- `get[ContractName]{Address, Bytecode, Abi}` functional forms should all be available in contracts-node.
- `get[ContractName]Address` has a minor difference between the two packages -- it returns a `Promise<string>` in contracts-node to allow it to work gracefully in hardhat tests. Rather than making things more annoying on the FE packages, I figure the packages that want to incorporate both can either manually handle both cases with a wrapper or just put an await in front of the call, which will work regardless of whether a value or Promise is returned. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
