### PR TITLE
feat(across-relayer): sort by deposit size when disputing

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -127,8 +127,11 @@ export class InsuredBridgeL1Client {
       : undefined;
   }
 
+  // Return all relays in the Pending state, ordered by amount relayed.
   getPendingRelayedDeposits(): Relay[] {
-    return this.getAllRelayedDeposits().filter((relay: Relay) => relay.relayState === ClientRelayState.Pending);
+    return this.getAllRelayedDeposits()
+      .filter((relay: Relay) => relay.relayState === ClientRelayState.Pending)
+      .sort((a, b) => (toBN(a.amount).lt(toBN(b.amount)) ? 1 : toBN(b.amount).lt(toBN(a.amount)) ? -1 : 0));
   }
 
   getPendingRelayedDepositsForL1Token(l1Token: string): Relay[] {

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -786,10 +786,12 @@ describe("InsuredBridgeL1Client", function () {
         JSON.stringify(expectedBridgePool2Relays)
       );
 
-      // Filtering by pendingRelays should return accordingly.
+      // Filtering by pendingRelays should return accordingly. Note that we need to put expectedBridgePool1Relays[1]
+      // second as this had a larger relay (of size 4.21 vs 4.20) and the getPendingRelayedDeposits orders by relay
+      // size to enable the disputer to dispute the most dangerous invalid relays first.
       assert.equal(
         JSON.stringify(await client.getPendingRelayedDeposits()),
-        JSON.stringify([expectedBridgePool1Relays[1], ...expectedBridgePool2Relays])
+        JSON.stringify([...expectedBridgePool2Relays, expectedBridgePool1Relays[1]])
       );
 
       assert.equal(

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -121,8 +121,8 @@ export class Relayer {
   async checkForPendingRelaysAndDispute(): Promise<void> {
     this.logger.debug({ at: "AcrossRelayer#Disputer", message: "Checking for pending relays and disputing" });
 
-    // Build dictionary of pending relays keyed by l1 token and deposit hash. getPendingRelays() filters
-    // out Finalized relays.
+    // Build dictionary of pending relays keyed by l1 token and deposit hash. getPendingRelays() filters out Finalized
+    // relays and orders by the relay size so we dispute the most dangerous relays first.
     const pendingRelays: Relay[] = this.l1Client.getPendingRelayedDeposits();
     if (pendingRelays.length == 0) {
       this.logger.debug({ at: "AcrossRelayer#Disputer", message: "No pending relays" });

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -1483,7 +1483,6 @@ describe("Relayer.ts", function () {
       // is no associated L2 deposit so all three are disputable.
       await l1Token.methods.mint(l1Owner, toBN(depositAmount).muln(4)).send({ from: l1Owner });
       await l1Token.methods.approve(bridgePool.options.address, toBN(depositAmount).muln(4)).send({ from: l1Owner });
-      console.log("a");
       await bridgePool.methods
         .relayDeposit(
           {
@@ -1499,7 +1498,6 @@ describe("Relayer.ts", function () {
           calculateRealizedLpFeePct(rateModel, toBNWei("0"), toBNWei("0.01"))
         )
         .send({ from: l1Owner });
-      console.log("b");
       await bridgePool.methods
         .relayDeposit(
           {
@@ -1515,7 +1513,6 @@ describe("Relayer.ts", function () {
           calculateRealizedLpFeePct(rateModel, toBNWei("0"), toBNWei("0.01"))
         )
         .send({ from: l1Owner });
-      console.log("c");
       await bridgePool.methods
         .relayDeposit(
           {

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -1547,11 +1547,9 @@ describe("Relayer.ts", function () {
       // Within the contract, the first dispute should be for the deposit hash extracted before for the largest deposit.
       assert.equal(disputeEvents[0].returnValues.depositHash, largestDepositDepositHash);
 
-      // There should be a total of 3 dispute logs generated.
-      assert.equal(
-        spy.getCalls().filter((_log: any) => _log.lastArg.message.includes("Disputed pending relay")).length,
-        3
-      );
+      // There should be a total of 3 dispute logs generated. within the multicall batch.
+      assert.isTrue(lastSpyLogIncludes(spy, "Multicall batch sent"));
+      assert.equal(spy.getCall(-1).lastArg.mrkdwn.match(/Disputed pending relay/g).length, 3);
     });
   });
   describe("Multiple whitelisted token mappings", function () {


### PR DESCRIPTION
**Motivation**

The disputer bot should dispute the largest invalid relays first to de-risk the system as much as posible.

**Summary**

Updates the L1 client to sort relays by deposit size, when working with the disputer.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
