### PR TITLE
WIP(insured-bridge-relayer): Remove deployTimestamps hardcoded mapping

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -53,6 +53,7 @@ export interface BridgePoolData {
   contract: BridgePoolWeb3;
   currentTime: number;
   relayNonce: number;
+  deploymentTime: number;
 }
 
 export class InsuredBridgeL1Client {
@@ -214,6 +215,7 @@ export class InsuredBridgeL1Client {
         // We'll set the following params when fetching bridge pool state in parallel.
         currentTime: 0,
         relayNonce: 0,
+        deploymentTime: 0,
       };
       this.relays[l1Token] = {};
       this.instantRelays[l1Token] = {};
@@ -236,6 +238,7 @@ export class InsuredBridgeL1Client {
         relayCanceledEvents,
         contractTime,
         relayNonce,
+        deploymentTime,
       ] = await Promise.all([
         bridgePool.contract.getPastEvents("DepositRelayed", blockSearchConfig),
         bridgePool.contract.getPastEvents("RelaySpedUp", blockSearchConfig),
@@ -244,12 +247,13 @@ export class InsuredBridgeL1Client {
         bridgePool.contract.getPastEvents("RelayCanceled", blockSearchConfig),
         bridgePool.contract.methods.getCurrentTime().call(),
         bridgePool.contract.methods.numberOfRelays().call(),
+        bridgePool.contract.methods.deploymentTimestamp().call(),
       ]);
 
-      // Store current contract time and relay nonce that user can use to send instant relays
-      // (where there is no pending relay) for a deposit.
+      // Store current contract state for bridge pool.
       bridgePool.currentTime = Number(contractTime);
       bridgePool.relayNonce = Number(relayNonce);
+      bridgePool.deploymentTime = Number(deploymentTime);
 
       for (const depositRelayedEvent of depositRelayedEvents) {
         const relayData: Relay = {

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -320,6 +320,10 @@ describe("InsuredBridgeL1Client", function () {
       client.getBridgePoolForDeposit(depositData).relayNonce,
       (await bridgePool.methods.numberOfRelays().call()).toString()
     );
+    assert.equal(
+      client.getBridgePoolForDeposit(depositData).deploymentTime,
+      (await bridgePool.methods.deploymentTimestamp().call()).toString()
+    );
 
     // OptimisticOracle liveness should be reset.
     assert.equal(client.optimisticOracleLiveness, defaultLiveness);

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -250,19 +250,6 @@ export class Relayer {
     ) {
       // Relay matched with a Deposit, now check if the relay params itself are valid.
 
-      // If deposit quote time is before the bridgepool's deployment time, then dispute it by default because
-      // we won't be able to determine otherwise if the realized LP fee % is valid.
-      if (deposit.quoteTimestamp < this.deployTimestamps[deposit.l1Token]) {
-        this.logger.debug({
-          at: "Disputer",
-          message: "Deposit quote time < bridge pool deployment for L1 token, disputing",
-          deposit,
-          deploymentTime: this.deployTimestamps[deposit.l1Token],
-        });
-        await this.disputeRelay(deposit, relay);
-        return;
-      }
-
       // Compute expected realized LP fee % and if the pending relay has a different fee then dispute it.
       const realizedLpFeePct = (await this.l1Client.calculateRealizedLpFeePctForDeposit(deposit)).toString();
       const relayDisputable = await this.isPendingRelayDisputable(relay, deposit, realizedLpFeePct);

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -797,8 +797,7 @@ export class Relayer {
     // search config bridge pool's deployment time. This allows us to capture any deposits that happened outside of
     // the L2 client's default block search config.
     else {
-      const bridgePoolDeploymentTime = this.l1Client.getBridgePoolForToken(relayableDeposit.deposit.l1Token)
-        .deploymentTime;
+      const bridgePoolDeploymentTime = this.l1Client.getBridgePoolForToken(relay.l1Token).deploymentTime;
       let blockSearchConfig = {
         fromBlock: bridgePoolDeploymentTime,
         toBlock: bridgePoolDeploymentTime + this.l2LookbackWindow,

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -784,10 +784,12 @@ export class Relayer {
     // search config bridge pool's deployment time. This allows us to capture any deposits that happened outside of
     // the L2 client's default block search config.
     else {
-      const bridgePoolDeploymentTime = this.l1Client.getBridgePoolForToken(relay.l1Token).deploymentTime;
+      const bridgePoolDeploymentBlockNumber = (
+        await this.l2BlockFinder.getBlockForTimestamp(this.l1Client.getBridgePoolForToken(relay.l1Token).deploymentTime)
+      ).number;
       let blockSearchConfig = {
-        fromBlock: bridgePoolDeploymentTime,
-        toBlock: bridgePoolDeploymentTime + this.l2LookbackWindow,
+        fromBlock: bridgePoolDeploymentBlockNumber,
+        toBlock: bridgePoolDeploymentBlockNumber + this.l2LookbackWindow,
       };
       const latestBlock = Number((await this.l2Client.l2Web3.eth.getBlock("latest")).number);
 

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -16,22 +16,6 @@ const supportedChainIds = [
   421611, // arbitrum testnet
 ];
 
-// This struct is a hack right now but prevents an edge case bug where a deposit.quoteTime < bridgePool.deployment time.
-// The deposit.quoteTime is used to call bridgePool.liquidityUtilizationCurrent at a specific block height. This call
-// always reverts if the quote time is before the bridge pool's deployment time. This causes the disputer to error out
-// because it cannot validate a relay's realizedLpFeePct properly. We need to therefore know which deposit quote times
-// are off-limits and need to either be ignored or auto-disputed. This is a hack because ideally the bridgePool sets
-// a timestamp on construction. Then we can easily query on-chain whether a deposit.quoteTime is before this timestamp.
-const bridgePoolDeployTimestamps = {
-  // Note: keyed by L1 token.
-  // WETH:
-  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": 1635305400,
-  // USDC:
-  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": 1635312600,
-  // UMA:
-  "0x04fa0d235c4abf4bcf4787af4cf447de572ef828": 1635312600,
-};
-
 export interface ProcessEnv {
   [key: string]: string | undefined;
 }
@@ -54,7 +38,6 @@ export class RelayerConfig {
   readonly activatedChainIds: number[];
   readonly l2BlockLookback: number;
   readonly botModes: BotModes;
-  readonly deployTimestamps: { [key: string]: number };
 
   constructor(env: ProcessEnv) {
     const {
@@ -69,7 +52,6 @@ export class RelayerConfig {
       FINALIZER_ENABLED,
       DISPUTER_ENABLED,
       WHITELISTED_CHAIN_IDS,
-      DEPLOY_TIMESTAMPS,
     } = env;
 
     this.botModes = {
@@ -89,8 +71,6 @@ export class RelayerConfig {
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;
     this.errorRetriesTimeout = ERROR_RETRIES_TIMEOUT ? Number(ERROR_RETRIES_TIMEOUT) : 1;
-
-    this.deployTimestamps = DEPLOY_TIMESTAMPS ? JSON.parse(DEPLOY_TIMESTAMPS) : bridgePoolDeployTimestamps;
 
     assert(RATE_MODELS, "RATE_MODELS required");
     const processingRateModels = JSON.parse(RATE_MODELS);

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -80,7 +80,6 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
       config.whitelistedRelayL1Tokens,
       accounts[0],
       config.whitelistedChainIds,
-      config.deployTimestamps,
       config.l2BlockLookback
     );
 

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -90,8 +90,6 @@ describe("Relayer.ts", function () {
   let l2Client: any;
   let gasEstimator: any;
 
-  let deployTimestamps: any;
-
   before(async function () {
     l1Accounts = await web3.eth.getAccounts();
     [l1Owner, l1Relayer, l1LiquidityProvider, l2Owner, l2Depositor, l2BridgeAdminImpersonator] = l1Accounts;
@@ -192,8 +190,6 @@ describe("Relayer.ts", function () {
       )
       .send({ from: l1Owner });
 
-    deployTimestamps = { [l1Token.options.address]: (await l1Timer.methods.getCurrentTime().call()).toString() };
-
     await bridgeDepositBox.methods
       .whitelistToken(l1Token.options.address, l2Token.options.address, bridgePool.options.address)
       .send({ from: l2BridgeAdminImpersonator });
@@ -218,7 +214,6 @@ describe("Relayer.ts", function () {
       [l1Token.options.address],
       l1Relayer,
       whitelistedChainIds,
-      deployTimestamps,
       defaultLookbackWindow
     );
   });
@@ -639,7 +634,7 @@ describe("Relayer.ts", function () {
     });
     it("Skips deposits with quote time < contract deployment time", async function () {
       // Deposit using quote time prior to deploy timestamp for this L1 token.
-      const quoteTime = Number(deployTimestamps[l1Token.options.address]) - 1;
+      const quoteTime = Number((await bridgePool.methods.deploymentTime().call()).toString()) - 1;
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
       await bridgeDepositBox.methods
         .deposit(
@@ -1019,7 +1014,6 @@ describe("Relayer.ts", function () {
         [l1Token.options.address],
         l1Relayer,
         whitelistedChainIds,
-        deployTimestamps,
         1 // Use small lookback window to test that the back up block search loop runs at least a few times before
         // finding the deposit.
       );
@@ -1191,7 +1185,6 @@ describe("Relayer.ts", function () {
         [l1Token.options.address],
         l1Relayer,
         [],
-        deployTimestamps,
         defaultLookbackWindow
       );
 

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -634,7 +634,7 @@ describe("Relayer.ts", function () {
     });
     it("Skips deposits with quote time < contract deployment time", async function () {
       // Deposit using quote time prior to deploy timestamp for this L1 token.
-      const quoteTime = Number((await bridgePool.methods.deploymentTime().call()).toString()) - 1;
+      const quoteTime = Number((await bridgePool.methods.deploymentTimestamp().call()).toString()) - 1;
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
       await bridgeDepositBox.methods
         .deposit(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This PR cannot be merged in until BridgePool contracts in production are updated with `master` and store `deploymentTime` in the contract state. This improves the relayer such that it can read `deploymentTime` from contract state instead of a hard coded mapping of deployment times.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
