### PR TITLE
fix(insured-bridge-l1-client): Delete pending relays on dispute events

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -38,7 +38,7 @@ export interface Relay {
   priceRequestTime: number;
   depositHash: string;
   relayState: ClientRelayState;
-  relayHash: string;
+  relayAncillaryDataHash: string;
   proposerBond: string;
   finalFee: string;
   settleable: SettleableRelay;
@@ -254,7 +254,7 @@ export class InsuredBridgeL1Client {
           priceRequestTime: Number(depositRelayedEvent.returnValues.relay.priceRequestTime),
           depositHash: depositRelayedEvent.returnValues.depositHash,
           relayState: ClientRelayState.Pending, // Should be equal to depositRelayedEvent.returnValues.relay.relayState
-          relayHash: depositRelayedEvent.returnValues.relayAncillaryDataHash,
+          relayAncillaryDataHash: depositRelayedEvent.returnValues.relayAncillaryDataHash,
           proposerBond: depositRelayedEvent.returnValues.relay.proposerBond,
           finalFee: depositRelayedEvent.returnValues.relay.finalFee,
           settleable: SettleableRelay.CannotSettle,

--- a/packages/financial-templates-lib/src/price-feed/InsuredBridgePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/InsuredBridgePriceFeed.ts
@@ -58,9 +58,9 @@ export class InsuredBridgePriceFeed extends PriceFeedInterface {
 
     // Parse ancillary data for relay request and find deposit if possible with matching params.
     const parsedAncillaryData = (parseAncillaryData(ancillaryData) as unknown) as RelayAncillaryData;
-    const relayHash = "0x" + parsedAncillaryData.relayHash;
+    const relayAncillaryDataHash = "0x" + parsedAncillaryData.relayHash;
     const relay = this.l1Client.getAllRelayedDeposits().find((relay) => {
-      return relay.relayHash === relayHash;
+      return relay.relayAncillaryDataHash === relayAncillaryDataHash;
     });
 
     if (!relay) {

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -145,7 +145,7 @@ describe("InsuredBridgeL1Client", function () {
       priceRequestTime: relayData.priceRequestTime,
       depositHash: depositHash,
       relayState: ClientRelayState.Pending,
-      relayHash,
+      relayAncillaryDataHash: relayHash,
       proposerBond,
       finalFee,
       settleable: SettleableRelay.CannotSettle,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently the bot will not submit relays for deposits with disputed relay events. This PR ensures that the L1 client deletes disputed relays from its memory.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested