### PR TITLE
fix(sdk): pass empty object instead of undefined to tx calls to fix c…

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -349,7 +349,7 @@ export class Client {
     this.transactionManagers[address] = txman;
     return txman;
   }
-  async addEthLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish, overrides?: Overrides) {
+  async addEthLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish, overrides: Overrides = {}) {
     const userAddress = await signer.getAddress();
     const contract = this.getOrCreatePoolContract(pool);
     const txman = this.getOrCreateTransactionManager(signer, userAddress);
@@ -374,7 +374,7 @@ export class Client {
     await txman.update();
     return id;
   }
-  async addTokenLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish, overrides?: Overrides) {
+  async addTokenLiquidity(signer: Signer, pool: string, l1TokenAmount: BigNumberish, overrides: Overrides = {}) {
     const userAddress = await signer.getAddress();
     const contract = this.getOrCreatePoolContract(pool);
     const txman = this.getOrCreateTransactionManager(signer, userAddress);
@@ -407,7 +407,7 @@ export class Client {
     const userState = this.getUser(poolAddress, userAddress);
     return validateWithdraw(poolState, userState, lpAmount);
   }
-  async removeTokenLiquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish, overrides?: Overrides) {
+  async removeTokenLiquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish, overrides: Overrides = {}) {
     const userAddress = await signer.getAddress();
     await this.validateWithdraw(pool, userAddress, lpTokenAmount);
     const contract = this.getOrCreatePoolContract(pool);
@@ -430,7 +430,7 @@ export class Client {
     await txman.update();
     return id;
   }
-  async removeEthliquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish, overrides?: Overrides) {
+  async removeEthliquidity(signer: Signer, pool: string, lpTokenAmount: BigNumberish, overrides: Overrides = {}) {
     const userAddress = await signer.getAddress();
     await this.validateWithdraw(pool, userAddress, lpTokenAmount);
     const contract = this.getOrCreatePoolContract(pool);


### PR DESCRIPTION
…all errors

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/3240/hotfix-sdk-transaction-calls-fail-when-passing-undefined-overrides

**Summary**

Ethers seems to count the number of arguments to function calls when you make transactions, it fails if there is a mismatch. For some reason it considers undefined where the overrides should be as an argument and will fail. This changes it to pass an empty object by default, which for some reason ethers detects as overrides and allows the call to be made without error.

Tested this on across for add/remove liquidity calls for tokens/eth.

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.shortcut.com/uma-project/story/3240/hotfix-sdk-transaction-calls-fail-when-passing-undefined-overrides
