### PR TITLE
fix(lsp): Fix requestEarlyExpiration and expire natspec comments

### DIFF
--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -272,6 +272,7 @@ contract LongShortPair is Testable, Lockable {
      * @notice Enables the LSP to request early expiration. This initiates a price request to the optimistic oracle at
      * the provided timestamp with a modified version of the ancillary data that includes the key "earlyExpiration:1"
      * which signals to the OO that this is an early expiration request, rather than standard settlement.
+     * @dev The caller must approve this contract to transfer `proposerReward` amount of collateral.
      * @dev Will revert if: a) the contract is already early expire, b) it is after the expiration timestamp, c)
      * early expiration is disabled for this contract, d) the proposed expiration timestamp is in the future.
      * e) an early expiration attempt has already been made (in pending state).
@@ -295,6 +296,7 @@ contract LongShortPair is Testable, Lockable {
 
     /**
      * @notice Expire the LSP contract. Makes a request to the optimistic oracle to inform the settlement price.
+     * @dev The caller must approve this contract to transfer `proposerReward` amount of collateral.
      * @dev Will revert if: a) the contract is already early expire, b) it is before the expiration timestamp or c)
      * an expire call has already been made.
      */


### PR DESCRIPTION
**Motivation**

OZ identified the following contract issues:

_The requestEarlyExpiration and expire functions of the LongShortPair contract each assume that the caller has granted the contract an allowance to pull the proposer reward._

This PR updates the natspec to include this information.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [X]  Untested
