### PR TITLE
feat(core): add new deployment addresses for across and update script

### DIFF
--- a/packages/common/src/HardhatConfig.ts
+++ b/packages/common/src/HardhatConfig.ts
@@ -73,6 +73,7 @@ export function getHardhatConfig(
       rinkeby: { chainId: 4, url: getNodeUrl("rinkeby", true), accounts: { mnemonic } },
       goerli: { chainId: 5, url: getNodeUrl("goerli", true), accounts: { mnemonic } },
       kovan: { chainId: 42, url: getNodeUrl("kovan", true), accounts: { mnemonic } },
+      arbitrum: { chainId: 42161, url: getNodeUrl("arbitrum", true), accounts: { mnemonic } },
       "arbitrum-rinkeby": { chainId: 421611, url: getNodeUrl("arbitrum-rinkeby", true), accounts: { mnemonic } },
       optimism: {
         chainId: 10,
@@ -81,7 +82,6 @@ export function getHardhatConfig(
         gasPrice: 15000000,
         compileWhitelist: optimismCompileWhitelist,
       },
-      matic: { chainId: 137, url: getNodeUrl("polygon-matic", true), accounts: { mnemonic } },
       "optimism-kovan": {
         ovm: true,
         chainId: 69,
@@ -90,7 +90,6 @@ export function getHardhatConfig(
         gasPrice: 15000000,
         compileWhitelist: optimismCompileWhitelist,
       },
-      mumbai: { chainId: 80001, url: getNodeUrl("polygon-mumbai", true), accounts: { mnemonic } },
       "optimism-test": {
         ovm: true,
         url: "http://127.0.0.1:8545",
@@ -104,6 +103,8 @@ export function getHardhatConfig(
         testWhitelist: ["oracle/Finder"],
         testBlacklist,
       },
+      matic: { chainId: 137, url: getNodeUrl("polygon-matic", true), accounts: { mnemonic } },
+      mumbai: { chainId: 80001, url: getNodeUrl("polygon-mumbai", true), accounts: { mnemonic } },
     },
     mocha: { timeout: 1800000 },
     etherscan: {

--- a/packages/common/src/PublicNetworks.ts
+++ b/packages/common/src/PublicNetworks.ts
@@ -70,6 +70,10 @@ export const PublicNetworks: PublicNetworksType = {
     etherscan: "https://mumbai.polygonscan.com/",
     customTruffleConfig: { confirmations: 2, timeoutBlocks: 200 },
   },
+  42161: {
+    name: "arbitrum",
+    etherscan: "https://arbiscan.io/",
+  },
   421611: {
     name: "arbitrum-rinkeby",
     etherscan: "https://testnet.arbiscan.io/",

--- a/packages/common/src/hardhat/tasks/acrossPool.ts
+++ b/packages/common/src/hardhat/tasks/acrossPool.ts
@@ -26,13 +26,13 @@ task("deploy-across-pool", "Deploys an L1 across pool and whitelists it within t
       bridgeAdmin.options.address, // _bridgeAdmin
       l1tokenaddress, // _l1Token
       lpfeeratepersecond, // _lpFeeRatePerSecond
-      Boolean(iswethpool), // _isWethPool
+      Boolean(JSON.parse(iswethpool)), // _isWethPool
       ZERO_ADDRESS, // _timer
     ];
 
     console.log(`Deploying bridgePool from ${deployer}`, args);
 
-    const bridgePool = await deploy("BridgePool", { from: deployer, args, log: true });
+    const bridgePool = await deploy("BridgePoolProd", { from: deployer, args, log: true });
 
     console.log("Bridge pool deployed @ ", bridgePool.address);
   });

--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -118,5 +118,13 @@
   {
     "contractName": "SuccessTokenLongShortPairFinancialProductLibrary",
     "address": "0x67DE29D1A34FF2ea2b8C390B326456F4CBBE628F"
+  },
+  {
+    "contractName": "Arbitrum_Messenger",
+    "address": "0x0d8563d3b8b3fec542aae50a530c606dac4d1c4f"
+  },
+  {
+    "contractName": "BridgeAdmin",
+    "address": "0x30B44C676A05F1264d1dE9cC31dB5F2A945186b6"
   }
 ]

--- a/packages/core/networks/42161.json
+++ b/packages/core/networks/42161.json
@@ -1,0 +1,6 @@
+[
+  {
+    "contractName": "AVM_BridgeDepositBox",
+    "address": "0xd8c6dd978a3768f7ddfe3a9aad2c3fd75fa9b6fd"
+  }
+]


### PR DESCRIPTION
**Motivation**

Small PR to uddate deployment addresses to latest mainnet and arbitrum deployments. Also contains a fix to the across pool script to address wethpool bool.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested