### PR TITLE
improve(insured-bridge): Reduce verbosity of _getDepositHash()

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -820,20 +820,7 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
     }
 
     function _getDepositHash(DepositData memory depositData) private view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    depositData.chainId,
-                    depositData.depositId,
-                    depositData.l1Recipient,
-                    depositData.l2Sender,
-                    address(l1Token),
-                    depositData.amount,
-                    depositData.slowRelayFeePct,
-                    depositData.instantRelayFeePct,
-                    depositData.quoteTimestamp
-                )
-            );
+        return keccak256(abi.encode(depositData, address(l1Token)));
     }
 
     // Proposes new price of True for relay event associated with `customAncillaryData` to optimistic oracle. If anyone

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -134,17 +134,17 @@ describe("BridgePool", () => {
   // Generate ABI encoded deposit data and deposit data hash.
   const generateDepositHash = (_depositData) => {
     const depositDataAbiEncoded = web3.eth.abi.encodeParameters(
-      ["uint256", "uint64", "address", "address", "address", "uint256", "uint64", "uint64", "uint64"],
+      ["uint256", "uint64", "address", "address", "uint256", "uint64", "uint64", "uint64", "address"],
       [
         _depositData.chainId,
         _depositData.depositId,
         _depositData.l1Recipient,
         _depositData.l2Sender,
-        l1Token.options.address,
         _depositData.amount,
         _depositData.slowRelayFeePct,
         _depositData.instantRelayFeePct,
         _depositData.quoteTimestamp,
+        l1Token.options.address,
       ]
     );
     const depositHash = soliditySha3(depositDataAbiEncoded);

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -95,17 +95,17 @@ export class InsuredBridgeL2Client {
 
   generateDepositHash = (depositData: Deposit): string => {
     const depositDataAbiEncoded = this.l2Web3.eth.abi.encodeParameters(
-      ["uint256", "uint64", "address", "address", "address", "uint256", "uint64", "uint64", "uint32"],
+      ["uint256", "uint64", "address", "address", "uint256", "uint64", "uint64", "uint32", "address"],
       [
         depositData.chainId,
         depositData.depositId,
         depositData.l1Recipient,
         depositData.l2Sender,
-        depositData.l1Token,
         depositData.amount,
         depositData.slowRelayFeePct,
         depositData.instantRelayFeePct,
         depositData.quoteTimestamp,
+        depositData.l1Token,
       ]
     );
     const depositHash = this.l2Web3.utils.soliditySha3(depositDataAbiEncoded);

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -90,17 +90,17 @@ describe("InsuredBridgeL1Client", function () {
   const generateRelayData = async (depositData, relayData, bridgePool, l1TokenAddress = l1Token.options.address) => {
     // Save other reused values.
     depositDataAbiEncoded = web3.eth.abi.encodeParameters(
-      ["uint256", "uint64", "address", "address", "address", "uint256", "uint64", "uint64", "uint32"],
+      ["uint256", "uint64", "address", "address", "uint256", "uint64", "uint64", "uint32", "address"],
       [
         depositData.chainId,
         depositData.depositId,
         depositData.l1Recipient,
         depositData.l2Sender,
-        l1TokenAddress,
         depositData.amount,
         depositData.slowRelayFeePct,
         depositData.instantRelayFeePct,
         depositData.quoteTimestamp,
+        l1TokenAddress,
       ]
     );
     depositHash = soliditySha3(depositDataAbiEncoded);

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
@@ -31,17 +31,17 @@ const quoteTimestampOffset = 60; // 60 seconds into the past.
 describe("InsuredBridgeL2Client", () => {
   const generateDepositHash = (depositData) => {
     const depositDataAbiEncoded = web3.eth.abi.encodeParameters(
-      ["uint256", "uint64", "address", "address", "address", "uint256", "uint64", "uint64", "uint32"],
+      ["uint256", "uint64", "address", "address", "uint256", "uint64", "uint64", "uint32", "address"],
       [
         depositData.chainId,
         depositData.depositId,
         depositData.l1Recipient,
         depositData.l2Sender,
-        depositData.l1Token,
         depositData.amount,
         depositData.slowRelayFeePct,
         depositData.instantRelayFeePct,
         depositData.quoteTimestamp,
+        depositData.l1Token,
       ]
     );
     return web3.utils.soliditySha3(depositDataAbiEncoded);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `_getDepositHash` function of the `BridgePool` contract unrolls the `depositData` struct to interstice the `l1Token` as an argument in the composition of `keccak256` with the abi encoding. This makes the operation unnecessarily verbose and can lead to bugs when reimplemented on other layers.
Consider simplifying the arguments to simply be the ordered pair `depositData` and `l1Token`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
