### PR TITLE
fix(BridgePool): address missing nat-spec

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/BridgeDepositBox.sol
@@ -97,6 +97,7 @@ abstract contract BridgeDepositBox is Testable, Lockable {
      * @notice Construct the Bridge Deposit Box
      * @param _minimumBridgingDelay Minimum second that must elapse between L2 -> L1 token transfer to prevent dos.
      * @param _chainId Chain identifier for the Bridge deposit box.
+     * @param _l1Weth Address of Weth on L1. Used to inform if the deposit should wrap ETH to WETH, if deposit is ETH.
      * @param timerAddress Timer used to synchronize contract time in testing. Set to 0x000... in production.
      */
     constructor(

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -168,6 +168,7 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
      * @param _bridgeAdmin Admin contract deployed alongside on L1. Stores global variables and has owner control.
      * @param _l1Token Address of the L1 token that this bridgePool holds. This is the token LPs deposit and is bridged.
      * @param _lpFeeRatePerSecond Interest rate payment that scales the amount of pending fees per second paid to LPs.
+     * @param _isWethPool Toggles if this is the WETH pool. If it is then can accept ETH and wrap to WETH for the user.
      * @param _timer Timer used to synchronize contract time in testing. Set to 0x000... in production.
      */
     constructor(

--- a/packages/core/contracts/insured-bridge/avm/AVM_BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/avm/AVM_BridgeDepositBox.sol
@@ -33,6 +33,7 @@ contract AVM_BridgeDepositBox is BridgeDepositBox, AVM_CrossDomainEnabled {
      * @param _crossDomainAdmin Address of the L1 contract that can call admin functions on this contract from L1.
      * @param _minimumBridgingDelay Minimum second that must elapse between L2->L1 token transfer to prevent dos.
      * @param _chainId L2 Chain identifier this deposit box is deployed on.
+     * @param _l1Weth Address of Weth on L1. Used to inform if the deposit should wrap ETH to WETH, if deposit is ETH.
      * @param timerAddress Timer used to synchronize contract time in testing. Set to 0x000... in production.
      */
     constructor(

--- a/packages/core/contracts/insured-bridge/ovm/OVM_BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/ovm/OVM_BridgeDepositBox.sol
@@ -50,6 +50,7 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
      * @param _crossDomainAdmin Address of the L1 contract that can call admin functions on this contract from L1.
      * @param _minimumBridgingDelay Minimum second that must elapse between L2->L1 token transfer to prevent dos.
      * @param _chainId L2 Chain identifier this deposit box is deployed on.
+     * @param _l1Weth Address of Weth on L1. Used to inform if the deposit should wrap ETH to WETH, if deposit is ETH.
      * @param timerAddress Timer used to synchronize contract time in testing. Set to 0x000... in production.
      */
     constructor(


### PR DESCRIPTION
**Motivation**

OZ pointed out the following issue:

_There are some instances throughout the codebase where the Ethereum Natural Specification is missing or incomplete. Examples include:_
- _the BridgeDepositBox, AVM_BridgeDepositBox and OVM_BridgeDepositBox constructors are missing a @param comment for the l1Weth parameter._
- _the BridgePool constructor is missing a @param comment for the isWethPool parameter._


This PR adds the correct natspec docs



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested