### PR TITLE
feat(insured-bridge): add back safe multicaller

### DIFF
--- a/packages/core/contracts/common/implementation/MultiCaller.sol
+++ b/packages/core/contracts/common/implementation/MultiCaller.sol
@@ -1,11 +1,13 @@
 // This contract is taken from Uniswaps's multi call implementation (https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol)
-// and was modified to be solidity 0.8 compatible. No other changes were made.
+// and was modified to be solidity 0.8 compatible. Additionally, the method was restricted to only work with msg.value
+// set to 0 to avoid any nasty attack vectors on function calls that use value sent with deposits.
 pragma solidity ^0.8.0;
 
 /// @title MultiCaller
 /// @notice Enables calling multiple methods in a single call to the contract
 contract MultiCaller {
     function multicall(bytes[] calldata data) external payable returns (bytes[] memory results) {
+        require(msg.value == 0, "Only multicall with 0 value");
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -13,6 +13,7 @@ import "../common/implementation/AncillaryData.sol";
 import "../common/implementation/Testable.sol";
 import "../common/implementation/FixedPoint.sol";
 import "../common/implementation/Lockable.sol";
+import "../common/implementation/MultiCaller.sol";
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -33,7 +34,7 @@ interface WETH9Like {
  * to post collateral by earning a fee per fulfilled deposit order.
  * @dev A "Deposit" is an order to send capital from L2 to L1, and a "Relay" is a fulfillment attempt of that order.
  */
-contract BridgePool is Testable, BridgePoolInterface, ERC20, Lockable {
+contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockable {
     using SafeERC20 for IERC20;
     using FixedPoint for FixedPoint.Unsigned;
     using Address for address;


### PR DESCRIPTION
**Motivation**

To enable more scalable off-chain infrastructure, it would be useful to be able to send batches of transactions. We can do this easily with multicall. However, multicall runs a risk of being used along side `msg.value`. to deal with this, we simply can prevent multicall usage with any transaction with `msg.value`.

**Summary**

Adds back multicall with a block on any tx with `msg.value`.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
