### PR TITLE
feat(across): allow relay and speed up to be called simultaneously

### DIFF
--- a/packages/core/contracts/common/implementation/Testable.sol
+++ b/packages/core/contracts/common/implementation/Testable.sol
@@ -42,7 +42,7 @@ abstract contract Testable {
      * Otherwise, it will return the block timestamp.
      * @return uint for the current Testable timestamp.
      */
-    function getCurrentTime() public view returns (uint256) {
+    function getCurrentTime() public view virtual returns (uint256) {
         if (timerAddress != address(0x0)) {
             return Timer(timerAddress).getCurrentTime();
         } else {

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -665,14 +665,14 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
         FinderInterface finder = FinderInterface(bridgeAdmin.finder());
 
         // Remove approval for old OO.
-        if (!isWethPool) l1Token.safeApprove(address(optimisticOracle), 0);
+        if (address(optimisticOracle) != address(0)) l1Token.safeApprove(address(optimisticOracle), 0);
 
         optimisticOracle = SkinnyOptimisticOracleInterface(
             finder.getImplementationAddress(OracleInterfaces.SkinnyOptimisticOracle)
         );
 
         // MAX approve the new OO so no approvals need to be done.
-        if (!isWethPool) l1Token.safeApprove(address(optimisticOracle), type(uint256).max);
+        if (address(optimisticOracle) != address(0)) l1Token.safeApprove(address(optimisticOracle), type(uint256).max);
 
         store = StoreInterface(finder.getImplementationAddress(OracleInterfaces.Store));
     }

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -636,22 +636,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
 
     // Returns hash of unique relay and deposit event. This is added to the relay request's ancillary data.
     function _getRelayHash(DepositData memory depositData, RelayData memory relayData) private view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    depositData.chainId,
-                    depositData.depositId,
-                    depositData.l1Recipient,
-                    depositData.l2Sender,
-                    depositData.amount,
-                    depositData.slowRelayFeePct,
-                    depositData.instantRelayFeePct,
-                    depositData.quoteTimestamp,
-                    relayData.relayId,
-                    relayData.realizedLpFeePct,
-                    address(l1Token)
-                )
-            );
+        return keccak256(abi.encode(depositData, relayData.relayId, relayData.realizedLpFeePct, address(l1Token)));
     }
 
     // Return hash of relay data, which is stored in state and mapped to a deposit hash.

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -664,10 +664,16 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, MultiCaller
     function syncWithFinderAddresses() public {
         FinderInterface finder = FinderInterface(bridgeAdmin.finder());
 
+        // Remove approval for old OO.
+        if (!isWethPool) l1Token.safeApprove(address(optimisticOracle), 0);
+
         optimisticOracle = SkinnyOptimisticOracleInterface(
             finder.getImplementationAddress(OracleInterfaces.SkinnyOptimisticOracle)
         );
-        l1Token.safeApprove(address(optimisticOracle), type(uint256).max);
+
+        // MAX approve the new OO so no approvals need to be done.
+        if (!isWethPool) l1Token.safeApprove(address(optimisticOracle), type(uint256).max);
+
         store = StoreInterface(finder.getImplementationAddress(OracleInterfaces.Store));
     }
 

--- a/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
@@ -684,3 +684,20 @@ contract SkinnyOptimisticOracle is SkinnyOptimisticOracleInterface, Testable, Lo
         return AncillaryData.appendKeyValueAddress(ancillaryData, "ooRequester", requester);
     }
 }
+
+/**
+ * @notice This is the SkinnyOptimisticOracle contract that should be deployed on live networks. It is exactly the same
+ * as the regular SkinnyOptimisticOracle contract, but it overrides getCurrentTime to make the call a simply return
+ * block.timestamp with no branching or storage queries.
+ */
+contract SkinnyOptimisticOracleProd is SkinnyOptimisticOracle {
+    constructor(
+        uint256 _liveness,
+        address _finderAddress,
+        address _timerAddress
+    ) SkinnyOptimisticOracle(_liveness, _finderAddress, _timerAddress) {}
+
+    function getCurrentTime() public view virtual override returns (uint256) {
+        return block.timestamp;
+    }
+}

