### PR TITLE
fix(insured-bridge): Call exchangeRateCurrent before external call

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -214,10 +214,12 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
         // Else, msg.value must be set to 0.
         require((isWethPool && msg.value == l1TokenAmount) || msg.value == 0, "Bad add liquidity Eth value");
 
+        // Since `exchangeRateCurrent()` reads this contract's balance and updates contract state using it,
+        // we must call it first before transferring any tokens to this contract.
+        uint256 lpTokensToMint = (l1TokenAmount * 1e18) / exchangeRateCurrent();
+
         if (msg.value > 0 && isWethPool) WETH9Like(address(l1Token)).deposit{ value: msg.value }();
         else l1Token.safeTransferFrom(msg.sender, address(this), l1TokenAmount);
-
-        uint256 lpTokensToMint = (l1TokenAmount * 1e18) / exchangeRateCurrent();
 
         _mint(msg.sender, lpTokensToMint);
 

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -1773,6 +1773,32 @@ describe("BridgePool", () => {
       assert.equal(await bridgePool.methods.liquidReserves().call(), "0");
       assert.equal(await bridgePool.methods.utilizedReserves().call(), defaultDepositData.amount);
     });
+    it("Can add liquidity multiple times", async () => {
+      // Approve funds and add to liquidity. The first addLiquidity always succeeds because `totalSupply = 0` so
+      // exchangeRateCurrent() always returns 1e18. In this test we test that subsequent calls to exchangeRateCurrent()
+      // from addLiquidity modify state as expected.
+      await l1Token.methods.approve(bridgePool.options.address, MAX_UINT_VAL).send({ from: liquidityProvider });
+      await bridgePool.methods.addLiquidity(initialPoolLiquidity).send({ from: liquidityProvider });
+
+      // Initiate a relay. The relay amount is 10% of the total pool liquidity.
+      await l1Token.methods.approve(bridgePool.options.address, MAX_UINT_VAL).send({ from: relayer });
+
+      // Utilized reserves are 0 before any relays. Added liquidity is available as liquid reserves.
+      assert.equal(await bridgePool.methods.utilizedReserves().call(), "0");
+      assert.equal(await bridgePool.methods.liquidReserves().call(), initialPoolLiquidity);
+
+      // Add more liquidity:
+      await l1Token.methods.mint(liquidityProvider, initialPoolLiquidity).send({ from: owner });
+      await bridgePool.methods.addLiquidity(initialPoolLiquidity).send({ from: liquidityProvider });
+
+      // Liquid reserves captures the two added liquidity transfers.
+      assert.equal(await bridgePool.methods.utilizedReserves().call(), "0");
+      assert.equal(await bridgePool.methods.liquidReserves().call(), toBN(initialPoolLiquidity).mul(toBN("2")));
+
+      // The above equation would fail if `addLiquidity()` transferred tokens to the contract before updating internal
+      // state via `sync()`, which checks the contract's balance and uses the number to update liquid + utilized
+      // reserves. If the contract's balance is higher than expected, then this state can be incorrect.
+    });
   });
   describe("Virtual balance accounting", () => {
     beforeEach(async function () {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Calling `exchangeRateCurrent()` after `transferFrom()` causes problems when modifying state inside `exchangeRateCurrent()` because it reads from the current `balanceOf(address(this))`.

The specific bug situation is on any subsequent call to `addLiquidity()`. The first call always succeeds because `exchangeRateCurrent()` returns early when `totalSupply() == 0`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
