### PR TITLE
fix: fix ci publish

### DIFF
--- a/packages/contract-notifier/package.json
+++ b/packages/contract-notifier/package.json
@@ -21,5 +21,9 @@
   "bin": "index.js",
   "bugs": {
     "url": "https://github.com/UMAprotocol/protocol/issues"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com/",
+    "access": "public"
   }
 }


### PR DESCRIPTION
**Motivation**

ci is broken due to a minor misconfiguration in the contract-notifier package.


**Summary**

Fixed the configuration so the publish settings work with a non paid npm account.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
