### PR TITLE
fix(across): address possible underflow in bridge pool

### DIFF
--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -739,6 +739,9 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
         _sync(); // Fetch any balance changes due to token bridging finalization and factor them in.
 
         // ExchangeRate := (liquidReserves + utilizedReserves - undistributedLpFees) / lpTokenSupply
+        // Note that utilizedReserves can be negative. If this is the case, then liquidReserves is offset by an equal
+        // and opposite size. LiquidReserves + utilizedReserves will always be larger than undistributedLpFees so this
+        // int will always be positive so there is no risk in underflow in type casting in the return line.
         int256 numerator = int256(liquidReserves) + utilizedReserves - int256(undistributedLpFees);
         return (uint256(numerator) * 1e18) / totalSupply();
     }

--- a/packages/core/contracts/insured-bridge/BridgePool.sol
+++ b/packages/core/contracts/insured-bridge/BridgePool.sol
@@ -739,10 +739,8 @@ contract BridgePool is MultiCaller, Testable, BridgePoolInterface, ERC20, Lockab
         _sync(); // Fetch any balance changes due to token bridging finalization and factor them in.
 
         // ExchangeRate := (liquidReserves + utilizedReserves - undistributedLpFees) / lpTokenSupply
-        uint256 numerator = liquidReserves - undistributedLpFees;
-        if (utilizedReserves > 0) numerator += uint256(utilizedReserves);
-        else numerator -= uint256(utilizedReserves * -1);
-        return (numerator * 1e18) / totalSupply();
+        int256 numerator = int256(liquidReserves) + utilizedReserves - int256(undistributedLpFees);
+        return (uint256(numerator) * 1e18) / totalSupply();
     }
 
     // Return UTF8-decodable ancillary data for relay price request associated with relay hash.


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
_undistributedLpFees should be thought of as a component of utilizedReserves. It's not guaranteed to be smaller than liquidReserves, which means line 742 could unexpected negative overflow. The exchange rate should compute liquidReserves + utilizedReserves first, and then subtract undistributedLpFees_

A manual test was done to verify this behaviour. Indeed, when `undistributedLpFees_` is greater than `liquidReserves ` the `exchangeRateCurrent` method reverts. The impact of this prevents adding/removing liquidity and does not break anything else. I created a test that would add liquidity then relay once to get a value in undistributedLpFees then relay again to use almost all liquidReserves such that `undistributedLpFees>liquidReserves` under this condition the following happens:
1) adding liquidity reverts.
2) removing liquidity reverts.
3) calling exchangeRateCurrent reverts.
All other methods seem to work fine. can relay (assuming the size is less than the liquid reserves), can settle a relay and can speed up.
Then, I mimicked funds coming over the canonical bridge. this resolves the `undistributedLpFees>liquidReserves`  condition and everything starts working again (users can add liquidity/remove liquidity/call exchange rate current).

What this means is that the current contracts do have a state in which they “lock up”. Effectively, this occurs when we are at just below  100% utilization. however, and most importantly, this does not break anything and the contracts unlock as soon as funds come over the bridge.

In any case, this PR fixes the issue in the pools.


**Summary**

Fixed underflow.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
