### PR TITLE
feat(contracts): optimize address -> utf8 conversion

### DIFF
--- a/packages/core/contracts/common/implementation/AncillaryData.sol
+++ b/packages/core/contracts/common/implementation/AncillaryData.sol
@@ -54,20 +54,8 @@ library AncillaryData {
      * @return utf8 encoded address bytes.
      */
     function toUtf8BytesAddress(address x) internal pure returns (bytes memory) {
-        bytes memory s = new bytes(40);
-        for (uint256 i = 0; i < 20; i++) {
-            bytes1 b = bytes1(uint8(uint256(uint160(x)) / (2**(8 * (19 - i)))));
-            bytes1 hi = bytes1(uint8(b) / 16);
-            bytes1 lo = bytes1(uint8(b) - 16 * uint8(hi));
-            s[2 * i] = char(hi);
-            s[2 * i + 1] = char(lo);
-        }
-        return s;
-    }
-
-    function char(bytes1 b) internal pure returns (bytes1 c) {
-        if (uint8(b) < 10) return bytes1(uint8(b) + 0x30);
-        else return bytes1(uint8(b) + 0x57);
+        return
+            abi.encodePacked(toUtf8Bytes32Bottom(bytes32(bytes20(x)) >> 128), bytes8(toUtf8Bytes32Bottom(bytes20(x))));
     }
 
     /**


### PR DESCRIPTION
**Motivation**

We should improve the gas efficiency of our address utf8 encoding process similar to bytes32.


**Summary**

Old gas:
```
Relay: 488411
Speed up: 94842
Settle: 255240
Total: 838493
```

New gas:
```
Relay: 455196
Speed up: 94842
Settle: 255240
Total: 805278
```

Improvement: `33215`


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
