### PR TITLE
improve(sdk): refactor fee calc to use ethers and bignumber

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,11 +38,9 @@
     "@uma/contracts-frontend": "^0.1.2",
     "@uma/contracts-node": "^0.1.2",
     "axios": "^0.21.4",
-    "bn.js": "^5.2.0",
     "decimal.js": "^10.3.1",
     "highland": "^2.13.5",
-    "lodash-es": "^4.17.21",
-    "web3": "^1.5.3"
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "ethers": "^5.4.2"

--- a/packages/sdk/src/across/feeCalculator.test.ts
+++ b/packages/sdk/src/across/feeCalculator.test.ts
@@ -4,13 +4,9 @@
 // and can skip the underlying methods as if they contain errors so will the calculateRealizedLpFeePct method.
 // The python implementation can be seen here: https://gist.github.com/chrismaree/a713725e4fe96c531c42ed7b629d4a85
 
-import { assert } from "chai";
-import web3 from "web3";
-const { toWei, toBN } = web3.utils;
-const toBNWei = (num: string) => toBN(toWei(num.toString()).toString());
-
+import assert from "assert";
 // Function to test
-const { calculateApyFromUtilization, calculateRealizedLpFeePct } = require("./feeCalculator");
+const { calculateApyFromUtilization, calculateRealizedLpFeePct, toBNWei } = require("./feeCalculator");
 
 // sample interest rate model. note these tests are in JS and so we can impose the RateModel type.
 const rateModel = { UBar: toBNWei("0.65"), R0: toBNWei("0.00"), R1: toBNWei("0.08"), R2: toBNWei("1.00") };
@@ -25,10 +21,10 @@ describe("Realized liquidity provision calculation", function () {
       { utilA: toBNWei("0"), utilB: toBNWei("0.50"), apy: "30769230769230768", wpy: "582965040710805" },
       { utilA: toBNWei("0.5"), utilB: toBNWei("0.51"), apy: "62153846153846200", wpy: "1160264449662626" },
       { utilA: toBNWei("0.5"), utilB: toBNWei("0.56"), apy: "65230769230769233", wpy: "1215959072035989" },
-      { utilA: toBNWei("0.5"), utilB: toBNWei("0.5").addn(100), apy: "60000000000000000", wpy: "1121183982821340" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.5").add(100), apy: "60000000000000000", wpy: "1121183982821340" },
       { utilA: toBNWei("0.6"), utilB: toBNWei("0.7"), apy: "114175824175824180", wpy: "2081296752280018" },
       { utilA: toBNWei("0.7"), utilB: toBNWei("0.75"), apy: "294285714285714280", wpy: "4973074331615530" },
-      { utilA: toBNWei("0.7"), utilB: toBNWei("0.7").addn(100), apy: "220000000000000000", wpy: "3831376003126766" },
+      { utilA: toBNWei("0.7"), utilB: toBNWei("0.7").add(100), apy: "220000000000000000", wpy: "3831376003126766" },
       { utilA: toBNWei("0.95"), utilB: toBNWei("1.00"), apy: "1008571428571428580", wpy: "13502339199904125" },
       { utilA: toBNWei("0"), utilB: toBNWei("0.99"), apy: "220548340548340547", wpy: "3840050658887291" },
       { utilA: toBNWei("0"), utilB: toBNWei("1.00"), apy: "229000000000000000", wpy: "3973273191633388" },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2406/refactor-across-fees-in-sdk-to-remove-web3-dependency

**Summary**

Was able to switch to using ethers native bignumber and utilities, ditching both web3 and bn.js. Was not able to remove the decimal.js dependency, since whats available in ethers (fixednumber) does not have `pow`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2406/refactor-across-fees-in-sdk-to-remove-web3-dependency
