### PR TITLE
improve(common): Speed up default behavior for findBlockNumberAtTImestamp

### DIFF
--- a/packages/affiliates/gas-rebate/VoterGasRebate.js
+++ b/packages/affiliates/gas-rebate/VoterGasRebate.js
@@ -634,8 +634,10 @@ async function Main(callback) {
       console.log(`- Using start date: ${moment.unix(startDate).toString()}`);
       console.log(`- Using end date: ${moment.unix(endDate).toString()}`);
 
-      endBlock = (await FindBlockAtTimestamp._findBlockNumberAtTimestamp(web3, Number(endDate))).blockNumber;
-      startBlock = (await FindBlockAtTimestamp._findBlockNumberAtTimestamp(web3, Number(startDate))).blockNumber;
+      endBlock = (await FindBlockAtTimestamp._findBlockNumberAtTimestamp(web3, Number(endDate), 15, 15, 4, 14))
+        .blockNumber;
+      startBlock = (await FindBlockAtTimestamp._findBlockNumberAtTimestamp(web3, Number(startDate), 15, 15, 4, 14))
+        .blockNumber;
     }
 
     // Fetch gas price data in parallel

--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -211,7 +211,6 @@ export async function findBlockNumberAtTimestamp(
   blockDelta = 4,
   averageBlockTime = 14
 ): Promise<{ blockNumber: number; error: number }> {
-  const start = Date.now();
   const higherLimitStamp = targetTimestamp + higherLimitMax;
   const lowerLimitStamp = targetTimestamp - lowerLimitMax;
 
@@ -262,6 +261,5 @@ export async function findBlockNumberAtTimestamp(
       }
     }
   }
-  console.log(`Elapsed time: ${Date.now() - start} ms`);
   return { blockNumber: block.number, error: Math.abs(targetTimestamp - parseInt(block.timestamp.toString())) };
 }

--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -200,7 +200,7 @@ export const blockUntilBlockMined = async (web3: Web3, blockerBlockNumber: numbe
  * @param blockDelta Amount of blocks to hop when binary searching for block. Increasing this increases error
  * but significantly reduces time to compute.
  * @param averageBlockTime Decreasing average block size will decrease precision and also decrease the amount of
- * requests made in order to find the closest block.
+ * requests made in order to find the closest block. Increasing this reduces time to compute but increases requests.
  * @returns {number, number} Block height and difference between block timestamp and target timestamp
  */
 export async function findBlockNumberAtTimestamp(
@@ -208,9 +208,10 @@ export async function findBlockNumberAtTimestamp(
   targetTimestamp: number,
   higherLimitMax = 15,
   lowerLimitMax = 15,
-  blockDelta = 5,
-  averageBlockTime = 13
+  blockDelta = 4,
+  averageBlockTime = 14
 ): Promise<{ blockNumber: number; error: number }> {
+  const start = Date.now();
   const higherLimitStamp = targetTimestamp + higherLimitMax;
   const lowerLimitStamp = targetTimestamp - lowerLimitMax;
 
@@ -229,6 +230,7 @@ export async function findBlockNumberAtTimestamp(
 
     blockNumber -= decreaseBlocks;
     block = await web3.eth.getBlock(blockNumber);
+    console.log(block.timestamp);
   }
 
   if (lowerLimitStamp && block.timestamp < lowerLimitStamp) {
@@ -260,5 +262,6 @@ export async function findBlockNumberAtTimestamp(
       }
     }
   }
+  console.log(`Elapsed time: ${Date.now() - start} ms`);
   return { blockNumber: block.number, error: Math.abs(targetTimestamp - parseInt(block.timestamp.toString())) };
 }

--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -208,8 +208,8 @@ export async function findBlockNumberAtTimestamp(
   targetTimestamp: number,
   higherLimitMax = 15,
   lowerLimitMax = 15,
-  blockDelta = 4,
-  averageBlockTime = 14
+  blockDelta = 1,
+  averageBlockTime = 13
 ): Promise<{ blockNumber: number; error: number }> {
   const higherLimitStamp = targetTimestamp + higherLimitMax;
   const lowerLimitStamp = targetTimestamp - lowerLimitMax;

--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -229,7 +229,6 @@ export async function findBlockNumberAtTimestamp(
 
     blockNumber -= decreaseBlocks;
     block = await web3.eth.getBlock(blockNumber);
-    console.log(block.timestamp);
   }
 
   if (lowerLimitStamp && block.timestamp < lowerLimitStamp) {

--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -188,23 +188,40 @@ export const blockUntilBlockMined = async (web3: Web3, blockerBlockNumber: numbe
     await new Promise((r) => setTimeout(r, delay));
   }
 };
+
+/**
+ * @notice Finds block closest to target timestamp. User can configure search based on error tolerance.
+ * @param web3 Web3 network to search blocks on.
+ * @param targetTimestamp Timestamp that we are finding a block for.
+ * @param higherLimitMax Returned block must have timestamp less than targetTimestamp + higherLimitMax. Increasing this
+ * increases error and reduces time to compute.
+ * @param lowerLimitMax Returned block must have timestamp more than targetTimestamp - lowerLimitMax. Increasing this
+ * increases error and reduces time to compute.
+ * @param blockDelta Amount of blocks to hop when binary searching for block. Increasing this increases error
+ * but significantly reduces time to compute.
+ * @param averageBlockTime Decreasing average block size will decrease precision and also decrease the amount of
+ * requests made in order to find the closest block.
+ * @returns {number, number} Block height and difference between block timestamp and target timestamp
+ */
 export async function findBlockNumberAtTimestamp(
   web3: Web3,
   targetTimestamp: number,
   higherLimitMax = 15,
-  lowerLimitMax = 15
+  lowerLimitMax = 15,
+  blockDelta = 5,
+  averageBlockTime = 13
 ): Promise<{ blockNumber: number; error: number }> {
   const higherLimitStamp = targetTimestamp + higherLimitMax;
   const lowerLimitStamp = targetTimestamp - lowerLimitMax;
-  // Decreasing average block size will decrease precision and also decrease the amount of requests made in order to
-  // find the closest block.
-  const averageBlockTime = 13;
 
   // get current block number
   const currentBlockNumber = await web3.eth.getBlockNumber();
   let block = await web3.eth.getBlock(currentBlockNumber);
   let blockNumber = currentBlockNumber;
 
+  // if current block timestamp > target timestamp, set block to approximate height using `averageBlockTime`, and
+  // repeat until we find a block below the target time. This loop should usually only run once, unless the
+  // `averageBlockTime` is set too high.
   while (block.timestamp > targetTimestamp) {
     const decreaseBlocks = Math.floor((parseInt(block.timestamp.toString()) - targetTimestamp) / averageBlockTime);
 
@@ -216,7 +233,7 @@ export async function findBlockNumberAtTimestamp(
 
   if (lowerLimitStamp && block.timestamp < lowerLimitStamp) {
     while (block.timestamp < lowerLimitStamp) {
-      blockNumber += 1;
+      blockNumber += blockDelta;
       block = await web3.eth.getBlock(blockNumber);
     }
   }
@@ -225,7 +242,7 @@ export async function findBlockNumberAtTimestamp(
   if (higherLimitStamp) {
     if (block.timestamp >= higherLimitStamp) {
       while (block.timestamp >= higherLimitStamp) {
-        blockNumber -= 1;
+        blockNumber -= blockDelta;
         block = await web3.eth.getBlock(blockNumber);
       }
     }
@@ -233,7 +250,7 @@ export async function findBlockNumberAtTimestamp(
     // If we ended up with a block lower than the upper limit walk block by block to make sure it's the correct one.
     if (block.timestamp < higherLimitStamp) {
       while (block.timestamp < higherLimitStamp) {
-        blockNumber += 1;
+        blockNumber += blockDelta;
         if (blockNumber > currentBlockNumber) break;
         const tempBlock = await web3.eth.getBlock(blockNumber);
         // Can't be equal or higher than upper limit as we want to find the last block before that limit.

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -147,7 +147,8 @@ export class InsuredBridgeL1Client {
     if (this.rateModels === undefined || this.rateModels[deposit.l1Token] === undefined)
       throw new Error("No rate model for l1Token");
 
-    const quoteBlockNumber = (await findBlockNumberAtTimestamp(this.l1Web3, deposit.quoteTimestamp)).blockNumber;
+    const quoteBlockNumber = (await findBlockNumberAtTimestamp(this.l1Web3, deposit.quoteTimestamp, 15, 15, 4, 14))
+      .blockNumber;
     const bridgePool = this.getBridgePoolForDeposit(deposit).contract;
     const [liquidityUtilizationCurrent, liquidityUtilizationPostRelay] = await Promise.all([
       bridgePool.methods.liquidityUtilizationCurrent().call(undefined, quoteBlockNumber),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This method is the compute-time bottle neck in the `Relayer`.


**Summary**

One way to speed up this method is to increase the number of blocks that we travel per search. Currently it binary searches up and down incrementing/decrementing by only 1 block. Empirically increasing this value speeds up time significantly.

Additionally, increasing averageBlockTime seems to also speed up time significantly. I believe this is the case because making more queries in the initial loop to find a `block.timestamp < targetTimestamp` is much less costly than overshooting on the first query and needing to crawl back.

For example, using an `averageBlockTime = 14` finds a `block.timestamp < targetTimestamp` in 4 tries and completes the function in 2.5 seconds. On the other hand, using `averageBlockTime = 13` finds a `block.timestamp < targetTimestamp` in one try but then takes 100 seconds to complete the function. This example uses a `blockDelta` step of 4.

From my experimenting, I can locate a block for a timestamp 1 week ago in 2 seconds using a `blockDelta=5` and `averageBlockTime=14`. This same call in current state takes > 5 minutes.

**Details**

I think simultaneously increasing the `blockDelta` and increasing `averageBlockTime` have offsetting effects and generally reduce in pretty low error. The former increases error, but the latter decreases error. And they both speed up the function!

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested