### PR TITLE
improve(insured-bridge-relayer): Remove deploymentTimestamp hard-coded mapping in favor of web3.eth.getCode check

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -38,11 +38,6 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
     using FixedPoint for FixedPoint.Unsigned;
     using Address for address;
 
-    // Useful for clients to know if any quote times are for a time prior to the contract's deployment. These
-    // deposits will be impossible to compute realized LP fee % for since there will be no utilization at that quote
-    // time. Therefore, clients need to deal with this special case.
-    uint32 public deploymentTimestamp;
-
     // Token that this contract receives as LP deposits.
     IERC20 public override l1Token;
 
@@ -180,7 +175,6 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
         lastLpFeeUpdate = uint32(getCurrentTime());
         lpFeeRatePerSecond = _lpFeeRatePerSecond;
         isWethPool = _isWethPool;
-        deploymentTimestamp = lastLpFeeUpdate;
 
         syncUmaEcosystemParams(); // Fetch OptimisticOracle and Store addresses and L1Token finalFee.
         syncWithBridgeAdminParams(); // Fetch ProposerBondPct OptimisticOracleLiveness, Identifier from the BridgeAdmin.

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -256,10 +256,6 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
      *      quoteTimestamp. The OO acts to verify the correctness of this realized fee. Cannot exceed 50%.
      */
     function relayAndSpeedUp(DepositData memory depositData, uint64 realizedLpFeePct) public nonReentrant() {
-        // If deposit quote time is before this contract's deployment, then clients will not be able to compute
-        // a realized LP fee %, so we should block such relays.
-        require(depositData.quoteTimestamp >= deploymentTimestamp, "Deposit before deployment");
-
         // If no pending relay for this deposit, then associate the caller's relay attempt with it.
         uint32 priceRequestTime = uint32(getCurrentTime());
 
@@ -385,10 +381,6 @@ contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
      *      quoteTimestamp. The OO acts to verify the correctness of this realized fee. Cannot exceed 50%.
      */
     function relayDeposit(DepositData memory depositData, uint64 realizedLpFeePct) public nonReentrant() {
-        // If deposit quote time is before this contract's deployment, then clients will not be able to compute
-        // a realized LP fee %, so we should block such relays.
-        require(depositData.quoteTimestamp >= deploymentTimestamp, "Deposit before deployment");
-
         // The realizedLPFeePct should never be greater than 0.5e18 and the slow and instant relay fees should never be
         // more than 0.25e18 each. Therefore, the sum of all fee types can never exceed 1e18 (or 100%).
         require(

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -55,6 +55,7 @@ const lpFeeRatePerSecond = toWei("0.0000015");
 const defaultProposerBondPct = toWei("0.05");
 const defaultSlowRelayFeePct = toWei("0.01");
 const defaultInstantRelayFeePct = toWei("0.01");
+const defaultQuoteTimestamp = "100000"; // no validation of this happens on L1.
 const defaultRealizedLpFee = toWei("0.1");
 const finalFee = toWei("1");
 const initialPoolLiquidity = toWei("1000");
@@ -103,8 +104,6 @@ let defaultRelayData;
 let defaultDepositData;
 let defaultDepositHash;
 let defaultRelayAncillaryData;
-let deploymentTime;
-let defaultQuoteTimestamp; // Must be >= deployment time so we'll set dynamically
 
 describe("BridgePool", () => {
   let accounts,
@@ -284,10 +283,6 @@ describe("BridgePool", () => {
       false, // this is not a weth pool (contains normal ERC20)
       timer.options.address
     ).send({ from: owner });
-
-    // Store deployment time and set default quote timestamp equal to it so relays can be submitted.
-    deploymentTime = Number((await bridgePool.methods.deploymentTimestamp().call()).toString());
-    defaultQuoteTimestamp = deploymentTime;
 
     // The bridge pool has an embedded ERC20 to represent LP positions.
     lpToken = await ERC20.at(bridgePool.options.address);
@@ -475,23 +470,11 @@ describe("BridgePool", () => {
         )
       );
 
-      // Cannot relay using quote time < deployment time.
-      assert(
-        await didContractThrow(
-          bridgePool.methods
-            .relayDeposit(...generateRelayParams({ quoteTimestamp: deploymentTime - 1 }, {}))
-            .send({ from: relayer })
-        )
-      );
-
       assert.equal(await bridgePool.methods.numberOfRelays().call(), "0"); // Relay index should start at 0.
 
       // Deposit with no relay attempt should have correct state and empty relay hash.
       const relayStatus = await bridgePool.methods.relays(defaultDepositHash).call();
       assert.equal(relayStatus, defaultRelayHash);
-
-      // Can relay with default params
-      assert.ok(await bridgePool.methods.relayDeposit(...generateRelayParams()).call({ from: relayer }));
     });
     it("Relay checks", async () => {
       // Proposer approves pool to withdraw total bond.
@@ -558,7 +541,7 @@ describe("BridgePool", () => {
           ev.depositData.amount === defaultDepositData.amount &&
           ev.depositData.slowRelayFeePct === defaultDepositData.slowRelayFeePct &&
           ev.depositData.instantRelayFeePct === defaultDepositData.instantRelayFeePct &&
-          ev.depositData.quoteTimestamp === defaultDepositData.quoteTimestamp.toString() &&
+          ev.depositData.quoteTimestamp === defaultDepositData.quoteTimestamp &&
           ev.relay.slowRelayer === relayer &&
           ev.relay.relayId.toString() === relayAttemptData.relayId.toString() &&
           ev.relay.realizedLpFeePct === relayAttemptData.realizedLpFeePct &&

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -335,12 +335,6 @@ describe("BridgePool", () => {
       .call();
   });
   it("Constructor validation", async function () {
-    // deployment timestamp is set.
-    assert.equal(
-      (await bridgePool.methods.deploymentTimestamp().call()).toString(),
-      (await bridgePool.methods.getCurrentTime().call()).toString()
-    );
-
     // LP Token symbol and name cannot be empty.
     assert(
       await didContractThrow(

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -277,8 +277,7 @@ describe("InsuredBridgeL1Client", function () {
       amount: relayAmount,
       slowRelayFeePct: defaultSlowRelayFeePct,
       instantRelayFeePct: defaultInstantRelayFeePct,
-      // quote time must be <= deployment time of BridgePool for relayDeposit to succeed
-      quoteTimestamp: Number((await bridgePool.methods.deploymentTimestamp().call()).toString()),
+      quoteTimestamp: (await web3.eth.getBlock("latest")).timestamp, // set this to the current block timestamp.
     };
     relayData = {
       relayId: 0,
@@ -806,15 +805,9 @@ describe("InsuredBridgeL1Client", function () {
       // at the top, is for a relay of 10 units. This should increment the pool utilization from 0% to 10%. From the
       // jupiter notebook, this should be a rate of 0.000117987509354032.
 
-      // Save quote time that we'll look up realized LP fee % for. We don't want to use the default
-      // depositData.quoteTimestamp because we want to simulate production and look up blocks by block time instead
-      // of contract time, as set by a Timer that might not exist on the tested network.
-      const _quoteTimestamp = (await web3.eth.getBlock("latest")).timestamp;
       await client.update();
       assert.equal(
-        (
-          await client.calculateRealizedLpFeePctForDeposit({ ...depositData, quoteTimestamp: _quoteTimestamp })
-        ).toString(),
+        (await client.calculateRealizedLpFeePctForDeposit(depositData)).toString(),
         toWei("0.000117987509354032")
       );
 
@@ -830,13 +823,12 @@ describe("InsuredBridgeL1Client", function () {
       // timestamp. Check that this has not moved.
       await client.update();
       assert.equal(
-        (
-          await client.calculateRealizedLpFeePctForDeposit({ ...depositData, quoteTimestamp: _quoteTimestamp })
-        ).toString(),
+        (await client.calculateRealizedLpFeePctForDeposit(depositData)).toString(),
         toWei("0.000117987509354032")
       );
 
       // If we set the quoteTimestamp to the current block time then the realizedLPFee should increase.
+
       assert.equal(
         (
           await client.calculateRealizedLpFeePctForDeposit({

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -54,9 +54,6 @@ export class Relayer {
     readonly whitelistedRelayL1Tokens: string[],
     readonly account: string,
     readonly whitelistedChainIds: number[],
-    // TODO: Deprecate `deployTimestamps` once BridgePools are upgraded and we can read `deployTimestamp` on-chain. For
-    // now, we need to hardcode each BP's deploy timestamp.
-    readonly deployTimestamps: { [key: string]: number },
     readonly l2LookbackWindow: number
   ) {
     this.l2BlockFinder = new BlockFinder<BlockTransactionBase>(this.l2Client.l2Web3.eth.getBlock);
@@ -84,15 +81,21 @@ export class Relayer {
         message: `Processing ${relayableDeposits[l1Token].length} relayable deposits for L1Token`,
         l1Token,
       });
+      const bridgePoolAddress = this.l1Client.getBridgePoolForToken(l1Token).contract.options.address;
       for (const relayableDeposit of relayableDeposits[l1Token]) {
         // If deposit quote time is before the bridgepool's deployment time, then skip it before attempting to calculate
         // the realized LP fee % as this will be impossible to query a contract for a timestamp before its deployment.
-        if (relayableDeposit.deposit.quoteTimestamp < this.deployTimestamps[relayableDeposit.deposit.l1Token]) {
+        const depositBlockNumber = (
+          await this.l2BlockFinder.getBlockForTimestamp(relayableDeposit.deposit.quoteTimestamp)
+        ).number;
+        const hasContractData =
+          (await this.l1Client.l1Web3.eth.getCode(bridgePoolAddress, depositBlockNumber)) !== "0x";
+        if (!hasContractData) {
           this.logger.debug({
             at: "InsuredBridgeRelayer#Relayer",
-            message: "Deposit quote time < bridge pool deployment for L1 token, skipping",
+            message: "Deposit quote time before bridge pool deployment for L1 token, skipping",
             deposit: relayableDeposit.deposit,
-            deploymentTime: this.deployTimestamps[relayableDeposit.deposit.l1Token],
+            computedDepositBlockNumber: depositBlockNumber,
           });
           continue;
         }
@@ -253,12 +256,15 @@ export class Relayer {
 
       // If deposit quote time is before the bridgepool's deployment time, then dispute it by default because
       // we won't be able to determine otherwise if the realized LP fee % is valid.
-      if (deposit.quoteTimestamp < this.deployTimestamps[deposit.l1Token]) {
+      const bridgePoolAddress = this.l1Client.getBridgePoolForToken(deposit.l1Token).contract.options.address;
+      const depositBlockNumber = (await this.l2BlockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number;
+      const hasContractData = (await this.l1Client.l1Web3.eth.getCode(bridgePoolAddress, depositBlockNumber)) !== "0x";
+      if (!hasContractData) {
         this.logger.debug({
           at: "Disputer",
-          message: "Deposit quote time < bridge pool deployment for L1 token, disputing",
+          message: "Deposit quote time before bridge pool deployment for L1 token, disputing",
           deposit,
-          deploymentTime: this.deployTimestamps[deposit.l1Token],
+          computedDepositBlockNumber: depositBlockNumber,
         });
         await this.disputeRelay(deposit, relay);
         return;
@@ -794,16 +800,15 @@ export class Relayer {
     // First try to fetch deposit from the L2 client's default block search config. This should work in most cases.
     let deposit: Deposit | undefined = this.l2Client.getDepositByHash(relay.depositHash);
     if (deposit !== undefined) return deposit;
-    // We could not find a deposit using the L2 client's default block search config. Next, we'll modify the block
-    // search config bridge pool's deployment time. This allows us to capture any deposits that happened outside of
-    // the L2 client's default block search config.
+    // We could not find a deposit using the L2 client's default block search config. As a fallback, we'll modify the
+    // the block search config such that we can find the valid deposit if it exists. This fallback logic is expensive
+    // and results in a lot of web3 requests, but will find the deposit in the worst case.
+    // TODO: We could improve this search by only looking +/- 10 minutes within the quote time, as this is a constraint
+    // enforced by the BridgeDepositBox. The hard part is that determining the average time per L2 block is not trivial.
     else {
-      const bridgePoolDeploymentTime = (
-        await this.l2BlockFinder.getBlockForTimestamp(this.deployTimestamps[relay.l1Token])
-      ).number;
       let blockSearchConfig = {
-        fromBlock: bridgePoolDeploymentTime,
-        toBlock: bridgePoolDeploymentTime + this.l2LookbackWindow,
+        fromBlock: 0,
+        toBlock: this.l2LookbackWindow,
       };
       const latestBlock = Number((await this.l2Client.l2Web3.eth.getBlock("latest")).number);
 

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -16,22 +16,6 @@ const supportedChainIds = [
   421611, // arbitrum testnet
 ];
 
-// This struct is a hack right now but prevents an edge case bug where a deposit.quoteTime < bridgePool.deployment time.
-// The deposit.quoteTime is used to call bridgePool.liquidityUtilizationCurrent at a specific block height. This call
-// always reverts if the quote time is before the bridge pool's deployment time. This causes the disputer to error out
-// because it cannot validate a relay's realizedLpFeePct properly. We need to therefore know which deposit quote times
-// are off-limits and need to either be ignored or auto-disputed. This is a hack because ideally the bridgePool sets
-// a timestamp on construction. Then we can easily query on-chain whether a deposit.quoteTime is before this timestamp.
-const bridgePoolDeployTimestamps = {
-  // Note: keyed by L1 token.
-  // WETH:
-  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": 1635305400,
-  // USDC:
-  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": 1635312600,
-  // UMA:
-  "0x04fa0d235c4abf4bcf4787af4cf447de572ef828": 1635312600,
-};
-
 export interface ProcessEnv {
   [key: string]: string | undefined;
 }
@@ -54,7 +38,6 @@ export class RelayerConfig {
   readonly activatedChainIds: number[];
   readonly l2BlockLookback: number;
   readonly botModes: BotModes;
-  readonly deployTimestamps: { [key: string]: number };
 
   constructor(env: ProcessEnv) {
     const {
@@ -69,7 +52,6 @@ export class RelayerConfig {
       FINALIZER_ENABLED,
       DISPUTER_ENABLED,
       WHITELISTED_CHAIN_IDS,
-      DEPLOY_TIMESTAMPS,
     } = env;
 
     this.botModes = {
@@ -89,8 +71,6 @@ export class RelayerConfig {
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;
     this.errorRetriesTimeout = ERROR_RETRIES_TIMEOUT ? Number(ERROR_RETRIES_TIMEOUT) : 1;
-
-    this.deployTimestamps = DEPLOY_TIMESTAMPS ? JSON.parse(DEPLOY_TIMESTAMPS) : bridgePoolDeployTimestamps;
 
     assert(RATE_MODELS, "RATE_MODELS required");
     const processingRateModels = JSON.parse(RATE_MODELS);

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -80,7 +80,6 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
       config.whitelistedRelayL1Tokens,
       accounts[0],
       config.whitelistedChainIds,
-      config.deployTimestamps,
       config.l2BlockLookback
     );
 

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -241,7 +241,7 @@ describe("Relayer.ts", function () {
         amount: depositAmount,
         slowRelayFeePct: defaultSlowRelayFeePct,
         instantRelayFeePct: defaultInstantRelayFeePct,
-        quoteTimestamp: Number((await bridgePool.methods.getCurrentTime().call()).toString()),
+        quoteTimestamp: 1,
         depositContract: bridgeDepositBox.options.address,
       };
 
@@ -655,6 +655,29 @@ describe("Relayer.ts", function () {
       await Promise.all([l1Client.update(), l2Client.update()]);
       await l1Token.methods.mint(l1Relayer, toBN(depositAmount).muln(2)).send({ from: l1Owner });
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Relayer });
+      await relayer.checkForPendingDepositsAndRelay();
+      assert.isTrue(lastSpyLogIncludes(spy, "Deposit quote time < bridge pool deployment"));
+
+      // Relay the deposit from another slow relayer, and check that the bot skips any attempt to speed up the relay
+      // since it cannot verify its realized LP fee %.
+      await l1Token.methods.mint(l1Owner, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await bridgePool.methods
+        .relayDeposit(
+          {
+            chainId: chainId,
+            depositId: "0",
+            l2Sender: l2Depositor,
+            l1Recipient: l2Depositor,
+            amount: depositAmount,
+            slowRelayFeePct: defaultSlowRelayFeePct,
+            instantRelayFeePct: defaultInstantRelayFeePct,
+            quoteTimestamp: quoteTime,
+          },
+          calculateRealizedLpFeePct(rateModel, toBNWei("0"), toBNWei("0.01")) // compute the expected fee for 1% utilization
+        )
+        .send({ from: l1Owner });
+      await Promise.all([l1Client.update(), l2Client.update()]);
       await relayer.checkForPendingDepositsAndRelay();
       assert.isTrue(lastSpyLogIncludes(spy, "Deposit quote time < bridge pool deployment"));
     });
@@ -1271,6 +1294,49 @@ describe("Relayer.ts", function () {
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Relayer });
       await _relayer.checkForPendingRelaysAndDispute();
       assert.isTrue(lastSpyLogIncludes(spy, "Disputed pending relay"));
+    });
+    it("Disputes relays that bot cannot compute realized LP fee % for", async function () {
+      // Deposit using quote time prior to deploy timestamp for this L1 token.
+      const quoteTime = Number(deployTimestamps[l1Token.options.address]) - 1;
+      await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
+      await bridgeDepositBox.methods
+        .deposit(
+          l2Depositor,
+          l2Token.options.address,
+          depositAmount,
+          defaultSlowRelayFeePct,
+          defaultInstantRelayFeePct,
+          quoteTime.toString()
+        )
+        .send({ from: l2Depositor });
+
+      // Relay the deposit from another slow relayer, and check that the bot disputes the relay
+      // since its quote time < deploy timestamp for the pool.
+      await l1Token.methods.mint(l1Owner, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await bridgePool.methods
+        .relayDeposit(
+          {
+            chainId: chainId,
+            depositId: "0",
+            l2Sender: l2Depositor,
+            l1Recipient: l2Depositor,
+            amount: depositAmount,
+            slowRelayFeePct: defaultSlowRelayFeePct,
+            instantRelayFeePct: defaultInstantRelayFeePct,
+            quoteTimestamp: quoteTime,
+          },
+          calculateRealizedLpFeePct(rateModel, toBNWei("0"), toBNWei("0.01")) // compute the expected fee for 1% utilization
+        )
+        .send({ from: l1Owner });
+      await Promise.all([l1Client.update(), l2Client.update()]);
+      await l1Token.methods.mint(l1Relayer, toBN(depositAmount).muln(2)).send({ from: l1Owner });
+      await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Relayer });
+      await relayer.checkForPendingRelaysAndDispute();
+      const targetLog = spy.getCalls().filter((_log: any) => {
+        return _log.lastArg.message.includes("Deposit quote time < bridge pool deployment");
+      });
+      assert.equal(targetLog.length, 1);
     });
   });
 });

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -90,8 +90,6 @@ describe("Relayer.ts", function () {
   let l2Client: any;
   let gasEstimator: any;
 
-  let deployTimestamps: any;
-
   before(async function () {
     l1Accounts = await web3.eth.getAccounts();
     [l1Owner, l1Relayer, l1LiquidityProvider, l2Owner, l2Depositor, l2BridgeAdminImpersonator] = l1Accounts;
@@ -192,8 +190,6 @@ describe("Relayer.ts", function () {
       )
       .send({ from: l1Owner });
 
-    deployTimestamps = { [l1Token.options.address]: (await l1Timer.methods.getCurrentTime().call()).toString() };
-
     await bridgeDepositBox.methods
       .whitelistToken(l1Token.options.address, l2Token.options.address, bridgePool.options.address)
       .send({ from: l2BridgeAdminImpersonator });
@@ -218,7 +214,6 @@ describe("Relayer.ts", function () {
       [l1Token.options.address],
       l1Relayer,
       whitelistedChainIds,
-      deployTimestamps,
       defaultLookbackWindow
     );
   });
@@ -639,7 +634,7 @@ describe("Relayer.ts", function () {
     });
     it("Skips deposits with quote time < contract deployment time", async function () {
       // Deposit using quote time prior to deploy timestamp for this L1 token.
-      const quoteTime = Number(deployTimestamps[l1Token.options.address]) - 1;
+      const quoteTime = Number((await bridgePool.methods.getCurrentTime().call()).toString()) - 1;
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
       await bridgeDepositBox.methods
         .deposit(
@@ -656,7 +651,7 @@ describe("Relayer.ts", function () {
       await l1Token.methods.mint(l1Relayer, toBN(depositAmount).muln(2)).send({ from: l1Owner });
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Relayer });
       await relayer.checkForPendingDepositsAndRelay();
-      assert.isTrue(lastSpyLogIncludes(spy, "Deposit quote time < bridge pool deployment"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Deposit quote time before bridge pool deployment"));
 
       // Relay the deposit from another slow relayer, and check that the bot skips any attempt to speed up the relay
       // since it cannot verify its realized LP fee %.
@@ -679,7 +674,7 @@ describe("Relayer.ts", function () {
         .send({ from: l1Owner });
       await Promise.all([l1Client.update(), l2Client.update()]);
       await relayer.checkForPendingDepositsAndRelay();
-      assert.isTrue(lastSpyLogIncludes(spy, "Deposit quote time < bridge pool deployment"));
+      assert.isTrue(lastSpyLogIncludes(spy, "Deposit quote time before bridge pool deployment"));
     });
   });
   describe("Settle Relay transaction functionality", () => {
@@ -1042,7 +1037,6 @@ describe("Relayer.ts", function () {
         [l1Token.options.address],
         l1Relayer,
         whitelistedChainIds,
-        deployTimestamps,
         1 // Use small lookback window to test that the back up block search loop runs at least a few times before
         // finding the deposit.
       );
@@ -1214,7 +1208,6 @@ describe("Relayer.ts", function () {
         [l1Token.options.address],
         l1Relayer,
         [],
-        deployTimestamps,
         defaultLookbackWindow
       );
 
@@ -1297,7 +1290,7 @@ describe("Relayer.ts", function () {
     });
     it("Disputes relays that bot cannot compute realized LP fee % for", async function () {
       // Deposit using quote time prior to deploy timestamp for this L1 token.
-      const quoteTime = Number(deployTimestamps[l1Token.options.address]) - 1;
+      const quoteTime = Number((await bridgePool.methods.getCurrentTime().call()).toString()) - 1;
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
       await bridgeDepositBox.methods
         .deposit(
@@ -1334,7 +1327,7 @@ describe("Relayer.ts", function () {
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(2)).send({ from: l1Relayer });
       await relayer.checkForPendingRelaysAndDispute();
       const targetLog = spy.getCalls().filter((_log: any) => {
-        return _log.lastArg.message.includes("Deposit quote time < bridge pool deployment");
+        return _log.lastArg.message.includes("Deposit quote time before bridge pool deployment");
       });
       assert.equal(targetLog.length, 1);
     });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

@mrice32 made a great point that there's a much easier way to check if a deposit.quoteTime is before a contract's deployment time without having to store a hardcoded mapping of contract deployment timestamps. The solution is to check the result of `web3.eth.getCode(bridgePoolAddress, blockForDepositQuoteTime)` and if it returns `0x` then the contract did not exist and we can act accordingly.

This PR therefore reverts #3516 in favor of simplifying the relayer logic to use `web3.eth.getCode` instead of the hardcoded `deploymentTimestamp`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
