### PR TITLE
fix(price-identifier-utils): Blacklist uPunks identifiers from OO

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.ts
+++ b/packages/common/src/PriceIdentifierUtils.ts
@@ -54,4 +54,6 @@ export const OPTIMISTIC_ORACLE_IGNORE = [
   "XSUSHI_APY",
   "V2migration_KPI_Aragon",
   "General_KPI",
+  "PUNKETH",
+  "PUNKETH_TWAP",
 ];


### PR DESCRIPTION
**Motivation**

This identifier does not have a price feed and therefore needs to be proposed manually and be blacklisted from the OO bots. 


**Summary**

Adds `PUNKETH` and `PUNKETH_TWAP` to OO ignore list.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**
NA
