### PR TITLE
fix(insured-bridge-relayer): Key deposits by deposit hash instead of deposit ID

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -23,7 +23,7 @@ export interface Deposit {
 export class InsuredBridgeL2Client {
   public bridgeDepositBox: BridgeDepositBoxWeb3;
 
-  private deposits: { [key: string]: Deposit } = {}; // DepositId=>Deposit
+  private deposits: { [key: string]: Deposit } = {}; // DepositHash=>Deposit
 
   private firstBlockToSearch: number;
 
@@ -44,11 +44,11 @@ export class InsuredBridgeL2Client {
   }
 
   getAllDeposits() {
-    return Object.keys(this.deposits).map((depositId: string) => this.deposits[depositId]);
+    return Object.keys(this.deposits).map((depositHash: string) => this.deposits[depositHash]);
   }
 
-  getDepositByID(depositId: string | number) {
-    return this.deposits[depositId.toString()];
+  getDepositByHash(depositHash: string) {
+    return this.deposits[depositHash];
   }
 
   // TODO: consider adding a method that limits how far back the deposits will be returned from. In this implementation
@@ -81,7 +81,7 @@ export class InsuredBridgeL2Client {
         depositContract: fundsDepositedEvent.address,
       };
       depositData.depositHash = this.generateDepositHash(depositData);
-      this.deposits[fundsDepositedEvent.returnValues.depositId] = depositData;
+      this.deposits[depositData.depositHash] = depositData;
     }
 
     this.firstBlockToSearch = blockSearchConfig.toBlock + 1;

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -197,7 +197,7 @@ export class Relayer {
     for (const relay of pendingRelays) {
       // Construct deposit from relay params if the deposit is undefined.
       const deposit =
-        this.l2Client.getDepositByID(relay.depositId) === undefined
+        this.l2Client.getDepositByHash(relay.depositHash) === undefined
           ? {
               chainId: relay.chainId,
               depositId: relay.depositId,
@@ -211,7 +211,7 @@ export class Relayer {
               quoteTimestamp: relay.quoteTimestamp,
               depositContract: this.l2Client.bridgeDepositAddress,
             }
-          : this.l2Client.getDepositByID(relay.depositId);
+          : this.l2Client.getDepositByHash(relay.depositHash);
 
       // Check if relay has expired, in which case we cannot dispute.
       const relayExpired = await this.isRelayExpired(relay, deposit);
@@ -326,7 +326,7 @@ export class Relayer {
         );
 
       for (const settleableRelay of settleableRelays) {
-        await this.settleRelay(this.l2Client.getDepositByID(settleableRelay.depositId), settleableRelay);
+        await this.settleRelay(this.l2Client.getDepositByHash(settleableRelay.depositHash), settleableRelay);
       }
       if (settleableRelays.length == 0) this.logger.debug({ at: "Finalizer", message: "No settleable relays" });
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently the bot will look up deposits on L2 based on the deposit.depositId. This means that someone can submit a `relayDeposit` for a `depositID` that (1) exists on L2 but (2) has already been relayed. The relayer will consider this relay valid since it can find the deposit using its `depositID` on L2, and assuming the rest of the relay params are valid for the timestamp.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested