### PR TITLE
fix(sdk): update user and pool after transaction confirms

### DIFF
--- a/packages/sdk/src/across/clients/README.md
+++ b/packages/sdk/src/across/clients/README.md
@@ -121,7 +121,7 @@ const transaction = lodash.get(state, ["transactions", txid])
 const transaction = client.getTx(txid)
 // {
 //   id: string;
-//   state: "requested" | "submitted" | "mined";
+//   state: "requested" | "submitted" | "mined" | "error";
 //   toAddress: string;
 //   fromAddress: string;
 //   type: "Add Liquidity" | "Remove Liquidity";
@@ -129,19 +129,19 @@ const transaction = client.getTx(txid)
 //   request?: TransactionRequest;
 //   hash?: string;
 //   receipt?: TransactionReceipt;
+//   error?: Error;
 // }
 ```
 
 ### Tracking Transactions
 
-You must manually call `updateTransactions` on an interval if you care about tracking transactions. This is optional.
+You must manually call `startInterval` or 'updateTransactions' on an interval manually you care about tracking transactions. This is optional.
 
 ```js
-// updates once a minute
-setInterval(() => {
-  client.updateTransactions().catch((err) => {
-    console.error("Something happened when updating transactions", err)
-  })
-}, 60000)
+// updates once every 30 seconds
+client.startInterval(/* optionally pass in ms to update, defaults to 30 seconds */)
 // completed transactions will have the state "mined"
+
+// stops checking for transactions
+client.stopInterval()
 ```

--- a/packages/sdk/src/across/transactionManager.ts
+++ b/packages/sdk/src/across/transactionManager.ts
@@ -2,33 +2,51 @@ import assert from "assert";
 import { Signer } from "ethers";
 import { TransactionRequest, TransactionReceipt } from "@ethersproject/abstract-provider";
 
-export type Emit = (event: string, key: string, data: TransactionReceipt | string | TransactionRequest) => void;
-export default (signer: Signer, emit: Emit = () => null) => {
+function makeKey(tx: TransactionRequest) {
+  return JSON.stringify(
+    Object.entries(tx).map(([key, value]) => {
+      return [key, (value || "").toString()];
+    })
+  );
+}
+
+type Config = {
+  confirmations?: number;
+};
+export type Emit = (event: string, key: string, data: TransactionReceipt | string | TransactionRequest | Error) => void;
+export default (config: Config, signer: Signer, emit: Emit = () => null) => {
   assert(signer.provider, "signer requires a provider, use signer.connect(provider)");
+  const { confirmations = 3 } = config;
   const requests = new Map<string, TransactionRequest>();
   const submissions = new Map<string, string>();
   const mined = new Map<string, TransactionReceipt>();
   async function request(unsignedTx: TransactionRequest) {
     const populated = await signer.populateTransaction(unsignedTx);
-    const key = JSON.stringify(populated);
+    const key = makeKey(populated);
     requests.set(key, populated);
-    emit("requested", key, populated);
     return key;
   }
   async function processRequest(key: string) {
     const request = requests.get(key);
     assert(request, "invalid request");
-    const sent = await signer.sendTransaction(request);
+    // always delete request, it should only be submitted once
     requests.delete(key);
-    submissions.set(key, sent.hash);
-    emit("submitted", key, sent.hash);
+    try {
+      const sent = await signer.sendTransaction(request);
+      submissions.set(key, sent.hash);
+      emit("submitted", key, sent.hash);
+    } catch (err) {
+      emit("error", key, err);
+    }
   }
   async function processSubmission(key: string) {
     const hash = submissions.get(key);
     assert(hash, "invalid submission");
     assert(signer.provider, "signer requires a provider, use signer.connect(provider)");
+    // we look for this transaction, but it may never find it if its sped up
     const receipt = await signer.provider.getTransactionReceipt(hash).catch(() => undefined);
     if (receipt == null) return;
+    if (receipt.confirmations < confirmations) return;
     submissions.delete(key);
     mined.set(key, receipt);
     emit("mined", key, receipt);


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2785/bridgepool-sdk-returns-a-negative-value-for-deposits

**Summary**

This automatically updates pool and user after it detects a transaction completes. Do not update manually, just wait for events to update state for you. This waits 3 confirmations because of inconsistency of events showing up in infura immediately after tx completes.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2785/bridgepool-sdk-returns-a-negative-value-for-deposits
