### PR TITLE
fix(BridgePool): add more indexed params

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/BridgeDepositBox.sol
@@ -82,7 +82,7 @@ abstract contract BridgeDepositBox is Testable, Lockable {
         uint64 instantRelayFeePct,
         uint64 quoteTimestamp
     );
-    event TokensBridged(address l2Token, uint256 numberOfTokensBridged, uint256 l1Gas, address caller);
+    event TokensBridged(address indexed l2Token, uint256 numberOfTokensBridged, uint256 l1Gas, address indexed caller);
 
     /****************************************
      *               MODIFIERS              *

--- a/packages/core/contracts/insured-bridge/avm/AVM_BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/avm/AVM_BridgeDepositBox.sol
@@ -25,7 +25,7 @@ contract AVM_BridgeDepositBox is BridgeDepositBox, AVM_CrossDomainEnabled {
     // Address of the Arbitrum L2 token gateway.
     address public l2GatewayRouter;
 
-    event SetXDomainAdmin(address newAdmin);
+    event SetXDomainAdmin(address indexed newAdmin);
 
     /**
      * @notice Construct the Arbitrum Bridge Deposit Box

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -17,7 +17,7 @@ interface BridgeAdminInterface {
     event WhitelistToken(uint256 chainId, address indexed l1Token, address indexed l2Token, address indexed bridgePool);
     event SetMinimumBridgingDelay(uint256 indexed chainId, uint64 newMinimumBridgingDelay);
     event DepositsEnabled(uint256 indexed chainId, address indexed l2Token, bool depositsEnabled);
-    event BridgePoolsAdminTransferred(address[] bridgePools, address newAdmin);
+    event BridgePoolsAdminTransferred(address[] bridgePools, address indexed newAdmin);
 
     function finder() external view returns (address);
 

--- a/packages/core/contracts/insured-bridge/ovm/OVM_BridgeDepositBox.sol
+++ b/packages/core/contracts/insured-bridge/ovm/OVM_BridgeDepositBox.sol
@@ -43,7 +43,7 @@ contract OVM_BridgeDepositBox is BridgeDepositBox, OVM_CrossDomainEnabled {
     // Address of the L1 contract that acts as the owner of this Bridge deposit box.
     address public crossDomainAdmin;
 
-    event SetXDomainAdmin(address newAdmin);
+    event SetXDomainAdmin(address indexed newAdmin);
 
     /**
      * @notice Construct the Optimism Bridge Deposit Box


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
_Many of the events defined in this codebase have parameters that should be indexed: • newAdmin in BridgePoolsAdminTransferred_
• _chainId in WhitelistToken_
• _l2Token in TokensBridged_
• _newAdmin in SetXDomainAdmin_
                         
This PR addresses some of these issues. Other similar issues were implemented in PR https://github.com/UMAprotocol/protocol/pull/3489

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
