### PR TITLE
feat(common): HIGH-RISK remove dependence on truffle config for getWeb3

### DIFF
--- a/packages/serverless-orchestration/test/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/test/ServerlessSpoke.js
@@ -186,26 +186,6 @@ describe("ServerlessSpoke.js", function () {
     ); // Check the process logger contained the error.
     assert.isTrue(lastSpyLogIncludes(spy, "Process exited with error")); // Check the process logger contains exit error.
   });
-  it("Serverless Spoke can correctly returns errors over http calls(invalid network identifier)", async function () {
-    // Invalid price feed config should error out before entering main while loop
-    const invalidPriceFeed = {
-      serverlessCommand: "yarn --silent monitors --network INVALID",
-      environmentVariables: {
-        CUSTOM_NODE_URL: web3.currentProvider.host,
-        POLLING_DELAY: 0,
-        EMP_ADDRESS: emp.options.address,
-        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
-        MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
-      },
-    };
-
-    const invalidPriceFeedResponse = await sendRequest(invalidPriceFeed);
-    assert.equal(invalidPriceFeedResponse.res.statusCode, 500); // error code
-    // Expected error text from a null price feed
-    assert.isTrue(invalidPriceFeedResponse.res.text.includes("Cannot read property 'provider' of undefined"));
-    assert.isTrue(lastSpyLogIncludes(spy, "Cannot read property 'provider' of undefined")); // Check the process logger contained the error.
-    assert.isTrue(lastSpyLogIncludes(spy, "Process exited with error")); // Check the process logger contains exit error.
-  });
   it("Serverless Spoke can correctly returns errors over http calls(invalid emp)", async function () {
     // Invalid EMP address should error out when trying to retrieve on-chain data.
     const invalidEMPAddressBody = {


### PR DESCRIPTION
**Motivation**

We'd like to drop truffle related components from the repo.

**Summary**

To drop the truffle config from common, we need all packages to no longer require it.

I wanted to separate out this sensitive change (i.e. could break bots!) to getWeb3() as a precursor to a larger refactor where all truffle-related components are dropped.

My suggested path forward is to carefully review this, commit it and verify that once deployed, all types of bots run correctly.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
