### PR TITLE
fix(across-bots): Address issue where relayer produces an error after every relay

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -191,7 +191,7 @@ export class InsuredBridgeL1Client {
   // Returns the L2 Deposit box address for a given bridgeAdmin on L1.
   async getL2DepositBoxAddress(chainId: number): Promise<string> {
     const depositContracts = (await this.bridgeAdmin.methods.depositContracts(chainId).call()) as any;
-    return depositContracts.depositContract || depositContracts[0];
+    return depositContracts.depositContract || depositContracts[0]; // When latest BridgeAdmin is redeployed, can remove the "|| depositContracts[0]".
   }
 
   async update(): Promise<void> {

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -346,3 +346,11 @@ export class InsuredBridgeL1Client {
       throw new Error("InsuredBridgeClient method called before initialization! Call `update` first.");
   }
 }
+
+// Returns the L2 Deposit box address for a given bridgeAdmin on L1.
+export async function getL2DepositBoxAddress(web3: Web3, chainId: number, bridgeAdminAddress: string): Promise<string> {
+  const depositContracts = await new web3.eth.Contract(getAbi("BridgeAdminInterface"), bridgeAdminAddress).methods
+    .depositContracts(chainId)
+    .call();
+  return depositContracts.depositContract;
+}

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -188,6 +188,7 @@ export class InsuredBridgeL1Client {
     return toBN(await this.bridgeAdmin.methods.proposerBondPct().call());
   }
 
+  // Returns the L2 Deposit box address for a given bridgeAdmin on L1.
   async getL2DepositBoxAddress(chainId: number): Promise<string> {
     const depositContracts = (await this.bridgeAdmin.methods.depositContracts(chainId).call()) as any;
     return depositContracts.depositContract || depositContracts[0];
@@ -349,5 +350,3 @@ export class InsuredBridgeL1Client {
       throw new Error("InsuredBridgeClient method called before initialization! Call `update` first.");
   }
 }
-
-// Returns the L2 Deposit box address for a given bridgeAdmin on L1.

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -47,6 +47,10 @@ export class InsuredBridgeL2Client {
     return Object.keys(this.deposits).map((depositHash: string) => this.deposits[depositHash]);
   }
 
+  getAllDepositsForL1Token(l1TokenAddress: string) {
+    return this.getAllDeposits().filter((deposit: Deposit) => deposit.l1Token === l1TokenAddress);
+  }
+
   getDepositByHash(depositHash: string) {
     return this.deposits[depositHash];
   }
@@ -112,12 +116,4 @@ export class InsuredBridgeL2Client {
     if (depositHash == "" || depositHash == null) throw new Error("Bad deposit hash");
     return depositHash;
   };
-}
-
-// Returns the L2 Deposit box address for a given bridgeAdmin on L1.
-export async function getL2DepositBoxAddress(web3: Web3, chainId: number, bridgeAdminAddress: string): Promise<string> {
-  const depositContracts = await new web3.eth.Contract(getAbi("BridgeAdminInterface"), bridgeAdminAddress).methods
-    .depositContracts(chainId)
-    .call();
-  return depositContracts.depositContract;
 }

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -34,7 +34,7 @@ import type { Logger } from "winston";
 import { NetworkerInterface } from "./Networker";
 import { PriceFeedInterface } from "./PriceFeedInterface";
 import { isDefined } from "../types";
-import { InsuredBridgeL1Client, InsuredBridgeL2Client, getL2DepositBoxAddress } from "..";
+import { InsuredBridgeL1Client, InsuredBridgeL2Client } from "..";
 import type { BlockTransactionBase } from "web3-eth";
 
 interface Block {
@@ -504,7 +504,7 @@ export async function createPriceFeed(
     const l2Client = new InsuredBridgeL2Client(
       logger,
       l2Web3,
-      await getL2DepositBoxAddress(providedWeb3, config.l2NetId, config.bridgeAdminAddress),
+      await l1Client.getL2DepositBoxAddress(config.l2NetId),
       config.l2NetId,
       currentL2Block - l2BlockLookback
     );

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -660,7 +660,7 @@ export class Relayer {
     const relayableDeposits: RelayableDeposits = {};
     for (const l1Token of this.whitelistedRelayL1Tokens) {
       this.logger.debug({ at: "Relayer", message: "Checking relays for token", l1Token });
-      const l2Deposits = this.l2Client.getAllDeposits();
+      const l2Deposits = this.l2Client.getAllDepositsForL1Token(l1Token);
       l2Deposits.forEach((deposit) => {
         const status = this.l1Client.getDepositRelayState(deposit);
         if (status != ClientRelayState.Finalized) {

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -65,9 +65,9 @@ export class RelayerConfig {
       RATE_MODELS,
       CHAIN_IDS,
       L2_BLOCK_LOOKBACK,
-      DISPUTER_ENABLED,
       RELAYER_ENABLED,
       FINALIZER_ENABLED,
+      DISPUTER_ENABLED,
       WHITELISTED_CHAIN_IDS,
       DEPLOY_TIMESTAMPS,
     } = env;

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -12,7 +12,6 @@ import {
   delay,
   InsuredBridgeL1Client,
   InsuredBridgeL2Client,
-  getL2DepositBoxAddress,
 } from "@uma/financial-templates-lib";
 
 import { approveL1Tokens } from "./RelayerHelpers";
@@ -57,7 +56,7 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
     const l2Client = new InsuredBridgeL2Client(
       logger,
       l2Web3,
-      await getL2DepositBoxAddress(l1Web3, config.activatedChainIds[0], config.bridgeAdmin),
+      await l1Client.getL2DepositBoxAddress(config.activatedChainIds[0]),
       config.activatedChainIds[0],
       l2StartBlock
     );


### PR DESCRIPTION
**Motivation**
Every time the relayer runs and sends relays it generates an error right after the fact. This is irritating. This PR fixes this behaviour.
**Summary**

The issue boiled down to double counting deposits due to incorrect filtering in the `Relayer.ts`. See code for more details on the bug and the solution.

Note that this issue was not shown in unit tests as it is an artefact of having multiple pools (more than 1 token) on one relayer.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
