### PR TITLE
fix(hardhat): update HRE syntax

### DIFF
--- a/packages/core/test/insured-bridge/AVM_BridgeDepositBox.js
+++ b/packages/core/test/insured-bridge/AVM_BridgeDepositBox.js
@@ -2,7 +2,7 @@
 // use of the AVM token bridge. Bridge Deposit logic is not directly tested. For this see the BridgeDepositBox.js tests.
 
 const hre = require("hardhat");
-const { web3 } = require("hardhat");
+const { web3 } = hre;
 const { toWei } = web3.utils;
 const { getContract, assertEventEmitted } = hre;
 

--- a/packages/core/test/insured-bridge/BridgeDepositBox.js
+++ b/packages/core/test/insured-bridge/BridgeDepositBox.js
@@ -5,7 +5,7 @@
 const hre = require("hardhat");
 const { getContract, assertEventEmitted } = hre;
 const { assert } = require("chai");
-const { web3 } = require("hardhat");
+const { web3 } = hre;
 const { toWei } = web3.utils;
 const { didContractThrow } = require("@uma/common");
 

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -1,6 +1,6 @@
 const { assert } = require("chai");
 const hre = require("hardhat");
-const { web3 } = require("hardhat");
+const { web3 } = hre;
 const {
   didContractThrow,
   interfaceName,

--- a/packages/core/test/insured-bridge/OVM_BridgeDepositBox.js
+++ b/packages/core/test/insured-bridge/OVM_BridgeDepositBox.js
@@ -2,7 +2,7 @@
 // use of the OVM token bridge. Bridge Deposit logic is not directly tested. For this see the BridgeDepositBox.js tests.
 
 const hre = require("hardhat");
-const { web3 } = require("hardhat");
+const { web3 } = hre;
 const { predeploys } = require("@eth-optimism/contracts");
 const { didContractThrow } = require("@uma/common");
 const { getContract, assertEventEmitted } = hre;

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -1,5 +1,5 @@
 const hre = require("hardhat");
-const { web3 } = require("hardhat");
+const { web3 } = hre;
 const { interfaceName, TokenRolesEnum, InsuredBridgeRelayStateEnum, ZERO_ADDRESS } = require("@uma/common");
 const { getContract } = hre;
 const { utf8ToHex, toWei, toBN, soliditySha3 } = web3.utils;

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
@@ -2,7 +2,7 @@ const { assert } = require("chai");
 const winston = require("winston");
 const hre = require("hardhat");
 const { getContract } = hre;
-const { web3 } = require("hardhat");
+const { web3 } = hre;
 const { toWei } = web3.utils;
 
 // Client to test


### PR DESCRIPTION
**Motivation**

There are some cases where we should use the `const { web3 } = hre;` (see @mrice32 's PR here: https://github.com/UMAprotocol/protocol/pull/3406#discussion_r719995423 where the changes were made on another PR)

**Summary**

Update the case where we already import `hre` to more correctly import `web3`. Note that there are still many files that use the old syntax. This is the case if we don't first import `const hre = require("hardhat");`. For example, see here: https://github.com/UMAprotocol/protocol/blob/8773494d29cf0428ca6d65f0272b135ba3dafcbf/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js#L1



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested