### PR TITLE
improve(across-relayer): Add unit tests for multiple whitelisted L1 tokens

### DIFF
--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -1365,6 +1365,187 @@ describe("Relayer.ts", function () {
       assert.equal(targetLog.length, 1);
     });
   });
+  describe("Multiple whitelisted token mappings", function () {
+    let newL1Token: any, newL2Token: any, newBridgePool: any;
+    beforeEach(async function () {
+      // Whitelist another L1-L2 token mapping:
+      newL1Token = await ERC20.new("TESTERC20 2.0", "TESTERC20 2.0", 18).send({ from: l1Owner });
+      await newL1Token.methods.addMember(TokenRolesEnum.MINTER, l1Owner).send({ from: l1Owner });
+      await collateralWhitelist.methods.addToWhitelist(newL1Token.options.address).send({ from: l1Owner });
+      newL2Token = await ERC20.new("L2ERC20 2.0", "L2ERC20 2.0", 18).send({ from: l2Owner });
+      await newL2Token.methods.addMember(TokenRolesEnum.MINTER, l2Owner).send({ from: l2Owner });
+      newBridgePool = await BridgePool.new(
+        "LP Token",
+        "LPT",
+        bridgeAdmin.options.address,
+        newL1Token.options.address,
+        lpFeeRatePerSecond,
+        false,
+        l1Timer.options.address
+      ).send({ from: l1Owner });
+      await bridgeAdmin.methods
+        .whitelistToken(
+          chainId,
+          newL1Token.options.address,
+          newL2Token.options.address,
+          newBridgePool.options.address,
+          0,
+          defaultGasLimit,
+          defaultGasPrice,
+          0
+        )
+        .send({ from: l1Owner });
+      l1DeployData = {
+        ...l1DeployData,
+        [newL1Token.options.address]: {
+          timestamp: (await l1Timer.methods.getCurrentTime().call()).toString(),
+        },
+      };
+      await bridgeDepositBox.methods
+        .whitelistToken(newL1Token.options.address, newL2Token.options.address, newBridgePool.options.address)
+        .send({ from: l2BridgeAdminImpersonator });
+
+      // Add liquidity to pools:
+      await l1Token.methods.mint(l1LiquidityProvider, initialPoolLiquidity).send({ from: l1Owner });
+      await l1Token.methods
+        .approve(bridgePool.options.address, initialPoolLiquidity)
+        .send({ from: l1LiquidityProvider });
+      await bridgePool.methods.addLiquidity(initialPoolLiquidity).send({ from: l1LiquidityProvider });
+      await newL1Token.methods.mint(l1LiquidityProvider, initialPoolLiquidity).send({ from: l1Owner });
+      await newL1Token.methods
+        .approve(newBridgePool.options.address, initialPoolLiquidity)
+        .send({ from: l1LiquidityProvider });
+      await newBridgePool.methods.addLiquidity(initialPoolLiquidity).send({ from: l1LiquidityProvider });
+
+      // Create new Relayer that is aware of new L1 token:
+      const rateModels = { [l1Token.options.address]: rateModel, [newL1Token.options.address]: rateModel };
+      l1Client = new InsuredBridgeL1Client(spyLogger, web3, bridgeAdmin.options.address, rateModels);
+      l2Client = new InsuredBridgeL2Client(spyLogger, web3, bridgeDepositBox.options.address, chainId);
+      relayer = new Relayer(
+        spyLogger,
+        gasEstimator,
+        l1Client,
+        l2Client,
+        [l1Token.options.address, newL1Token.options.address],
+        l1Relayer,
+        whitelistedChainIds,
+        l1DeployData,
+        l2DeployData,
+        defaultLookbackWindow
+      );
+
+      // Mint and approve tokens for depositor:
+      await newL2Token.methods.mint(l2Depositor, depositAmount).send({ from: l2Owner });
+      await newL2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
+      await l2Token.methods.mint(l2Depositor, depositAmount).send({ from: l2Owner });
+      await l2Token.methods.approve(bridgeDepositBox.options.address, depositAmount).send({ from: l2Depositor });
+
+      // Mint and approve tokens for relayer and disputer:
+      await newL1Token.methods.mint(l1Relayer, toBN(depositAmount).muln(4)).send({ from: l1Owner });
+      await newL1Token.methods
+        .approve(newBridgePool.options.address, toBN(depositAmount).muln(4))
+        .send({ from: l1Relayer });
+      await l1Token.methods.mint(l1Relayer, toBN(depositAmount).muln(4)).send({ from: l1Owner });
+      await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(4)).send({ from: l1Relayer });
+    });
+    it("Can relay and settle deposits", async function () {
+      // Deposit #1
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
+      const depositData = {
+        chainId,
+        depositId: "0",
+        l1Recipient: l2Depositor,
+        l2Sender: l2Depositor,
+        amount: depositAmount,
+        slowRelayFeePct: defaultSlowRelayFeePct,
+        instantRelayFeePct: defaultInstantRelayFeePct,
+        quoteTimestamp: quoteTime,
+      };
+      await bridgeDepositBox.methods
+        .deposit(
+          depositData.l1Recipient,
+          newL2Token.options.address,
+          depositData.amount,
+          depositData.slowRelayFeePct,
+          depositData.instantRelayFeePct,
+          depositData.quoteTimestamp
+        )
+        .send({ from: l2Depositor });
+
+      // Deposit #2
+      await bridgeDepositBox.methods
+        .deposit(
+          depositData.l1Recipient,
+          l2Token.options.address,
+          depositData.amount,
+          depositData.slowRelayFeePct,
+          depositData.instantRelayFeePct,
+          depositData.quoteTimestamp
+        )
+        .send({ from: l2Depositor });
+
+      // Update and run the relayer
+      await Promise.all([l1Client.update(), l2Client.update()]);
+      await relayer.checkForPendingDepositsAndRelay();
+
+      assert.equal((await bridgePool.methods.numberOfRelays().call()).toString(), "1");
+      assert.equal((await newBridgePool.methods.numberOfRelays().call()).toString(), "1");
+
+      // Advance time to get the relay into a settable state.
+      await l1Timer.methods
+        .setCurrentTime(Number((await l1Timer.methods.getCurrentTime().call()) + defaultLiveness + 1))
+        .send({ from: l1Owner });
+
+      await Promise.all([l1Client.update(), l2Client.update()]);
+      await relayer.checkforSettleableRelaysAndSettle();
+      assert.equal((await bridgePool.getPastEvents("RelaySettled", { fromBlock: 0 })).length, 1);
+      assert.equal((await newBridgePool.getPastEvents("RelaySettled", { fromBlock: 0 })).length, 1);
+    });
+    it("Can dispute relays", async function () {
+      const quoteTime = (await web3.eth.getBlock("latest")).timestamp;
+
+      // Invalid relay #1
+      await bridgePool.methods
+        .relayDeposit(
+          {
+            chainId: chainId,
+            depositId: "99", // deposit ID doesn't exist
+            l2Sender: l2Depositor,
+            l1Recipient: l2Depositor,
+            amount: depositAmount,
+            slowRelayFeePct: defaultSlowRelayFeePct,
+            instantRelayFeePct: defaultInstantRelayFeePct,
+            quoteTimestamp: quoteTime,
+          },
+          defaultRealizedLpFeePct
+        )
+        .send({ from: l1Relayer });
+
+      // Invalid relay #2
+      await newBridgePool.methods
+        .relayDeposit(
+          {
+            chainId: chainId,
+            depositId: "100", // deposit ID doesn't exist
+            l2Sender: l2Depositor,
+            l1Recipient: l2Depositor,
+            amount: depositAmount,
+            slowRelayFeePct: defaultSlowRelayFeePct,
+            instantRelayFeePct: defaultInstantRelayFeePct,
+            quoteTimestamp: quoteTime,
+          },
+          defaultRealizedLpFeePct
+        )
+        .send({ from: l1Relayer });
+
+      // Update and run the relayer
+      await Promise.all([l1Client.update(), l2Client.update()]);
+      await relayer.checkForPendingRelaysAndDispute();
+
+      assert.equal((await bridgePool.getPastEvents("RelayDisputed", { fromBlock: 0 })).length, 1);
+      assert.equal((await newBridgePool.getPastEvents("RelayDisputed", { fromBlock: 0 })).length, 1);
+    });
+  });
   describe("Multicall Batching", function () {
     beforeEach(async function () {
       // Add liquidity to the L1 pool to facilitate the relay action.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

There are currently no unit tests for whether bot can handle multiple L1 whitelisted tokens. These unit tests would have caught the bug that #3580 fixed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
