### PR TITLE
feat(insured-bridge): Add reentrancy guards

### DIFF
--- a/packages/core/contracts-ovm/insured-bridge/external/OVM_Lockable.sol
+++ b/packages/core/contracts-ovm/insured-bridge/external/OVM_Lockable.sol
@@ -1,0 +1,64 @@
+// Temp contract until we can use the canonical UMA lockable once Optimism support solidity 0.8.
+// No code was changed here. It is a direct copy paste from the UMA lockable, simply with a modified solidity version.
+
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.7.6;
+
+/**
+ * @title A contract that provides modifiers to prevent reentrancy to state-changing and view-only methods. This contract
+ * is inspired by https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/ReentrancyGuard.sol
+ * and https://github.com/balancer-labs/balancer-core/blob/master/contracts/BPool.sol.
+ */
+contract OVM_Lockable {
+    bool private _notEntered;
+
+    constructor() {
+        // Storing an initial non-zero value makes deployment a bit more expensive, but in exchange the refund on every
+        // call to nonReentrant will be lower in amount. Since refunds are capped to a percentage of the total
+        // transaction's gas, it is best to keep them low in cases like this one, to increase the likelihood of the full
+        // refund coming into effect.
+        _notEntered = true;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant` function is not supported. It is possible to
+     * prevent this from happening by making the `nonReentrant` function external, and making it call a `private`
+     * function that does the actual state modification.
+     */
+    modifier nonReentrant() {
+        _preEntranceCheck();
+        _preEntranceSet();
+        _;
+        _postEntranceReset();
+    }
+
+    /**
+     * @dev Designed to prevent a view-only method from being re-entered during a call to a `nonReentrant()` state-changing method.
+     */
+    modifier nonReentrantView() {
+        _preEntranceCheck();
+        _;
+    }
+
+    // Internal methods are used to avoid copying the require statement's bytecode to every `nonReentrant()` method.
+    // On entry into a function, `_preEntranceCheck()` should always be called to check if the function is being
+    // re-entered. Then, if the function modifies state, it should call `_postEntranceSet()`, perform its logic, and
+    // then call `_postEntranceReset()`.
+    // View-only methods can simply call `_preEntranceCheck()` to make sure that it is not being re-entered.
+    function _preEntranceCheck() internal view {
+        // On the first call to nonReentrant, _notEntered will be true
+        require(_notEntered, "ReentrancyGuard: reentrant call");
+    }
+
+    function _preEntranceSet() internal {
+        // Any calls to nonReentrant after this point will fail
+        _notEntered = false;
+    }
+
+    function _postEntranceReset() internal {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _notEntered = true;
+    }
+}

--- a/packages/core/contracts-ovm/insured-bridge/implementation/OVM_BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/OVM_BridgeDepositBox.sol
@@ -126,7 +126,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable, OVM_Locka
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _bridgeAdmin address of the new L1 admin contract.
      */
-    function setBridgeAdmin(address _bridgeAdmin) public onlyFromCrossDomainAccount(bridgeAdmin) nonReentrant() {
+    function setBridgeAdmin(address _bridgeAdmin) public onlyFromCrossDomainAccount(bridgeAdmin) {
         _setBridgeAdmin(_bridgeAdmin);
     }
 
@@ -135,11 +135,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable, OVM_Locka
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _minimumBridgingDelay the new minimum delay.
      */
-    function setMinimumBridgingDelay(uint64 _minimumBridgingDelay)
-        public
-        onlyFromCrossDomainAccount(bridgeAdmin)
-        nonReentrant()
-    {
+    function setMinimumBridgingDelay(uint64 _minimumBridgingDelay) public onlyFromCrossDomainAccount(bridgeAdmin) {
         _setMinimumBridgingDelay(_minimumBridgingDelay);
     }
 
@@ -154,7 +150,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable, OVM_Locka
         address l1Token,
         address l2Token,
         address l1BridgePool
-    ) public onlyFromCrossDomainAccount(bridgeAdmin) nonReentrant() {
+    ) public onlyFromCrossDomainAccount(bridgeAdmin) {
         whitelistedTokens[l2Token] = L2TokenRelationships({
             l1Token: l1Token,
             l1BridgePool: l1BridgePool,
@@ -171,11 +167,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable, OVM_Locka
      * @param _l2Token address of L2 token to enable/disable deposits for.
      * @param _depositsEnabled bool to set if the deposit box should accept/reject deposits.
      */
-    function setEnableDeposits(address _l2Token, bool _depositsEnabled)
-        public
-        onlyFromCrossDomainAccount(bridgeAdmin)
-        nonReentrant()
-    {
+    function setEnableDeposits(address _l2Token, bool _depositsEnabled) public onlyFromCrossDomainAccount(bridgeAdmin) {
         whitelistedTokens[_l2Token].depositsEnabled = _depositsEnabled;
         emit DepositsEnabled(_l2Token, _depositsEnabled);
     }

--- a/packages/core/contracts-ovm/insured-bridge/implementation/OVM_BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/OVM_BridgeDepositBox.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.7.6;
 
 import "../external/OVM_Testable.sol"; //TODO: replace this with the normal UMA Testable once we can use 0.8 solidity.
+import "../external/OVM_Lockable.sol"; //TODO: replace this with the normal UMA Lockable once we can use 0.8 solidity.
 
 import { OVM_CrossDomainEnabled } from "@eth-optimism/contracts/libraries/bridge/OVM_CrossDomainEnabled.sol";
 import { Lib_PredeployAddresses } from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
@@ -43,7 +44,7 @@ interface StandardBridgeLike {
  * @notice Accepts deposits on Optimism L2 to relay to Ethereum L1 as part of the UMA insured bridge system.
  */
 
-contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
+contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable, OVM_Lockable {
     /*************************************
      *  OVM DEPOSIT BOX DATA STRUCTURES  *
      *************************************/
@@ -125,7 +126,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _bridgeAdmin address of the new L1 admin contract.
      */
-    function setBridgeAdmin(address _bridgeAdmin) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    function setBridgeAdmin(address _bridgeAdmin) public onlyFromCrossDomainAccount(bridgeAdmin) nonReentrant() {
         _setBridgeAdmin(_bridgeAdmin);
     }
 
@@ -134,7 +135,11 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _minimumBridgingDelay the new minimum delay.
      */
-    function setMinimumBridgingDelay(uint64 _minimumBridgingDelay) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    function setMinimumBridgingDelay(uint64 _minimumBridgingDelay)
+        public
+        onlyFromCrossDomainAccount(bridgeAdmin)
+        nonReentrant()
+    {
         _setMinimumBridgingDelay(_minimumBridgingDelay);
     }
 
@@ -149,7 +154,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
         address l1Token,
         address l2Token,
         address l1BridgePool
-    ) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    ) public onlyFromCrossDomainAccount(bridgeAdmin) nonReentrant() {
         whitelistedTokens[l2Token] = L2TokenRelationships({
             l1Token: l1Token,
             l1BridgePool: l1BridgePool,
@@ -166,7 +171,11 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
      * @param _l2Token address of L2 token to enable/disable deposits for.
      * @param _depositsEnabled bool to set if the deposit box should accept/reject deposits.
      */
-    function setEnableDeposits(address _l2Token, bool _depositsEnabled) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    function setEnableDeposits(address _l2Token, bool _depositsEnabled)
+        public
+        onlyFromCrossDomainAccount(bridgeAdmin)
+        nonReentrant()
+    {
         whitelistedTokens[_l2Token].depositsEnabled = _depositsEnabled;
         emit DepositsEnabled(_l2Token, _depositsEnabled);
     }
@@ -194,7 +203,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
         uint64 slowRelayFeePct,
         uint64 instantRelayFeePct,
         uint64 quoteTimestamp
-    ) public onlyIfDepositsEnabled(l2Token) {
+    ) public onlyIfDepositsEnabled(l2Token) nonReentrant() {
         require(isWhitelistToken(l2Token), "deposit token not whitelisted");
         // We limit the sum of slow and instant relay fees to 50% to prevent the user spending all their funds on fees.
         // The realizedLPFeePct on L1 is limited to 50% so the total spent on fees does not ever exceed 100%.
@@ -238,7 +247,7 @@ contract OVM_BridgeDepositBox is OVM_CrossDomainEnabled, OVM_Testable {
      * @param l2Token L2 token to relay over the canonical bridge.
      * @param l1Gas Unused by optimism, but included for potential forward compatibility considerations.
      */
-    function bridgeTokens(address l2Token, uint32 l1Gas) public {
+    function bridgeTokens(address l2Token, uint32 l1Gas) public nonReentrant() {
         uint256 bridgeDepositBoxBalance = TokenLike(l2Token).balanceOf(address(this));
         require(bridgeDepositBoxBalance > 0, "can't bridge zero tokens");
         require(isWhitelistToken(l2Token), "can't bridge non-whitelisted token");


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Functions that make external contract calls should guard against reentrancy.

Modifiers add ~10,000 gas on average to calls. As an example, this represents a 1% increase to `relayDeposit`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
