### PR TITLE
fix(ancillary-data-lib): Fix faulty append function

### DIFF
--- a/packages/core/contracts/common/implementation/AncillaryData.sol
+++ b/packages/core/contracts/common/implementation/AncillaryData.sol
@@ -90,7 +90,7 @@ library AncillaryData {
         bytes32 value
     ) internal pure returns (bytes memory) {
         bytes memory prefix = constructPrefix(currentAncillaryData, key);
-        return abi.encodePacked(prefix, toUtf8Bytes(value));
+        return abi.encodePacked(currentAncillaryData, prefix, toUtf8Bytes(value));
     }
 
     /**

--- a/packages/core/contracts/common/test/AncillaryDataTest.sol
+++ b/packages/core/contracts/common/test/AncillaryDataTest.sol
@@ -20,6 +20,14 @@ contract AncillaryDataTest {
         return AncillaryData.appendKeyValueAddress(currentAncillaryData, key, value);
     }
 
+    function appendKeyValueBytes32(
+        bytes memory currentAncillaryData,
+        bytes memory key,
+        bytes32 value
+    ) external pure returns (bytes memory) {
+        return AncillaryData.appendKeyValueBytes32(currentAncillaryData, key, value);
+    }
+
     function appendKeyValueUint(
         bytes memory currentAncillaryData,
         bytes memory key,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `appendKeyValueBytes32` function should combine its inputs into a formatted bytes array. However, the `currentAncillaryData` is incorrectly discarded.

Since the ancillary data influences the oracle resolution process, an incorrect value could undermine the oracle results. Fortunately, there is only one call to `appendKeyValueBytes32` in the codebase, and it uses an empty `currentAncillaryData` buffer, so the bug does not affect this case.

This PR updates the `appendKeyValueBytes32` function so that the `currentAncillaryData` is included in the returned bytes array.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
