### PR TITLE
fix(BridgePool): remove redundant ExpandedERC20 import

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -13,7 +13,6 @@ import "../common/implementation/AncillaryData.sol";
 import "../common/implementation/Testable.sol";
 import "../common/implementation/FixedPoint.sol";
 import "../common/implementation/Lockable.sol";
-import "../common/implementation/ExpandedERC20.sol";
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:


_The BridgePool contract inherits from ExpandedERC20 so that it can issue LP tokens to liquidity providers. This inherits the functionality of OpenZeppelin's ERC20 contract and also provides administrator privileges to the contract deployer, which allows them to mint and burn LP tokens. However, this power is not required and, if exercised, could unfairly penalize liquidity providers._

This issue was previously fixed in PR https://github.com/UMAprotocol/protocol/pull/3492

However, there was still a lingering redundant import. This PR fixes this.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [X]  Untested
