### PR TITLE
feat(pf-configs): Add PUNKETH-1221 and GASETH-1221 default pf configs

### DIFF
--- a/packages/common/src/PriceIdentifierUtils.ts
+++ b/packages/common/src/PriceIdentifierUtils.ts
@@ -42,6 +42,8 @@ export const OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY = [
   "uSTONKS_JUN21",
   "uSTONKS_0921",
   "GASETH-0921",
+  "PUNKETH-1221",
+  "GASETH-1221",
 ];
 
 // Any identifier on this list

--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
@@ -964,6 +964,18 @@ export const defaultConfigs: { [name: string]: { type: string; [key: string]: an
     twapLength: 7200,
     invertPrice: true,
   },
+  "PUNKETH-1221": {
+    type: "uniswap",
+    uniswapAddress: "0x9469313a1702dC275015775249883cFc35Aa94d8",
+    twapLength: 7200,
+    invertPrice: false,
+  },
+  "GASETH-1221": {
+    type: "uniswap",
+    uniswapAddress: "0xF6E15Cdf292D36A589276C835cC576F0DF0Fe53A",
+    twapLength: 7200,
+    invertPrice: true,
+  },
 };
 
 // Pull in the number of decimals for each identifier from the common getPrecisionForIdentifier. This is used within the


### PR DESCRIPTION
**Motivation**

PUNKETH-1221 and GASETH-1221 are both self referential price identifiers that reference their own token's trading price prior to expiry. Both identifiers need default price feed configs and need to be ignored for OO expiry requests, since those requests will require a different pricing calculation. 


**Summary**

Adds default pf configs for PUNKETH-1221 and GASETH-1221 and ignores them for OO expiry requests. 


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
