### PR TITLE
feat: use faster block finder

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -35,6 +35,7 @@ import { NetworkerInterface } from "./Networker";
 import { PriceFeedInterface } from "./PriceFeedInterface";
 import { isDefined } from "../types";
 import { InsuredBridgeL1Client, InsuredBridgeL2Client, getL2DepositBoxAddress } from "..";
+import type { BlockTransactionBase } from "web3-eth";
 
 interface Block {
   number: number;
@@ -643,14 +644,14 @@ export async function createPriceFeed(
   }
 }
 
-const _blockFinderWorkaround = (web3: Web3) => BlockFinder((number: number | string) => web3.eth.getBlock(number));
-type BlockFinder = ReturnType<typeof _blockFinderWorkaround>;
-
 // Simple function to grab a singleton instance of the blockFinder to share the cache.
-const getSharedBlockFinder: { (web3: Web3): BlockFinder; blockFinder?: BlockFinder } = (web3: Web3): BlockFinder => {
+const getSharedBlockFinder: {
+  (web3: Web3): BlockFinder<BlockTransactionBase>;
+  blockFinder?: BlockFinder<BlockTransactionBase>;
+} = (web3: Web3): BlockFinder<BlockTransactionBase> => {
   // Attach the blockFinder to this function.
   if (!getSharedBlockFinder.blockFinder) {
-    getSharedBlockFinder.blockFinder = BlockFinder((number: number | string) => web3.eth.getBlock(number));
+    getSharedBlockFinder.blockFinder = new BlockFinder<BlockTransactionBase>(web3.eth.getBlock);
   }
   return getSharedBlockFinder.blockFinder;
 };

--- a/packages/financial-templates-lib/src/price-feed/FundingRateMultiplierPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/FundingRateMultiplierPriceFeed.ts
@@ -7,13 +7,7 @@ import type { Logger } from "winston";
 import Web3 from "web3";
 import { PerpetualWeb3 } from "@uma/contracts-frontend";
 import { BN, Abi, Awaited } from "../types";
-import { BlockTransactionString } from "web3-eth";
-
-const _blockFinderGenericWorkaround = (requestBlock: (number: string | number) => Promise<BlockTransactionString>) => {
-  return BlockFinder(requestBlock);
-};
-
-type BlockFinder = ReturnType<typeof _blockFinderGenericWorkaround>;
+import type { BlockTransactionBase } from "web3-eth";
 
 interface Params {
   logger: Logger;
@@ -22,7 +16,7 @@ interface Params {
   perpetualAddress: string;
   multicallAddress: string;
   getTime: () => Promise<number>;
-  blockFinder?: BlockFinder;
+  blockFinder?: BlockFinder<BlockTransactionBase>;
   minTimeBetweenUpdates?: number;
   priceFeedDecimals?: number;
 }
@@ -32,7 +26,7 @@ export class FundingRateMultiplierPriceFeed extends PriceFeedInterface {
   private readonly web3: Web3;
   private readonly getTime: () => Promise<number>;
   private readonly multicallAddress: string;
-  private readonly blockFinder: BlockFinder;
+  private readonly blockFinder: BlockFinder<BlockTransactionBase>;
   private readonly minTimeBetweenUpdates: number;
   private readonly priceFeedDecimals: number;
   private lastUpdateTime: number | null = null;
@@ -85,7 +79,7 @@ export class FundingRateMultiplierPriceFeed extends PriceFeedInterface {
     this.priceFeedDecimals = priceFeedDecimals;
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
     // Must wrap the getBlock in a lambda to specify the overload.
-    this.blockFinder = blockFinder || BlockFinder((number: number | string) => web3.eth.getBlock(number));
+    this.blockFinder = blockFinder || new BlockFinder<BlockTransactionBase>(web3.eth.getBlock);
     this.convertDecimals = ConvertDecimals(18, priceFeedDecimals);
   }
 

--- a/packages/financial-templates-lib/src/price-feed/LPPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/LPPriceFeed.ts
@@ -5,15 +5,9 @@ import assert from "assert";
 import type { Logger } from "winston";
 import type { Abi } from "../types";
 import Web3 from "web3";
-import type { BlockTransactionString } from "web3-eth";
+import type { BlockTransactionBase } from "web3-eth";
 import type { ERC20Web3 } from "@uma/contracts-node";
 import type { BN } from "../types";
-
-const _blockFinderGenericWorkaround = (requestBlock: (number: string | number) => Promise<BlockTransactionString>) => {
-  return BlockFinder(requestBlock);
-};
-
-type BlockFinder = ReturnType<typeof _blockFinderGenericWorkaround>;
 
 interface Params {
   logger: Logger;
@@ -22,7 +16,7 @@ interface Params {
   poolAddress: string;
   tokenAddress: string;
   getTime: () => Promise<number>;
-  blockFinder?: BlockFinder;
+  blockFinder?: BlockFinder<BlockTransactionBase>;
   minTimeBetweenUpdates?: number;
   priceFeedDecimals?: number;
 }
@@ -37,7 +31,7 @@ export class LPPriceFeed extends PriceFeedInterface {
   private readonly getTime: () => Promise<number>;
   private readonly priceFeedDecimals: number;
   private readonly minTimeBetweenUpdates: number;
-  private readonly blockFinder: BlockFinder;
+  private readonly blockFinder: BlockFinder<BlockTransactionBase>;
 
   private price: BN | null = null;
   private lastUpdateTime: number | null = null;
@@ -90,7 +84,7 @@ export class LPPriceFeed extends PriceFeedInterface {
     this.getTime = getTime;
     this.priceFeedDecimals = priceFeedDecimals;
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
-    this.blockFinder = blockFinder || BlockFinder((number: number | string) => web3.eth.getBlock(number));
+    this.blockFinder = blockFinder || new BlockFinder<BlockTransactionBase>(web3.eth.getBlock);
   }
 
   public getCurrentPrice(): BN | null {

--- a/packages/financial-templates-lib/src/price-feed/VaultPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/VaultPriceFeed.ts
@@ -6,9 +6,7 @@ import type { Logger } from "winston";
 import Web3 from "web3";
 import { VaultInterfaceWeb3, HarvestVaultInterfaceWeb3 } from "@uma/contracts-frontend";
 import { BN, Abi } from "../types";
-
-const _blockFinderWorkaround = (web3: Web3) => BlockFinder((number: number | string) => web3.eth.getBlock(number));
-type BlockFinder = ReturnType<typeof _blockFinderWorkaround>;
+import { BlockTransactionBase } from "web3-eth";
 
 interface Params {
   logger: Logger;
@@ -17,7 +15,7 @@ interface Params {
   web3: Web3;
   vaultAddress: string;
   getTime: () => Promise<number>;
-  blockFinder: BlockFinder;
+  blockFinder: BlockFinder<BlockTransactionBase>;
   minTimeBetweenUpdates?: number;
   priceFeedDecimals?: number;
 }
@@ -31,7 +29,7 @@ export abstract class VaultPriceFeedBase extends PriceFeedInterface {
   private readonly getTime: () => Promise<number>;
   private readonly priceFeedDecimals: number;
   private readonly minTimeBetweenUpdates: number;
-  private readonly blockFinder: BlockFinder;
+  private readonly blockFinder: BlockFinder<BlockTransactionBase>;
   private cachedConvertDecimalsFn: ReturnType<typeof ConvertDecimals> | null = null;
   private price: BN | null = null;
   private lastUpdateTime: number | null = null;
@@ -82,7 +80,7 @@ export abstract class VaultPriceFeedBase extends PriceFeedInterface {
     this.getTime = getTime;
     this.priceFeedDecimals = priceFeedDecimals;
     this.minTimeBetweenUpdates = minTimeBetweenUpdates;
-    this.blockFinder = blockFinder || BlockFinder((number: number | string) => web3.eth.getBlock(number));
+    this.blockFinder = blockFinder || new BlockFinder<BlockTransactionBase>(web3.eth.getBlock);
   }
 
   public getCurrentPrice(): BN | null {

--- a/packages/financial-templates-lib/test/price-feed/FundingRateMultiplierPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/FundingRateMultiplierPriceFeed.js
@@ -158,7 +158,7 @@ describe("FundingRateMultiplierPriceFeed.js", function () {
   });
 
   it("BlockFinder correctly passed in", async function () {
-    const blockFinder = BlockFinder(() => {
+    const blockFinder = new BlockFinder(() => {
       throw "err";
     }); // BlockFinder should throw immediately.
     fundingRateMultiplierPriceFeed = new FundingRateMultiplierPriceFeed({

--- a/packages/financial-templates-lib/test/price-feed/HarvestVaultPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/HarvestVaultPriceFeed.js
@@ -119,7 +119,7 @@ describe("HarvestVaultPriceFeed.js", function () {
   });
 
   it("BlockFinder correctly passed in", async function () {
-    const blockFinder = BlockFinder(() => {
+    const blockFinder = new BlockFinder(() => {
       throw "err";
     }); // BlockFinder should throw immediately.
     vaultPriceFeed = new HarvestVaultPriceFeed({

--- a/packages/financial-templates-lib/test/price-feed/LPPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/LPPriceFeed.js
@@ -131,7 +131,7 @@ describe("LPPriceFeed.js", function () {
   });
 
   it("BlockFinder correctly passed in", async function () {
-    const blockFinder = BlockFinder(() => {
+    const blockFinder = new BlockFinder(() => {
       throw "err";
     }); // BlockFinder should throw immediately.
 

--- a/packages/financial-templates-lib/test/price-feed/VaultPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/VaultPriceFeed.js
@@ -119,7 +119,7 @@ describe("VaultPriceFeed.js", function () {
   });
 
   it("BlockFinder correctly passed in", async function () {
-    const blockFinder = BlockFinder(() => {
+    const blockFinder = new BlockFinder(() => {
       throw "err";
     }); // BlockFinder should throw immediately.
     vaultPriceFeed = new VaultPriceFeed({

--- a/packages/financial-templates-lib/test/price-feed/utils.js
+++ b/packages/financial-templates-lib/test/price-feed/utils.js
@@ -109,7 +109,7 @@ describe("Price Feed Utils", async function () {
         return { number: blockNumber, timestamp: blockNumber };
       };
 
-      const blockFinder = BlockFinder(getBlock);
+      const blockFinder = new BlockFinder(getBlock);
 
       // Ensure that a timestamp _after_ the last block fails.
       assert.equal((await blockFinder.getBlockForTimestamp(latestBlockNumber + 1)).number, latestBlockNumber);
@@ -126,7 +126,7 @@ describe("Price Feed Utils", async function () {
         return { number: blockNumber, timestamp: blockNumber ** 2 };
       };
 
-      const blockFinder = BlockFinder(getBlock);
+      const blockFinder = new BlockFinder(getBlock);
 
       // Last timestamp is just the last block number squared.
       const cases = generateCases(0, latestBlockNumber ** 2);
@@ -159,7 +159,7 @@ describe("Price Feed Utils", async function () {
         return blocks.find((block) => block.number === blockNumber);
       };
 
-      const blockFinder = BlockFinder(getBlock);
+      const blockFinder = new BlockFinder(getBlock);
 
       // Last timestamp is just the last block number squared.
       const cases = generateCases(blocks[0].timestamp, blocks[blocks.length - 1].timestamp);

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -399,8 +399,8 @@ describe("Relayer.ts", function () {
 
       // Make a deposit on L2 and check the bot relays it accordingly.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const relaytime = await bridgePool.methods.getCurrentTime().call();
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const relayTime = await bridgePool.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       const depositData = {
         chainId,
         depositId: "0",
@@ -433,7 +433,7 @@ describe("Relayer.ts", function () {
       assert.isTrue(lastSpyLogIncludes(spy, "Slow Relay executed"));
 
       // Advance time such that relay has expired and check that bot correctly identifies it as expired.
-      const expirationTime = Number(relaytime.toString()) + defaultLiveness;
+      const expirationTime = Number(relayTime.toString()) + defaultLiveness;
       await bridgePool.methods.setCurrentTime(expirationTime).send({ from: l1Owner });
       await l1Client.update();
       await relayer.checkForPendingDepositsAndRelay();
@@ -450,7 +450,7 @@ describe("Relayer.ts", function () {
     it("Can correctly detect and produce speedup relays", async function () {
       // Make a deposit on L2 and relay it. Then, check the relayer picks this up and speeds up the relay.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const currentBlockTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const currentBlockTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -502,7 +502,7 @@ describe("Relayer.ts", function () {
     it("Can correctly instantly relay deposits", async function () {
       // Make a deposit on L2 and see that the relayer correctly sends a slow relay and speedup it in the same tx.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const currentBlockTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const currentBlockTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -531,8 +531,8 @@ describe("Relayer.ts", function () {
       // Make a deposit on L2 and relay it with invalid relay params. The relayer should detect that the relay params
       // are invalid and skip it.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const relaytime = await bridgePool.methods.getCurrentTime().call();
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const relayTime = await bridgePool.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -575,7 +575,7 @@ describe("Relayer.ts", function () {
 
       // Advance time such that relay has expired and check that bot correctly identifies it as expired. Even if the
       // relay params are invalid, post-expiry its not disputable.
-      const expirationTime = Number(relaytime.toString()) + defaultLiveness;
+      const expirationTime = Number(relayTime.toString()) + defaultLiveness;
       await bridgePool.methods.setCurrentTime(expirationTime).send({ from: l1Owner });
       await Promise.all([l1Client.update()]);
       await relayer.checkForPendingDepositsAndRelay();
@@ -646,7 +646,7 @@ describe("Relayer.ts", function () {
 
       // Make a deposit on L2, relay it, advance time and check the bot settles it accordingly.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const currentBlockTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const currentBlockTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -762,7 +762,7 @@ describe("Relayer.ts", function () {
       // Make a deposit on L2 and relay it with invalid relay params. The disputer should detect that the relay params
       // are invalid and dispute it.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -807,7 +807,7 @@ describe("Relayer.ts", function () {
       // Make a deposit on L2 and relay it with invalid relay params. The disputer should detect that the relay params
       // are invalid and dispute it.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -858,7 +858,7 @@ describe("Relayer.ts", function () {
       // Relay a deposit that doesn't exist on-chain
       await l1Token.methods.mint(l1Owner, toBN(depositAmount).muln(2)).send({ from: l1Owner });
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgePool.methods
         .relayDeposit(
           {
@@ -894,7 +894,7 @@ describe("Relayer.ts", function () {
     it("Ignores relay for different whitelisted chain ID than the one set on L2 client", async function () {
       await l1Token.methods.mint(l1Owner, toBN(depositAmount).muln(2)).send({ from: l1Owner });
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
 
       // This relay should be disputed because the deposit doesn't exist on L2, but the disputer should skip it because
       // the L2 client is set for a different chain ID than the one included on the relay, and the chain ID
@@ -928,7 +928,7 @@ describe("Relayer.ts", function () {
     it("Does not dispute valid relay data that contains a valid deposit hash", async function () {
       // Make a deposit on L2 and relay it with valid relay params.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,
@@ -1023,7 +1023,7 @@ describe("Relayer.ts", function () {
 
       // Make a deposit on L2 and relay it with valid relay params.
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
-      const quoteTime = await bridgeDepositBox.methods.getCurrentTime().call();
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
       await bridgeDepositBox.methods
         .deposit(
           l2Depositor,


### PR DESCRIPTION
**Motivation**

We'd like to speed up our block searching by timestamp in the relay bots.

**Summary**

This PR changes two things:
- Swaps out the finder algorithm in the relay client for one that uses binary search rather than a linear search as the current one does.
- Makes the BlockFinder a true class rather than a function that returns a function. This makes it easier to work with in typescript. There was a little bit of cleanup in the price feeds related to this change. Overall, this simplified the integration in the price feeds and the relayer bot.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
