### PR TITLE
improve(across-relayer): Should prune whitelisted L1 tokens using L2 events

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -27,7 +27,6 @@ export class InsuredBridgeL2Client {
   private whitelistedTokens: { [key: string]: string } = {}; // L1Token=>L2Token
 
   private firstBlockToSearch: number;
-  private lastBlockToSearch: number | null;
 
   constructor(
     private readonly logger: Logger,
@@ -43,7 +42,6 @@ export class InsuredBridgeL2Client {
     ) as unknown) as BridgeDepositBoxWeb3;
 
     this.firstBlockToSearch = startingBlockNumber;
-    this.lastBlockToSearch = endingBlockNumber;
   }
 
   getAllDeposits() {
@@ -69,7 +67,7 @@ export class InsuredBridgeL2Client {
     // Define a config to bound the queries by.
     const blockSearchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.lastBlockToSearch || (await this.l2Web3.eth.getBlockNumber()),
+      toBlock: this.endingBlockNumber || (await this.l2Web3.eth.getBlockNumber()),
     };
     // TODO: update this state retrieval to include looking for L2 liquidity in the deposit box that can be sent over
     // the bridge. This should consider the minimumBridgingDelay and the lastBridgeTime for a respective L2Token.
@@ -104,10 +102,7 @@ export class InsuredBridgeL2Client {
       this.deposits[depositData.depositHash] = depositData;
     }
 
-    // Advance block search one same-length window forwards.
-    const blockSearchWindowLength = blockSearchConfig.toBlock - blockSearchConfig.fromBlock;
     this.firstBlockToSearch = blockSearchConfig.toBlock + 1;
-    this.lastBlockToSearch = this.firstBlockToSearch + blockSearchWindowLength;
 
     this.logger.debug({
       at: "InsuredBridgeL2Client",

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
@@ -147,4 +147,15 @@ describe("InsuredBridgeL2Client", () => {
     expectedDeposits[1].depositHash = generateDepositHash(expectedDeposits[1]);
     assert.equal(JSON.stringify(client.getAllDeposits()), JSON.stringify(expectedDeposits));
   });
+
+  it("Correctly returns whitelisted token event information", async () => {
+    // Before updating, should return false for whitelisted token.
+    assert.isFalse(client.isWhitelistedToken(l1TokenAddress));
+
+    await client.update();
+    assert.isTrue(client.isWhitelistedToken(l1TokenAddress));
+
+    // Should return false if l1 token address is not whitelisted
+    assert.isFalse(client.isWhitelistedToken(l2Token.options.address));
+  });
 });

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -273,6 +273,10 @@ export class Relayer {
       // we won't be able to determine otherwise if the realized LP fee % is valid.
       // Similarly, if deposit.quoteTimestamp > relay.blockTime then its also an invalid relay because it would have
       // been impossible for the relayer to compute the realized LP fee % for the deposit.quoteTime in the future.
+      // Note: This means that if the bridgepool contract is upgraded, all deposits should be disabled until the L2
+      // block time has caught up to the bridge pool's deployment time. For example, if the Optimism block time is 15
+      // minutes before Mainnet's block time, and a new bridge pool is deployed, all deposits on Optimism should be
+      // disabled for 15 minutes until deposit quote timestamps catch up to the bridge pool's deployment time.
       const relayBlockTime = Number((await this.l1Client.l1Web3.eth.getBlock(relay.blockNumber)).timestamp);
       if (
         deposit.quoteTimestamp < this.l1DeployData[deposit.l1Token].timestamp ||

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -136,8 +136,6 @@ export class RelayerConfig {
 
     this.l1DeployData = replaceAddressCase(L1_DEPLOY_DATA ? JSON.parse(L1_DEPLOY_DATA) : bridgePoolDeployData);
     this.l2DeployData = L2_DEPLOY_DATA ? JSON.parse(L2_DEPLOY_DATA) : bridgeDepositBoxDeployData;
-
-    assert(RATE_MODELS, "RATE_MODELS required");
     const processingRateModels = RATE_MODELS ? JSON.parse(RATE_MODELS) : across.constants.RATE_MODELS;
 
     for (const l1Token of Object.keys(processingRateModels)) {

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -82,6 +82,7 @@ export class RelayerConfig {
   readonly rateModels: { [key: string]: RateModel } = {};
   readonly activatedChainIds: number[];
   readonly l2BlockLookback: number;
+  readonly l2EndBlock: number;
   readonly crossDomainFinalizationThreshold: number;
   readonly botModes: BotModes;
   readonly l1DeployData: { [key: string]: { timestamp: number } };
@@ -96,6 +97,7 @@ export class RelayerConfig {
       RATE_MODELS,
       CHAIN_IDS,
       L2_BLOCK_LOOKBACK,
+      L2_END_BLOCK,
       CROSS_DOMAIN_FINALIZATION_THRESHOLD,
       RELAYER_ENABLED,
       FINALIZER_ENABLED,
@@ -126,6 +128,7 @@ export class RelayerConfig {
     // constrain L1 start blocks but this hasn't been an issue empirically. As a data point, Arbitrum Infura has a
     // query limit of up to 100,000 blocks into the past.
     this.l2BlockLookback = L2_BLOCK_LOOKBACK ? Number(L2_BLOCK_LOOKBACK) : 99999;
+    this.l2EndBlock = L2_END_BLOCK ? Number(L2_END_BLOCK) : 0;
 
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -82,7 +82,6 @@ export class RelayerConfig {
   readonly rateModels: { [key: string]: RateModel } = {};
   readonly activatedChainIds: number[];
   readonly l2BlockLookback: number;
-  readonly l2EndBlock: number;
   readonly crossDomainFinalizationThreshold: number;
   readonly botModes: BotModes;
   readonly l1DeployData: { [key: string]: { timestamp: number } };
@@ -97,7 +96,6 @@ export class RelayerConfig {
       RATE_MODELS,
       CHAIN_IDS,
       L2_BLOCK_LOOKBACK,
-      L2_END_BLOCK,
       CROSS_DOMAIN_FINALIZATION_THRESHOLD,
       RELAYER_ENABLED,
       FINALIZER_ENABLED,
@@ -128,7 +126,6 @@ export class RelayerConfig {
     // constrain L1 start blocks but this hasn't been an issue empirically. As a data point, Arbitrum Infura has a
     // query limit of up to 100,000 blocks into the past.
     this.l2BlockLookback = L2_BLOCK_LOOKBACK ? Number(L2_BLOCK_LOOKBACK) : 99999;
-    this.l2EndBlock = L2_END_BLOCK ? Number(L2_END_BLOCK) : 0;
 
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;

--- a/packages/insured-bridge-relayer/src/RelayerHelpers.ts
+++ b/packages/insured-bridge-relayer/src/RelayerHelpers.ts
@@ -48,7 +48,7 @@ export async function pruneWhitelistedL1Tokens(
   const filteredWhitelistedRelayL1Tokens = whitelistedRelayL1Tokens.filter((l1TokenAddress: string) => {
     return l2Client.isWhitelistedToken(l1TokenAddress);
   });
-  logger.info({
+  logger.debug({
     at: "AcrossRelayer#index",
     message: "Filtered out tokens that are not whitelisted on L2",
     filteredWhitelistedRelayL1Tokens,

--- a/packages/insured-bridge-relayer/src/RelayerHelpers.ts
+++ b/packages/insured-bridge-relayer/src/RelayerHelpers.ts
@@ -4,7 +4,7 @@ const { toBN } = Web3.utils;
 import winston from "winston";
 import { getAbi } from "@uma/contracts-node";
 import { ZERO_ADDRESS } from "@uma/common";
-import { GasEstimator, setAllowance } from "@uma/financial-templates-lib";
+import { GasEstimator, setAllowance, InsuredBridgeL2Client } from "@uma/financial-templates-lib";
 
 import type { BN } from "@uma/common";
 
@@ -33,6 +33,27 @@ export async function approveL1Tokens(
         approvalTx: approvalTx.tx.transactionHash,
       });
   }
+}
+
+// Iterate over provided list of whitelisted L1 tokens and remove any that are not whitelisted on a specific L2.
+// The Relayer will use this whitelist to determine which deposits to relay. By default, the whitelist will be set
+// to the list of all possible tokens provided in the RateModels dictionary. However, not all L1 tokens in this
+// dictionary will be whitelisted for all L2 deposit boxes.
+export async function pruneWhitelistedL1Tokens(
+  logger: winston.Logger,
+  l2Client: InsuredBridgeL2Client,
+  whitelistedRelayL1Tokens: string[]
+): Promise<string[]> {
+  await l2Client.update();
+  const filteredWhitelistedRelayL1Tokens = whitelistedRelayL1Tokens.filter((l1TokenAddress: string) => {
+    return l2Client.isWhitelistedToken(l1TokenAddress);
+  });
+  logger.info({
+    at: "AcrossRelayer#index",
+    message: "Filtered out tokens that are not whitelisted on L2",
+    filteredWhitelistedRelayL1Tokens,
+  });
+  return filteredWhitelistedRelayL1Tokens;
 }
 
 // Return the ballance of account on tokenAddress for a given web3 network.

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -67,29 +67,18 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
     // Update the L2 client and filter out tokens that are not whitelisted on the L2 from the whitelisted
     // L1 relay list.
     await l2Client.update();
-    const filteredWhitelistedRelayL1Tokens = await pruneWhitelistedL1Tokens(
-      logger,
-      l2Client,
-      config.whitelistedRelayL1Tokens
-    );
+    const filteredL1Whitelist = await pruneWhitelistedL1Tokens(logger, l2Client, config.whitelistedRelayL1Tokens);
 
     // For all specified whitelisted L1 tokens that this relayer supports, approve the bridge pool to spend them. This
     // method will error if the bot runner has specified a L1 tokens that is not part of the Bridge Admin whitelist.
-    await approveL1Tokens(
-      logger,
-      l1Web3,
-      gasEstimator,
-      accounts[0],
-      config.bridgeAdmin,
-      filteredWhitelistedRelayL1Tokens
-    );
+    await approveL1Tokens(logger, l1Web3, gasEstimator, accounts[0], config.bridgeAdmin, filteredL1Whitelist);
 
     const relayer = new Relayer(
       logger,
       gasEstimator,
       l1Client,
       l2Client,
-      filteredWhitelistedRelayL1Tokens,
+      filteredL1Whitelist,
       accounts[0],
       config.whitelistedChainIds,
       config.l1DeployData,

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -53,15 +53,13 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
     const l2Web3 = getWeb3ByChainId(config.activatedChainIds[0]);
     const latestL2BlockNumber = await l2Web3.eth.getBlockNumber();
     const l2StartBlock = Math.max(0, latestL2BlockNumber - config.l2BlockLookback);
-    const l2EndBlock = config.l2EndBlock > 0 ? config.l2EndBlock : null;
 
     const l2Client = new InsuredBridgeL2Client(
       logger,
       l2Web3,
       await l1Client.getL2DepositBoxAddress(config.activatedChainIds[0]),
       config.activatedChainIds[0],
-      l2StartBlock,
-      l2EndBlock
+      l2StartBlock
     );
 
     // Update the L2 client and filter out tokens that are not whitelisted on the L2 from the whitelisted

--- a/packages/insured-bridge-relayer/test/index.ts
+++ b/packages/insured-bridge-relayer/test/index.ts
@@ -13,7 +13,7 @@ const { toWei, toBN, utf8ToHex, toChecksumAddress, randomHex } = web3.utils;
 const toBNWei = (number: string | number) => toBN(toWei(number.toString()).toString());
 
 let l2Web3: typeof Web3 = undefined;
-const startGanacheServer = (chainId: number, port: number): typeof Web3 => {
+const startGanacheServer = (chainId: number, port: number) => {
   if (l2Web3 !== undefined) return;
   const node = ganache.server({ _chainIdRpc: chainId });
   node.listen(port);
@@ -150,7 +150,7 @@ describe("index.js", function () {
       transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
     });
 
-    const l2Web3 = await startGanacheServer(chainId, 7777);
+    await startGanacheServer(chainId, 7777);
     const [l2Owner, l2BridgeAdminImpersonator] = await l2Web3.eth.getAccounts();
 
     // Deploy deposit box on L2 web3 so that L2 client can read its events.
@@ -242,6 +242,7 @@ describe("index.js", function () {
     const targetLog = spy.getCalls().filter((_log: any) => {
       return _log.lastArg.message.includes("Filtered out tokens that are not whitelisted on L2");
     })[0];
-    assert.equal(targetLog.filteredWhitelistedRelayL1Tokens, [l1Token.options.address]);
+    assert.equal(targetLog.lastArg.filteredWhitelistedRelayL1Tokens.length, 1);
+    assert.equal(targetLog.lastArg.filteredWhitelistedRelayL1Tokens[0], l1Token.options.address);
   });
 });

--- a/packages/insured-bridge-relayer/test/index.ts
+++ b/packages/insured-bridge-relayer/test/index.ts
@@ -12,13 +12,12 @@ const { web3, getContract } = hre as HRE;
 const { toWei, toBN, utf8ToHex, toChecksumAddress, randomHex } = web3.utils;
 const toBNWei = (number: string | number) => toBN(toWei(number.toString()).toString());
 
-let isGanacheServerStarted = false;
-const startGanacheServer = (chainId: number, port: number) => {
-  if (isGanacheServerStarted) return;
+let l2Web3: typeof Web3 = undefined;
+const startGanacheServer = (chainId: number, port: number): typeof Web3 => {
+  if (l2Web3 !== undefined) return;
   const node = ganache.server({ _chainIdRpc: chainId });
   node.listen(port);
-  isGanacheServerStarted = true;
-  return new Web3("http://127.0.0.1:" + port);
+  l2Web3 = new Web3("http://127.0.0.1:" + port);
 };
 
 // Helper contracts

--- a/packages/insured-bridge-relayer/test/index.ts
+++ b/packages/insured-bridge-relayer/test/index.ts
@@ -214,7 +214,6 @@ describe("index.js", function () {
     process.env.DISPUTER_ENABLED = "1";
     process.env.FINALIZER_ENABLED = "1";
     process.env.POLLING_DELAY = "0";
-    process.env.L2_END_BLOCK = "1000"; // Set end block to ensure WhitelistToken event is captured
 
     // Add another L1 token to rate model that is not whitelisted.
     const unWhitelistedL1Token = toChecksumAddress(randomHex(20));

--- a/packages/insured-bridge-relayer/test/index.ts
+++ b/packages/insured-bridge-relayer/test/index.ts
@@ -6,15 +6,18 @@ const { assert } = require("chai");
 const Web3 = require("web3");
 const ganache = require("ganache-core");
 
-import { interfaceName, TokenRolesEnum, HRE } from "@uma/common";
+import { interfaceName, TokenRolesEnum, HRE, ZERO_ADDRESS } from "@uma/common";
 
 const { web3, getContract } = hre as HRE;
-const { toWei, toBN, utf8ToHex } = web3.utils;
+const { toWei, toBN, utf8ToHex, toChecksumAddress, randomHex } = web3.utils;
 const toBNWei = (number: string | number) => toBN(toWei(number.toString()).toString());
 
+let isGanacheServerStarted = false;
 const startGanacheServer = (chainId: number, port: number) => {
+  if (isGanacheServerStarted) return;
   const node = ganache.server({ _chainIdRpc: chainId });
   node.listen(port);
+  isGanacheServerStarted = true;
   return new Web3("http://127.0.0.1:" + port);
 };
 
@@ -22,6 +25,7 @@ const startGanacheServer = (chainId: number, port: number) => {
 const chainId = 10;
 const Messenger = getContract("MessengerMock");
 const BridgePool = getContract("BridgePool");
+const BridgeDepositBox = getContract("BridgeDepositBoxMock");
 const BridgeAdmin = getContract("BridgeAdmin");
 const Finder = getContract("Finder");
 const IdentifierWhitelist = getContract("IdentifierWhitelist");
@@ -36,6 +40,7 @@ const MockOracle = getContract("MockOracleAncillary");
 let messenger: any;
 let bridgeAdmin: any;
 let bridgePool: any;
+let bridgeDepositBox: any;
 let finder: any;
 let store: any;
 let identifierWhitelist: any;
@@ -54,6 +59,7 @@ const defaultLiveness = 100;
 const lpFeeRatePerSecond = toWei("0.0000015");
 const finalFee = toWei("1");
 const defaultProposerBondPct = toWei("0.05");
+const minimumBridgingDelay = 60; // L2->L1 token bridging must wait at least this time.
 
 // Tested file
 import { run } from "../src/index";
@@ -61,7 +67,6 @@ import { run } from "../src/index";
 describe("index.js", function () {
   let accounts;
   let owner: string;
-  let depositContractImpersonator: string;
   let spyLogger: any;
   let spy: any;
   let originalEnv: any;
@@ -71,7 +76,7 @@ describe("index.js", function () {
   });
   before(async function () {
     accounts = await web3.eth.getAccounts();
-    [owner, l2Token, depositContractImpersonator] = accounts;
+    [owner, l2Token] = accounts;
     originalEnv = process.env;
 
     // Deploy or fetch deployed contracts:
@@ -128,9 +133,6 @@ describe("index.js", function () {
       defaultProposerBondPct,
       defaultIdentifier
     ).send({ from: owner });
-    await bridgeAdmin.methods
-      .setDepositContract(chainId, depositContractImpersonator, messenger.options.address)
-      .send({ from: owner });
 
     // New BridgePool linked to BridgeAdmin
     bridgePool = await BridgePool.new(
@@ -143,7 +145,31 @@ describe("index.js", function () {
       timer.options.address
     ).send({ from: owner });
 
-    // Add L1-L2 token mapping
+    spy = sinon.spy();
+    spyLogger = winston.createLogger({
+      level: "debug",
+      transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
+    });
+
+    const l2Web3 = await startGanacheServer(chainId, 7777);
+    const [l2Owner, l2BridgeAdminImpersonator] = await l2Web3.eth.getAccounts();
+
+    // Deploy deposit box on L2 web3 so that L2 client can read its events.
+    const L2BridgeDepositBox = new l2Web3.eth.Contract(BridgeDepositBox.abi);
+    bridgeDepositBox = await L2BridgeDepositBox.deploy({
+      data: BridgeDepositBox.bytecode,
+      arguments: [l2BridgeAdminImpersonator, minimumBridgingDelay, ZERO_ADDRESS, ZERO_ADDRESS],
+    }).send({
+      from: l2Owner,
+      gas: 6000000,
+      gasPrice: toWei("1", "gwei"),
+    });
+
+    await bridgeAdmin.methods
+      .setDepositContract(chainId, bridgeDepositBox.options.address, messenger.options.address)
+      .send({ from: owner });
+
+    // Add L1-L2 token mapping after deposit box address is set.
     await bridgeAdmin.methods
       .whitelistToken(
         chainId,
@@ -156,16 +182,10 @@ describe("index.js", function () {
         0
       )
       .send({ from: owner });
-
-    spy = sinon.spy();
-    spyLogger = winston.createLogger({
-      level: "debug",
-      transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
-    });
-
-    await startGanacheServer(69, 7777);
+    await bridgeDepositBox.methods
+      .whitelistToken(l1Token.options.address, l2Token, bridgePool.options.address)
+      .send({ from: l2BridgeAdminImpersonator });
   });
-
   it("Runs with no errors and correctly sets approvals for whitelisted L1 tokens", async function () {
     process.env.BRIDGE_ADMIN_ADDRESS = bridgeAdmin.options.address;
     process.env.RELAYER_ENABLED = "1";
@@ -180,13 +200,49 @@ describe("index.js", function () {
         R2: toBNWei("1.00"),
       },
     });
-    process.env.CHAIN_IDS = JSON.stringify([69]);
-    process.env.NODE_URL_69 = "http://localhost:7777";
+    process.env.CHAIN_IDS = JSON.stringify([chainId]);
+    process.env[`NODE_URL_${chainId}`] = "http://localhost:7777";
 
     // Must not throw.
     await run(spyLogger, web3);
 
     // Approvals are set correctly
     assert.notEqual((await l1Token.methods.allowance(owner, bridgePool.options.address)).toString(), "0");
+  });
+  it("Filters L1 token whitelist on L2 whitelist events", async function () {
+    process.env.BRIDGE_ADMIN_ADDRESS = bridgeAdmin.options.address;
+    process.env.RELAYER_ENABLED = "1";
+    process.env.DISPUTER_ENABLED = "1";
+    process.env.FINALIZER_ENABLED = "1";
+    process.env.POLLING_DELAY = "0";
+    process.env.L2_END_BLOCK = "1000"; // Set end block to ensure WhitelistToken event is captured
+
+    // Add another L1 token to rate model that is not whitelisted.
+    const unWhitelistedL1Token = toChecksumAddress(randomHex(20));
+    process.env.RATE_MODELS = JSON.stringify({
+      [l1Token.options.address]: {
+        UBar: toBNWei("0.65"),
+        R0: toBNWei("0.00"),
+        R1: toBNWei("0.08"),
+        R2: toBNWei("1.00"),
+      },
+      [unWhitelistedL1Token]: {
+        UBar: toBNWei("0.75"),
+        R0: toBNWei("0.00"),
+        R1: toBNWei("0.06"),
+        R2: toBNWei("2.00"),
+      },
+    });
+    process.env.CHAIN_IDS = JSON.stringify([chainId]);
+    process.env[`NODE_URL_${chainId}`] = "http://localhost:7777";
+
+    // Must not throw.
+    await run(spyLogger, web3);
+
+    // Check logs for filtered whitelist, which should contain only the whitelisted L1 token.
+    const targetLog = spy.getCalls().filter((_log: any) => {
+      return _log.lastArg.message.includes("Filtered out tokens that are not whitelisted on L2");
+    })[0];
+    assert.equal(targetLog.filteredWhitelistedRelayL1Tokens, [l1Token.options.address]);
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently the user must specify the `RATE_MODELS` for any L2 network that hasn't whitelisted all of the tokens in the default `RATE_MODELS` dictionary in `@uma/sdk`. We should not ask the user to specify `RATE_MODELS` and they should instead be able to rely on the default in the code. This PR prunes the whitelist derived from `RATE_MODELS` for a specific L2 by removing any L1 tokens not on that chain's specific deposit box.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
