### PR TITLE
fix(BridgeAdmin): validated amount sent is correct when making admin calls

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -188,7 +188,6 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         uint256 l2GasPrice,
         uint256 maxSubmissionCost
     ) public payable onlyOwner canRelay(chainId) nonReentrant() {
-        require(l1CallValue == msg.value, "Wrong number of ETH sent");
         _relayMessage(
             _depositContracts[chainId].messengerContract,
             l1CallValue,
@@ -353,6 +352,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         );
     }
 
+    // Send msg.value == l1CallValue to Messenger, which can then use it in any way to execute cross domain message.
     function _relayMessage(
         address messengerContract,
         uint256 l1CallValue,
@@ -363,8 +363,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         uint256 maxSubmissionCost,
         bytes memory message
     ) private {
-        // Send msg.value == l1CallValue to Messenger contract, which can then use it in any way to execute cross
-        // domain message.
+        require(l1CallValue == msg.value, "Wrong number of ETH sent");
         MessengerInterface(messengerContract).relayMessage{ value: l1CallValue }(
             target,
             user,

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -188,6 +188,7 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         uint256 l2GasPrice,
         uint256 maxSubmissionCost
     ) public payable onlyOwner canRelay(chainId) nonReentrant() {
+        require(l1CallValue == msg.value, "Wrong number of ETH sent");
         _relayMessage(
             _depositContracts[chainId].messengerContract,
             l1CallValue,


### PR DESCRIPTION
**Motivation**

OZ pointed out that:

_All functions in BridgeAdmin that call _relayMessage assume the transaction value matches the l1CallValue parameter, but this is not enforced._

This PR addresses this by adding a require to the internal `_relayMesage` method to make this requirement.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
