### PR TITLE
fix(lsp): Fix incorrect inequality for expiration timestamp in settle method

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -228,9 +228,10 @@ contract LongShortPair is Testable, Lockable {
         nonReentrant()
         returns (uint256 collateralReturned)
     {
-        // Either early expiration is enabled and its before the expiration timestamp or it is after the expiration time.
+        // Either early expiration is enabled and it's before the expiration time or it's after the expiration time.
         require(
-            (enableEarlyExpiration && getCurrentTime() < expirationTimestamp) || getCurrentTime() > expirationTimestamp,
+            (enableEarlyExpiration && getCurrentTime() < expirationTimestamp) ||
+                getCurrentTime() >= expirationTimestamp,
             "Can not settle"
         );
 


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

_The settle function of the LongShortPair contract considers settlement conditions when the current time is strictly before or after the expiration timestamp. However, it incorrectly reverts when the current time matches the expiration timestamp._

This PR fixes this by making a small modification to the settle method, as recommended by OZ.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
