### PR TITLE
feat: add Admin_ChildMessenger

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/ChildMessengerInterface.sol";
+import "../interfaces/ChildMessengerConsumerInterface.sol";
+import "../../common/implementation/Lockable.sol";
+
+/**
+ * @notice A version of the child messenger that allows an admin to relay messages on its behalf.
+ * @dev No parent messenger is needed for this case, as the admin could be trusted to manually send DVM requests on
+ * mainnet. This is intended to be used as a "beta" deployment compatible with any EVM-compatible chains before
+ * impleenting a full bridge adapter. Put simply, it is meant as a stop-gap.
+ */
+contract Admin_ChildMessenger is Ownable, Lockable, ChildMessengerInterface {
+    // The only child network contract that can send messages over the bridge via the messenger is the oracle spoke.
+    address public oracleSpoke;
+
+    event SetOracleSpoke(address newOracleSpoke);
+    event MessageSentToParent(bytes data);
+    event MessageReceivedFromParent(bytes data, address indexed targetSpoke, address indexed caller);
+
+    /**
+     * @notice Changes the stored address of the Oracle spoke, deployed on L2.
+     * @dev The caller of this function must be the admin.
+     * @param newOracleSpoke address of the new oracle spoke, deployed on L2.
+     */
+    function setOracleSpoke(address newOracleSpoke) public onlyOwner nonReentrant() {
+        oracleSpoke = newOracleSpoke;
+        emit SetOracleSpoke(newOracleSpoke);
+    }
+
+    /**
+     * @notice Logs a message to be manually relayed to L1.
+     * @dev The caller must be the OracleSpoke on L2. No other contract is permissioned to call this function.
+     * @param data data message sent to the L1 messenger. Should be an encoded function call or packed data.
+     */
+    function sendMessageToParent(bytes memory data) public override nonReentrant() {
+        require(msg.sender == oracleSpoke, "Only callable by oracleSpoke");
+
+        // The data formmat is kept the same to match the format in other ChildMessenger classes.
+        bytes memory dataSentToParent = abi.encodeWithSignature("processMessageFromCrossChainChild(bytes)", data);
+
+        // Note: only emit an event. These messages will be manually relayed.
+        emit MessageSentToParent(dataSentToParent);
+    }
+
+    /**
+     * @notice Process a received message from the admin.
+     * @dev The caller must be the the admin.
+     * @param data data message sent from the admin. Should be an encoded function call or packed data.
+     * @param target desired recipient of `data`. Target must implement the `processMessageFromParent` function. Having
+     * this as a param enables the Admin to send messages to arbitrary addresses on the L2. This is primarily
+     * used to send messages to the OracleSpoke and GovernorSpoke on L2.
+     */
+    function processMessageFromCrossChainParent(bytes memory data, address target) public onlyOwner nonReentrant() {
+        ChildMessengerConsumerInterface(target).processMessageFromParent(data);
+        emit MessageReceivedFromParent(data, target, msg.sender);
+    }
+}

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
@@ -17,7 +17,7 @@ contract Admin_ChildMessenger is Ownable, Lockable, ChildMessengerInterface {
     address public oracleSpoke;
 
     event SetOracleSpoke(address newOracleSpoke);
-    event MessageSentToParent(bytes data);
+    event MessageSentToParent(bytes data, address indexed oracleSpoke);
     event MessageReceivedFromParent(bytes data, address indexed targetSpoke, address indexed caller);
 
     /**
@@ -38,11 +38,8 @@ contract Admin_ChildMessenger is Ownable, Lockable, ChildMessengerInterface {
     function sendMessageToParent(bytes memory data) public override nonReentrant() {
         require(msg.sender == oracleSpoke, "Only callable by oracleSpoke");
 
-        // The data formmat is kept the same to match the format in other ChildMessenger classes.
-        bytes memory dataSentToParent = abi.encodeWithSignature("processMessageFromCrossChainChild(bytes)", data);
-
         // Note: only emit an event. These messages will be manually relayed.
-        emit MessageSentToParent(dataSentToParent);
+        emit MessageSentToParent(data, oracleSpoke);
     }
 
     /**

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
@@ -47,8 +47,8 @@ contract Admin_ChildMessenger is Ownable, Lockable, ChildMessengerInterface {
      * @dev The caller must be the the admin.
      * @param data data message sent from the admin. Should be an encoded function call or packed data.
      * @param target desired recipient of `data`. Target must implement the `processMessageFromParent` function. Having
-     * this as a param enables the Admin to send messages to arbitrary addresses on the L2. This is primarily
-     * used to send messages to the OracleSpoke and GovernorSpoke on L2.
+     * this as a param enables the Admin to send messages to arbitrary addresses from the messenger contract. This is
+     * primarily used to send messages to the OracleSpoke and GovernorSpoke.
      */
     function processMessageFromCrossChainParent(bytes memory data, address target) public onlyOwner nonReentrant() {
         ChildMessengerConsumerInterface(target).processMessageFromParent(data);

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ChildMessenger.sol
@@ -20,7 +20,7 @@ contract Arbitrum_ChildMessenger is AVM_CrossDomainEnabled, ChildMessengerInterf
 
     event SetOracleSpoke(address newOracleSpoke);
     event SetParentMessenger(address newParentMessenger);
-    event MessageSentToParent(bytes data, address indexed parentAddress, uint256 id);
+    event MessageSentToParent(bytes data, address indexed parentAddress, address indexed oracleSpoke, uint256 id);
     event MessageReceivedFromParent(bytes data, address indexed targetSpoke, address indexed parentAddress);
 
     /**
@@ -65,7 +65,7 @@ contract Arbitrum_ChildMessenger is AVM_CrossDomainEnabled, ChildMessengerInterf
         require(msg.sender == oracleSpoke, "Only callable by oracleSpoke");
         bytes memory dataSentToParent = abi.encodeWithSignature("processMessageFromCrossChainChild(bytes)", data);
         uint256 id = sendCrossDomainMessage(msg.sender, parentMessenger, dataSentToParent);
-        emit MessageSentToParent(dataSentToParent, parentMessenger, id);
+        emit MessageSentToParent(dataSentToParent, parentMessenger, oracleSpoke, id);
     }
 
     /**

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ChildMessenger.sol
@@ -28,7 +28,7 @@ contract Optimism_ChildMessenger is CrossDomainEnabled, ChildMessengerInterface,
     event SetOracleSpoke(address newOracleSpoke);
     event SetParentMessenger(address newParentMessenger);
     event SetDefaultGasLimit(uint32 newDefaultGasLimit);
-    event MessageSentToParent(bytes data, address indexed parentAddress, uint32 gasLimit);
+    event MessageSentToParent(bytes data, address indexed parentAddress, address oracleSpoke, uint32 gasLimit);
     event MessageReceivedFromParent(bytes data, address indexed targetSpoke, address indexed parentAddress);
 
     /**
@@ -87,7 +87,7 @@ contract Optimism_ChildMessenger is CrossDomainEnabled, ChildMessengerInterface,
         require(msg.sender == oracleSpoke, "Only callable by oracleSpoke");
         bytes memory dataSentToParent = abi.encodeWithSignature("processMessageFromCrossChainChild(bytes)", data);
         sendCrossDomainMessage(parentMessenger, defaultGasLimit, dataSentToParent);
-        emit MessageSentToParent(dataSentToParent, parentMessenger, defaultGasLimit);
+        emit MessageSentToParent(dataSentToParent, parentMessenger, oracleSpoke, defaultGasLimit);
     }
 
     /**

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
@@ -20,7 +20,7 @@ contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, L
 
     event SetOracleSpoke(address newOracleSpoke);
     event SetOracleHub(address newOracleHub);
-    event MessageSentToParent(bytes data, address indexed targetHub);
+    event MessageSentToParent(bytes data, address indexed targetHub, address indexed oracleSpoke);
     event MessageReceivedFromParent(address indexed targetSpoke, bytes dataToSendToTarget);
 
     /**
@@ -63,7 +63,7 @@ contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, L
     function sendMessageToParent(bytes memory data) public override nonReentrant() {
         require(msg.sender == oracleSpoke, "Only callable by oracleSpoke");
         _sendMessageToRoot(abi.encode(data, oracleHub));
-        emit MessageSentToParent(data, oracleHub);
+        emit MessageSentToParent(data, oracleHub, oracleSpoke);
     }
 
     /**

--- a/packages/core/test/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.js
+++ b/packages/core/test/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.js
@@ -1,0 +1,126 @@
+const hre = require("hardhat");
+const { web3, assertEventEmitted, getContract } = hre;
+const { randomHex, utf8ToHex } = web3.utils;
+const { assert } = require("chai");
+
+const { didContractThrow, runDefaultFixture, RegistryRolesEnum } = require("@uma/common");
+
+const Admin_ChildMessenger = getContract("Admin_ChildMessenger");
+const OracleSpoke = getContract("OracleSpoke");
+const Finder = getContract("Finder");
+const Registry = getContract("Registry");
+const Timer = getContract("Timer");
+
+describe("Admin_ChildMessenger", function () {
+  let owner, rando, oracleSpoke;
+  let messenger;
+
+  beforeEach(async () => {
+    const accounts = await web3.eth.getAccounts();
+    [owner, rando, oracleSpoke] = accounts;
+
+    messenger = await Admin_ChildMessenger.new().send({ from: owner });
+    await messenger.methods.setOracleSpoke(oracleSpoke).send({ from: owner });
+  });
+
+  it("Setting oracle spoke", async () => {
+    // Only owner can set the oracle spoke.
+    assert(await didContractThrow(messenger.methods.setOracleSpoke(rando).send({ from: rando })));
+    assert(await didContractThrow(messenger.methods.setOracleSpoke(rando).send({ from: oracleSpoke })));
+
+    // Events
+    const newOracleSpoke = randomHex(20).toLowerCase();
+    const receipt = await messenger.methods.setOracleSpoke(newOracleSpoke).send({ from: owner });
+
+    await assertEventEmitted(
+      receipt,
+      messenger,
+      "SetOracleSpoke",
+      (event) => event.newOracleSpoke.toLowerCase() === newOracleSpoke
+    );
+  });
+
+  it("Send message to parent", async () => {
+    const data = utf8ToHex("PRICEREQUESTDATA");
+
+    // Only the oracle spoke can send a message to the parent.
+    assert(await didContractThrow(messenger.methods.sendMessageToParent(data).send({ from: rando })));
+    assert(await didContractThrow(messenger.methods.sendMessageToParent(data).send({ from: owner })));
+
+    // Events
+    const receipt = await messenger.methods.sendMessageToParent(data).send({ from: oracleSpoke });
+
+    await assertEventEmitted(
+      receipt,
+      messenger,
+      "MessageSentToParent",
+      (event) => event.oracleSpoke === oracleSpoke && event.data === data
+    );
+  });
+
+  it("Process message from parent", async () => {
+    // Set up commmon infra to run real price requests.
+    await runDefaultFixture(hre);
+    const finder = await Finder.deployed();
+    const registry = await Registry.deployed();
+    const timer = await Timer.deployed();
+    await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, owner).send({ from: owner });
+    await registry.methods.registerContract([], owner).send({ from: owner });
+    const identifier = utf8ToHex("TESTID");
+    const timestamp = await timer.methods.getCurrentTime().call();
+    const ancillaryData = utf8ToHex("TESTDATA");
+
+    // Create the spoke oracle and connect it to the messenger.
+    const oracleSpokeReal = await OracleSpoke.new(finder.options.address, messenger.options.address).send({
+      from: owner,
+    });
+    await messenger.methods.setOracleSpoke(oracleSpokeReal.options.address).send({ from: owner });
+
+    // Because owner is a registered contract we should be able to send a price request.
+    let receipt = await oracleSpokeReal.methods
+      .requestPrice(identifier, timestamp, ancillaryData)
+      .send({ from: owner });
+    await assertEventEmitted(receipt, messenger, "MessageSentToParent");
+
+    // Encode price response data.
+    const dataToSend = web3.eth.abi.encodeParameters(
+      ["bytes32", "uint256", "bytes", "int256"],
+      [identifier, timestamp, ancillaryData, "100"]
+    );
+
+    // Only the owner can send a message to the spoke contracts.
+    assert(
+      await didContractThrow(
+        messenger.methods
+          .processMessageFromCrossChainParent(dataToSend, oracleSpokeReal.options.address)
+          .send({ from: oracleSpoke })
+      )
+    );
+    assert(
+      await didContractThrow(
+        messenger.methods
+          .processMessageFromCrossChainParent(dataToSend, oracleSpokeReal.options.address)
+          .send({ from: rando })
+      )
+    );
+
+    receipt = await messenger.methods
+      .processMessageFromCrossChainParent(dataToSend, oracleSpokeReal.options.address)
+      .send({ from: owner });
+
+    // Events
+    await assertEventEmitted(
+      receipt,
+      messenger,
+      "MessageReceivedFromParent",
+      (event) =>
+        event.data === dataToSend && event.targetSpoke === oracleSpokeReal.options.address && event.caller === owner
+    );
+
+    // Check the price.
+    assert.equal(
+      await oracleSpokeReal.methods.getPrice(identifier, timestamp, ancillaryData).call({ from: owner }),
+      "100"
+    );
+  });
+});

--- a/packages/core/test/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.js
+++ b/packages/core/test/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.js
@@ -15,6 +15,10 @@ describe("Admin_ChildMessenger", function () {
   let owner, rando, oracleSpoke;
   let messenger;
 
+  before(async () => {
+    await runDefaultFixture(hre);
+  });
+
   beforeEach(async () => {
     const accounts = await web3.eth.getAccounts();
     [owner, rando, oracleSpoke] = accounts;
@@ -60,7 +64,6 @@ describe("Admin_ChildMessenger", function () {
 
   it("Process message from parent", async () => {
     // Set up commmon infra to run real price requests.
-    await runDefaultFixture(hre);
     const finder = await Finder.deployed();
     const registry = await Registry.deployed();
     const timer = await Timer.deployed();


### PR DESCRIPTION
**Motivation**

We would like to support EVM compatible chains that we haven't built specialized bridge integrations for.

**Summary**

This contract matches the interface of other ChildMessengers, but instead of bridging, it just emits logs on incoming messages and allows an admin to send messages out.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
