### PR TITLE
feat(sdk): add estimated apy calculation to bridgepool read client

### DIFF
--- a/packages/sdk/src/across/clients/README.md
+++ b/packages/sdk/src/across/clients/README.md
@@ -31,8 +31,11 @@ const poolState = await readClient.read()
 //{
 //  pool: {
 //    address: '0xf42bB7EC88d065dF48D60cb672B88F8330f9f764',
-//    totalPoolSize: '13900116882750652331',
-//    l1Token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+//    totalPoolSize: '900112495947893496',
+//    l1Token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+//    exchangeRateCurrent: '1000014111309289196',
+//    exchangeRatePrevious: '1000014110936934497',
+//    estimatedApy: '0.0008646096530698983'
 //  }
 //}
 
@@ -48,8 +51,11 @@ const userState = await readClient.read("0x9A8f92a830A5cB89a3816e3D267CB7791c16b
 //  },
 //  pool: {
 //    address: '0xf42bB7EC88d065dF48D60cb672B88F8330f9f764',
-//    totalPoolSize: '13900116882750652331',
-//    l1Token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+//    totalPoolSize: '900112495947893496',
+//    l1Token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+//    exchangeRateCurrent: '1000014111309289196',
+//    exchangeRatePrevious: '1000014110936934497',
+//    estimatedApy: '0.0008646096530698983'
 //  }
 //}
 ```

--- a/packages/sdk/src/across/clients/bridgePool.e2e.ts
+++ b/packages/sdk/src/across/clients/bridgePool.e2e.ts
@@ -5,6 +5,7 @@ import assert from "assert";
 
 dotenv.config();
 
+// TODO: update these with addresses to newest contract. Latest ABI no longer compatible.
 const multicall2Address = "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696";
 const address = "0xf42bB7EC88d065dF48D60cb672B88F8330f9f764";
 describe("BridgePool.ReadClient", function () {
@@ -22,7 +23,6 @@ describe("BridgePool.ReadClient", function () {
   });
   test("getUserState", async function () {
     const result = await client.read("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
-    console.log(result);
     assert.ok(result.user.address);
     assert.ok(result.user.lpTokens);
     assert.ok(result.user.positionValue);

--- a/packages/sdk/src/across/clients/bridgePool.test.ts
+++ b/packages/sdk/src/across/clients/bridgePool.test.ts
@@ -14,3 +14,25 @@ test("previewRemoval", function () {
   assert.equal(BigNumber.from(result.position.recieve).add(result.position.remain), user.positionValue);
   assert.equal(BigNumber.from(result.fees.recieve).add(result.fees.remain), user.feesEarned);
 });
+test("calculateApy", function () {
+  const pool = {
+    address: "0xf42bB7EC88d065dF48D60cb672B88F8330f9f764",
+    totalPoolSize: "13900116882750652331",
+    l1Token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    exchangeRateCurrent: "1000000666720227009",
+    exchangeRatePrevious: "1000000666644862062",
+  };
+  const result = bridgePool.calculateApy(pool.exchangeRateCurrent, pool.exchangeRatePrevious);
+  assert.ok(result);
+});
+test("calculateApy2", function () {
+  const pool = {
+    address: "0xf42bB7EC88d065dF48D60cb672B88F8330f9f764",
+    totalPoolSize: "13900116882750652331",
+    l1Token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    exchangeRateCurrent: "1000100000000000000",
+    exchangeRatePrevious: "1000000000000000000",
+  };
+  const result = bridgePool.calculateApy(pool.exchangeRateCurrent, pool.exchangeRatePrevious);
+  assert.ok(result);
+});

--- a/packages/sdk/src/across/utils.ts
+++ b/packages/sdk/src/across/utils.ts
@@ -1,5 +1,6 @@
 import { BigNumber, ethers } from "ethers";
 import { ConvertDecimals } from "../utils";
+import Decimal from "decimal.js";
 
 export type BigNumberish = string | number | BigNumber;
 export type BN = BigNumber;
@@ -108,6 +109,42 @@ export function calculateGasFees(
   return ethToToken(amountEth, price, decimals);
 }
 
+/**
+ * percent.
+ *
+ * @param {BigNumberish} numerator
+ * @param {BigNumberish} denominator
+ * @returns {BN}
+ */
 export function percent(numerator: BigNumberish, denominator: BigNumberish): BN {
   return fixedPointAdjustment.mul(numerator).div(denominator);
 }
+
+/**
+ * calcInterest. Calculates a compounding interest:  https://www.calculatorsoup.com/calculators/financial/compound-interest-calculator.php
+ *
+ * @param {number} startPrice
+ * @param {number} endPrice
+ * @param {number} periodsRemaining
+ * @param {number} periods
+ */
+export const calcInterest = (startPrice: string, endPrice: string, periods: string, periodsRemaining = "1") => {
+  return new Decimal(periods)
+    .mul(
+      new Decimal(endPrice)
+        .div(startPrice)
+        .pow(new Decimal(1).div(new Decimal(periodsRemaining).div(periods).mul(periods)))
+        .sub(1)
+    )
+    .toString();
+};
+
+/**
+ * calcApy. Calculates apy based on interest rate: https://www.omnicalculator.com/finance/apy#how-does-this-apy-calculator-work
+ *
+ * @param {number} interest
+ * @param {number} periods
+ */
+export const calcApy = (interest: string, periods: string) => {
+  return new Decimal(interest).div(periods).add(1).pow(periods).sub(1).toString();
+};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/2691/bridgepool-client-estimated-apy-calculator

**Summary**
Takes some Apy and compound interest functions from emp-tools and convert them to use decimal.js.  Returns an `estimatedApy` for the pool based on 1 block difference in `exchangeRate`


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2691/bridgepool-client-estimated-apy-calculator