### PR TITLE
improve(api): provide option to overwrite emp registry address

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -42,6 +42,9 @@ debug=1
 
 # LSP Creator addresses are used to discover deployed lsp contracts. Currently we have to manually specify old creator addresses
 lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10
+
+# Overwrite the default Emp Registry Contract address
+EMP_REGISTRY_ADDRESS=0x...
 ```
 
 ## Starting

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -126,7 +126,7 @@ export default async (env: ProcessEnv) => {
   const services = {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, appState),
-    registry: await Services.Registry({ debug }, appState, (event, data) =>
+    registry: await Services.Registry({ debug, registryAddress: env.EMP_REGISTRY_ADDRESS }, appState, (event, data) =>
       serviceEvents.emit("empRegistry", event, data)
     ),
     collateralPrices: Services.CollateralPrices({ debug }, appState),

--- a/packages/api/src/apps/datastore_api/README.md
+++ b/packages/api/src/apps/datastore_api/README.md
@@ -45,6 +45,9 @@ debug=1
 
 # LSP Creator addresses are used to discover deployed lsp contracts. Currently we have to manually specify old creator addresses
 lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10
+
+# Overwrite the default Emp Registry Contract address
+EMP_REGISTRY_ADDRESS=0x...
 ```
 
 ## Build

--- a/packages/api/src/apps/datastore_api/app.ts
+++ b/packages/api/src/apps/datastore_api/app.ts
@@ -129,7 +129,7 @@ export default async (env: ProcessEnv) => {
   const services = {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, appState),
-    registry: await Services.Registry({ debug }, appState, (event, data) =>
+    registry: await Services.Registry({ debug, registryAddress: env.EMP_REGISTRY_ADDRESS }, appState, (event, data) =>
       serviceEvents.emit("empRegistry", event, data)
     ),
     collateralPrices: Services.CollateralPrices({ debug }, appState),

--- a/packages/api/src/apps/lsp_api/README.md
+++ b/packages/api/src/apps/lsp_api/README.md
@@ -37,6 +37,9 @@ debug=1
 
 # LSP Creator addresses are used to discover deployed lsp contracts. Currently we have to manually specify old creator addresses
 lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10
+
+# Overwrite the default Emp Registry Contract address
+EMP_REGISTRY_ADDRESS=0x...
 ```
 
 ## Starting

--- a/packages/api/src/apps/lsp_api/app.ts
+++ b/packages/api/src/apps/lsp_api/app.ts
@@ -128,7 +128,7 @@ export default async (env: ProcessEnv) => {
   const services = {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, appState),
-    registry: await Services.Registry({ debug }, appState, (event, data) =>
+    registry: await Services.Registry({ debug, registryAddress: env.EMP_REGISTRY_ADDRESS }, appState, (event, data) =>
       serviceEvents.emit("empRegistry", event, data)
     ),
     collateralPrices: Services.CollateralPrices({ debug }, appState),

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -6,6 +6,7 @@ const { registry } = clients;
 
 interface Config extends BaseConfig {
   network?: number;
+  registryAddress?: string;
 }
 type Dependencies = Pick<AppState, "registeredEmps" | "provider" | "registeredEmpsMetadata">;
 
@@ -20,9 +21,9 @@ export type EmitData = {
 export type Events = "created";
 
 export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
-  const { network = 1 } = config;
+  const { network = 1, registryAddress } = config;
   const { registeredEmps, provider, registeredEmpsMetadata } = appState;
-  const address = await registry.getAddress(network);
+  const address = registryAddress || (await registry.getAddress(network));
   const contract = registry.connect(address, provider);
 
   async function update(startBlock?: number, endBlock?: number) {


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2356/allow-env-to-override-emp-registry-address-in-api

**Summary**

This PR adds option to overwrite the address of the Emp Registry contract by providing a custom env variable.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
