### PR TITLE
fix(across-relayer): Deposit search should start at BridgeDeposit block height, not BridgePool block height

### DIFF
--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -800,7 +800,7 @@ export class Relayer {
     // search config using the bridge deposit box's deployment block. This allows us to capture any deposits that
     // happened outside of the L2 client's default block search config.
     else {
-      let blockSearchConfig = {
+      let l2BlockSearchConfig = {
         fromBlock: this.l2DeployData[relay.chainId].blockNumber,
         toBlock: this.l2DeployData[relay.chainId].blockNumber + this.l2LookbackWindow,
       };
@@ -809,7 +809,7 @@ export class Relayer {
       // Look up all blocks from contract deployment time to latest to ensure that a deposit, if it exists, is found.
       while (deposit === undefined) {
         const [fundsDepositedEvents] = await Promise.all([
-          this.l2Client.bridgeDepositBox.getPastEvents("FundsDeposited", blockSearchConfig),
+          this.l2Client.bridgeDepositBox.getPastEvents("FundsDeposited", l2BlockSearchConfig),
         ]);
         // For any found deposits, try to match it with the relay:
         for (const fundsDepositedEvent of fundsDepositedEvents) {
@@ -831,7 +831,7 @@ export class Relayer {
             this.logger.debug({
               at: "InsuredBridgeRelayer#Disputer",
               message: "Matched deposit using relay quote time to run new block search",
-              blockSearchConfig,
+              l2BlockSearchConfig,
               deposit,
               relay,
             });
@@ -842,12 +842,12 @@ export class Relayer {
 
         // Exit loop if block search encompasses "latest" block number. Breaking the loop here guarantees that the
         // above event search executes at least once.
-        if (blockSearchConfig.toBlock >= latestBlock) break;
+        if (l2BlockSearchConfig.toBlock >= latestBlock) break;
 
         // Increment block search.
-        blockSearchConfig = {
-          fromBlock: blockSearchConfig.toBlock,
-          toBlock: Math.min(latestBlock, blockSearchConfig.toBlock + this.l2LookbackWindow),
+        l2BlockSearchConfig = {
+          fromBlock: l2BlockSearchConfig.toBlock,
+          toBlock: Math.min(latestBlock, l2BlockSearchConfig.toBlock + this.l2LookbackWindow),
         };
       }
     }

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -25,23 +25,29 @@ const supportedChainIds = [
 // a timestamp on construction. Then we can easily query on-chain whether a deposit.quoteTime is before this timestamp.
 // The alternative to using this hard-coded mapping is to call `web3.eth.getCode(bridgePoolAddress, blockNumber)` but
 // making a web3 call per relay is expensive. Therefore this mapping is also a runtime optimization where we can
-// eliminate web3 calls. This is also why we store block numbers for the deploy timestamp.
+// eliminate web3 calls.
 const bridgePoolDeployData = {
   // Note: keyed by L1 token.
   // WETH:
   "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
     timestamp: 1635962805,
-    blockNumber: 13545377,
   },
   // USDC:
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
     timestamp: 1635964115,
-    blockNumber: 13545487,
   },
   // UMA:
   "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828": {
     timestamp: 1635964053,
-    blockNumber: 13545478,
+  },
+};
+
+// For similar reasons to why we store BridgePool deployment times, we store BridgeDepositBox times for each L2 network
+// here. We use this in the fallback search for a FundsDeposited L2 event to optimize how we search for the event. We
+// don't need to search for events earlier than the BridgeDepositBox's deployment block.
+const bridgeDepositBoxDeployData = {
+  42161: {
+    blockNumber: 2811998,
   },
 };
 
@@ -67,7 +73,8 @@ export class RelayerConfig {
   readonly activatedChainIds: number[];
   readonly l2BlockLookback: number;
   readonly botModes: BotModes;
-  readonly deployTimestamps: { [key: string]: { timestamp: number; blockNumber: number } };
+  readonly l1DeployData: { [key: string]: { timestamp: number } };
+  readonly l2DeployData: { [key: string]: { blockNumber: number } };
 
   constructor(env: ProcessEnv) {
     const {
@@ -82,7 +89,8 @@ export class RelayerConfig {
       FINALIZER_ENABLED,
       DISPUTER_ENABLED,
       WHITELISTED_CHAIN_IDS,
-      DEPLOY_TIMESTAMPS,
+      L1_DEPLOY_DATA,
+      L2_DEPLOY_DATA,
     } = env;
 
     this.botModes = {
@@ -103,9 +111,8 @@ export class RelayerConfig {
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;
     this.errorRetriesTimeout = ERROR_RETRIES_TIMEOUT ? Number(ERROR_RETRIES_TIMEOUT) : 1;
 
-    this.deployTimestamps = replaceAddressCase(
-      DEPLOY_TIMESTAMPS ? JSON.parse(DEPLOY_TIMESTAMPS) : bridgePoolDeployData
-    );
+    this.l1DeployData = replaceAddressCase(L1_DEPLOY_DATA ? JSON.parse(L1_DEPLOY_DATA) : bridgePoolDeployData);
+    this.l2DeployData = L2_DEPLOY_DATA ? JSON.parse(L2_DEPLOY_DATA) : bridgeDepositBoxDeployData;
 
     assert(RATE_MODELS, "RATE_MODELS required");
     const processingRateModels = JSON.parse(RATE_MODELS);

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -80,7 +80,8 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
       config.whitelistedRelayL1Tokens,
       accounts[0],
       config.whitelistedChainIds,
-      config.deployTimestamps,
+      config.l1DeployData,
+      config.l2DeployData,
       config.l2BlockLookback
     );
 

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -90,7 +90,8 @@ describe("Relayer.ts", function () {
   let l2Client: any;
   let gasEstimator: any;
 
-  let deployTimestamps: any;
+  let l1DeployData: any;
+  let l2DeployData: any;
 
   before(async function () {
     l1Accounts = await web3.eth.getAccounts();
@@ -192,9 +193,13 @@ describe("Relayer.ts", function () {
       )
       .send({ from: l1Owner });
 
-    deployTimestamps = {
+    l1DeployData = {
       [l1Token.options.address]: {
         timestamp: (await l1Timer.methods.getCurrentTime().call()).toString(),
+      },
+    };
+    l2DeployData = {
+      [chainId]: {
         blockNumber: await web3.eth.getBlockNumber(),
       },
     };
@@ -223,7 +228,8 @@ describe("Relayer.ts", function () {
       [l1Token.options.address],
       l1Relayer,
       whitelistedChainIds,
-      deployTimestamps,
+      l1DeployData,
+      l2DeployData,
       defaultLookbackWindow
     );
   });
@@ -644,7 +650,7 @@ describe("Relayer.ts", function () {
     });
     it("Skips deposits with quote time < contract deployment time", async function () {
       // Deposit using quote time prior to deploy timestamp for this L1 token.
-      const quoteTime = Number(deployTimestamps[l1Token.options.address].timestamp) - 1;
+      const quoteTime = Number(l1DeployData[l1Token.options.address].timestamp) - 1;
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
       await bridgeDepositBox.methods
         .deposit(
@@ -1047,7 +1053,8 @@ describe("Relayer.ts", function () {
         [l1Token.options.address],
         l1Relayer,
         whitelistedChainIds,
-        deployTimestamps,
+        l1DeployData,
+        l2DeployData,
         1 // Use small lookback window to test that the back up block search loop runs at least a few times before
         // finding the deposit.
       );
@@ -1219,7 +1226,8 @@ describe("Relayer.ts", function () {
         [l1Token.options.address],
         l1Relayer,
         [],
-        deployTimestamps,
+        l1DeployData,
+        l2DeployData,
         defaultLookbackWindow
       );
 
@@ -1302,7 +1310,7 @@ describe("Relayer.ts", function () {
     });
     it("Disputes relays that bot cannot compute realized LP fee % for", async function () {
       // Deposit using quote time prior to deploy timestamp for this L1 token.
-      const quoteTime = Number(deployTimestamps[l1Token.options.address].timestamp) - 1;
+      const quoteTime = Number(l1DeployData[l1Token.options.address].timestamp) - 1;
       await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
       await bridgeDepositBox.methods
         .deposit(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

There is a current bug in the relayer's `matchRelayWithDeposit` method that begins a fallback search for a `FundsDeposited` event at the **BridgePool's deployment block height**, but this is nonsensical as the event is emitted by the **BridgeDepositBox**. 

Therefore this PR adds a new mapping of L2 deposit box deployment block heights.

This PR also renames config variables to be more accurate.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
