### PR TITLE
fix(skinny-optimistic-oracle): Default proposer bond to final fee in requestAndProposePriceFor

### DIFF
--- a/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
@@ -318,7 +318,7 @@ contract SkinnyOptimisticOracle is SkinnyOptimisticOracleInterface, Testable, Lo
         request.currency = currency;
         request.reward = reward;
         request.finalFee = finalFee;
-        request.bond = bond;
+        request.bond = bond != 0 ? bond : finalFee;
         request.customLiveness = customLiveness;
         request.proposer = proposer;
         request.proposedPrice = proposedPrice;


### PR DESCRIPTION
…

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We default the proposer bond amount to the final fee in the case where the caller sets it to 0. Original discussion for this decision in the `requestPrice` method can be found [here](https://github.com/UMAprotocol/protocol/pull/3409#discussion_r719747949).

We forgot to do the same default logic in `requestAndProposePriceFor`.

From the audit:

> The `requestPrice` function of the `SkinnyOptimisticOracle` contract uses the final fee as the bond if the bond is not specified. However, the `requestAndProposePriceFor` function may use a zero bond, which contradicts its `@notice` and `@param` comments. A zero bond weakens the incentive against invalid proposal or disputes.
Fortunately, the only call to this function in the code base sets a proposer bond. Nevertheless, consider using the final fee if the bond is not specified.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
