### PR TITLE
fix(insured-bridge): Instant relayer should only receive refund iff they sped up valid relay

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -100,7 +100,8 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         address slowRelayer,
         address l1Token,
         uint64 realizedLpFeePct,
-        bytes32 indexed depositHash
+        bytes32 indexed depositHash,
+        bytes32 indexed relayHash
     );
     event RelaySpedUp(bytes32 indexed depositHash, address indexed instantRelayer, uint64 realizedLpFeePct);
     event RelaySettled(bytes32 indexed depositHash, bytes32 indexed relayHash);
@@ -390,7 +391,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         updateAccumulatedLpFees();
         allocateLpFees(_getAmountFromPct(relay.realizedLpFeePct, _depositData.amount));
 
-        emit RelaySettled(depositHash, relayHash, msg.sender);
+        emit RelaySettled(depositHash, relayHash);
 
         delete relay.realizedLpFeePct;
         delete relay.instantRelayer;

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -368,8 +368,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
                 _getAmountFromPct(relay.realizedLpFeePct + _depositData.slowRelayFeePct, _depositData.amount);
 
         // Refund the instant relayer iff the instant relay params match the approved relay.
-        bytes32 instantRelayHash = keccak256(abi.encode(depositHash, relay.realizedLpFeePct));
-        address instantRelayer = instantRelays[instantRelayHash];
+        address instantRelayer = instantRelays[keccak256(abi.encode(depositHash, relay.realizedLpFeePct))];
 
         l1Token.safeTransfer(
             instantRelayer != address(0) ? instantRelayer : _depositData.l1Recipient,

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -323,7 +323,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
 
         l1Token.safeTransferFrom(msg.sender, _depositData.l1Recipient, _depositData.amount - feesTotal);
 
-        // TODO: does this need more info?
         emit RelaySpedUp(depositHash, msg.sender, relay.realizedLpFeePct);
     }
 

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -390,6 +390,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
 
         emit RelaySettled(depositHash, relayHash, msg.sender);
 
+        delete instantRelays[keccak256(abi.encode(depositHash, relay.realizedLpFeePct))];
         delete relay.realizedLpFeePct;
         delete relay.priceRequestTime;
     }

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -108,7 +108,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         uint64 realizedLpFeePct,
         bytes32 indexed depositHash
     );
