### PR TITLE
fix(sdk): fix typo in PoolClient

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -265,7 +265,7 @@ function joinPoolState(
     estimatedApr,
     blocksElapsed,
     secondsElapsed,
-    liquidityUtilizationCurrent: poolState.exchangeRatePrevious.toString(),
+    liquidityUtilizationCurrent: poolState.liquidityUtilizationCurrent.toString(),
   };
 }
 export class ReadPoolClient {


### PR DESCRIPTION
**Motivation**

Bug fix.


**Summary**

There's a typo that causes the PoolState to export the wrong variable for `liquidityUtilizationCurrent`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
