### PR TITLE
fix(insured-bridge-relayer): Handle case where computing realized LP fee % fails

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/BridgeDepositBox.sol
@@ -187,6 +187,9 @@ abstract contract BridgeDepositBox is Testable, Lockable {
         // Note that the OVM's notion of `block.timestamp` is different to the main ethereum L1 EVM. The OVM timestamp
         // corresponds to the L1 timestamp of the last confirmed L1 ⇒ L2 transaction. The quoteTime must be within 10
         // mins of the current time to allow for this variance.
+        // Note also that `quoteTimestamp` cannot be less than 10 minutes otherwise the following arithmetic can result
+        // in underflow. This isn't a problem as the deposit will revert, but the error might be unexpected for clients.
+        // Consider requiring `quoteTimestamp >= 10 minutes`.
         require(
             getCurrentTime() >= quoteTimestamp - 10 minutes && getCurrentTime() <= quoteTimestamp + 10 minutes,
             "deposit mined after deadline"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
Computing `realizedLpFeePct` can fail if a relay contains certain deposit parameters. For example, if the deposit contains a `quoteTime` for a timestamp that is earlier than a bridge pool's deployment time, then querying the contract's `liquidityUtilization()` methods for those timestamps will always revert. We should handle this situation differently depending if we are relaying or disputing:

- For relays, skip all deposits that we cannot compute a realized LP fee % for
- For disputes, dispute all relays that we cannot compute a realized LP fee % for

This latter rule seems like it might cause false positives. An alternative implementation would ideally look up a contract's deployment timestamp and skip any relays where `relay.quoteTime < contract.deploymentTimestamp` but this artifact is hard to retrieve.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
