### PR TITLE
fix(across-relayer): Finalizer can settle multiple L1 tokens

### DIFF
--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -153,7 +153,7 @@ export class Relayer {
 
       if (settleableRelays.length == 0) {
         this.logger.debug({ at: "AcrossRelayer#Finalizer", message: "No settleable relays" });
-        return;
+        continue;
       }
 
       for (const settleableRelay of settleableRelays) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
I noticed that Finalizer was not settling an UMA relay, but settled ETH relays that occurred after it. This was because there was a "return" statement where there should be a "continue" statement in the Finalizer's `for` loop.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
