### PR TITLE
feat(insured-bridge): Add "ownable" bridge deposit box to simplify testing

### DIFF
--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgeDepositBox.sol
@@ -26,16 +26,6 @@ interface TokenLike {
     function balanceOf(address guy) external returns (uint256 wad);
 }
 
-interface StandardBridgeLike {
-    function withdrawTo(
-        address _l2Token,
-        address _to,
-        uint256 _amount,
-        uint32 _l1Gas,
-        bytes calldata _data
-    ) external;
-}
-
 /**
  * @title OVM Bridge Deposit Box.
  * @notice Accepts deposits on Optimism L2 to relay to Ethereum L1 as part of the UMA insured bridge system.

--- a/packages/core/contracts-ovm/insured-bridge/implementation/Ownable_BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/Ownable_BridgeDepositBox.sol
@@ -3,37 +3,26 @@ pragma solidity >=0.7.6;
 
 import "./BridgeDepositBox.sol";
 
-import { OVM_CrossDomainEnabled } from "@eth-optimism/contracts/libraries/bridge/OVM_CrossDomainEnabled.sol";
-import { Lib_PredeployAddresses } from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
-
-interface StandardBridgeLike {
-    function withdrawTo(
-        address _l2Token,
-        address _to,
-        uint256 _amount,
-        uint32 _l1Gas,
-        bytes calldata _data
-    ) external;
-}
-
-/**
- * @notice OVM specific bridge deposit box. Uses OVM cross-domain-enabled logic for access control.
- */
-
-contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
+contract OVM_BridgeDepositBox is BridgeDepositBox {
     // Address of the L1 contract that acts as the owner of this Bridge deposit box.
     address public bridgeAdmin;
 
     event SetBridgeAdmin(address newBridgeAdmin);
 
+    modifier onlyBridgeAdmin() {
+        require(msg.sender == bridgeAdmin, "Not bridge admin");
+        _;
+    }
+
+    /**
+     * @notice Ownable bridge deposit box. Used for testing environments that don't have specific l1/l2 messaging logic.
+     */
+
     constructor(
         address _bridgeAdmin,
         uint64 _minimumBridgingDelay,
         address timerAddress
-    )
-        OVM_CrossDomainEnabled(Lib_PredeployAddresses.L2_CROSS_DOMAIN_MESSENGER)
-        BridgeDepositBox(_minimumBridgingDelay, 10, timerAddress)
-    {
+    ) BridgeDepositBox(_minimumBridgingDelay, 10, timerAddress) {
         _setBridgeAdmin(_bridgeAdmin);
     }
 
@@ -46,7 +35,7 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _bridgeAdmin address of the new L1 admin contract.
      */
-    function setBridgeAdmin(address _bridgeAdmin) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    function setBridgeAdmin(address _bridgeAdmin) public onlyBridgeAdmin() {
         _setBridgeAdmin(_bridgeAdmin);
     }
 
@@ -55,7 +44,7 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
      * @dev Only callable by the existing bridgeAdmin via the optimism cross domain messenger.
      * @param _minimumBridgingDelay the new minimum delay.
      */
-    function setMinimumBridgingDelay(uint64 _minimumBridgingDelay) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    function setMinimumBridgingDelay(uint64 _minimumBridgingDelay) public onlyBridgeAdmin() {
         _setMinimumBridgingDelay(_minimumBridgingDelay);
     }
 
@@ -70,7 +59,7 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
         address l1Token,
         address l2Token,
         address l1BridgePool
-    ) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    ) public onlyBridgeAdmin() {
         _whitelistToken(l1Token, l2Token, l1BridgePool);
     }
 
@@ -80,7 +69,7 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
      * @param _l2Token address of L2 token to enable/disable deposits for.
      * @param _depositsEnabled bool to set if the deposit box should accept/reject deposits.
      */
-    function setEnableDeposits(address _l2Token, bool _depositsEnabled) public onlyFromCrossDomainAccount(bridgeAdmin) {
+    function setEnableDeposits(address _l2Token, bool _depositsEnabled) public onlyBridgeAdmin() {
         _setEnableDeposits(_l2Token, _depositsEnabled);
     }
 
@@ -104,12 +93,12 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
 
         whitelistedTokens[l2Token].lastBridgeTime = uint64(getCurrentTime());
 
-        StandardBridgeLike(Lib_PredeployAddresses.L2_STANDARD_BRIDGE).withdrawTo(
-            l2Token, // _l2Token. Address of the L2 token to bridge over.
-            whitelistedTokens[l2Token].l1BridgePool, // _to. Withdraw, over the bridge, to the l1 withdraw contract.
-            bridgeDepositBoxBalance, // _amount. Send the full balance of the deposit box to bridge.
-            l1Gas, // _l1Gas. Unused, but included for potential forward compatibility considerations
-            "0x" // _data. TODO: add additional info into this data prop this.
+        // Note in this test contract we simply send the l2 tokens to the l1BridgePool.
+        TokenHelper.safeTransferFrom(
+            l2Token,
+            address(this),
+            whitelistedTokens[l2Token].l1BridgePool,
+            bridgeDepositBoxBalance
         );
 
         emit TokensBridged(l2Token, bridgeDepositBoxBalance, l1Gas, msg.sender);

--- a/packages/core/contracts-ovm/insured-bridge/implementation/Ownable_BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/Ownable_BridgeDepositBox.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.6;
 
 import "./BridgeDepositBox.sol";
 
-contract OVM_BridgeDepositBox is BridgeDepositBox {
+contract Ownable_BridgeDepositBox is BridgeDepositBox {
     // Address of the L1 contract that acts as the owner of this Bridge deposit box.
     address public bridgeAdmin;
 


### PR DESCRIPTION
**Motivation**

As part of testing, we often require a setup that is not dependent on one L1/L2 implementation. Rather than mimicking every possible combination, it would be nice to have a bridge deposit box designed for this kind of environment. Think front end testing. To this effect, this PR adds a `Ownable_BridgeDepositBox` which is meant to be deployed on the same provider as the other across contracts to aid in testing.

**Summary**

This PR also moved the `StandardBridgeLike` interface into the `OVM_BridgeDepositBox` file as this is where it is used.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested