### PR TITLE
fix(lsp): Fix request early expiration with timestamp of 0

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -285,7 +285,7 @@ contract LongShortPair is Testable, Lockable {
     {
         require(enableEarlyExpiration, "Early expiration disabled");
         require(_earlyExpirationTimestamp <= getCurrentTime(), "Only propose expire in the past");
-        require(_earlyExpirationTimestamp > 0, "Early expiration time > 0");
+        require(_earlyExpirationTimestamp > 0, "Early expiration can't be 0");
 
         earlyExpirationTimestamp = _earlyExpirationTimestamp;
 

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -285,6 +285,7 @@ contract LongShortPair is Testable, Lockable {
     {
         require(enableEarlyExpiration, "Early expiration disabled");
         require(_earlyExpirationTimestamp <= getCurrentTime(), "Only propose expire in the past");
+        require(_earlyExpirationTimestamp > 0, "Early expiration time > 0");
 
         earlyExpirationTimestamp = _earlyExpirationTimestamp;
 

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -910,9 +910,18 @@ describe("LongShortPair", function () {
     });
 
     it("Can not attempt early expiration post expiration", async function () {
-      const earlyExpirationTimestamp = Number(await timer.methods.getCurrentTime().call()) - 10;
-      await longShortPair.methods.requestEarlyExpiration(earlyExpirationTimestamp).send({ from: rando });
+      const earlyExpirationTimestamp = Number(await timer.methods.getCurrentTime().call());
+      assert(
+        await didContractThrow(
+          longShortPair.methods.requestEarlyExpiration(earlyExpirationTimestamp + 10).send({ from: rando })
+        )
+      );
     });
+
+    it("Can not attempt early expiration with a timestamp of 0", async function () {
+      assert(await didContractThrow(longShortPair.methods.requestEarlyExpiration(0).send({ from: rando })));
+    });
+
     it("Optimistic oracle returning 'do nothing' number blocks early expiration", async function () {
       // In the event that someone tried to incorrectly settle the contract early, the OO will return type(int256).min.
       // This indicates that the contract should "do nothing" (i.e keep running).


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
_In the LongShortPair contract, a zero early expiration timestamp is used as a flag to indicate that nobody has triggered the early expiration mechanism. However, it is possible to trigger that mechanism with a zero timestamp. In this scenario, the Optimistic Oracle will be be invoked but the protection against subsequent price requests will not be effective. Fortunately, once the settlement price is chosen, it won't be overriden, so this won't lead to inconsistent settlements. Nevertheless, a subsequent price request could change the recorded early expiration timestamp, even if the zero timestamp is used to determine the settlement price. It could also emit a misleading event._

This PR fixes this by preventing the request early expire method with a 0 timestamp. tests were also updated accordingly.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested