### PR TITLE
fix(skinny-optimistic-oracle): Reentrancy guard requestAndProposePriceFor

### DIFF
--- a/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol
@@ -300,7 +300,7 @@ contract SkinnyOptimisticOracle is SkinnyOptimisticOracleInterface, Testable, Lo
         uint256 customLiveness,
         address proposer,
         int256 proposedPrice
-    ) external override returns (uint256 totalBond) {
+    ) external override nonReentrant() returns (uint256 totalBond) {
         bytes32 requestId = _getId(msg.sender, identifier, timestamp, ancillaryData);
         require(requests[requestId] == bytes32(0), "Request already initialized");
         require(proposer != address(0), "proposer address must be non 0");


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `requestAndProposePriceFor` function of the `SkinnyOptimisticOracle` contract makes a call to an untrusted `msg.sender` but is not guarded by a `nonReentrant` modifier. While, in this instance, this does not seem to be a security concern, this can introduce unexpected behavior.

Consider adding the `nonReentrant` modifier to all functions which make calls to possibly untrusted contracts.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