--- a/packages/core/test/insured-bridge/ArbitrumMessenger.js
+++ b/packages/core/test/insured-bridge/ArbitrumMessenger.js
@@ -18,6 +18,7 @@ const Finder = getContract("Finder");
 const BridgeDepositBox = getContract("BridgeDepositBoxMock");
 const IdentifierWhitelist = getContract("IdentifierWhitelist");
 const AddressWhitelist = getContract("AddressWhitelist");
+const ERC20 = getContract("ERC20");
 
 // Contract objects
 let arbitrumMessenger;
@@ -48,11 +49,11 @@ describe("ArbitrumMessenger integration with BridgeAdmin", () => {
   before(async function () {
     accounts = await web3.eth.getAccounts();
     [owner, rando, rando2, depositBoxImpersonator] = accounts;
-    l1Token = rando;
     l2Token = rando2;
     await runDefaultFixture(hre);
     timer = await Timer.new().send({ from: owner });
     finder = await Finder.new().send({ from: owner });
+    l1Token = (await ERC20.new("", "").send({ from: owner })).options.address;
     collateralWhitelist = await AddressWhitelist.new().send({ from: owner });
     await finder.methods
       .changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.options.address)

--- a/packages/core/test/insured-bridge/BridgeAdmin.js
+++ b/packages/core/test/insured-bridge/BridgeAdmin.js
@@ -14,6 +14,7 @@ const Finder = getContract("Finder");
 const BridgeDepositBox = getContract("BridgeDepositBoxMock");
 const IdentifierWhitelist = getContract("IdentifierWhitelist");
 const AddressWhitelist = getContract("AddressWhitelist");
+const ERC20 = getContract("ERC20");
 
 // Contract objects
 let messenger;
@@ -43,7 +44,7 @@ describe("BridgeAdmin", () => {
   before(async function () {
     accounts = await web3.eth.getAccounts();
     [owner, rando, rando2, depositBoxImpersonator] = accounts;
-    l1Token = rando;
+    l1Token = (await ERC20.new("", "").send({ from: owner })).options.address;
     l2Token = rando2;
     finder = await Finder.new().send({ from: owner });
     collateralWhitelist = await AddressWhitelist.new().send({ from: owner });

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -833,7 +833,7 @@ describe("BridgePool", () => {
       await l1Token.methods.transfer(instantRelayer, instantRelayAmountSubFee).send({ from: rando });
       await l1Token.methods.approve(bridgePool.options.address, totalRelayBond).send({ from: rando });
 
-      await bridgePool.methods.relayDeposit(...generateRelayParams()).send({ from: rando });
+      await bridgePool.methods.relayDeposit(...generateRelayParams({}, relayAttemptData)).send({ from: rando });
 
       // Cannot repeatedly speed relay up.
       await l1Token.methods

--- a/packages/core/test/insured-bridge/OptimismMessenger.js
+++ b/packages/core/test/insured-bridge/OptimismMessenger.js
@@ -17,6 +17,7 @@ const Finder = getContract("Finder");
 const BridgeDepositBox = getContract("BridgeDepositBoxMock");
 const IdentifierWhitelist = getContract("IdentifierWhitelist");
 const AddressWhitelist = getContract("AddressWhitelist");
+const ERC20 = getContract("ERC20");
 
 // Contract objects
 let optimismMessenger;
@@ -47,7 +48,7 @@ describe("OptimismMessenger integration with BridgeAdmin", () => {
   before(async function () {
     accounts = await web3.eth.getAccounts();
     [owner, rando, rando2, depositBoxImpersonator] = accounts;
-    l1Token = rando;
+    l1Token = (await ERC20.new("", "").send({ from: owner })).options.address;
     l2Token = rando2;
 
     timer = await Timer.new().send({ from: owner });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We'd like relay and speed up to be able to be called in the same transaction. Using multicall is intractible because it requires the caller to predict the time.


**Summary**

This adds a method relayAndSpeedUp to allow relay and speed up to be done simultaneously. There's a fair amount of repeated code, but the advantage is that there are some gas savings that we get from not having to do repeated transfers or verifications.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A