### PR TITLE
fix(insured-bridge): fix whitelist to work with multiple L2 chains

### DIFF
--- a/packages/core/contracts-ovm/insured-bridge/implementation/BridgeDepositBox.sol
+++ b/packages/core/contracts-ovm/insured-bridge/implementation/BridgeDepositBox.sol
@@ -49,7 +49,7 @@ abstract contract BridgeDepositBox is Legacy_Testable, Legacy_Lockable {
     }
 
     // Mapping of whitelisted L2Token to L2TokenRelationships. Contains L1 TokenAddress and the last time this token
-    // type was bridged. Used to rate limit bridging actions to prevent DOS on L1.
+    // type was bridged. Used to rate limit bridging actions to rate limit withdraws to L1.
     mapping(address => L2TokenRelationships) public whitelistedTokens;
 
     // Minimum time that must elapse between bridging actions for a given token. Used to rate limit bridging back to L1.

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -222,7 +222,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         require(address(BridgePoolInterface(_bridgePool).l1Token()) == _l1Token, "Bridge pool has different L1 token");
 
         L1TokenRelationships storage l1TokenRelationships = _whitelistedTokens[_l1Token];
-        l1TokenRelationships.l2Token[_chainId] = _l2Token; // Set the L2Token at the index of the chainId.
+        l1TokenRelationships.l2Tokens[_chainId] = _l2Token; // Set the L2Token at the index of the chainId.
         l1TokenRelationships.bridgePool = _bridgePool;
 
         MessengerInterface(_depositContracts[_chainId].messengerContract).relayMessage(
@@ -247,7 +247,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         override
         returns (address l2Token, address bridgePool)
     {
-        return (_whitelistedTokens[_l1Token].l2Token[chainId], _whitelistedTokens[_l1Token].bridgePool);
+        return (_whitelistedTokens[_l1Token].l2Tokens[chainId], _whitelistedTokens[_l1Token].bridgePool);
     }
 
     /**************************************

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -28,7 +28,7 @@ interface BridgeAdminInterface {
     function depositContracts(uint256) external view returns (DepositUtilityContracts memory);
 
     struct L1TokenRelationships {
-        mapping(uint256 => address) l2Token;
+        mapping(uint256 => address) l2Tokens; // L2 Chain Id to l2Token address.
         address bridgePool;
     }
 

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -28,11 +28,11 @@ interface BridgeAdminInterface {
     function depositContracts(uint256) external view returns (DepositUtilityContracts memory);
 
     struct L1TokenRelationships {
-        address l2Token;
+        mapping(uint256 => address) l2Token;
         address bridgePool;
     }
 
-    function whitelistedTokens(address) external view returns (L1TokenRelationships memory);
+    function whitelistedTokens(address, uint256) external view returns (address, address);
 
     function optimisticOracleLiveness() external view returns (uint64);
 

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -32,7 +32,7 @@ interface BridgeAdminInterface {
         address bridgePool;
     }
 
-    function whitelistedTokens(address, uint256) external view returns (address, address);
+    function whitelistedTokens(address, uint256) external view returns (address l2Token, address bridgePool);
 
     function optimisticOracleLiveness() external view returns (uint64);
 

--- a/packages/core/test/insured-bridge/BridgeAdmin.js
+++ b/packages/core/test/insured-bridge/BridgeAdmin.js
@@ -228,6 +228,12 @@ describe("BridgeAdmin", () => {
           await bridgeAdmin.methods
             .whitelistToken(chainId, l1Token, l2Token, bridgePool.options.address, defaultGasLimit, defaultGasPrice)
             .send({ from: owner });
+
+          const tokenMapping = await bridgeAdmin.methods.whitelistedTokens(l1Token, chainId).call();
+          assert.isTrue(
+            tokenMapping.l2Token === l2Token && tokenMapping.bridgePool === bridgePool.options.address,
+            "Token mapping not created correctly"
+          );
         });
         it("Add token mapping on L1 and sends xchain message", async () => {
           await bridgeAdmin.methods
@@ -247,7 +253,7 @@ describe("BridgeAdmin", () => {
               ev.bridgePool === bridgePool.options.address
             );
           });
-          const tokenMapping = await bridgeAdmin.methods.whitelistedTokens(l1Token).call();
+          const tokenMapping = await bridgeAdmin.methods.whitelistedTokens(l1Token, chainId).call();
           assert.isTrue(
             tokenMapping.l2Token === l2Token && tokenMapping.bridgePool === bridgePool.options.address,
             "Token mapping not created correctly"
@@ -256,6 +262,91 @@ describe("BridgeAdmin", () => {
           // Validate xchain message
           const expectedAbiData = depositBox.methods
             .whitelistToken(l1Token, l2Token, bridgePool.options.address)
+            .encodeABI();
+          await assertEventEmitted(whitelistTxn, messenger, "RelayedMessage", (ev) => {
+            return (
+              ev.target === depositBoxImpersonator &&
+              ev.gasLimit === defaultGasLimit.toString() &&
+              ev.gasPrice === defaultGasPrice &&
+              ev.message === expectedAbiData
+            );
+          });
+        });
+        it("Can whitelist multiple L2 tokens for one L1 token and bridgePool pair", async () => {
+          await bridgeAdmin.methods
+            .setDepositContract(chainId, depositBoxImpersonator, messenger.options.address)
+            .send({ from: owner });
+          await collateralWhitelist.methods.addToWhitelist(l1Token).send({ from: owner });
+
+          // Whitelist multiple L2 tokens for the one L1 tokens and bridge pool.
+          await bridgeAdmin.methods
+            .whitelistToken(chainId, l1Token, l2Token, bridgePool.options.address, defaultGasLimit, defaultGasPrice)
+            .send({ from: owner });
+          // Create a new L2 token address to mock being having this pool serve multiple L2s. EG USDC on Arbitrum and
+          // Optimism. This will have the same L1 bridge pool, multiple L2Tokens and bridge deposit boxes (for each L2).
+          // use a fake address to pretend to be the depositBoxImpersonator for the second chainId
+          const l2Token2 = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
+          const chainId2 = chainId + 1;
+          const depositBoxImpersonator2 = web3.utils.toChecksumAddress(web3.utils.randomHex(20));
+
+          await bridgeAdmin.methods
+            .setDepositContract(chainId2, depositBoxImpersonator2, messenger.options.address)
+            .send({ from: owner });
+
+          await bridgeAdmin.methods
+            .whitelistToken(chainId2, l1Token, l2Token2, bridgePool.options.address, defaultGasLimit, defaultGasPrice)
+            .send({ from: owner });
+          const tokenMapping1 = await bridgeAdmin.methods.whitelistedTokens(l1Token, chainId).call();
+          assert.isTrue(
+            tokenMapping1.l2Token === l2Token && tokenMapping1.bridgePool === bridgePool.options.address,
+            "Token mapping not created correctly"
+          );
+
+          const tokenMapping2 = await bridgeAdmin.methods.whitelistedTokens(l1Token, chainId2).call();
+          assert.isTrue(
+            tokenMapping2.l2Token === l2Token2 && tokenMapping2.bridgePool === bridgePool.options.address,
+            "Token mapping not created correctly"
+          );
+        });
+        it("Can use whitelist to update the address of the bridge pool on L2 for a given deposit box", async () => {
+          // The whitelistToken method has a secondary function in providing the ability to update the address of the
+          // bridge pool for a given L2 chain by re-whitelisting the same L2 token with a new bridge pool address.
+          await bridgeAdmin.methods
+            .setDepositContract(chainId, depositBoxImpersonator, messenger.options.address)
+            .send({ from: owner });
+          await collateralWhitelist.methods.addToWhitelist(l1Token).send({ from: owner });
+
+          // Whitelist multiple L2 tokens for the one L1 tokens and bridge pool.
+          await bridgeAdmin.methods
+            .whitelistToken(chainId, l1Token, l2Token, bridgePool.options.address, defaultGasLimit, defaultGasPrice)
+            .send({ from: owner });
+
+          // Now consider the case where we have change the address of the bridge pool on L1 due to an upgrade. We now
+          // need to send messages to each L2 deposit box to update this address. Create a new fake bridgePool and re
+          // whitelist the same l1Token/l2Token pair on the new pool address.
+          const bridgePool2 = await BridgePool.new(
+            "LP Token2",
+            "LPT2",
+            bridgeAdmin.options.address,
+            l1Token,
+            lpFeeRatePerSecond,
+            timer.options.address
+          ).send({ from: owner });
+          const whitelistTxn = await bridgeAdmin.methods
+            .whitelistToken(chainId, l1Token, l2Token, bridgePool2.options.address, defaultGasLimit, defaultGasPrice)
+            .send({ from: owner });
+
+          // After this whitelist call the address in the bridge admin should have been updated as expected and the
+          // messenger should have sent the call to update the latest bridgePool.
+          const tokenMapping = await bridgeAdmin.methods.whitelistedTokens(l1Token, chainId).call();
+          assert.isTrue(
+            tokenMapping.l2Token === l2Token && tokenMapping.bridgePool === bridgePool2.options.address,
+            "Token mapping not created correctly"
+          );
+
+          // Validate xchain message correctly updates to the new bridgePool2 address
+          const expectedAbiData = depositBox.methods
+            .whitelistToken(l1Token, l2Token, bridgePool2.options.address)
             .encodeABI();
           await assertEventEmitted(whitelistTxn, messenger, "RelayedMessage", (ev) => {
             return (

--- a/packages/insured-bridge-relayer/src/RelayerHelpers.ts
+++ b/packages/insured-bridge-relayer/src/RelayerHelpers.ts
@@ -21,7 +21,7 @@ export async function approveL1Tokens(
   const bridgeAdmin = new web3.eth.Contract(getAbi("BridgeAdminInterface"), bridgeAdminAddress);
 
   for (const whitelistedL1Token of whitelistedRelayL1Tokens) {
-    const bridgePool = (await bridgeAdmin.methods.whitelistedTokens(whitelistedL1Token).call()).bridgePool;
+    const bridgePool = (await bridgeAdmin.methods.whitelistedTokens(whitelistedL1Token, 0).call()).bridgePool;
     if (bridgePool === ZERO_ADDRESS) throw new Error("whitelistedRelayL1Tokens contains not-whitelisted token");
     const approvalTx = await setAllowance(web3, gasEstimator, account, bridgePool, whitelistedL1Token);
     if (approvalTx)


### PR DESCRIPTION
**Motivation**

The current Bridge Admin has no means to support a 1:n relationship between L1 tokens and L2 tokens. For example, consider USDC on arbitrum L2 and optimism L2. This PR updates the implementation to support this kind of whitelisting behaviour.
**Summary**

In addition to solving the relationship problem within the data structure, this PR also adds a unit test to show how the `whitelistToken` method should be used when updating the `bridgePool` address within L2 `BridgeDepositBox`es.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
