### PR TITLE
feat(insured-bridge): optimize bytes32 encode function

### DIFF
--- a/packages/core/contracts/common/implementation/AncillaryData.sol
+++ b/packages/core/contracts/common/implementation/AncillaryData.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "hardhat/console.sol";
-
 /**
  * @title Library for encoding and decoding ancillary data for DVM price requests.
  * @notice  We assume that on-chain ancillary data can be formatted directly from bytes to utf8 encoding via

--- a/packages/core/contracts/common/implementation/AncillaryData.sol
+++ b/packages/core/contracts/common/implementation/AncillaryData.sol
@@ -32,7 +32,7 @@ library AncillaryData {
             uint256 j = (x & 0x0202020202020202020202020202020202020202020202020202020202020202) / 2;
             x = x + (h & (i | j)) * 0x27 + 0x3030303030303030303030303030303030303030303030303030303030303030;
 
-            // Store and load next batch
+            // Return the result.
             return bytes32(x);
         }
     }

--- a/packages/core/contracts/common/implementation/AncillaryData.sol
+++ b/packages/core/contracts/common/implementation/AncillaryData.sol
@@ -12,17 +12,11 @@ import "hardhat/console.sol";
  * https://docs.google.com/document/d/1zhKKjgY1BupBGPPrY_WOJvui0B6DMcd-xDR8-9-SPDw/edit
  */
 library AncillaryData {
-    /**
-     * @notice Returns utf8-encoded bytes32 string that can be read via web3.utils.hexToUtf8.
-     * Source: brilliant implementation at https://gitter.im/ethereum/solidity?at=5840d23416207f7b0ed08c9b.
-     * @dev Will return bytes32 in all lower case hex characters and without the leading 0x.
-     * This has minor changes from the toUtf8BytesAddress to control for the size of the input.
-     * @param bytesIn bytes32 to encode.
-     * @return utf8 encoded bytes32.
-     */
-    function toUtf8Bytes(bytes32 bytesIn) internal pure returns (bytes memory) {
+    // This converts the bottom half of a bytes32 input to hex in a highly gas-optimized way.
+    // Source: the brilliant implementation at https://gitter.im/ethereum/solidity?at=5840d23416207f7b0ed08c9b.
+    function toUtf8Bytes32Bottom(bytes32 bytesIn) private pure returns (bytes32) {
         unchecked {
-            uint256 x = uint256(bytesIn) / 2**128;
+            uint256 x = uint256(bytesIn);
 
             // Nibble interleave
             x = x & 0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff;
@@ -39,25 +33,19 @@ library AncillaryData {
             x = x + (h & (i | j)) * 0x27 + 0x3030303030303030303030303030303030303030303030303030303030303030;
 
             // Store and load next batch
-            bytes32 first = bytes32(x);
-            x = uint256(bytesIn);
-
-            // Nibble interleave
-            x = x & 0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff;
-            x = (x | (x * 2**64)) & 0x0000000000000000ffffffffffffffff0000000000000000ffffffffffffffff;
-            x = (x | (x * 2**32)) & 0x00000000ffffffff00000000ffffffff00000000ffffffff00000000ffffffff;
-            x = (x | (x * 2**16)) & 0x0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff;
-            x = (x | (x * 2**8)) & 0x00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff;
-            x = (x | (x * 2**4)) & 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f;
-
-            // Hex encode
-            h = (x & 0x0808080808080808080808080808080808080808080808080808080808080808) / 8;
-            i = (x & 0x0404040404040404040404040404040404040404040404040404040404040404) / 4;
-            j = (x & 0x0202020202020202020202020202020202020202020202020202020202020202) / 2;
-            x = x + (h & (i | j)) * 0x27 + 0x3030303030303030303030303030303030303030303030303030303030303030;
-
-            return abi.encodePacked(first, x);
+            return bytes32(x);
         }
+    }
+
+    /**
+     * @notice Returns utf8-encoded bytes32 string that can be read via web3.utils.hexToUtf8.
+     * @dev Will return bytes32 in all lower case hex characters and without the leading 0x.
+     * This has minor changes from the toUtf8BytesAddress to control for the size of the input.
+     * @param bytesIn bytes32 to encode.
+     * @return utf8 encoded bytes32.
+     */
+    function toUtf8Bytes(bytes32 bytesIn) internal pure returns (bytes memory) {
+        return abi.encodePacked(toUtf8Bytes32Bottom(bytesIn >> 128), toUtf8Bytes32Bottom(bytesIn));
     }
 
     /**


### PR DESCRIPTION
**Motivation**

Converting bytes32 to utf8 is expensive.

**Summary**

I found a brilliant implementation from 2016 on a the solidity gitter here https://gitter.im/ethereum/solidity?at=5840d23416207f7b0ed08c9b, which brought the gas cost down to nearly nothing. It was originally built for addresses, but some quick mods made it work for bytes32. Note: I tried to modify the implementation as little as possible on the first go, but I will try to optimize it a bit more for code size, maintainability (comments), and gas. I quickly did compare its output to our other conversion function to verify the output and it seemed to work. 

Before:
```
Relay: 546086
Speed up: 94842
Settle: 312914
Total: 953842
```

After:
```
Relay: 488411
Speed up: 94842
Settle: 255240
Total: 838493
```

Total savings: `115349`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A