### PR TITLE
fix: use timestamps to calculate apy periods for more accuracy

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.e2e.ts
+++ b/packages/sdk/src/across/clients/bridgePool.e2e.ts
@@ -10,7 +10,7 @@ import get from "lodash/get";
 dotenv.config();
 
 const multicall2Address = "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696";
-const wethAddress = "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17";
+const wethAddress = "0x7355Efc63Ae731f584380a9838292c7046c1e433";
 const users = [
   "0x06d8aeb52f99f8542429df3009ed26535c22d5aa",
   "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",

--- a/packages/sdk/src/across/clients/bridgePool.test.ts
+++ b/packages/sdk/src/across/clients/bridgePool.test.ts
@@ -15,25 +15,3 @@ test("previewRemoval", function () {
   assert.equal(BigNumber.from(result.fees.recieve).add(result.fees.remain).toString(), user.feesEarned);
   assert.equal(BigNumber.from(result.total.recieve).add(result.total.remain).toString(), user.positionValue);
 });
-test("calculateApy", function () {
-  const pool = {
-    address: "0xf42bB7EC88d065dF48D60cb672B88F8330f9f764",
-    totalPoolSize: "13900116882750652331",
-    l1Token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    exchangeRateCurrent: "1000000666720227009",
-    exchangeRatePrevious: "1000000666644862062",
-  };
-  const result = bridgePool.calculateApy(pool.exchangeRateCurrent, pool.exchangeRatePrevious);
-  assert.ok(result);
-});
-test("calculateApy2", function () {
-  const pool = {
-    address: "0xf42bB7EC88d065dF48D60cb672B88F8330f9f764",
-    totalPoolSize: "13900116882750652331",
-    l1Token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    exchangeRateCurrent: "1000100000000000000",
-    exchangeRatePrevious: "1000000000000000000",
-  };
-  const result = bridgePool.calculateApy(pool.exchangeRateCurrent, pool.exchangeRatePrevious);
-  assert.ok(result);
-});

--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -14,8 +14,6 @@ import has from "lodash/has";
 export type { Provider };
 export type BatchReadWithErrorsType = ReturnType<ReturnType<typeof BatchReadWithErrors>>;
 
-// may be able to replace with dynamic value https://docs.etherscan.io/api-endpoints/blocks#get-daily-block-count-and-rewards
-export const BLOCKS_PER_YEAR = 2317876; // estimated from https://ycharts.com/indicators/ethereum_blocks_per_day
 export const SECONDS_PER_YEAR = 31557600; // based on 365.25 days per year
 export const DEFAULT_BLOCK_DELTA = 10; // look exchange rate up based on 10 block difference by default
 
@@ -39,8 +37,6 @@ export type Pool = {
   exchangeRatePrevious: string;
   estimatedApy: string;
   estimatedApr: string;
-  estimatedApyBlocks: string;
-  estimatedAprBlocks: string;
   blocksElapsed: number;
   secondsElapsed: number;
 };
@@ -252,14 +248,6 @@ function joinPoolState(
   );
   const estimatedApr = calcApr(exchangeRatePrevious, exchangeRateCurrent, secondsElapsed, SECONDS_PER_YEAR);
 
-  const estimatedApyBlocks = calcPeriodicCompoundInterest(
-    exchangeRatePrevious,
-    exchangeRateCurrent,
-    blocksElapsed,
-    BLOCKS_PER_YEAR
-  );
-  const estimatedAprBlocks = calcApr(exchangeRatePrevious, exchangeRateCurrent, blocksElapsed, BLOCKS_PER_YEAR);
-
   return {
     address: poolState.address,
     totalPoolSize: totalPoolSize.toString(),
@@ -270,8 +258,6 @@ function joinPoolState(
     exchangeRatePrevious: poolState.exchangeRatePrevious.toString(),
     estimatedApy,
     estimatedApr,
-    estimatedApyBlocks,
-    estimatedAprBlocks,
     blocksElapsed,
     secondsElapsed,
   };

--- a/packages/sdk/src/across/utils.test.ts
+++ b/packages/sdk/src/across/utils.test.ts
@@ -48,3 +48,29 @@ test("percent", async function () {
   percent = utils.percent(5, 88);
   assert.equal(utils.fromWei(percent), "0.056818181818181818");
 });
+test("calcContinuousCompoundInterest", function () {
+  const startPrice = "1";
+  const endPrice = "2";
+  const periodsElapsed = "365";
+  const periodsPerYear = "365";
+  const result = utils.calcContinuousCompoundInterest(startPrice, endPrice, periodsElapsed, periodsPerYear);
+  // https://www.calculatorsoup.com/calculators/financial/compound-interest-calculator.php?given_data=find_r&A=2.00&P=1.00&n=0&t=1&given_data_last=find_r&action=solve
+  assert.equal((Number(result) * 100).toFixed(3), "69.315");
+});
+test("calcPeriodicCompoundInterest", function () {
+  const startPrice = "1";
+  const endPrice = "2";
+  const periodsElapsed = "365";
+  const periodsPerYear = "365";
+  const result = utils.calcPeriodicCompoundInterest(startPrice, endPrice, periodsElapsed, periodsPerYear);
+  // https://www.calculatorsoup.com/calculators/financial/compound-interest-calculator.php?given_data=find_r&A=2.00&P=1.00&n=365&t=1&given_data_last=find_r&action=solve
+  assert.equal((Number(result) * 100).toFixed(3), "69.381");
+});
+test("calcApr", function () {
+  const startPrice = "1";
+  const endPrice = "2";
+  const periodsElapsed = "365";
+  const periodsPerYear = "365";
+  const result = utils.calcApr(startPrice, endPrice, periodsElapsed, periodsPerYear);
+  assert.equal(Number(result), 1);
+});

--- a/packages/sdk/src/across/utils.ts
+++ b/packages/sdk/src/across/utils.ts
@@ -148,9 +148,3 @@ export const calcInterest = (startPrice: string, endPrice: string, periods: stri
 export const calcApy = (interest: string, periods: string) => {
   return new Decimal(interest).div(periods).add(1).pow(periods).sub(1).toString();
 };
-export const calcApr = (startPrice: string, endPrice: string, periods: string) => {
-  return new Decimal(endPrice).sub(startPrice).mul(periods).toString();
-};
-export const calcPeriods = (secondsElapsed: number, secondsInPeriod: number) => {
-  return new Decimal(secondsInPeriod).div(secondsElapsed).toString();
-};

--- a/packages/sdk/src/across/utils.ts
+++ b/packages/sdk/src/across/utils.ts
@@ -151,3 +151,6 @@ export const calcApy = (interest: string, periods: string) => {
 export const calcApr = (startPrice: string, endPrice: string, periods: string) => {
   return new Decimal(endPrice).sub(startPrice).mul(periods).toString();
 };
+export const calcPeriods = (secondsElapsed: number, secondsInPeriod: number) => {
+  return new Decimal(secondsInPeriod).div(secondsElapsed).toString();
+};


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/2966/pool-apy-appears-to-be-inaccurate

**Summary**
Use timestamps to calculate more accurate periods for apy/apr calcs

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/2966/pool-apy-appears-to-be-inaccurate
