### PR TITLE
feat(insured-bridge): Block instant relays post-expiry and change relayDeposit interface to match relayAndSpeedUp

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -84,10 +84,10 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
     /**
      * @notice Sets challenge period for relayed deposits. BridgePools will read this value from this contract.
      * @dev Can only be called by the current owner.
-     * @param _liveness New OptimisticOracle liveness period to set for relay price requests.
+     * @param liveness New OptimisticOracle liveness period to set for relay price requests.
      */
-    function setOptimisticOracleLiveness(uint32 _liveness) public onlyOwner nonReentrant() {
-        _setOptimisticOracleLiveness(_liveness);
+    function setOptimisticOracleLiveness(uint32 liveness) public onlyOwner nonReentrant() {
+        _setOptimisticOracleLiveness(liveness);
     }
 
     /**
@@ -120,14 +120,14 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
     /**
      * @notice Enables the current owner to transfer ownership of a set of owned bridge pools to a new owner.
      * @dev Only callable by the current owner.
-     * @param _bridgePools array of bridge pools to transfer ownership.
-     * @param _newAdmin new admin contract to set ownership to.
+     * @param bridgePools array of bridge pools to transfer ownership.
+     * @param newAdmin new admin contract to set ownership to.
      */
-    function transferBridgePoolAdmin(address[] memory _bridgePools, address _newAdmin) public onlyOwner nonReentrant() {
-        for (uint8 i = 0; i < _bridgePools.length; i++) {
-            BridgePoolInterface(_bridgePools[i]).changeAdmin(_newAdmin);
+    function transferBridgePoolAdmin(address[] memory bridgePools, address newAdmin) public onlyOwner nonReentrant() {
+        for (uint8 i = 0; i < bridgePools.length; i++) {
+            BridgePoolInterface(bridgePools[i]).changeAdmin(newAdmin);
         }
-        emit BridgePoolsAdminTransferred(_bridgePools, _newAdmin);
+        emit BridgePoolsAdminTransferred(bridgePools, newAdmin);
     }
 
     /**************************************************
@@ -331,12 +331,12 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         emit SetRelayIdentifier(identifier);
     }
 
-    function _setOptimisticOracleLiveness(uint32 _liveness) private {
+    function _setOptimisticOracleLiveness(uint32 liveness) private {
         // The following constraints are copied from a similar function in the OptimisticOracle contract:
         // - https://github.com/UMAprotocol/protocol/blob/dd211c4e3825fe007d1161025a34e9901b26031a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol#L621
-        require(_liveness < 5200 weeks, "Liveness too large");
-        require(_liveness > 0, "Liveness cannot be 0");
-        optimisticOracleLiveness = _liveness;
+        require(liveness < 5200 weeks, "Liveness too large");
+        require(liveness > 0, "Liveness cannot be 0");
+        optimisticOracleLiveness = liveness;
         emit SetOptimisticOracleLiveness(optimisticOracleLiveness);
     }
 

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -425,7 +425,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, Lockable {
      * the instant relayer will be reimbursed. Therefore, the caller has the same responsibility as the disputer in
      * validating the relay data.
      * @dev Caller must have approved this contract to spend the deposit amount of L1 tokens to relay. There can only
-     * be one instant relayer per relay attempt.
+     * be one instant relayer per relay attempt. You cannot speed up a relay that is past liveness.
      * @param depositData Unique set of L2 deposit data that caller is trying to instantly relay.
      * @param relayData Parameters of Relay that caller is attempting to speedup. Must hash to the stored relay hash
      * for this deposit or this method will revert.
@@ -783,6 +783,7 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, Lockable {
 
     // Proposes new price of True for relay event associated with `customAncillaryData` to optimistic oracle. If anyone
     // disagrees with the relay parameters and whether they map to an L2 deposit, they can dispute with the oracle.
+    // Note: This struct was created to address a "Stack too deep" issue in the following method.
     struct PriceRequestData {
         bytes ancillaryData;
         address disputer;

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -164,7 +164,7 @@ describe("BridgePool", () => {
   const generateRelayHash = (_relayData) => {
     return soliditySha3(
       web3.eth.abi.encodeParameters(
-        ["uint256", "address", "uint32", "uint64", "uint256", "uint256", "uint256", "uint32"],
+        ["uint256", "address", "uint32", "uint64", "uint256", "uint256", "uint256"],
         [
           _relayData.relayState,
           _relayData.slowRelayer,
@@ -173,7 +173,6 @@ describe("BridgePool", () => {
           _relayData.priceRequestTime,
           _relayData.proposerBond,
           _relayData.finalFee,
-          _relayData.liveness,
         ]
       )
     );
@@ -327,7 +326,6 @@ describe("BridgePool", () => {
       slowRelayer: relayer,
       finalFee: finalFee,
       proposerBond: proposalBond.toString(),
-      liveness: defaultLiveness.toString(),
     };
 
     // Save other reused values.
@@ -524,7 +522,6 @@ describe("BridgePool", () => {
           ev.l1Token === l1Token.options.address &&
           ev.relay.slowRelayer === relayer &&
           ev.relay.relayId.toString() === relayAttemptData.relayId.toString() &&
-          ev.relay.liveness === relayAttemptData.liveness &&
           ev.relay.realizedLpFeePct === relayAttemptData.realizedLpFeePct &&
           ev.relay.priceRequestTime === relayAttemptData.priceRequestTime &&
           ev.relay.relayState === relayAttemptData.relayState &&
@@ -588,7 +585,6 @@ describe("BridgePool", () => {
           ev.relay.relayId === relayAttemptData.relayId.toString() &&
           ev.relay.realizedLpFeePct === relayAttemptData.realizedLpFeePct &&
           ev.relay.priceRequestTime === relayAttemptData.priceRequestTime &&
-          ev.relay.liveness === relayAttemptData.liveness &&
           ev.relay.relayState === relayAttemptData.relayState
         );
       });
@@ -716,7 +712,6 @@ describe("BridgePool", () => {
           ev.relay.relayId === relayAttemptData.relayId.toString() &&
           ev.relay.realizedLpFeePct === relayAttemptData.realizedLpFeePct &&
           ev.relay.priceRequestTime === relayAttemptData.priceRequestTime &&
-          ev.relay.liveness === relayAttemptData.liveness &&
           ev.relay.relayState === relayAttemptData.relayState
         );
       });
@@ -1413,7 +1408,6 @@ describe("BridgePool", () => {
           ev.relay.relayId === relayAttemptData.relayId.toString() &&
           ev.relay.realizedLpFeePct === relayAttemptData.realizedLpFeePct &&
           ev.relay.priceRequestTime === relayAttemptData.priceRequestTime &&
-          ev.relay.liveness === relayAttemptData.liveness &&
           ev.relay.relayState === relayAttemptData.relayState
         );
       });

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -31,6 +31,7 @@ export interface Relay {
   quoteTimestamp: number;
   realizedLpFeePct: string;
   priceRequestTime: number;
+  liveness: number;
   depositHash: string;
   relayState: ClientRelayState;
   relayHash: string;
@@ -222,6 +223,7 @@ export class InsuredBridgeL1Client {
           quoteTimestamp: Number(depositRelayedEvent.returnValues.depositData.quoteTimestamp),
           realizedLpFeePct: depositRelayedEvent.returnValues.relay.realizedLpFeePct,
           priceRequestTime: Number(depositRelayedEvent.returnValues.relay.priceRequestTime),
+          liveness: Number(depositRelayedEvent.returnValues.relay.liveness),
           depositHash: depositRelayedEvent.returnValues.depositHash,
           relayState: ClientRelayState.Pending, // Should be equal to depositRelayedEvent.returnValues.relay.relayState
           relayHash: depositRelayedEvent.returnValues.relayAncillaryDataHash,
@@ -239,6 +241,7 @@ export class InsuredBridgeL1Client {
           this.relays[l1Token][relayData.depositHash].relayId = relayData.relayId;
           this.relays[l1Token][relayData.depositHash].realizedLpFeePct = relayData.realizedLpFeePct;
           this.relays[l1Token][relayData.depositHash].priceRequestTime = relayData.priceRequestTime;
+          this.relays[l1Token][relayData.depositHash].liveness = relayData.liveness;
           // relayState should be the same.
         }
         // Else, if this if this is the first time we see this deposit hash, then store it.

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -31,7 +31,6 @@ export interface Relay {
   quoteTimestamp: number;
   realizedLpFeePct: string;
   priceRequestTime: number;
-  liveness: number;
   depositHash: string;
   relayState: ClientRelayState;
   relayHash: string;
@@ -223,7 +222,6 @@ export class InsuredBridgeL1Client {
           quoteTimestamp: Number(depositRelayedEvent.returnValues.depositData.quoteTimestamp),
           realizedLpFeePct: depositRelayedEvent.returnValues.relay.realizedLpFeePct,
           priceRequestTime: Number(depositRelayedEvent.returnValues.relay.priceRequestTime),
-          liveness: Number(depositRelayedEvent.returnValues.relay.liveness),
           depositHash: depositRelayedEvent.returnValues.depositHash,
           relayState: ClientRelayState.Pending, // Should be equal to depositRelayedEvent.returnValues.relay.relayState
           relayHash: depositRelayedEvent.returnValues.relayAncillaryDataHash,
@@ -241,7 +239,6 @@ export class InsuredBridgeL1Client {
           this.relays[l1Token][relayData.depositHash].relayId = relayData.relayId;
           this.relays[l1Token][relayData.depositHash].realizedLpFeePct = relayData.realizedLpFeePct;
           this.relays[l1Token][relayData.depositHash].priceRequestTime = relayData.priceRequestTime;
-          this.relays[l1Token][relayData.depositHash].liveness = relayData.liveness;
           // relayState should be the same.
         }
         // Else, if this if this is the first time we see this deposit hash, then store it.

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -140,7 +140,6 @@ describe("InsuredBridgeL1Client", function () {
       quoteTimestamp: Number(depositData.quoteTimestamp),
       realizedLpFeePct: relayData.realizedLpFeePct,
       priceRequestTime: relayData.priceRequestTime,
-      liveness: defaultLiveness,
       depositHash: depositHash,
       relayState: ClientRelayState.Pending,
       relayHash,
@@ -285,7 +284,6 @@ describe("InsuredBridgeL1Client", function () {
       slowRelayer: relayer,
       proposerBond: proposerBond,
       finalFee: finalFee,
-      liveness: defaultLiveness,
     };
 
     ({ depositHash, relayAncillaryData, relayAncillaryDataHash } = await generateRelayData(
@@ -336,7 +334,6 @@ describe("InsuredBridgeL1Client", function () {
         relayId: client.getBridgePoolForDeposit(depositData).relayNonce,
         realizedLpFeePct: defaultRealizedLpFee,
         priceRequestTime: client.getBridgePoolForDeposit(depositData).currentTime,
-        liveness: defaultLiveness,
         proposerBond,
         finalFee,
       };
@@ -430,7 +427,6 @@ describe("InsuredBridgeL1Client", function () {
         relayId: client.getBridgePoolForDeposit(depositData).relayNonce,
         realizedLpFeePct: defaultRealizedLpFee,
         priceRequestTime: client.getBridgePoolForDeposit(depositData).currentTime,
-        liveness: defaultLiveness,
         proposerBond,
         finalFee,
       };
@@ -576,7 +572,6 @@ describe("InsuredBridgeL1Client", function () {
         relayId: client.getBridgePoolForDeposit(depositData).relayNonce,
         realizedLpFeePct: defaultRealizedLpFee,
         priceRequestTime: client.getBridgePoolForDeposit(depositData).currentTime,
-        liveness: defaultLiveness,
         proposerBond,
         finalFee,
       };

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -80,10 +80,7 @@ describe("InsuredBridgeL1Client", function () {
   const generateRelayParams = (depositDataOverride = {}, relayDataOverride = {}) => {
     const _depositData = { ...depositData, ...depositDataOverride };
     const _relayData = { ...relayData, ...relayDataOverride };
-    // Remove the l1Token. This is part of the deposit data (hash) but is not part of the params for relayDeposit.
-    // eslint-disable-next-line no-unused-vars
-    const { l1Token, ...params } = _depositData;
-    return [...Object.values(params), _relayData.realizedLpFeePct];
+    return [_depositData, _relayData.realizedLpFeePct];
   };
 
   const generateRelayData = async (depositData, relayData, bridgePool, l1TokenAddress = l1Token.options.address) => {
@@ -143,6 +140,7 @@ describe("InsuredBridgeL1Client", function () {
       quoteTimestamp: Number(depositData.quoteTimestamp),
       realizedLpFeePct: relayData.realizedLpFeePct,
       priceRequestTime: relayData.priceRequestTime,
+      liveness: defaultLiveness,
       depositHash: depositHash,
       relayState: ClientRelayState.Pending,
       relayHash,
@@ -287,6 +285,7 @@ describe("InsuredBridgeL1Client", function () {
       slowRelayer: relayer,
       proposerBond: proposerBond,
       finalFee: finalFee,
+      liveness: defaultLiveness,
     };
 
     ({ depositHash, relayAncillaryData, relayAncillaryDataHash } = await generateRelayData(
@@ -337,6 +336,7 @@ describe("InsuredBridgeL1Client", function () {
         relayId: client.getBridgePoolForDeposit(depositData).relayNonce,
         realizedLpFeePct: defaultRealizedLpFee,
         priceRequestTime: client.getBridgePoolForDeposit(depositData).currentTime,
+        liveness: defaultLiveness,
         proposerBond,
         finalFee,
       };
@@ -430,6 +430,7 @@ describe("InsuredBridgeL1Client", function () {
         relayId: client.getBridgePoolForDeposit(depositData).relayNonce,
         realizedLpFeePct: defaultRealizedLpFee,
         priceRequestTime: client.getBridgePoolForDeposit(depositData).currentTime,
+        liveness: defaultLiveness,
         proposerBond,
         finalFee,
       };
@@ -575,6 +576,7 @@ describe("InsuredBridgeL1Client", function () {
         relayId: client.getBridgePoolForDeposit(depositData).relayNonce,
         realizedLpFeePct: defaultRealizedLpFee,
         priceRequestTime: client.getBridgePoolForDeposit(depositData).currentTime,
+        liveness: defaultLiveness,
         proposerBond,
         finalFee,
       };

--- a/packages/financial-templates-lib/test/price-feed/InsuredBridgePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/InsuredBridgePriceFeed.js
@@ -125,7 +125,6 @@ describe("InsuredBridgePriceFeed", function () {
       slowRelayer: relayer,
       finalFee,
       proposerBond,
-      liveness: defaultLiveness,
       ...relayDataOverride,
     };
 

--- a/packages/financial-templates-lib/test/price-feed/InsuredBridgePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/InsuredBridgePriceFeed.js
@@ -84,10 +84,7 @@ describe("InsuredBridgePriceFeed", function () {
   const generateRelayParams = (depositDataOverride = {}, relayDataOverride = {}) => {
     const _depositData = { ...depositData, ...depositDataOverride };
     const _relayData = { ...relayData, ...relayDataOverride };
-    // Remove the l1Token. This is part of the deposit data (hash) but is not part of the params for relayDeposit.
-    // eslint-disable-next-line no-unused-vars
-    const { l1Token, ...params } = _depositData;
-    return [...Object.values(params), _relayData.realizedLpFeePct];
+    return [_depositData, _relayData.realizedLpFeePct];
   };
 
   const generateRelayAncillaryData = async (depositData, relayData, bridgePool) => {
@@ -128,6 +125,7 @@ describe("InsuredBridgePriceFeed", function () {
       slowRelayer: relayer,
       finalFee,
       proposerBond,
+      liveness: defaultLiveness,
       ...relayDataOverride,
     };
 

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -237,6 +237,7 @@ export class Relayer {
           relayId: receipt.events.DepositRelayed.returnValues.relay.relayId,
           relayState: receipt.events.DepositRelayed.returnValues.relay.relayState,
           priceRequestTime: receipt.events.DepositRelayed.returnValues.relay.priceRequestTime,
+          liveness: receipt.events.DepositRelayed.returnValues.relay.liveness,
           relayAncillaryDataHash: receipt.events.DepositRelayed.returnValues.relayAncillaryDataHash,
           depositHash: receipt.events.DepositRelayed.returnValues.depositHash,
           transactionConfig,
@@ -268,6 +269,7 @@ export class Relayer {
           relayId: receipt.events.RelaySpedUp.returnValues.relay.relayId,
           relayState: receipt.events.RelaySpedUp.returnValues.relay.relayState,
           priceRequestTime: receipt.events.RelaySpedUp.returnValues.relay.priceRequestTime,
+          liveness: receipt.events.RelaySpedUp.returnValues.relay.liveness,
           slowRelayer: receipt.events.RelaySpedUp.returnValues.relay.slowRelayer,
           transactionConfig,
         });
@@ -297,6 +299,7 @@ export class Relayer {
           relayId: receipt.events.RelaySpedUp.returnValues.relay.relayId,
           relayState: receipt.events.RelaySpedUp.returnValues.relay.relayState,
           priceRequestTime: receipt.events.RelaySpedUp.returnValues.relay.priceRequestTime,
+          liveness: receipt.events.RelaySpedUp.returnValues.relay.liveness,
           slowRelayer: receipt.events.RelaySpedUp.returnValues.relay.slowRelayer,
           transactionConfig,
         });
@@ -309,14 +312,16 @@ export class Relayer {
   private generateSlowRelayTx(deposit: Deposit, realizedLpFeePct: BN): TransactionType {
     const bridgePool = this.l1Client.getBridgePoolForDeposit(deposit).contract;
     return (bridgePool.methods.relayDeposit(
-      deposit.chainId,
-      deposit.depositId,
-      deposit.l1Recipient,
-      deposit.l2Sender,
-      deposit.amount,
-      deposit.slowRelayFeePct,
-      deposit.instantRelayFeePct,
-      deposit.quoteTimestamp,
+      [
+        deposit.chainId,
+        deposit.depositId,
+        deposit.l1Recipient,
+        deposit.l2Sender,
+        deposit.amount,
+        deposit.slowRelayFeePct,
+        deposit.instantRelayFeePct,
+        deposit.quoteTimestamp,
+      ],
       realizedLpFeePct
     ) as unknown) as TransactionType;
   }

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -237,7 +237,6 @@ export class Relayer {
           relayId: receipt.events.DepositRelayed.returnValues.relay.relayId,
           relayState: receipt.events.DepositRelayed.returnValues.relay.relayState,
           priceRequestTime: receipt.events.DepositRelayed.returnValues.relay.priceRequestTime,
-          liveness: receipt.events.DepositRelayed.returnValues.relay.liveness,
           relayAncillaryDataHash: receipt.events.DepositRelayed.returnValues.relayAncillaryDataHash,
           depositHash: receipt.events.DepositRelayed.returnValues.depositHash,
           transactionConfig,
@@ -269,7 +268,6 @@ export class Relayer {
           relayId: receipt.events.RelaySpedUp.returnValues.relay.relayId,
           relayState: receipt.events.RelaySpedUp.returnValues.relay.relayState,
           priceRequestTime: receipt.events.RelaySpedUp.returnValues.relay.priceRequestTime,
-          liveness: receipt.events.RelaySpedUp.returnValues.relay.liveness,
           slowRelayer: receipt.events.RelaySpedUp.returnValues.relay.slowRelayer,
           transactionConfig,
         });
@@ -299,7 +297,6 @@ export class Relayer {
           relayId: receipt.events.RelaySpedUp.returnValues.relay.relayId,
           relayState: receipt.events.RelaySpedUp.returnValues.relay.relayState,
           priceRequestTime: receipt.events.RelaySpedUp.returnValues.relay.priceRequestTime,
-          liveness: receipt.events.RelaySpedUp.returnValues.relay.liveness,
           slowRelayer: receipt.events.RelaySpedUp.returnValues.relay.slowRelayer,
           transactionConfig,
         });

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -422,14 +422,16 @@ describe("Relayer.ts", function () {
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
       await bridgePool.methods
         .relayDeposit(
-          chainId,
-          "0",
-          l2Depositor,
-          l2Depositor,
-          depositAmount,
-          defaultSlowRelayFeePct,
-          defaultInstantRelayFeePct,
-          currentBlockTime,
+          {
+            chainId: chainId,
+            depositId: "0",
+            l2Sender: l2Depositor,
+            l1Recipient: l2Depositor,
+            amount: depositAmount,
+            slowRelayFeePct: defaultSlowRelayFeePct,
+            instantRelayFeePct: defaultInstantRelayFeePct,
+            quoteTimestamp: currentBlockTime,
+          },
           calculateRealizedLpFeePct(rateModel, toBNWei("0"), toBNWei("0.01")) // compute the expected fee for 1% utilization
         )
         .send({ from: l1Owner });
@@ -496,14 +498,16 @@ describe("Relayer.ts", function () {
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
       await bridgePool.methods
         .relayDeposit(
-          chainId,
-          "0",
-          l2Depositor,
-          l2Depositor,
-          depositAmount,
-          defaultSlowRelayFeePct,
-          defaultInstantRelayFeePct,
-          currentBlockTime,
+          {
+            chainId: chainId,
+            depositId: "0",
+            l2Sender: l2Depositor,
+            l1Recipient: l2Depositor,
+            amount: depositAmount,
+            slowRelayFeePct: defaultSlowRelayFeePct,
+            instantRelayFeePct: defaultInstantRelayFeePct,
+            quoteTimestamp: currentBlockTime,
+          },
           toBN(defaultRealizedLpFeePct)
             .mul(toBN(toWei("2")))
             .div(toBN(toWei("1")))


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

`relayAndSpeedUp` takes a `DepositData` struct as first param, while `relayDeposit` takes in de-structured `DepositData` params. The latter can easily take in a `DepositData` struct.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
