### PR TITLE
fix(sdk): fix next startblock for pooleventstate

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.e2e.ts
+++ b/packages/sdk/src/across/clients/bridgePool.e2e.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
-import { Client, Provider } from "./bridgePool";
+import { Client, Provider, PoolEventState } from "./bridgePool";
+import { bridgePool } from "../../clients";
 import { ethers } from "ethers";
 import assert from "assert";
 import set from "lodash/set";
@@ -14,6 +15,20 @@ const users = [
   "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
   "0x718648C8c531F91b528A7757dD2bE813c3940608",
 ];
+describe("PoolEventState", function () {
+  let provider: Provider;
+  let client: PoolEventState;
+  beforeAll(async () => {
+    provider = ethers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+    const instance = bridgePool.connect(wethAddress, provider);
+    client = new PoolEventState(instance, 13496023);
+  });
+  test("read events", async function () {
+    let result = await client.read(13496024);
+    result = await client.read(13496025);
+    assert.ok(result);
+  });
+});
 describe("Client", function () {
   const state = {};
   let provider: Provider;

--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -96,7 +96,7 @@ class PoolState {
   }
 }
 
-class PoolEventState {
+export class PoolEventState {
   constructor(
     private contract: bridgePool.Instance,
     private startBlock = 0,
@@ -115,7 +115,8 @@ class PoolEventState {
       if (a.logIndex < b.logIndex) return -1;
       return 1;
     });
-    this.startBlock = endBlock;
+    // ethers queries are inclusive [start,end] unless start === end, then exclusive (start,end). we increment to make sure we dont see same event twice
+    this.startBlock = endBlock + 1;
     this.state = bridgePool.getEventState(events, this.state);
     return this.state;
   }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2919/sdk-across-pooleventstate-can-sometimes-query-the-same-event-more-than-once

**Summary**

When querying events, this class stores the last endBlock as the new startBlock for the next event query. The problem is that events returned are inclusive for start/end blocks. It may lead to duplicate events being returned. So this simply increements the next startBlock to be endblock+ 1.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2919/sdk-across-pooleventstate-can-sometimes-query-the-same-event-more-than-once
