### PR TITLE
Feature/sc 2565/create initial serverless api write app

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -45,7 +45,8 @@
     "lint": "yarn prettier --write && yarn eslint --fix",
     "api": "node build/start api",
     "lsp_api": "node build/start lsp_api",
-    "datastore_api": "node build/start datastore_api"
+    "datastore_api": "node build/start datastore_api",
+    "ingestor_app": "node build/start ingestor_app"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/packages/api/src/apps/index.ts
+++ b/packages/api/src/apps/index.ts
@@ -1,3 +1,4 @@
 export { default as api } from "./api";
 export { default as lsp_api } from "./lsp_api";
 export { default as datastore_api } from "./datastore_api";
+export { default as ingestor_app } from "./ingestor_app";

--- a/packages/api/src/apps/ingestor_app/README.md
+++ b/packages/api/src/apps/ingestor_app/README.md
@@ -1,0 +1,52 @@
+# Uma Serverless Ingestor App
+
+This is the application for ingesting data into Google Datastore. It is designed to run on a schedule basis, so it has to be lightweight and stateless.
+
+## Environment
+
+Add these to a .env file in the root of the `protocol/packages/api` folder.
+
+```
+CUSTOM_NODE_URL=wss://mainnet.infura.io/ws/v3/${your project key}
+
+# Provide authentication credentials to the api application to be able to use Google Datastore service
+GOOGLE_APPLICATION_CREDENTIALS=<path_to_json_file>
+
+# these configure synthetic price feed. These price feeds may require paid api keys.
+cryptowatchApiKey=
+tradermadeApiKey=
+quandlApiKey=
+defipulseApiKey=
+
+# 0x price feed gets us market prices on tokens
+zrxBaseUrl=https://api.0x.org
+
+# how many days of price history we should query on startup, leave empty to disable, history will start at the time app is started
+backfillDays=
+
+# required for lsp and emp state updates. this is a valid multicall2 address on mainnet.
+MULTI_CALL_2_ADDRESS=0x5ba1e12693dc8f9c48aad8770482f4739beed696
+
+# any non null value will turn on debugging. This adds additional logs and time profiles for key calls.
+debug=1
+
+# LSP Creator addresses are used to discover deployed lsp contracts. Currently we have to manually specify old creator addresses
+lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D097B7F092EFaB2E085AC0a82F42,0x31C893843685f1255A26502eaB5379A3518Aa5a9,0x9504b4ab8cd743b06074757d3B1bE3a3aF9cea10
+
+# Overwrite the default Emp Registry Contract address
+EMP_REGISTRY_ADDRESS=0x...
+```
+
+## Build
+
+`yarn build`
+
+## Starting
+
+Assuming all dependencies are installed and `.env` is configured:
+
+from package script:
+`yarn ingestor_app`
+
+or directly:
+`npx ts-node src/start.ts ingestor_app`

--- a/packages/api/src/apps/ingestor_app/app.ts
+++ b/packages/api/src/apps/ingestor_app/app.ts
@@ -1,0 +1,231 @@
+import assert from "assert";
+import { ethers } from "ethers";
+import moment from "moment";
+import { tables, Coingecko, Multicall2 } from "@uma/sdk";
+import { Datastore } from "@google-cloud/datastore";
+
+import * as Services from "../../services";
+import { appStats, empStats, empStatsHistory, lsps, StoresFactory } from "../../tables";
+import Zrx from "../../libs/zrx";
+import { Profile, parseEnvArray, getWeb3, expirePromise } from "../../libs/utils";
+
+import type { ProcessEnv, DatastoreAppState } from "../../types";
+
+export default async (env: ProcessEnv) => {
+  assert(env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
+  assert(env.zrxBaseUrl, "requires zrxBaseUrl");
+  assert(env.MULTI_CALL_2_ADDRESS, "requires MULTI_CALL_2_ADDRESS");
+  const lspCreatorAddresses = parseEnvArray(env.lspCreatorAddresses || "");
+
+  // debug flag for more verbose logs
+  const debug = Boolean(env.debug);
+  const profile = Profile(debug);
+
+  const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL);
+
+  // we need web3 for syth price feeds
+  const web3 = getWeb3(env.CUSTOM_NODE_URL);
+
+  const datastoreClient = new Datastore();
+  const datastores = StoresFactory(datastoreClient);
+  // state shared between services
+  const appState: DatastoreAppState = {
+    provider,
+    web3,
+    coingecko: new Coingecko(),
+    zrx: new Zrx(env.zrxBaseUrl),
+    emps: {
+      active: tables.emps.Table("Active Emp", datastores.empsActive),
+      expired: tables.emps.Table("Expired Emp", datastores.empsExpired),
+    },
+    prices: {
+      usd: {
+        latest: {},
+        history: {},
+      },
+    },
+    synthPrices: {
+      latest: {},
+      history: {},
+    },
+    marketPrices: {
+      usdc: {
+        latest: {},
+        history: empStatsHistory.Table("Market Price", datastores.empStatsHistory),
+      },
+    },
+    erc20s: tables.erc20s.Table("Erc20", datastores.erc20),
+    stats: {
+      emp: {
+        usd: {
+          latest: {
+            tvm: empStats.Table("Latest Tvm", datastores.empStatsTvm),
+            tvl: empStats.Table("Latest Tvl", datastores.empStatsTvl),
+          },
+          history: {
+            tvm: empStatsHistory.Table("Tvm History", datastores.empStatsTvlHistory),
+            tvl: empStatsHistory.Table("Tvl History", datastores.empStatsTvmHistory),
+          },
+        },
+      },
+      lsp: {
+        usd: {
+          latest: {
+            tvl: empStats.Table("Latest Tvl", datastores.lspStatsTvl),
+            tvm: empStats.Table("Latest Tvm", datastores.lspStatsTvm),
+          },
+          history: {
+            tvl: empStatsHistory.Table("Tvl History", datastores.lspStatsTvlHistory),
+          },
+        },
+      },
+      global: {
+        usd: {
+          latest: {
+            tvl: [0, "0"],
+          },
+          history: {
+            tvl: empStatsHistory.Table("Tvl Global History"),
+          },
+        },
+      },
+    },
+    lastBlockUpdate: 0,
+    registeredEmps: new Set<string>(),
+    registeredEmpsMetadata: new Map(),
+    registeredLsps: new Set<string>(),
+    registeredLspsMetadata: new Map(),
+    collateralAddresses: new Set<string>(),
+    syntheticAddresses: new Set<string>(),
+    // lsp related props. could be its own state object
+    longAddresses: new Set<string>(),
+    shortAddresses: new Set<string>(),
+    multicall2: new Multicall2(env.MULTI_CALL_2_ADDRESS, provider),
+    lsps: {
+      active: lsps.Table("Active LSP", datastores.lspsActive),
+      expired: lsps.Table("Expired LSP", datastores.lspsExpired),
+    },
+    appStats: appStats.Table("App Stats", datastores.appStats),
+  };
+
+  // services for ingesting data
+  const services = {
+    // these services can optionally be configured with a config object, but currently they are undefined or have defaults
+    emps: Services.EmpState({ debug }, appState),
+    registry: await Services.Registry({ debug, registryAddress: env.EMP_REGISTRY_ADDRESS }, appState),
+    collateralPrices: Services.CollateralPrices({ debug }, appState),
+    syntheticPrices: Services.SyntheticPrices(
+      {
+        debug,
+        cryptowatchApiKey: env.cryptowatchApiKey,
+        tradermadeApiKey: env.tradermadeApiKey,
+        quandlApiKey: env.quandlApiKey,
+        defipulseApiKey: env.defipulseApiKey,
+      },
+      appState
+    ),
+    erc20s: Services.Erc20s({ debug }, appState),
+    empStats: Services.stats.Emp({ debug }, appState),
+    marketPrices: Services.MarketPrices({ debug }, appState),
+    lspCreator: await Services.MultiLspCreator({ debug, addresses: lspCreatorAddresses }, appState),
+    lsps: Services.LspState({ debug }, appState),
+    lspStats: Services.stats.Lsp({ debug }, appState),
+    globalStats: Services.stats.Global({ debug }, appState),
+  };
+
+  async function detectNewContracts(startBlock: number, endBlock: number) {
+    // ignore case when startblock == endblock, this can happen when loop is run before a new block has changed
+    if (startBlock === endBlock) return;
+    assert(startBlock < endBlock, "Startblock must be lower than endBlock");
+    await services.registry(startBlock, endBlock);
+    await services.lspCreator.update(startBlock, endBlock);
+  }
+
+  // break all state updates by block events into a cleaner function
+  async function updateContractState(startBlock: number, endBlock: number) {
+    // ignore case when startblock == endblock, this can happen when loop is run before a new block has changed
+    if (startBlock === endBlock) return;
+    assert(startBlock < endBlock, "Startblock must be lower than endBlock");
+    // update everyting
+    await services.emps.update(startBlock, endBlock);
+    await services.lsps.update(startBlock, endBlock);
+    await services.erc20s.update();
+    await appState.appStats.setLastBlockUpdate(endBlock);
+  }
+
+  // separate out price updates into a different loop to query every few minutes
+  async function updatePrices() {
+    await services.collateralPrices.update();
+    await services.syntheticPrices.update();
+    await services.marketPrices.update();
+    await services.empStats.update();
+    await services.lspStats.update();
+    await services.globalStats.update();
+  }
+
+  async function getLatestBlockNumber() {
+    const block = await provider.getBlock("latest");
+    return block.number;
+  }
+
+  const lastBlockUpdate = (await appState.appStats.getLastBlockUpdate()) || 0;
+  const lastBlock = await getLatestBlockNumber();
+
+  async function detectContractsProfiled() {
+    const end = profile("Detecting New Contracts");
+    // adding in a timeout rejection if the update takes too long
+    await expirePromise(
+      async () => {
+        await detectNewContracts(lastBlockUpdate, lastBlock);
+        console.log("Checked for new contracts between blocks", lastBlockUpdate, lastBlock);
+        // error out if this fails to complete in 5 minutes
+      },
+      5 * 60 * 1000,
+      "Detecting new contracts timed out"
+    )
+      .catch(console.error)
+      .finally(end);
+  }
+
+  async function updateContractsStateProfiled() {
+    const end = profile("Running contract state updates");
+    // adding in a timeout rejection if the update takes too long
+    await expirePromise(
+      async () => {
+        await updateContractState(lastBlockUpdate, lastBlock);
+        console.log("Updated Contract state between blocks", lastBlockUpdate, lastBlock);
+        // throw an error if this fails to process in 15 minutes
+      },
+      15 * 60 * 1000,
+      "Contract state updates timed out"
+    )
+      .catch(console.error)
+      .finally(end);
+  }
+
+  async function updatePricesProfiled() {
+    const end = profile("Update all prices");
+    await updatePrices().catch(console.error).finally(end);
+  }
+
+  await detectContractsProfiled();
+  await updateContractsStateProfiled();
+
+  // backfill price histories, disable if not specified in env
+  if (env.backfillDays) {
+    console.log(`Backfilling price history from ${env.backfillDays} days ago`);
+    await services.collateralPrices.backfill(moment().subtract(env.backfillDays, "days").valueOf());
+    console.log("Updated Collateral Prices Backfill");
+
+    // backfill price history only if runs for the first time
+    if (!(await appState.appStats.getLastBlockUpdate())) {
+      await services.empStats.backfill();
+      console.log("Updated EMP Backfill");
+
+      await services.lspStats.backfill();
+      console.log("Updated LSP Backfill");
+    }
+  }
+
+  await updatePricesProfiled();
+};

--- a/packages/api/src/apps/ingestor_app/index.ts
+++ b/packages/api/src/apps/ingestor_app/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./app";

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -20,7 +20,7 @@ export type EmitData = {
 // type of events
 export type Events = "created";
 
-export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
+export default async (config: Config, appState: Dependencies, emit?: (event: Events, data: EmitData) => void) => {
   const { network = 1, registryAddress } = config;
   const { registeredEmps, provider, registeredEmpsMetadata } = appState;
   const address = registryAddress || (await registry.getAddress(network));
@@ -39,7 +39,10 @@ export default async (config: Config, appState: Dependencies, emit: (event: Even
       const blockNumber = contracts[address].blockNumber;
       registeredEmpsMetadata.set(address, { blockNumber });
       registeredEmps.add(address);
-      emit("created", { address, blockNumber, startBlock, endBlock });
+
+      if (emit) {
+        emit("created", { address, blockNumber, startBlock, endBlock });
+      }
     });
   }
 

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -19,7 +19,7 @@ export type EmitData = {
 
 export type Events = "created";
 
-export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
+export default async (config: Config, appState: Dependencies, emit?: (event: Events, data: EmitData) => void) => {
   const { network = 1, address = await lspCreator.getAddress(network) } = config;
   const { registeredLsps, provider, registeredLspsMetadata } = appState;
 
@@ -38,7 +38,9 @@ export default async (config: Config, appState: Dependencies, emit: (event: Even
       registeredLspsMetadata.set(address, { blockNumber });
       registeredLsps.add(address);
       // emit that a new contract was found. Must be done after saving meta data
-      emit("created", { address, blockNumber, startBlock, endBlock });
+      if (emit) {
+        emit("created", { address, blockNumber, startBlock, endBlock });
+      }
     });
   }
 

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -15,7 +15,7 @@ export type { EmitData };
 
 export type { Events };
 
-export default async (config: Config, appState: Dependencies, emit: (event: Events, data: EmitData) => void) => {
+export default async (config: Config, appState: Dependencies, emit?: (event: Events, data: EmitData) => void) => {
   const { addresses = [], network = 1 } = config;
 
   // always include latest known address


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2565/create-initial-serverless-api-write-app

**Summary**

I created a new application `ingestor_app` (feel free to suggest a better naming) that is designed to run on a schedule basis. It is responsible for updating the state with the contracts addresses, contracts state and prices. Some parts of the default `api` were removed: the loops running the updates, the event emitter and the public `express` server.
These are another upcoming PRs that will improve this implementation
- move the entire state in Datastore
- refactor the services.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
