### PR TITLE
fix(contracts-frontend): remove surrounding quote characters from bytecode

### DIFF
--- a/packages/common/src/hardhat/tasks/artifacts.ts
+++ b/packages/common/src/hardhat/tasks/artifacts.ts
@@ -117,8 +117,8 @@ export type { ${normalizeClassName(contractName)}Web3Events };\n`
       fs.appendFileSync(out, `export function get${contractName}Abi(): any[] { return JSON.parse(\`${abi}\`); }\n`);
     });
     artifacts.forEach(({ contractName, relativePath }) => {
-      const bytecode = JSON.stringify(JSON.parse(fs.readFileSync(relativePath).toString("utf8")).bytecode);
-      fs.appendFileSync(out, `export function get${contractName}Bytecode(): string { return \`${bytecode}\`; }\n`);
+      const bytecode = JSON.parse(fs.readFileSync(relativePath).toString("utf8")).bytecode;
+      fs.appendFileSync(out, `export function get${contractName}Bytecode(): string { return "${bytecode}"; }\n`);
     });
 
     // Creates get[name]Address(chainId) for using switch statements.


### PR DESCRIPTION
**Motivation**

The exported bytecode string has surrounding quotes _within the string_, which causes it to be unparseable by ethers, web3, etc.

**Summary**

Removed the unnecessary JSON.stringify that was copied from the abi writing portion of the code.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

To test, I double checked the exported typescript code and verified that the bytecode matches the expected `return "0x1234"` format.

**Issue(s)**

N/A
