### PR TITLE
improve(arbitrum-messenger): Emit event including return value of Arbitrum sys contract call

### DIFF
--- a/packages/core/contracts/insured-bridge/avm/Arbitrum_Messenger.sol
+++ b/packages/core/contracts/insured-bridge/avm/Arbitrum_Messenger.sol
@@ -56,15 +56,7 @@ contract Arbitrum_Messenger is Ownable, Arbitrum_CrossDomainEnabled, MessengerIn
     ) external payable override onlyOwner {
         // Since we know the L2 target's address in advance, we don't need to alias an L1 address.
         uint256 seqNumber =
-            sendTxToL2NoAliassing(
-                target,
-                userToRefund,
-                l1CallValue,
-                maxSubmissionCost, // TODO: Determine the max submission cost. From the docs: "current base submission fee is queryable via ArbRetryableTx.getSubmissionPrice"
-                gasLimit,
-                gasPrice,
-                message
-            );
+            sendTxToL2NoAliassing(target, userToRefund, l1CallValue, maxSubmissionCost, gasLimit, gasPrice, message);
         emit RelayedMessage(
             msg.sender,
             target,

--- a/packages/core/contracts/insured-bridge/avm/Arbitrum_Messenger.sol
+++ b/packages/core/contracts/insured-bridge/avm/Arbitrum_Messenger.sol
@@ -13,6 +13,18 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * owner for L2 contracts that expect to receive cross domain messages.
  */
 contract Arbitrum_Messenger is Ownable, Arbitrum_CrossDomainEnabled, MessengerInterface {
+    event RelayedMessage(
+        address indexed from,
+        address indexed to,
+        uint256 indexed seqNum,
+        address userToRefund,
+        uint256 l1CallValue,
+        uint256 gasLimit,
+        uint256 gasPrice,
+        uint256 maxSubmissionCost,
+        bytes data
+    );
+
     /**
      * @param _inbox Contract that sends generalized messages to the Arbitrum chain.
      */
@@ -43,13 +55,25 @@ contract Arbitrum_Messenger is Ownable, Arbitrum_CrossDomainEnabled, MessengerIn
         bytes memory message
     ) external payable override onlyOwner {
         // Since we know the L2 target's address in advance, we don't need to alias an L1 address.
-        sendTxToL2NoAliassing(
+        uint256 seqNumber =
+            sendTxToL2NoAliassing(
+                target,
+                userToRefund,
+                l1CallValue,
+                maxSubmissionCost, // TODO: Determine the max submission cost. From the docs: "current base submission fee is queryable via ArbRetryableTx.getSubmissionPrice"
+                gasLimit,
+                gasPrice,
+                message
+            );
+        emit RelayedMessage(
+            msg.sender,
             target,
+            seqNumber,
             userToRefund,
             l1CallValue,
-            maxSubmissionCost, // TODO: Determine the max submission cost. From the docs: "current base submission fee is queryable via ArbRetryableTx.getSubmissionPrice"
             gasLimit,
             gasPrice,
+            maxSubmissionCost,
             message
         );
     }

--- a/packages/core/contracts/insured-bridge/test/Arbitrum_InboxMock.sol
+++ b/packages/core/contracts/insured-bridge/test/Arbitrum_InboxMock.sol
@@ -14,6 +14,6 @@ contract Arbitrum_InboxMock is iArbitrum_Inbox {
         uint256 gasPriceBid,
         bytes calldata data
     ) external payable override returns (uint256) {
-        return 1;
+        return 0;
     }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `relayMessage` function of the `Arbitrum_Messenger` contract does not emit a relevant event after executing a sensitive action. The `relayMessage` function calls as a subroutine `sentTxToL2NoAliasing` which itself returns the `uint256` value `seqNum`, but this return value is not logged in the `relayMessage` function.
Consider emitting events after sensitive changes take place, to facilitate tracking and notify off-chain clients following the contract's activity.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
