### PR TITLE
feat(api): add ability to pull in Polygon contracts

### DIFF
--- a/packages/api/src/apps/api/README.md
+++ b/packages/api/src/apps/api/README.md
@@ -45,6 +45,9 @@ lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D09
 
 # Overwrite the default Emp Registry Contract address
 EMP_REGISTRY_ADDRESS=0x...
+
+# optional parameter for defining a custom chain id (1: mainnet, 137: polygon, ...)
+NETWORK_CHAIN_ID=1
 ```
 
 ## Starting

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -140,7 +140,7 @@ export default async (env: ProcessEnv) => {
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("empRegistry", event, data)
     ),
-    collateralPrices: Services.CollateralPrices({ debug }, { tables: appState, appClients }),
+    collateralPrices: Services.CollateralPrices({ debug, network: networkChainId }, { tables: appState, appClients }),
     syntheticPrices: Services.SyntheticPrices(
       {
         debug,

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -51,7 +51,7 @@ export default async (env: ProcessEnv) => {
 
   // services can emit events when necessary, though for now any services that depend on events must be in same process
   const serviceEvents = new Events();
-  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : undefined;
+  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : (await provider.getNetwork()).chainId;
   // state shared between services
   const appState: AppState = {
     emps: {

--- a/packages/api/src/apps/api/app.ts
+++ b/packages/api/src/apps/api/app.ts
@@ -51,7 +51,7 @@ export default async (env: ProcessEnv) => {
 
   // services can emit events when necessary, though for now any services that depend on events must be in same process
   const serviceEvents = new Events();
-
+  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : undefined;
   // state shared between services
   const appState: AppState = {
     emps: {
@@ -136,7 +136,7 @@ export default async (env: ProcessEnv) => {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, { tables: appState, appClients }),
     registry: await Services.Registry(
-      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS },
+      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS, network: networkChainId },
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("empRegistry", event, data)
     ),
@@ -156,7 +156,7 @@ export default async (env: ProcessEnv) => {
     empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, { tables: appState, appClients }),
     lspCreator: await Services.MultiLspCreator(
-      { debug, addresses: lspCreatorAddresses },
+      { debug, addresses: lspCreatorAddresses, network: networkChainId },
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("multiLspCreator", event, data)
     ),

--- a/packages/api/src/apps/datastore_api/app.ts
+++ b/packages/api/src/apps/datastore_api/app.ts
@@ -56,6 +56,7 @@ export default async (env: ProcessEnv) => {
 
   const datastoreClient = new Datastore();
   const datastores = StoresFactory(datastoreClient);
+  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : (await provider.getNetwork()).chainId;
   // state shared between services
   const appState: AppState = {
     emps: {
@@ -140,7 +141,7 @@ export default async (env: ProcessEnv) => {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, { tables: appState, appClients }),
     registry: await Services.Registry(
-      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS },
+      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS, network: networkChainId },
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("empRegistry", event, data)
     ),
@@ -160,7 +161,7 @@ export default async (env: ProcessEnv) => {
     empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, { tables: appState, appClients }),
     lspCreator: await Services.MultiLspCreator(
-      { debug, addresses: lspCreatorAddresses },
+      { debug, addresses: lspCreatorAddresses, network: networkChainId },
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("multiLspCreator", event, data)
     ),

--- a/packages/api/src/apps/datastore_api/app.ts
+++ b/packages/api/src/apps/datastore_api/app.ts
@@ -145,7 +145,7 @@ export default async (env: ProcessEnv) => {
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("empRegistry", event, data)
     ),
-    collateralPrices: Services.CollateralPrices({ debug }, { tables: appState, appClients }),
+    collateralPrices: Services.CollateralPrices({ debug, network: networkChainId }, { tables: appState, appClients }),
     syntheticPrices: Services.SyntheticPrices(
       {
         debug,

--- a/packages/api/src/apps/lsp_api/app.ts
+++ b/packages/api/src/apps/lsp_api/app.ts
@@ -142,7 +142,7 @@ export default async (env: ProcessEnv) => {
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("empRegistry", event, data)
     ),
-    collateralPrices: Services.CollateralPrices({ debug }, { tables: appState, appClients }),
+    collateralPrices: Services.CollateralPrices({ debug, network: networkChainId }, { tables: appState, appClients }),
     erc20s: Services.Erc20s({ debug }, { tables: appState, appClients }),
     empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, { tables: appState, appClients }),

--- a/packages/api/src/apps/lsp_api/app.ts
+++ b/packages/api/src/apps/lsp_api/app.ts
@@ -52,7 +52,7 @@ export default async (env: ProcessEnv) => {
 
   // services can emit events when necessary, though for now any services that depend on events must be in same process
   const serviceEvents = new Events();
-
+  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : (await provider.getNetwork()).chainId;
   // state shared between services
   const appState: AppState = {
     emps: {
@@ -138,7 +138,7 @@ export default async (env: ProcessEnv) => {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, { tables: appState, appClients }),
     registry: await Services.Registry(
-      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS },
+      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS, network: networkChainId },
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("empRegistry", event, data)
     ),
@@ -147,7 +147,7 @@ export default async (env: ProcessEnv) => {
     empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, { tables: appState, appClients }),
     lspCreator: await Services.MultiLspCreator(
-      { debug, addresses: lspCreatorAddresses },
+      { debug, addresses: lspCreatorAddresses, network: networkChainId },
       { tables: appState, appClients },
       (event, data) => serviceEvents.emit("multiLspCreator", event, data)
     ),

--- a/packages/api/src/apps/serverless_write/README.md
+++ b/packages/api/src/apps/serverless_write/README.md
@@ -35,6 +35,9 @@ lspCreatorAddresses=0x0b8de441B26E36f461b2748919ed71f50593A67b,0x60F3f5DDE708D09
 
 # Overwrite the default Emp Registry Contract address
 EMP_REGISTRY_ADDRESS=0x...
+
+# optional parameter for defining a custom chain id (1: mainnet, 137: polygon, ...)
+NETWORK_CHAIN_ID=1
 ```
 
 ## Build

--- a/packages/api/src/apps/serverless_write/app.ts
+++ b/packages/api/src/apps/serverless_write/app.ts
@@ -37,6 +37,12 @@ export default async (env: ProcessEnv) => {
   const datastoreClient = new Datastore();
   const datastores = StoresFactory(datastoreClient);
   const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : undefined;
+  const detectContractsBatchSize = env.DETECT_CONTRACTS_BATCH_SIZE
+    ? parseInt(env.DETECT_CONTRACTS_BATCH_SIZE)
+    : undefined;
+  const updateContractsBatchSize = env.UPDATE_CONTRACTS_BATCH_SIZE
+    ? parseInt(env.UPDATE_CONTRACTS_BATCH_SIZE)
+    : undefined;
   // state shared between services
   const appState: AppState = {
     emps: {
@@ -150,7 +156,10 @@ export default async (env: ProcessEnv) => {
 
   // Orchestrator services are services that coordinate and aggregate other services
   const orchestratorServices: OrchestratorServices = {
-    contracts: Services.Contracts({ debug }, { tables: appState, profile, appClients, services }),
+    contracts: Services.Contracts(
+      { debug, detectContractsBatchSize, updateContractsBatchSize },
+      { tables: appState, profile, appClients, services }
+    ),
     prices: Services.Prices(
       { backfillDays: parseInt(env.backfillDays || "") },
       { services, tables: appState, appClients, profile }

--- a/packages/api/src/apps/serverless_write/app.ts
+++ b/packages/api/src/apps/serverless_write/app.ts
@@ -31,7 +31,7 @@ export default async (env: ProcessEnv) => {
   // debug flag for more verbose logs
   const debug = Boolean(env.debug);
   const profile = Profile(debug);
-  const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL);
+  const provider = new ethers.providers.JsonRpcProvider(env.CUSTOM_NODE_URL);
   // we need web3 for syth price feeds
   const web3 = getWeb3(env.CUSTOM_NODE_URL);
   const datastoreClient = new Datastore();

--- a/packages/api/src/apps/serverless_write/app.ts
+++ b/packages/api/src/apps/serverless_write/app.ts
@@ -130,7 +130,7 @@ export default async (env: ProcessEnv) => {
       { debug, registryAddress: env.EMP_REGISTRY_ADDRESS, network: networkChainId },
       { tables: appState, appClients }
     ),
-    collateralPrices: Services.CollateralPrices({ debug }, { tables: appState, appClients }),
+    collateralPrices: Services.CollateralPrices({ debug, network: networkChainId }, { tables: appState, appClients }),
     syntheticPrices: Services.SyntheticPrices(
       {
         debug,

--- a/packages/api/src/apps/serverless_write/app.ts
+++ b/packages/api/src/apps/serverless_write/app.ts
@@ -36,7 +36,7 @@ export default async (env: ProcessEnv) => {
   const web3 = getWeb3(env.CUSTOM_NODE_URL);
   const datastoreClient = new Datastore();
   const datastores = StoresFactory(datastoreClient);
-  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : undefined;
+  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : (await provider.getNetwork()).chainId;
   const detectContractsBatchSize = env.DETECT_CONTRACTS_BATCH_SIZE
     ? parseInt(env.DETECT_CONTRACTS_BATCH_SIZE)
     : undefined;

--- a/packages/api/src/apps/serverless_write/app.ts
+++ b/packages/api/src/apps/serverless_write/app.ts
@@ -36,6 +36,7 @@ export default async (env: ProcessEnv) => {
   const web3 = getWeb3(env.CUSTOM_NODE_URL);
   const datastoreClient = new Datastore();
   const datastores = StoresFactory(datastoreClient);
+  const networkChainId = env.NETWORK_CHAIN_ID ? parseInt(env.NETWORK_CHAIN_ID) : undefined;
   // state shared between services
   const appState: AppState = {
     emps: {
@@ -120,7 +121,7 @@ export default async (env: ProcessEnv) => {
     // these services can optionally be configured with a config object, but currently they are undefined or have defaults
     emps: Services.EmpState({ debug }, { tables: appState, appClients }),
     registry: await Services.Registry(
-      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS },
+      { debug, registryAddress: env.EMP_REGISTRY_ADDRESS, network: networkChainId },
       { tables: appState, appClients }
     ),
     collateralPrices: Services.CollateralPrices({ debug }, { tables: appState, appClients }),
@@ -139,7 +140,7 @@ export default async (env: ProcessEnv) => {
     empStats: Services.stats.Emp({ debug }, appState),
     marketPrices: Services.MarketPrices({ debug }, { tables: appState, appClients }),
     lspCreator: await Services.MultiLspCreator(
-      { debug, addresses: lspCreatorAddresses },
+      { debug, addresses: lspCreatorAddresses, network: networkChainId },
       { tables: appState, appClients }
     ),
     lsps: Services.LspState({ debug }, { tables: appState, appClients }),

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -240,3 +240,25 @@ export async function expirePromise(promise: () => Promise<any>, timeoutms: numb
   const [rejectPromise, cancel] = rejectAfterDelay(timeoutms, errorMessage);
   return Promise.race([promise(), rejectPromise]).finally(cancel);
 }
+
+/**
+ * Takes two values and returns a list of number intervals
+ *
+ * @example
+ * ```js
+ * getSamplesBetween(1, 10, 3) //returns [[1, 4], [5, 8], [9, 10]]
+ * ```
+ */
+export function getSamplesBetween(min: number, max: number, size: number) {
+  let keepIterate = true;
+  const intervals = [];
+
+  while (keepIterate) {
+    const to = Math.min(min + size, max);
+    intervals.push([min, to]);
+    min = to + 1;
+    if (min >= max) keepIterate = false;
+  }
+
+  return intervals;
+}

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -194,9 +194,15 @@ export function getWeb3Websocket(url: string, options: Obj = {}) {
   );
 }
 
+export function getWeb3Http(url: string) {
+  return new Web3(new Web3.providers.HttpProvider(url));
+}
+
 export function getWeb3(url: string, options: Obj = {}) {
   if (url.startsWith("ws")) return getWeb3Websocket(url, options);
-  throw new Error("Only supporting websocket provider URLs for Web3");
+  if (url.startsWith("http")) return getWeb3Http(url);
+
+  throw new Error("Web3 provider URLs not supported");
 }
 
 // this just maintains the start/endblock given sporadic updates with a latest block number

--- a/packages/api/src/services/collateral-prices.ts
+++ b/packages/api/src/services/collateral-prices.ts
@@ -3,6 +3,7 @@ import bluebird from "bluebird";
 import assert from "assert";
 import { AppState, CurrencySymbol, BaseConfig, AppClients } from "../types";
 interface Config extends BaseConfig {
+  network: number;
   currency?: CurrencySymbol;
 }
 import { parseUnits, msToS } from "../libs/utils";
@@ -66,7 +67,11 @@ export function CollateralPrices(config: Config, dependencies: Dependencies) {
   }
 
   async function updateLatestPrices(addresses: string[]) {
-    const prices = await coingecko.getContractPrices(addresses, currency);
+    const platforms = (await coingecko.getPlatforms()).filter(
+      (platform) => platform.chain_identifier === config.network
+    );
+    if (platforms.length === 0) throw new Error("Platform not found on CoinGecko");
+    const prices = await coingecko.getContractPrices(addresses, currency, platforms[0].id);
     return prices.map(updateLatestPrice);
   }
 

--- a/packages/api/src/services/emp-registry.ts
+++ b/packages/api/src/services/emp-registry.ts
@@ -6,7 +6,7 @@ import { AppClients, AppState, BaseConfig } from "../types";
 const { registry } = clients;
 
 interface Config extends BaseConfig {
-  network?: number;
+  network: number;
   registryAddress?: string;
 }
 
@@ -30,7 +30,7 @@ export const Registry = async (
     return;
   }
 ) => {
-  const { network = 1, registryAddress } = config;
+  const { network, registryAddress } = config;
   const { appClients, tables } = dependencies;
   const { registeredEmps } = tables;
   const { provider } = appClients;

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -6,7 +6,7 @@ import { AppClients, AppState, BaseConfig } from "../types";
 
 type Instance = uma.clients.emp.Instance;
 type Config = BaseConfig & {
-  updateEmpsConcurrency: number;
+  updateEmpsConcurrency?: number;
 };
 type Dependencies = {
   tables: Pick<AppState, "registeredEmps" | "emps" | "collateralAddresses" | "syntheticAddresses">;

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -143,16 +143,20 @@ export const EmpState = (config: Config, dependencies: Dependencies) => {
   }
 
   async function updateAll(addresses: string[], startBlock?: number, endBlock?: number) {
-    await Promise.mapSeries(addresses, async (address: string) => {
-      const end = profile(`Update Emp state for ${address}`);
-      try {
-        return await updateOne(address, startBlock, endBlock);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        end();
-      }
-    });
+    await Promise.map(
+      addresses,
+      async (address: string) => {
+        const end = profile(`Update Emp state for ${address}`);
+        try {
+          return await updateOne(address, startBlock, endBlock);
+        } catch (err) {
+          console.error(err);
+        } finally {
+          end();
+        }
+      },
+      { concurrency: 10 }
+    );
   }
 
   async function update(startBlock?: number, endBlock?: number) {

--- a/packages/api/src/services/emp-state.ts
+++ b/packages/api/src/services/emp-state.ts
@@ -5,7 +5,9 @@ import { BatchReadWithErrors, nowS, parseBytes, Profile, toNumber, toString } fr
 import { AppClients, AppState, BaseConfig } from "../types";
 
 type Instance = uma.clients.emp.Instance;
-type Config = BaseConfig;
+type Config = BaseConfig & {
+  updateEmpsConcurrency: number;
+};
 type Dependencies = {
   tables: Pick<AppState, "registeredEmps" | "emps" | "collateralAddresses" | "syntheticAddresses">;
   appClients: AppClients;
@@ -143,6 +145,7 @@ export const EmpState = (config: Config, dependencies: Dependencies) => {
   }
 
   async function updateAll(addresses: string[], startBlock?: number, endBlock?: number) {
+    const { updateEmpsConcurrency = 10 } = config;
     await Promise.map(
       addresses,
       async (address: string) => {
@@ -155,7 +158,7 @@ export const EmpState = (config: Config, dependencies: Dependencies) => {
           end();
         }
       },
-      { concurrency: 10 }
+      { concurrency: updateEmpsConcurrency }
     );
   }
 

--- a/packages/api/src/services/lsp-creator.ts
+++ b/packages/api/src/services/lsp-creator.ts
@@ -6,7 +6,7 @@ import { AppClients, AppState, BaseConfig } from "../types";
 const { lspCreator } = clients;
 
 interface Config extends BaseConfig {
-  network?: number;
+  network: number;
   address?: string;
 }
 type Dependencies = {
@@ -28,7 +28,7 @@ export const LspCreator = async (
   dependencies: Dependencies,
   emit: (event: Events, data: EmitData) => void
 ) => {
-  const { network = 1, address = await lspCreator.getAddress(network) } = config;
+  const { network, address = await lspCreator.getAddress(network) } = config;
   const { appClients, tables } = dependencies;
   const { registeredLsps } = tables;
   const { provider } = appClients;

--- a/packages/api/src/services/multi-lsp-creator.ts
+++ b/packages/api/src/services/multi-lsp-creator.ts
@@ -7,7 +7,7 @@ const { lspCreator } = clients;
 
 interface Config extends BaseConfig {
   addresses?: string[];
-  network?: number;
+  network: number;
   debug?: boolean;
 }
 type Dependencies = {
@@ -25,7 +25,7 @@ export default async (
     return;
   }
 ) => {
-  const { addresses = [], network = 1 } = config;
+  const { addresses = [], network } = config;
 
   // always include latest known address
   const latestAddress = await lspCreator.getAddress(network);

--- a/packages/sdk/src/coingecko/coingecko.ts
+++ b/packages/sdk/src/coingecko/coingecko.ts
@@ -6,6 +6,13 @@ export function msToS(ms: number) {
   return Math.floor(ms / 1000);
 }
 
+type CoinGeckoAssetPlatform = {
+  id: string;
+  chain_identifier: number;
+  name: string;
+  shortname: string;
+};
+
 class Coingecko {
   private host: string;
   constructor(host = "https://api.coingecko.com/api/v3") {
@@ -38,7 +45,7 @@ class Coingecko {
   }
   // Return an array of spot prices for an array of collateral addresses in one async call. Note we might in future
   // This was adapted from packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
-  async getContractPrices(addresses: Array<string>, currency = "usd") {
+  async getContractPrices(addresses: Array<string>, currency = "usd", platform_id = "ethereum") {
     // Generate a unique set with no repeated. join the set with the required coingecko delimiter.
     const contract_addresses = Array.from(new Set(addresses.filter((n) => n).values()));
     assert(contract_addresses.length > 0, "Must supply at least 1 contract address");
@@ -56,7 +63,7 @@ class Coingecko {
       };
     };
     const result: Result = await this.call(
-      `simple/token_price/ethereum?contract_addresses=${contract_addresses.join(
+      `simple/token_price/${platform_id}?contract_addresses=${contract_addresses.join(
         "%2C"
       )}&vs_currencies=${currency}&include_last_updated_at=true`
     );
@@ -64,6 +71,11 @@ class Coingecko {
       return { address: lookup[key], timestamp: value.last_updated_at, price: value.usd };
     });
   }
+
+  async getPlatforms(): Promise<CoinGeckoAssetPlatform[]> {
+    return this.call(`asset_platforms`);
+  }
+
   async call(path: string) {
     try {
       const { host } = this;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2389/ability-to-pull-in-polygon-contracts-in-api

**Summary**

Required changes in order to support Polygon contracts:

- Add support for other networks: optional env added `NETWORK_CHAIN_ID`
- Configure `serverless_write` application to use http web3 provider
- Implement fetching contract events in batches because some web3 providers proved to be really slow (see details in the Testing section below)
- Deploy Multicall2 contract on Polygon chain `0xf279b9d041e2449998Ab244995c1D8810F48321B`
- other optimisations

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

Infura and Chainstack web3 providers proved to be really slow for querying events of Polygon EMP contracts. On the first hand, Infura imposes a 100k blocks limit for which you can query events, but this aspect is irrelevant because in fact querying events for more than 15k blocks throws a lot of timeout errors.
For addressing this issue I implemented the option of querying contract events in batches with a configurable size via env variables (`DETECT_CONTRACTS_BATCH_SIZE` and `UPDATE_CONTRACTS_BATCH_SIZE`), but it's still inefficient because it will take hours to fetch events from millions of blocks.
⚠️ After testing the application in various scenarios, **my recommendation** is to use Alchemy for querying events on Polygon.

**Benchmarks**
Start block `18905141` | End block (current) `20990906`

**Infura**
- detect contracts: batch size: `15k`, time: `2min 58s`
- update contracts state: batch size: `10k`, time: `73min 12s`

**Alchemy**
- detect contracts: no batches, time: `6s`
- update contracts state: no batches, time: `18s`


