### PR TITLE
fix(lsp): Fix inconsistent type casting for expiration timestamp

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -362,7 +362,7 @@ contract LongShortPair is Testable, Lockable {
 
     // Request a price in the optimistic oracle for a given request timestamp and ancillary data combo. Set the bonds
     // accordingly to the deployer's parameters. Will revert if re-requesting for a previously requested combo.
-    function _requestOraclePrice(uint256 requestTimestamp, bytes memory requestAncillaryData) internal {
+    function _requestOraclePrice(uint64 requestTimestamp, bytes memory requestAncillaryData) internal {
         OptimisticOracleInterface optimisticOracle = _getOptimisticOracle();
 
         // If the proposer reward was set then pull it from the caller of the function.
@@ -372,7 +372,7 @@ contract LongShortPair is Testable, Lockable {
         }
         optimisticOracle.requestPrice(
             priceIdentifier,
-            requestTimestamp,
+            uint256(requestTimestamp),
             requestAncillaryData,
             collateralToken,
             proposerReward
@@ -381,13 +381,18 @@ contract LongShortPair is Testable, Lockable {
         // Set the Optimistic oracle liveness for the price request.
         optimisticOracle.setCustomLiveness(
             priceIdentifier,
-            requestTimestamp,
+            uint256(requestTimestamp),
             requestAncillaryData,
             optimisticOracleLivenessTime
         );
 
         // Set the Optimistic oracle proposer bond for the price request.
-        optimisticOracle.setBond(priceIdentifier, requestTimestamp, requestAncillaryData, optimisticOracleProposerBond);
+        optimisticOracle.setBond(
+            priceIdentifier,
+            uint256(requestTimestamp),
+            requestAncillaryData,
+            optimisticOracleProposerBond
+        );
     }
 
     // Fetch the optimistic oracle expiration price. If the oracle has the price for the provided expiration timestamp


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

_The LongShortPair contract generally treats timestamps as uint64 values, which are implicitly cast to uint256 values when passed to the Optimistic Oracle. However, the requestTimestamp parameter of the _requestOraclePrice function is prematurely cast to a uint256. This has no functional consequences._

While this does not present any issues, the code was updated for consistency with the rest of the codebase.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [X]  Untested
