### PR TITLE
feat(across): Add Setter for LP Fee %/second in BridgePool

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -137,9 +137,9 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
      * @param bridgePool Bridge Pool to change LP fee rate for.
      * @param newLpFeeRate The new rate to set for the `bridgePool`.
      */
-    function changeLpFeeRatePerSecond(address bridgePool, uint64 newLpFeeRate) public onlyOwner nonReentrant() {
-        BridgePoolInterface(bridgePool).changeLpFeeRatePerSecond(newLpFeeRate);
-        emit ChangedLpFeeRate(bridgePool, newLpFeeRate);
+    function setLpFeeRatePerSecond(address bridgePool, uint64 newLpFeeRate) public onlyOwner nonReentrant() {
+        BridgePoolInterface(bridgePool).setLpFeeRatePerSecond(newLpFeeRate);
+        emit SetLpFeeRate(bridgePool, newLpFeeRate);
     }
 
     /**************************************************

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -130,6 +130,11 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         emit BridgePoolsAdminTransferred(bridgePools, newAdmin);
     }
 
+    function changeLpFeeRatePerSecond(address bridgePool, uint64 newLpFeeRate) public onlyOwner nonReentrant() {
+        BridgePoolInterface(bridgePool).changeLpFeeRatePerSecond(newLpFeeRate);
+        emit ChangedLpFeeRate(bridgePool, newLpFeeRate);
+    }
+
     /**************************************************
      *        CROSSDOMAIN ADMIN FUNCTIONS             *
      **************************************************/

--- a/packages/core/contracts/insured-bridge/BridgeAdmin.sol
+++ b/packages/core/contracts/insured-bridge/BridgeAdmin.sol
@@ -130,6 +130,13 @@ contract BridgeAdmin is BridgeAdminInterface, Ownable, Lockable {
         emit BridgePoolsAdminTransferred(bridgePools, newAdmin);
     }
 
+    /**
+     * @notice Enable the current owner to change the decay rate at which LP shares accumulate fees for a particular
+     * BridgePool. The higher this value, the faster LP shares realize pending fees.
+     * @dev Only callable by the current owner.
+     * @param bridgePool Bridge Pool to change LP fee rate for.
+     * @param newLpFeeRate The new rate to set for the `bridgePool`.
+     */
     function changeLpFeeRatePerSecond(address bridgePool, uint64 newLpFeeRate) public onlyOwner nonReentrant() {
         BridgePoolInterface(bridgePool).changeLpFeeRatePerSecond(newLpFeeRate);
         emit ChangedLpFeeRate(bridgePool, newLpFeeRate);

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -186,7 +186,7 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
         syncUmaEcosystemParams(); // Fetch OptimisticOracle and Store addresses and L1Token finalFee.
         syncWithBridgeAdminParams(); // Fetch ProposerBondPct OptimisticOracleLiveness, Identifier from the BridgeAdmin.
 
-        emit LpFeeRateChanged(lpFeeRatePerSecond);
+        emit LpFeeRateSet(lpFeeRatePerSecond);
     }
 
     /*************************************************

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -152,6 +152,11 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
     event BridgePoolAdminTransferred(address oldAdmin, address newAdmin);
     event LpFeeRateChanged(uint64 newLpFeeRatePerSecond);
 
+    modifier onlyBridgeAdmin() {
+        require(msg.sender == address(bridgeAdmin), "Caller not bridge admin");
+        _;
+    }
+
     /**
      * @notice Construct the Bridge Pool.
      * @param _lpTokenName Name of the LP token to be deployed by this contract.
@@ -659,10 +664,10 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
 
     /**
      * @notice Enable the current bridge admin to transfer admin to to a new address.
+     * @dev Caller must be BridgeAdmin contract.
      * @param _newAdmin Admin address of the new admin.
      */
-    function changeAdmin(address _newAdmin) public override nonReentrant() {
-        require(msg.sender == address(bridgeAdmin));
+    function changeAdmin(address _newAdmin) public override onlyBridgeAdmin() nonReentrant() {
         bridgeAdmin = BridgeAdminInterface(_newAdmin);
         emit BridgePoolAdminTransferred(msg.sender, _newAdmin);
     }
@@ -670,10 +675,10 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
     /**
      * @notice Enable the bridge admin to change the decay rate at which LP shares accumulate fees. The higher this
      * value, the faster LP shares realize pending fees.
+     * @dev Caller must be BridgeAdmin contract.
      * @param _newLpFeeRatePerSecond The new rate to set.
      */
-    function changeLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) public override nonReentrant() {
-        require(msg.sender == address(bridgeAdmin));
+    function changeLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) public override onlyBridgeAdmin() nonReentrant() {
         lpFeeRatePerSecond = _newLpFeeRatePerSecond;
         emit LpFeeRateChanged(lpFeeRatePerSecond);
     }

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -150,7 +150,7 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
     event RelayCanceled(bytes32 indexed depositHash, bytes32 indexed relayHash, address indexed disputer);
     event RelaySettled(bytes32 indexed depositHash, address indexed caller, RelayData relay);
     event BridgePoolAdminTransferred(address oldAdmin, address newAdmin);
-    event LpFeeRateChanged(uint64 newLpFeeRatePerSecond);
+    event LpFeeRateSet(uint64 newLpFeeRatePerSecond);
 
     modifier onlyBridgeAdmin() {
         require(msg.sender == address(bridgeAdmin), "Caller not bridge admin");
@@ -678,9 +678,9 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
      * @dev Caller must be BridgeAdmin contract.
      * @param _newLpFeeRatePerSecond The new rate to set.
      */
-    function changeLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) public override onlyBridgeAdmin() nonReentrant() {
+    function setLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) public override onlyBridgeAdmin() nonReentrant() {
         lpFeeRatePerSecond = _newLpFeeRatePerSecond;
-        emit LpFeeRateChanged(lpFeeRatePerSecond);
+        emit LpFeeRateSet(lpFeeRatePerSecond);
     }
 
     /************************************

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -18,6 +18,7 @@ interface BridgeAdminInterface {
     event SetMinimumBridgingDelay(uint256 indexed chainId, uint64 newMinimumBridgingDelay);
     event DepositsEnabled(uint256 indexed chainId, address indexed l2Token, bool depositsEnabled);
     event BridgePoolsAdminTransferred(address[] bridgePools, address indexed newAdmin);
+    event ChangedLpFeeRate(address indexed bridgePool, uint64 newLpFeeRatePerSecond);
 
     function finder() external view returns (address);
 

--- a/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgeAdminInterface.sol
@@ -18,7 +18,7 @@ interface BridgeAdminInterface {
     event SetMinimumBridgingDelay(uint256 indexed chainId, uint64 newMinimumBridgingDelay);
     event DepositsEnabled(uint256 indexed chainId, address indexed l2Token, bool depositsEnabled);
     event BridgePoolsAdminTransferred(address[] bridgePools, address indexed newAdmin);
-    event ChangedLpFeeRate(address indexed bridgePool, uint64 newLpFeeRatePerSecond);
+    event SetLpFeeRate(address indexed bridgePool, uint64 newLpFeeRatePerSecond);
 
     function finder() external view returns (address);
 

--- a/packages/core/contracts/insured-bridge/interfaces/BridgePoolInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgePoolInterface.sol
@@ -8,5 +8,5 @@ interface BridgePoolInterface {
 
     function changeAdmin(address newAdmin) external;
 
-    function changeLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) external;
+    function setLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) external;
 }

--- a/packages/core/contracts/insured-bridge/interfaces/BridgePoolInterface.sol
+++ b/packages/core/contracts/insured-bridge/interfaces/BridgePoolInterface.sol
@@ -7,4 +7,6 @@ interface BridgePoolInterface {
     function l1Token() external view returns (IERC20);
 
     function changeAdmin(address newAdmin) external;
+
+    function changeLpFeeRatePerSecond(uint64 _newLpFeeRatePerSecond) external;
 }

--- a/packages/core/test/insured-bridge/BridgeAdmin.js
+++ b/packages/core/test/insured-bridge/BridgeAdmin.js
@@ -232,6 +232,26 @@ describe("BridgeAdmin", () => {
       assert.equal(await bridgePool.methods.bridgeAdmin().call(), owner);
       assert.equal(await bridgePool2.methods.bridgeAdmin().call(), owner);
     });
+    it("Set LP fee rate %/second", async () => {
+      const newRate = toWei("0.0000025");
+      assert(
+        await didContractThrow(
+          bridgeAdmin.methods.changeLpFeeRatePerSecond(bridgePool.options.address, newRate).send({ from: rando })
+        ),
+        "OnlyOwner modifier not enforced"
+      );
+
+      const txn = await bridgeAdmin.methods
+        .changeLpFeeRatePerSecond(bridgePool.options.address, newRate)
+        .send({ from: owner });
+
+      // Check for L1 logs and state change
+
+      await assertEventEmitted(txn, bridgeAdmin, "ChangedLpFeeRate", (ev) => {
+        return ev.bridgePool == bridgePool.options.address && ev.newLpFeeRatePerSecond.toString() == newRate;
+      });
+      assert.equal(await bridgePool.methods.lpFeeRatePerSecond().call(), newRate);
+    });
     describe("Cross domain Admin functions", () => {
       describe("Whitelist tokens", () => {
         it("Basic checks", async () => {

--- a/packages/core/test/insured-bridge/BridgeAdmin.js
+++ b/packages/core/test/insured-bridge/BridgeAdmin.js
@@ -236,18 +236,18 @@ describe("BridgeAdmin", () => {
       const newRate = toWei("0.0000025");
       assert(
         await didContractThrow(
-          bridgeAdmin.methods.changeLpFeeRatePerSecond(bridgePool.options.address, newRate).send({ from: rando })
+          bridgeAdmin.methods.setLpFeeRatePerSecond(bridgePool.options.address, newRate).send({ from: rando })
         ),
         "OnlyOwner modifier not enforced"
       );
 
       const txn = await bridgeAdmin.methods
-        .changeLpFeeRatePerSecond(bridgePool.options.address, newRate)
+        .setLpFeeRatePerSecond(bridgePool.options.address, newRate)
         .send({ from: owner });
 
       // Check for L1 logs and state change
 
-      await assertEventEmitted(txn, bridgeAdmin, "ChangedLpFeeRate", (ev) => {
+      await assertEventEmitted(txn, bridgeAdmin, "SetLpFeeRate", (ev) => {
         return ev.bridgePool == bridgePool.options.address && ev.newLpFeeRatePerSecond.toString() == newRate;
       });
       assert.equal(await bridgePool.methods.lpFeeRatePerSecond().call(), newRate);

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -384,6 +384,26 @@ describe("BridgePool", () => {
       return ev.oldAdmin === bridgeAdmin.options.address && ev.newAdmin === owner;
     });
   });
+  it("Lp Fee %/second", async function () {
+    // Can only be set by current admin.
+    const newRate = toWei("0.0000025");
+    assert(
+      await didContractThrow(
+        bridgeAdmin.methods.changeLpFeeRatePerSecond(bridgePool.options.address, newRate).send({ from: rando })
+      )
+    );
+
+    // Calling from the correct address succeeds.
+    const tx = await bridgeAdmin.methods
+      .changeLpFeeRatePerSecond(bridgePool.options.address, newRate)
+      .send({ from: owner });
+
+    assert.equal(await bridgePool.methods.lpFeeRatePerSecond().call(), newRate);
+
+    await assertEventEmitted(tx, bridgePool, "LpFeeRateChanged", (ev) => {
+      return ev.newLpFeeRatePerSecond.toString() === newRate;
+    });
+  });
   it("Constructs utf8-encoded ancillary data for relay", async function () {
     assert.equal(
       hexToUtf8(defaultRelayAncillaryData),

--- a/packages/core/test/insured-bridge/BridgePool.js
+++ b/packages/core/test/insured-bridge/BridgePool.js
@@ -389,18 +389,18 @@ describe("BridgePool", () => {
     const newRate = toWei("0.0000025");
     assert(
       await didContractThrow(
-        bridgeAdmin.methods.changeLpFeeRatePerSecond(bridgePool.options.address, newRate).send({ from: rando })
+        bridgeAdmin.methods.setLpFeeRatePerSecond(bridgePool.options.address, newRate).send({ from: rando })
       )
     );
 
     // Calling from the correct address succeeds.
     const tx = await bridgeAdmin.methods
-      .changeLpFeeRatePerSecond(bridgePool.options.address, newRate)
+      .setLpFeeRatePerSecond(bridgePool.options.address, newRate)
       .send({ from: owner });
 
     assert.equal(await bridgePool.methods.lpFeeRatePerSecond().call(), newRate);
 
-    await assertEventEmitted(tx, bridgePool, "LpFeeRateChanged", (ev) => {
+    await assertEventEmitted(tx, bridgePool, "LpFeeRateSet", (ev) => {
       return ev.newLpFeeRatePerSecond.toString() === newRate;
     });
   });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This rate is not easy to set and forget and should be configurable by Bridge admin.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested