### PR TITLE
improve(cross-chain-oracle): Allow publishPrice to be called for any DVM resolved price

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/OracleBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleBase.sol
@@ -42,6 +42,8 @@ abstract contract OracleBase {
     /**
      * @notice Enqueues a request (if a request isn't already present) for the given (identifier, time,
      * ancillary data) combination. Will only emit an event if the request has never been requested.
+     * @return True if price request is new, false otherwise. This is useful for caller to keep track of
+     * duplicate price requests.
      */
     function _requestPrice(
         bytes32 identifier,
@@ -61,7 +63,7 @@ abstract contract OracleBase {
     }
 
     /**
-     * @notice Publishes price for a requested query. Will only emit an event if the request has never been resolved.
+     * @notice Publishes price for a requested query.
      */
     function _publishPrice(
         bytes32 identifier,
@@ -71,11 +73,9 @@ abstract contract OracleBase {
     ) internal {
         bytes32 priceRequestId = _encodePriceRequest(identifier, time, ancillaryData);
         Price storage lookup = prices[priceRequestId];
-        if (lookup.state == RequestState.Requested) {
-            lookup.price = price;
-            lookup.state = RequestState.Resolved;
-            emit PushedPrice(identifier, time, ancillaryData, lookup.price, priceRequestId);
-        }
+        lookup.price = price;
+        lookup.state = RequestState.Resolved;
+        emit PushedPrice(identifier, time, ancillaryData, lookup.price, priceRequestId);
     }
 
     /**

--- a/packages/core/contracts/cross-chain-oracle/OracleBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleBase.sol
@@ -64,6 +64,7 @@ abstract contract OracleBase {
 
     /**
      * @notice Publishes price for a requested query.
+     * @dev Does not update price state if price is already resolved.
      */
     function _publishPrice(
         bytes32 identifier,
@@ -73,6 +74,7 @@ abstract contract OracleBase {
     ) internal {
         bytes32 priceRequestId = _encodePriceRequest(identifier, time, ancillaryData);
         Price storage lookup = prices[priceRequestId];
+        if (lookup.state == RequestState.Resolved) return;
         lookup.price = price;
         lookup.state = RequestState.Resolved;
         emit PushedPrice(identifier, time, ancillaryData, lookup.price, priceRequestId);

--- a/packages/core/contracts/cross-chain-oracle/OracleHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleHub.sol
@@ -58,9 +58,9 @@ contract OracleHub is OracleBase, ParentMessengerConsumerInterface, Ownable, Loc
      * @notice Publishes a DVM resolved price to the OracleSpoke deployed on the network linked  with `chainId`, or
      * reverts if not resolved yet. This contract must be registered with the DVM to query price requests.
      * The DVM price resolution is communicated to the OracleSpoke via the Parent-->Child messenger channel.
-     * @dev This method will return silently if already called for this price request, but will still attempt to call
-     * `messenger.sendMessageToChild` again even if it is a duplicate call. Therefore the Messenger contract for this
-     * `chainId` should determine how to handle duplicate calls.
+     * @dev This method will always attempt to call `messenger.sendMessageToChild` even if it is a duplicate call for
+     * this price request. Therefore the Messenger contract for this `chainId` should determine how to handle duplicate
+     * calls.
      * @param chainId Network to resolve price for.
      * @param identifier Identifier of price request to resolve.
      * @param time Timestamp of price request to resolve.

--- a/packages/core/test/cross-chain-oracle/OracleBase.js
+++ b/packages/core/test/cross-chain-oracle/OracleBase.js
@@ -73,6 +73,12 @@ describe("OracleBase", async () => {
         event.ancillaryData.toLowerCase() === testAncillary.toLowerCase() &&
         event.price.toString() === testPrice
     );
+
+    // Duplicate call does not emit an event.
+    txn = await oracle.methods
+      .publishPrice(testIdentifier, testRequestTime, testAncillary, testPrice)
+      .send({ from: owner });
+    await assertEventNotEmitted(txn, oracle, "PushedPrice");
   });
   it("encodePriceRequest", async function () {
     const encodedPrice = await oracle.methods.encodePriceRequest(testIdentifier, testRequestTime, testAncillary).call();

--- a/packages/core/test/cross-chain-oracle/OracleBase.js
+++ b/packages/core/test/cross-chain-oracle/OracleBase.js
@@ -60,7 +60,6 @@ describe("OracleBase", async () => {
     await assertEventNotEmitted(txn, oracle, "PriceRequestAdded");
   });
   it("publishPrice", async function () {
-    await oracle.methods.requestPrice(testIdentifier, testRequestTime, testAncillary).send({ from: owner });
     let txn = await oracle.methods
       .publishPrice(testIdentifier, testRequestTime, testAncillary, testPrice)
       .send({ from: owner });
@@ -74,11 +73,6 @@ describe("OracleBase", async () => {
         event.ancillaryData.toLowerCase() === testAncillary.toLowerCase() &&
         event.price.toString() === testPrice
     );
-    // Duplicate call does not emit an event.
-    txn = await oracle.methods
-      .publishPrice(testIdentifier, testRequestTime, testAncillary, testPrice)
-      .send({ from: owner });
-    await assertEventNotEmitted(txn, oracle, "PushedPrice");
   });
   it("encodePriceRequest", async function () {
     const encodedPrice = await oracle.methods.encodePriceRequest(testIdentifier, testRequestTime, testAncillary).call();

--- a/packages/core/test/cross-chain-oracle/OracleSpoke.js
+++ b/packages/core/test/cross-chain-oracle/OracleSpoke.js
@@ -81,12 +81,7 @@ describe("OracleSpoke.js", async () => {
     assert.equal((await messenger.methods.messageCount().call()).toString(), "2");
   });
   it("processMessageFromParent", async function () {
-    // Request a price on OracleSpoke so that _publishPrice will emit an event.
-    await oracleSpoke.methods
-      .requestPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
-      .send({ from: owner });
     const expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData, owner).call();
-
     const expectedData = web3.eth.abi.encodeParameters(
       ["bytes32", "uint256", "bytes", "int256"],
       [defaultIdentifier, defaultTimestamp, expectedAncillaryData, defaultPrice]
@@ -121,9 +116,6 @@ describe("OracleSpoke.js", async () => {
         .call({ from: owner })
     );
 
-    await oracleSpoke.methods
-      .requestPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
-      .send({ from: owner });
     let expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData, owner).call();
     await messenger.methods
       .publishPrice(
@@ -150,7 +142,6 @@ describe("OracleSpoke.js", async () => {
 
     // Can call has without ancillary data:
     assert.isFalse(await oracleSpoke.methods.hasPrice(defaultIdentifier, defaultTimestamp).call({ from: owner }));
-    await oracleSpoke.methods.requestPrice(defaultIdentifier, defaultTimestamp).send({ from: owner });
     expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData("0x", owner).call();
     await messenger.methods
       .publishPrice(
@@ -171,9 +162,6 @@ describe("OracleSpoke.js", async () => {
       )
     );
 
-    await oracleSpoke.methods
-      .requestPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
-      .send({ from: owner });
     let expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData, owner).call();
     await messenger.methods
       .publishPrice(
@@ -200,7 +188,6 @@ describe("OracleSpoke.js", async () => {
     );
 
     // Can call has without ancillary data:
-    await oracleSpoke.methods.requestPrice(defaultIdentifier, defaultTimestamp).send({ from: owner });
     expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData("0x", owner).call();
     await messenger.methods
       .publishPrice(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

`OracleBase.publishPrice` can currently only be called after a price is requested, which usually comes via a cross-chain price request. This is unnecessarily restrictive as the `OracleSpokes` should be able to make all prices available that have been resolved on the DVM, even if they weren't originally requested via the `OracleSpoke` on the child network.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