-    event RelaySpedUp(bytes32 indexed depositHash, address indexed instantRelayer);
+    event RelaySpedUp(bytes32 indexed depositHash, address indexed instantRelayer, uint64 realizedLpFeePct);
     event RelaySettled(
         bytes32 indexed depositHash,
         bytes32 indexed priceRequestAncillaryDataHash,
@@ -329,7 +329,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
 
         l1Token.safeTransferFrom(msg.sender, _depositData.l1Recipient, _depositData.amount - feesTotal);
 
-        emit RelaySpedUp(depositHash, msg.sender);
+        emit RelaySpedUp(depositHash, msg.sender, relay.realizedLpFeePct);
     }
 
     /**

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -104,7 +104,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         bytes32 indexed relayHash
     );
     event RelaySpedUp(bytes32 indexed depositHash, address indexed instantRelayer, uint64 realizedLpFeePct);
-    event RelaySettled(bytes32 indexed depositHash, bytes32 indexed relayHash);
+    event RelaySettled(bytes32 indexed depositHash, bytes32 indexed relayHash, address indexed caller);
 
     /**
      * @notice Construct the Bridge Pool
@@ -391,7 +391,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         updateAccumulatedLpFees();
         allocateLpFees(_getAmountFromPct(relay.realizedLpFeePct, _depositData.amount));
 
-        emit RelaySettled(depositHash, relayHash);
+        emit RelaySettled(depositHash, relayHash, msg.sender);
 
         delete relay.realizedLpFeePct;
         delete relay.instantRelayer;

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -79,7 +79,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         address slowRelayer;
         uint32 relayId;
         uint64 realizedLpFeePct;
-        address instantRelayer;
         uint256 priceRequestTime;
     }
 
@@ -394,7 +393,6 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         emit RelaySettled(depositHash, relayHash, msg.sender);
 
         delete relay.realizedLpFeePct;
-        delete relay.instantRelayer;
         delete relay.priceRequestTime;
     }
 

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -538,7 +538,11 @@ describe("BridgePool", () => {
         .send({ from: instantRelayer });
       const speedupTxn = await bridgePool.methods.speedUpRelay(depositData).send({ from: instantRelayer });
       await assertEventEmitted(speedupTxn, bridgePool, "RelaySpedUp", (ev) => {
-        return ev.instantRelayer === instantRelayer && ev.depositHash === depositHash;
+        return (
+          ev.instantRelayer === instantRelayer &&
+          ev.depositHash === depositHash &&
+          ev.realizedLpFeePct === relayData.realizedLpFeePct
+        );
       });
       const speedupRelayStatus = await bridgePool.methods.relays(depositHash).call();
       assert.equal(speedupRelayStatus.relayState, InsuredBridgeRelayStateEnum.PENDING);

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -152,6 +152,14 @@ describe("BridgePool", () => {
     return depositHash;
   };
 
+  const generateInstantRelayHash = (depositHash, relayData) => {
+    const instantRelayDataAbiEncoded = web3.eth.abi.encodeParameters(
+      ["bytes32", "uint64"],
+      [depositHash, relayData.realizedLpFeePct]
+    );
+    return soliditySha3(instantRelayDataAbiEncoded);
+  };
+
   before(async function () {
     accounts = await web3.eth.getAccounts();
     [
@@ -272,7 +280,6 @@ describe("BridgePool", () => {
       priceRequestTime: 0,
       realizedLpFeePct: defaultRealizedLpFee,
       slowRelayer: relayer,
-      instantRelayer: ZERO_ADDRESS,
     };
 
     // Save other reused values.
@@ -410,9 +417,12 @@ describe("BridgePool", () => {
       assert.equal(relayStatus.relayId.toString(), relayData.relayId.toString());
       assert.equal(relayStatus.relayState, InsuredBridgeRelayStateEnum.PENDING);
       assert.equal(relayStatus.priceRequestTime.toString(), requestTimestamp);
-      assert.equal(relayStatus.instantRelayer, ZERO_ADDRESS);
       assert.equal(relayStatus.slowRelayer, relayer);
       assert.equal(relayStatus.realizedLpFeePct.toString(), defaultRealizedLpFee);
+
+      // Instant relayer for this relay should be uninitialized.
+      const instantRelayHash = generateInstantRelayHash(depositHash, relayData);
+      assert.equal(await bridgePool.methods.instantRelays(instantRelayHash).call(), ZERO_ADDRESS);
 
       // Check event is logged correctly and emits all information needed to recreate the relay and associated deposit.
       await assertEventEmitted(txn, bridgePool, "DepositRelayed", (ev) => {
@@ -533,9 +543,13 @@ describe("BridgePool", () => {
       const speedupRelayStatus = await bridgePool.methods.relays(depositHash).call();
       assert.equal(speedupRelayStatus.relayState, InsuredBridgeRelayStateEnum.PENDING);
       assert.equal(speedupRelayStatus.priceRequestTime.toString(), requestTimestamp);
-      assert.equal(speedupRelayStatus.instantRelayer, instantRelayer);
       assert.equal(speedupRelayStatus.slowRelayer, rando);
       assert.equal(speedupRelayStatus.realizedLpFeePct.toString(), defaultRealizedLpFee);
+      const instantRelayHash = generateInstantRelayHash(
+        depositHash,
+        relayData // Note: the relay data should be the same as the original relay that was disputed.
+      );
+      assert.equal(await bridgePool.methods.instantRelays(instantRelayHash).call(), instantRelayer);
 
       // Check that contract pulled relay amount from instant relayer.
       assert.equal(
@@ -553,6 +567,138 @@ describe("BridgePool", () => {
       await l1Token.methods.mint(instantRelayer, instantRelayAmountSubFee).send({ from: owner });
       await l1Token.methods.approve(bridgePool.options.address, slowRelayAmountSubFee).send({ from: instantRelayer });
       assert(await didContractThrow(bridgePool.methods.speedUpRelay(depositData).call({ from: instantRelayer })));
+
+      // Burn newly minted tokens to make accounting simpler.
+      await l1Token.methods.transfer(owner, instantRelayAmountSubFee).send({ from: instantRelayer });
+
+      // Expire relay. Since instant relayed amount was correct, instant relayer should be refunded and user should
+      // still just have the instant relay amount.
+      const expectedExpirationTimestamp = (Number(requestTimestamp) + defaultLiveness).toString();
+      await timer.methods.setCurrentTime(expectedExpirationTimestamp).send({ from: owner });
+      await bridgePool.methods.settleRelay(depositData).send({ from: rando });
+
+      // Check token balances.
+      // - Slow relayer should get back their proposal bond from OO and reward from BridgePool.
+      // - Fast relayer should get reward from BridgePool and the relayed amount, minus LP and slow relay fee. This
+      // is equivalent to what the l1Recipient received + the instant relayer fee.
+      // - Recipient already got paid by fast relayer and should receive no further tokens.
+      assert.equal(
+        (await l1Token.methods.balanceOf(rando).call()).toString(),
+        toBN(totalRelayBond).add(realizedSlowRelayFeeAmount).toString(),
+        "Slow relayer should receive proposal bond + slow relay reward"
+      );
+      assert.equal(
+        (await l1Token.methods.balanceOf(instantRelayer).call()).toString(),
+        toBN(instantRelayAmountSubFee).add(realizedInstantRelayFeeAmount).toString(),
+        "Instant relayer should receive instant relay reward + the instant relay amount sub fees"
+      );
+      assert.equal(
+        (await l1Token.methods.balanceOf(depositData.l1Recipient).call()).toString(),
+        instantRelayAmountSubFee,
+        "Recipient should still have the full amount, minus slow & instant fees"
+      );
+      assert.equal(
+        (await l1Token.methods.balanceOf(optimisticOracle.options.address).call()).toString(),
+        totalDisputeRefund.toString(),
+        "OptimisticOracle should still hold dispute refund since dispute has not resolved yet"
+      );
+      assert.equal(
+        (await l1Token.methods.balanceOf(bridgePool.options.address).call()).toString(),
+        toBN(initialPoolLiquidity)
+          .sub(toBN(instantRelayAmountSubFee).add(realizedInstantRelayFeeAmount).add(realizedSlowRelayFeeAmount))
+          .toString(),
+        "BridgePool should have balance reduced by relayed amount to l1Recipient"
+      );
+    });
+    it("Invalid instant relay, disputed correctly, instant relayer receives no refund following subsequent valid relay", async function () {
+      // Propose new invalid relay where realizedFee is too large.
+      const invalidRealizedLpFee = toWei("0.4");
+      const invalidRelayData = { ...relayData, realizedLpFeePct: invalidRealizedLpFee };
+      await l1Token.methods.approve(bridgePool.options.address, totalRelayBond).send({ from: relayer });
+      await bridgePool.methods.relayDeposit(...generateRelayParams({}, invalidRelayData)).send({ from: relayer });
+
+      // Grab OO price request information from Relay struct.
+      const relayStatus = await bridgePool.methods.relays(depositHash).call();
+
+      // Invalid instant relay with incorrect fee sends incorrect amount to user
+      const invalidRealizedLpFeeAmount = toBN(invalidRealizedLpFee)
+        .mul(toBN(relayAmount))
+        .div(toBN(toWei("1")));
+      const invalidInstantRelayAmountSubFee = toBN(relayAmount)
+        .sub(invalidRealizedLpFeeAmount)
+        .sub(realizedSlowRelayFeeAmount)
+        .sub(realizedInstantRelayFeeAmount)
+        .toString();
+      await l1Token.methods
+        .approve(bridgePool.options.address, invalidInstantRelayAmountSubFee)
+        .send({ from: instantRelayer });
+      await bridgePool.methods.speedUpRelay(depositData).send({ from: instantRelayer });
+      const startingInstantRelayerAmount = (await l1Token.methods.balanceOf(instantRelayer).call()).toString();
+
+      // User receives invalid instant relay amount.
+      assert.equal(
+        (await l1Token.methods.balanceOf(depositData.l1Recipient).call()).toString(),
+        invalidInstantRelayAmountSubFee
+      );
+
+      // Before slow relay expires, it is disputed.
+      const _relayAncillaryData = await bridgePool.methods
+        .getRelayAncillaryData(depositData, { ...relayData, realizedLpFeePct: invalidRealizedLpFee })
+        .call();
+      await l1Token.methods.approve(optimisticOracle.options.address, totalRelayBond).send({ from: disputer });
+      await optimisticOracle.methods
+        .disputePrice(
+          bridgePool.options.address,
+          defaultIdentifier,
+          relayStatus.priceRequestTime.toString(),
+          _relayAncillaryData
+        )
+        .send({ from: disputer });
+
+      // While dispute is pending resolution, a valid relay is resubmitted. Advance time so that
+      // price request data is different.
+      await l1Token.methods.mint(rando, totalRelayBond).send({ from: owner });
+      await l1Token.methods.approve(bridgePool.options.address, totalRelayBond).send({ from: rando });
+      await advanceTime(1);
+      const requestTimestamp = (await bridgePool.methods.getCurrentTime().call()).toString();
+      await bridgePool.methods.relayDeposit(...generateRelayParams()).send({ from: rando });
+
+      // Expire this valid relay and check payouts.
+      const expectedExpirationTimestamp = (Number(requestTimestamp) + defaultLiveness).toString();
+      await timer.methods.setCurrentTime(expectedExpirationTimestamp).send({ from: owner });
+      await bridgePool.methods.settleRelay(depositData).send({ from: rando });
+
+      // User should receive correct relay amount + the amount they received from invalid instant relay.
+      assert.equal(
+        (await l1Token.methods.balanceOf(depositData.l1Recipient).call()).toString(),
+        toBN(instantRelayAmountSubFee)
+          .add(toBN(realizedInstantRelayFeeAmount))
+          .add(toBN(invalidInstantRelayAmountSubFee))
+          .toString()
+      );
+
+      // Invalid instant relayer receives nothing further from settlement.
+      assert.equal((await l1Token.methods.balanceOf(instantRelayer).call()).toString(), startingInstantRelayerAmount);
+
+      // Slow relayer gets slow relay reward
+      assert.equal(
+        (await l1Token.methods.balanceOf(rando).call()).toString(),
+        toBN(totalRelayBond).add(realizedSlowRelayFeeAmount).toString()
+      );
+
+      // OptimisticOracle should still hold dispute refund since dispute has not resolved yet
+      assert.equal(
+        (await l1Token.methods.balanceOf(optimisticOracle.options.address).call()).toString(),
+        totalDisputeRefund.toString()
+      );
+
+      // BridgePool should have balance reduced by full amount sent to to l1Recipient.
+      assert.equal(
+        (await l1Token.methods.balanceOf(bridgePool.options.address).call()).toString(),
+        toBN(initialPoolLiquidity)
+          .sub(toBN(instantRelayAmountSubFee).add(realizedInstantRelayFeeAmount).add(realizedSlowRelayFeeAmount))
+          .toString()
+      );
     });
   });
   describe("Dispute pending relay", () => {
@@ -633,13 +779,14 @@ describe("BridgePool", () => {
       const requestTimestamp = (await bridgePool.methods.getCurrentTime().call()).toString();
       await bridgePool.methods.relayDeposit(...generateRelayParams()).send({ from: rando });
 
-      // Check that the instant relayer address is copied over.
+      // Check that the instant relayer address persists for the original relay params.
       const newRelayStatus = await bridgePool.methods.relays(depositHash).call();
       assert.equal(newRelayStatus.relayState, InsuredBridgeRelayStateEnum.PENDING);
       assert.equal(newRelayStatus.priceRequestTime.toString(), requestTimestamp);
-      assert.equal(newRelayStatus.instantRelayer, instantRelayer);
       assert.equal(newRelayStatus.slowRelayer, rando);
       assert.equal(newRelayStatus.realizedLpFeePct.toString(), defaultRealizedLpFee);
+      const instantRelayHash = generateInstantRelayHash(depositHash, relayData);
+      assert.equal(await bridgePool.methods.instantRelays(instantRelayHash).call(), instantRelayer);
     });
   });
   describe("Settle finalized relay", () => {
@@ -766,7 +913,7 @@ describe("BridgePool", () => {
       );
       assert.equal(
         (await l1Token.methods.balanceOf(instantRelayer).call()).toString(),
-        toBN(instantRelayAmountSubFee).add(realizedInstantRelayFeeAmount),
+        toBN(instantRelayAmountSubFee).add(realizedInstantRelayFeeAmount).toString(),
         "Instant relayer should receive instant relayer fee + relay amount - LP fee"
       );
       assert.equal(

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -1,5 +1,5 @@
 import Web3 from "web3";
-const { toBN } = Web3.utils;
+const { toBN, soliditySha3 } = Web3.utils;
 
 import { findBlockNumberAtTimestamp } from "@uma/common";
 import { getAbi } from "@uma/contracts-node";
@@ -238,7 +238,7 @@ export class InsuredBridgeL1Client {
   }
 
   private _getInstantRelayHash(depositHash: string, realizedLpFeePct: string): string | null {
-    const instantRelayDataHash = this.web3.utils.soliditySha3(
+    const instantRelayDataHash = soliditySha3(
       this.web3.eth.abi.encodeParameters(["bytes32", "uint64"], [depositHash, realizedLpFeePct])
     );
     return instantRelayDataHash;

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -1,6 +1,6 @@
 const hre = require("hardhat");
 const { web3 } = require("hardhat");
-const { interfaceName, TokenRolesEnum, InsuredBridgeRelayStateEnum, ZERO_ADDRESS } = require("@uma/common");
+const { interfaceName, TokenRolesEnum, InsuredBridgeRelayStateEnum } = require("@uma/common");
 const { getContract } = hre;
 const { utf8ToHex, toWei, toBN, soliditySha3 } = web3.utils;
 const toBNWei = (number) => toBN(toWei(number.toString()).toString());
@@ -21,7 +21,7 @@ const Timer = getContract("Timer");
 const MockOracle = getContract("MockOracleAncillary");
 
 // Client to test
-const { InsuredBridgeL1Client } = require("../../dist/clients/InsuredBridgeL1Client");
+const { InsuredBridgeL1Client, ClientRelayState } = require("../../dist/clients/InsuredBridgeL1Client");
 
 // tested client
 let client;
@@ -112,7 +112,6 @@ describe("InsuredBridgeL1Client", function () {
       l2Sender: depositData.l2Sender,
       slowRelayer: relayData.slowRelayer,
       disputedSlowRelayers: [],
-      instantRelayer: relayData.instantRelayer, // not sped up so should be 0x000...
       l1Recipient: depositData.l1Recipient,
       l1Token: _l1TokenAddress,
       amount: depositData.amount,
@@ -256,7 +255,6 @@ describe("InsuredBridgeL1Client", function () {
       priceRequestTime: 0,
       realizedLpFeePct: defaultRealizedLpFee,
       slowRelayer: relayer,
-      instantRelayer: ZERO_ADDRESS,
     };
 
     ({ depositHash, relayAncillaryData, relayAncillaryDataHash } = await generateRelayData(
@@ -336,12 +334,13 @@ describe("InsuredBridgeL1Client", function () {
 
       await client.update();
 
-      // After the fast relay, there should be an instant relayer set and the relayState should be updated.
-      expectedRelayedDepositInformation.instantRelayer = instantRelayer;
-      expectedRelayedDepositInformation.relayState = 1; // sped up
-
+      // After the fast relay, there should be an instant relayer set. Relay data should be the same.
+      assert.isTrue(client.hasInstantRelayer(l1Token.options.address, depositHash, relayData.realizedLpFeePct));
       assert.equal(JSON.stringify(client.getAllRelayedDeposits()), JSON.stringify([expectedRelayedDepositInformation]));
-      assert.equal(JSON.stringify(client.getPendingRelayedDeposits()), JSON.stringify([])); // Not pending anymore
+      assert.equal(
+        JSON.stringify(client.getPendingRelayedDeposits()),
+        JSON.stringify([expectedRelayedDepositInformation])
+      ); // Not pending anymore
 
       // Next, advance time and settle the relay. State should update accordingly.
       await timer.methods
@@ -360,7 +359,7 @@ describe("InsuredBridgeL1Client", function () {
       await bridgePool.methods.settleRelay(depositData).send({ from: rando });
 
       await client.update();
-      expectedRelayedDepositInformation.relayState = 3; // settled
+      expectedRelayedDepositInformation.relayState = ClientRelayState.Finalized;
       assert.equal(JSON.stringify(client.getAllRelayedDeposits()), JSON.stringify([expectedRelayedDepositInformation]));
       assert.equal(JSON.stringify(client.getPendingRelayedDeposits()), JSON.stringify([])); // Not pending anymore
     });
@@ -418,12 +417,13 @@ describe("InsuredBridgeL1Client", function () {
 
       await client.update();
 
-      // After the fast relay, there should be an instant relayer set and the relayState should be updated.
-      expectedRelayedDepositInformation.instantRelayer = instantRelayer;
-      expectedRelayedDepositInformation.relayState = 1; // sped up
-
+      // After the fast relay, there should be an instant relayer set. Relay data should be the same.
+      assert.isTrue(client.hasInstantRelayer(l1Token.options.address, depositHash, relayData.realizedLpFeePct));
       assert.equal(JSON.stringify(client.getAllRelayedDeposits()), JSON.stringify([expectedRelayedDepositInformation]));
-      assert.equal(JSON.stringify(client.getPendingRelayedDeposits()), JSON.stringify([]));
+      assert.equal(
+        JSON.stringify(client.getPendingRelayedDeposits()),
+        JSON.stringify([expectedRelayedDepositInformation])
+      ); // Not pending anymore
 
       // Next, dispute the relay.
       await timer.methods.setCurrentTime(Number(await timer.methods.getCurrentTime().call()) + 1).send({ from: owner });
@@ -451,7 +451,10 @@ describe("InsuredBridgeL1Client", function () {
       expectedRelayedDepositInformation.slowRelayer = rando; // The re-relayer was the rando account.
       expectedRelayedDepositInformation.disputedSlowRelayers.push(relayer); // disputed
       assert.equal(JSON.stringify(client.getAllRelayedDeposits()), JSON.stringify([expectedRelayedDepositInformation]));
-      assert.equal(JSON.stringify(client.getPendingRelayedDeposits()), JSON.stringify([]));
+      assert.equal(
+        JSON.stringify(client.getPendingRelayedDeposits()),
+        JSON.stringify([expectedRelayedDepositInformation])
+      );
     });
   });
   describe("Multi-relay, multi pool tests", function () {
@@ -524,7 +527,7 @@ describe("InsuredBridgeL1Client", function () {
       await bridgePool.methods.settleRelay(depositData).send({ from: rando });
 
       // Construct the expected relay data that the client should return.
-      expectedRelayedDepositInformation.relayState = 3; // settled
+      expectedRelayedDepositInformation.relayState = ClientRelayState.Finalized; // settled
       let expectedBridgePool1Relays = [JSON.parse(JSON.stringify(expectedRelayedDepositInformation))]; // deep copy
 
       // Change some of the variables and and re-relay.

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -88,7 +88,17 @@ export class Relayer {
         }
         // If relay is valid, then account for profitability and bot token balance when deciding how to relay.
         const realizedLpFeePct = await this.l1Client.calculateRealizedLpFeePctForDeposit(relayableDeposit.deposit);
-        const shouldRelay = await this.shouldRelay(relayableDeposit.deposit, relayableDeposit.status, realizedLpFeePct);
+        const hasInstantRelayer = this.l1Client.hasInstantRelayer(
+          relayableDeposit.deposit.l1Token,
+          relayableDeposit.deposit.depositHash,
+          realizedLpFeePct.toString()
+        );
+        const shouldRelay = await this.shouldRelay(
+          relayableDeposit.deposit,
+          relayableDeposit.status,
+          realizedLpFeePct,
+          hasInstantRelayer
+        );
         switch (shouldRelay) {
           case ShouldRelay.Ignore:
             this.logger.warn({
@@ -150,7 +160,8 @@ export class Relayer {
   private async shouldRelay(
     deposit: Deposit,
     clientRelayState: ClientRelayState,
-    realizedLpFeePct: BN
+    realizedLpFeePct: BN,
+    hasInstantRelayer: boolean
   ): Promise<ShouldRelay> {
     const [l1TokenBalance, proposerBondPct] = await Promise.all([
       getTokenBalance(this.l1Client.l1Web3, deposit.l1Token, this.account),
@@ -170,7 +181,11 @@ export class Relayer {
 
     // b) Balance is large enough to instant relay. Deposit is in any state except finalized (i.e can be slow relayed
     // and sped up or only sped up.)
-    if (l1TokenBalance.gte(relayTokenRequirement.instant) && clientRelayState !== ClientRelayState.Finalized)
+    if (
+      !hasInstantRelayer &&
+      l1TokenBalance.gte(relayTokenRequirement.instant) &&
+      clientRelayState !== ClientRelayState.Finalized
+    )
       speedUpProfit = toBN(deposit.amount).mul(toBN(deposit.instantRelayFeePct)).div(fixedPointAdjustment);
 
     // c) Balance is large enough to slow relay and then speed up. Only considered if no L1 action has happened yet as

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -179,7 +179,7 @@ export class Relayer {
     if (l1TokenBalance.gte(relayTokenRequirement.slow) && clientRelayState === ClientRelayState.Uninitialized)
       slowProfit = toBN(deposit.amount).mul(toBN(deposit.slowRelayFeePct)).div(fixedPointAdjustment);
 
-    // b) Balance is large enough to instant relay. Deposit is in any state except finalized (i.e can be slow relayed
+    // b) Balance is large enough to instant relay and the relay does not have an instant relayer. Deposit is in any state except finalized (i.e can be slow relayed
     // and sped up or only sped up.)
     if (
       !hasInstantRelayer &&

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -297,7 +297,7 @@ describe("Relayer.ts", function () {
 
       // Modifying any of the above 4 conditions should make the bot not instant relay.
 
-      // a) There  already exists an instant relayer for this relay.
+      // a) There already exists an instant relayer for this relay.
       assert.notEqual(
         await relayer.shouldRelay(deposit, clientRelayState, toBN(defaultRealizedLpFeePct), true),
         ShouldRelay.Instant


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

If an instant relayer underpays a recipient, perhaps because the realizedLpFeePct specified by the Relay is set too high, then currently they will receive the full relay amount when the Relay eventually settles. They will net the amount that they underpaid.

We need a way to keep track of whether instant relayers paid the correct amount, and to make sure that users always receive the correct relayed amount.

**Summary**

This PR introduces a new mapping of hashed `{depositHash, relay.realizedLpFeePct}` to `instantRelayer` address. Whenever a relay is proposed for a deposit, this `instantRelayHash` is deterministically linked to it and allows any `instantRelayer` to speed up the relay. If the relay params end up getting finalized, then the instant relayer who sped up those exact relay params will get refunded. If the instant relayer sped up an incorrect relay that ended up getting disputed, then their address won't be linked to a subsequent valid relay unless they speed it up again.

In either case, the responsibility still lies on the `instantRelayer` to validate the relay off-chain before speeding it up. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested