### PR TITLE
improve(core): remove dependent solcover config

### DIFF
--- a/packages/core/.solcover.js
+++ b/packages/core/.solcover.js
@@ -1,1 +1,0 @@
-module.exports = require("@uma/common").SolcoverConfig;


### PR DESCRIPTION
**Motivation**

Solcover config was left in core accidentally


**Summary**

Removed the core .solcover file that depended on the common one that was removed in #3398.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
