### PR TITLE
feat(insured-bridge): Add the ability to transfer bridgeAdmin in the bridgePool to enable upgradability

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -116,6 +116,19 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         emit SetDepositContracts(_chainId, _depositContract, _messengerContract);
     }
 
+    /**
+     * @notice Enables the current owner to transfer ownership of all owned bridge pools to a new owner.
+     * @dev Only callable by the current owner.
+     * @param _bridgePools array of bridge pools to transfer ownership.
+     * @param _newAdmin new admin contract to set ownership to.
+     */
+    function transferBridgePoolAdmin(address[] memory _bridgePools, address _newAdmin) public onlyOwner nonReentrant() {
+        for (uint8 i = 0; i < _bridgePools.length; i++) {
+            BridgePoolInterface(_bridgePools[i]).changeAdmin(_newAdmin);
+        }
+        emit BridgePoolsAdminTransferred(_bridgePools, _newAdmin);
+    }
+
     /**************************************************
      *        CROSSDOMAIN ADMIN FUNCTIONS             *
      **************************************************/

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -123,7 +123,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
      * @param _newAdmin new admin contract to set ownership to.
      */
     function transferBridgePoolAdmin(address[] memory _bridgePools, address _newAdmin) public onlyOwner nonReentrant() {
-        for (uint16 i = 0; i < _bridgePools.length; i++) {
+        for (uint8 i = 0; i < _bridgePools.length; i++) {
             BridgePoolInterface(_bridgePools[i]).changeAdmin(_newAdmin);
         }
         emit BridgePoolsAdminTransferred(_bridgePools, _newAdmin);

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -123,7 +123,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
      * @param _newAdmin new admin contract to set ownership to.
      */
     function transferBridgePoolAdmin(address[] memory _bridgePools, address _newAdmin) public onlyOwner nonReentrant() {
-        for (uint8 i = 0; i < _bridgePools.length; i++) {
+        for (uint16 i = 0; i < _bridgePools.length; i++) {
             BridgePoolInterface(_bridgePools[i]).changeAdmin(_newAdmin);
         }
         emit BridgePoolsAdminTransferred(_bridgePools, _newAdmin);

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -117,7 +117,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
     }
 
     /**
-     * @notice Enables the current owner to transfer ownership of all owned bridge pools to a new owner.
+     * @notice Enables the current owner to transfer ownership of a set of owned bridge pools to a new owner.
      * @dev Only callable by the current owner.
      * @param _bridgePools array of bridge pools to transfer ownership.
      * @param _newAdmin new admin contract to set ownership to.

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -439,15 +439,15 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
     /**
      * @notice Computes the liquidity utilization ratio post a relay of known size.
      * @dev Used in computing realizedLpFeePct off-chain.
-     * @param _relayedAmount Size of the relayed deposit to factor into the utilization calculation.
+     * @param relayedAmount Size of the relayed deposit to factor into the utilization calculation.
      */
-    function liquidityUtilizationPostRelay(uint256 _relayedAmount) public returns (uint256) {
+    function liquidityUtilizationPostRelay(uint256 relayedAmount) public returns (uint256) {
         sync(); // Fetch any balance changes due to token bridging finalization and factor them in.
 
-        // The liquidity utilization ratio is the ratio of utilized liquidity (pendingReserves + _relayedAmount
+        // The liquidity utilization ratio is the ratio of utilized liquidity (pendingReserves + relayedAmount
         // +utilizedReserves) divided by the liquid reserves.
         FixedPoint.Unsigned memory numerator =
-            FixedPoint.Unsigned(pendingReserves).add(FixedPoint.Unsigned(_relayedAmount));
+            FixedPoint.Unsigned(pendingReserves).add(FixedPoint.Unsigned(relayedAmount));
         if (utilizedReserves > 0) numerator = numerator.add(FixedPoint.Unsigned(uint256(utilizedReserves)));
         else numerator = numerator.sub(FixedPoint.Unsigned(uint256(utilizedReserves * -1)));
 

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -17,6 +17,7 @@ interface BridgeAdminInterface {
     event WhitelistToken(uint256 chainId, address indexed l1Token, address indexed l2Token, address indexed bridgePool);
     event SetMinimumBridgingDelay(uint256 indexed chainId, uint64 newMinimumBridgingDelay);
     event DepositsEnabled(uint256 indexed chainId, address indexed l2Token, bool depositsEnabled);
+    event BridgePoolsAdminTransferred(address[] bridgePools, address newAdmin);
 
     function finder() external view returns (address);
 

--- a/packages/core/contracts/insured-bridge/interfaces/BridgePoolInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgePoolInterface.sol
@@ -5,4 +5,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface BridgePoolInterface {
     function l1Token() external view returns (IERC20);
+
+    function changeAdmin(address newAdmin) external;
 }

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -305,6 +305,27 @@ describe("BridgePool", () => {
       )
     );
   });
+  it("Bridge Admin functionality", async function () {
+    // Admin can only be transferred by current admin.
+    assert.equal(await bridgePool.methods.bridgeAdmin().call(), bridgeAdmin.options.address);
+
+    assert(
+      await didContractThrow(
+        bridgeAdmin.methods.transferBridgePoolAdmin([bridgePool.options.address], rando).send({ from: rando })
+      )
+    );
+
+    // Calling from the correct address can transfer ownership.
+    const tx = await bridgeAdmin.methods
+      .transferBridgePoolAdmin([bridgePool.options.address], owner)
+      .send({ from: owner });
+
+    assert.equal(await bridgePool.methods.bridgeAdmin().call(), owner);
+
+    await assertEventEmitted(tx, bridgePool, "BridgePoolAdminTransferred", (ev) => {
+      return ev.oldAdmin === bridgeAdmin.options.address && ev.newAdmin === owner;
+    });
+  });
   it("Constructs utf8-encoded ancillary data for relay", async function () {
     const parameters = [
       { t: "uint8", v: depositData.chainId },


### PR DESCRIPTION
**Motivation**

The bridge pool currently has a set owner that cant be changed. There might be cases where we wish to upgrade the bridge admin to a new address, if we change just the bridge admin contract implementation. 

**Summary**

This PR adds a small change to the bridge Pool and Bridge admin to enable the upgradability of the bridgeAdmin address


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested