### PR TITLE
fix(lsp): remove duplicate transfer in factory

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -68,7 +68,6 @@ contract LongShortPairCreator is Testable, Lockable {
 
     /**
      * @notice Creates a longShortPair contract and associated long and short tokens.
-     * @dev The caller must approve this contract to transfer `proposerReward` amount of collateral.
      * @param params Constructor params used to initialize the LSP. Key-valued object with the following structure:
      *     - `pairName`: Name of the long short pair contract.
      *     - `expirationTimestamp`: Unix timestamp of when the contract will expire.

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPairCreator.sol
@@ -108,10 +108,6 @@ contract LongShortPairCreator is Testable, Lockable {
         // Deploy the LPS contract.
         LongShortPair lsp = new LongShortPair(_convertParams(params, longToken, shortToken));
 
-        // Move prepaid proposer reward from the deployer to the newly deployed contract.
-        if (params.proposerReward > 0)
-            params.collateralToken.safeTransferFrom(msg.sender, address(lsp), params.proposerReward);
-
         address lspAddress = address(lsp);
 
         // Give permissions to new lsp contract and then hand over ownership.

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPairCreator.js
@@ -181,21 +181,6 @@ describe("LongShortPairCreator", function () {
     assert.equal(await (await Token.at(await lsp.methods.shortToken().call())).methods.decimals().call(), "6");
   });
 
-  it("Transfers proposerReward", async function () {
-    const customProposerReward = toWei("100");
-    await collateralToken.methods.mint(deployer, customProposerReward).send({ from: accounts[0] });
-    await collateralToken.methods
-      .approve(longShortPairCreator.options.address, customProposerReward)
-      .send({ from: accounts[0] });
-    await longShortPairCreator.methods
-      .createLongShortPair({ ...constructorParams, proposerReward: customProposerReward })
-      .send({ from: accounts[0] });
-
-    const lspAddress = (await longShortPairCreator.getPastEvents("CreatedLongShortPair"))[0].returnValues.longShortPair;
-
-    assert.equal((await collateralToken.methods.balanceOf(lspAddress).call()).toString(), customProposerReward);
-  });
-
   it("Rejects on past expirationTimestamp", async function () {
     assert(
       await didContractThrow(


### PR DESCRIPTION
**Motivation**

OZ audit identified the following issue:

_The LongShortPair contract retrieves a proposer reward from whichever address triggers the expiration, which is used to incentivize price proposals in the Optimistic Oracle. However, the LongShortPairCreator contract also retrieves and forwards the funds from the deployer address. These additional funds are not passed to the Optimistic Oracle, and instead remain trapped within the LongShortPair contract._

To address this, the duplicate transfer in the factory was removed.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
