### PR TITLE
fix(bridge-pool): BridgePool should set same fee % bounds as DepositBox

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -272,8 +272,8 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, Lockable {
         // The realizedLPFeePct should never be greater than 0.5e18 and the slow and instant relay fees should never be
         // more than 0.25e18 each. Therefore, the sum of all fee types can never exceed 1e18 (or 100%).
         require(
-            depositData.slowRelayFeePct < 0.25e18 &&
-                depositData.instantRelayFeePct < 0.25e18 &&
+            depositData.slowRelayFeePct <= 0.25e18 &&
+                depositData.instantRelayFeePct <= 0.25e18 &&
                 realizedLpFeePct < 0.5e18
         );
 
@@ -395,8 +395,8 @@ contract BridgePool is Testable, BridgePoolInterface, ExpandedERC20, Lockable {
         // The realizedLPFeePct should never be greater than 0.5e18 and the slow and instant relay fees should never be
         // more than 0.25e18 each. Therefore, the sum of all fee types can never exceed 1e18 (or 100%).
         require(
-            depositData.slowRelayFeePct < 0.25e18 &&
-                depositData.instantRelayFeePct < 0.25e18 &&
+            depositData.slowRelayFeePct <= 0.25e18 &&
+                depositData.instantRelayFeePct <= 0.25e18 &&
                 realizedLpFeePct < 0.5e18
         );
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently `BridgeDepositBox` constrains fees to be inclusive some bounds while `BridgePool` constrains same fees with exclusive bounds. This creates a situation where a deposit with a 25% fee is valid on L2 but cannot be relayed on L1.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
