### PR TITLE
fix(skinny-optimistic-oracle): proposePrice callback should be to requester not msg.sender

### DIFF
--- a/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
@@ -241,9 +241,9 @@ contract SkinnyOptimisticOracle is SkinnyOptimisticOracleInterface, Testable, Lo
         emit ProposePrice(requester, identifier, timestamp, ancillaryData, proposedRequest);
 
         // Callback.
-        if (address(msg.sender).isContract())
+        if (address(requester).isContract())
             try
-                OptimisticRequester(msg.sender).priceProposed(identifier, timestamp, ancillaryData, proposedRequest)
+                OptimisticRequester(requester).priceProposed(identifier, timestamp, ancillaryData, proposedRequest)
             {} catch {}
     }
 


### PR DESCRIPTION
…

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `SkinnyOptimisticOracle` invokes callback functions on the price requester, if they exist, so the requester can respond to significant state changes. However, the callback is incorrectly invoked on the price proposer instead of the price requester in the `proposePriceFor` function. This means the price requester is unable to respond to price proposals.

Fortunately, this feature is not used in the current code base. Nevertheless, consider invoking the `priceProposed`callback on the requester.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
