### PR TITLE
fix(sdk): do not pre-populate transactions, allow overrides

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -1,21 +1,21 @@
 import assert from "assert";
 import { bridgePool } from "../../clients";
-import { BigNumber, Signer } from "ethers";
 import { toBNWei, fixedPointAdjustment, calcPeriodicCompoundInterest, calcApr, BigNumberish } from "../utils";
 import { BatchReadWithErrors, loop, exists } from "../../utils";
 import Multicall2 from "../../multicall2";
 import TransactionManager from "../transactionManager";
-import { ethers } from "ethers";
+import { ethers, Signer, BigNumber } from "ethers";
+import type { Overrides } from "@ethersproject/contracts";
 import { TransactionRequest, TransactionReceipt, Provider, Log, Block } from "@ethersproject/abstract-provider";
 import set from "lodash/set";
 import get from "lodash/get";
 import has from "lodash/has";
 
-export type { Provider };
-export type BatchReadWithErrorsType = ReturnType<ReturnType<typeof BatchReadWithErrors>>;
-
 export const SECONDS_PER_YEAR = 31557600; // based on 365.25 days per year
 export const DEFAULT_BLOCK_DELTA = 10; // look exchange rate up based on 10 block difference by default
+
+export type { Provider };
+export type BatchReadWithErrorsType = ReturnType<ReturnType<typeof BatchReadWithErrors>>;
 
 export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 
@@ -349,12 +349,16 @@ export class Client {
     this.transactionManagers[address] = txman;
     return txman;
   }
-  async addEthLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish) {
+  async addEthLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish, overrides?: Overrides) {
     const userAddress = await signer.getAddress();
     const contract = this.getOrCreatePoolContract(pool);
     const txman = this.getOrCreateTransactionManager(signer, userAddress);
 
-    const request = await contract.populateTransaction.addLiquidity(l1TokenAmount, { value: l1TokenAmount });
+    // dont allow override value here
+    const request = await contract.populateTransaction.addLiquidity(l1TokenAmount, {
+      ...overrides,
+      value: l1TokenAmount,
+    });
     const id = await txman.request(request);
 
     this.state.transactions[id] = {
@@ -370,12 +374,12 @@ export class Client {
     await txman.update();
     return id;
   }
-  async addTokenLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish) {
+  async addTokenLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish, overrides?: Overrides) {
     const userAddress = await signer.getAddress();
     const contract = this.getOrCreatePoolContract(pool);
     const txman = this.getOrCreateTransactionManager(signer, userAddress);
 
-    const request = await contract.populateTransaction.addLiquidity(l1TokenAmount);
+    const request = await contract.populateTransaction.addLiquidity(l1TokenAmount, overrides);
     const id = await txman.request(request);
 
     this.state.transactions[id] = {
@@ -403,13 +407,13 @@ export class Client {
     const userState = this.getUser(poolAddress, userAddress);
     return validateWithdraw(poolState, userState, lpAmount);
   }
-  async removeTokenLiquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish) {
+  async removeTokenLiquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish, overrides?: Overrides) {
     const userAddress = await signer.getAddress();
     await this.validateWithdraw(pool, userAddress, lpTokenAmount);
     const contract = this.getOrCreatePoolContract(pool);
     const txman = this.getOrCreateTransactionManager(signer, userAddress);
 
-    const request = await contract.populateTransaction.removeLiquidity(lpTokenAmount, false);
+    const request = await contract.populateTransaction.removeLiquidity(lpTokenAmount, false, overrides);
     const id = await txman.request(request);
 
     this.state.transactions[id] = {
@@ -426,13 +430,13 @@ export class Client {
     await txman.update();
     return id;
   }
-  async removeEthliquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish) {
+  async removeEthliquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish, overrides?: Overrides) {
     const userAddress = await signer.getAddress();
     await this.validateWithdraw(pool, userAddress, lpTokenAmount);
     const contract = this.getOrCreatePoolContract(pool);
     const txman = this.getOrCreateTransactionManager(signer, userAddress);
 
-    const request = await contract.populateTransaction.removeLiquidity(lpTokenAmount, true);
+    const request = await contract.populateTransaction.removeLiquidity(lpTokenAmount, true, overrides);
     const id = await txman.request(request);
 
     this.state.transactions[id] = {

--- a/packages/sdk/src/across/transactionManager.ts
+++ b/packages/sdk/src/across/transactionManager.ts
@@ -20,9 +20,12 @@ export default (config: Config, signer: Signer, emit: Emit = () => null) => {
   const requests = new Map<string, TransactionRequest>();
   const submissions = new Map<string, string>();
   const mined = new Map<string, TransactionReceipt>();
-  async function request(unsignedTx: TransactionRequest) {
-    const populated = await signer.populateTransaction(unsignedTx);
+  function request(unsignedTx: TransactionRequest) {
+    // this no longer calls signer.populateTransaction, to allow metamask to fill in missing details instead
+    // use overrides if you want to manually fill in other tx details, including the overrides.customData field.
+    const populated = unsignedTx;
     const key = makeKey(populated);
+    assert(!requests.has(key), "Transaction already in progress");
     requests.set(key, populated);
     return key;
   }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/3217/trezor-trezor-one-hw-wallets-cannot-add-liquidity-on-across-pool

**Summary**

This removes  signer.populateTransaction from the transaction manager. This actually caused 2 major problems. 

1.  it assumed signers were eip-1559 compatible, causing errors when sent to metamask with hardware wallets that are not compatible.
2.  it set gas estimates that might be different from what the app was estimating during a "max eth send" event, causing the transaction to fail validation before being sent to metamask.  

Now all unset fields will be set by metamask, which has more control and information about the wallet environment.

Because we remove populateTransaction, we allow manual overrides in case you want any of these fields set for any reason. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/3217/trezor-trezor-one-hw-wallets-cannot-add-liquidity-on-across-pool
