### PR TITLE
fix(across-relayer): Skipped relay should add `undefined` to disputeRelay array, not `null`

### DIFF
--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -130,7 +130,11 @@ export class Relayer {
     }
     this.logger.debug({
       at: "AcrossRelayer#Disputer",
-      message: `Processing ${Object.keys(pendingRelays).length} l1 token pending relays`,
+      message: `Processing pending relays for ${Object.keys(pendingRelays).length} l1 tokens`,
+      // Log # of relays for each L1 token:
+      pendingRelayCounts: Object.keys(pendingRelays).map((l1Token) => ({
+        [l1Token]: pendingRelays[l1Token].length,
+      })),
     });
     for (const l1Token of Object.keys(pendingRelays)) {
       const disputeTransactions = []; // Array of dispute transactions to send.
@@ -249,7 +253,7 @@ export class Relayer {
         l2ClientChainId: this.l2Client.chainId,
         relay,
       });
-      return null;
+      return;
     }
 
     // Fetch deposit for relay.
@@ -513,7 +517,7 @@ export class Relayer {
     transactions: { transaction: TransactionType | any; message: string; mrkdwn: string; level: string }[]
   ) {
     // Remove any undefined transaction objects or objects that contain null transactions.
-    transactions = transactions.filter((transaction) => transaction && transaction.transaction);
+    transactions = transactions.filter((transaction) => transaction && transaction !== null && transaction.transaction);
 
     if (transactions.length == 0) return;
     if (transactions.length == 1) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

For the disputer, when a pending relay is skipped because its `chainID !== L2Client's chain ID` but the `chainID` is whitelisted, the bot should add an `undefined` entry to the relaysToDispute array, but incorrectly adds `null`.

I discovered this bug because the `Optimism` bot was timing out unexpectedly when there were ONLY pending relays for `Arbitrum` deposits, and therefore an array of `null` pending relays were being passed to `_generateRelayTransactionForPendingDeposit` which only filters out `undefined` relays. However, this bug mysteriously 
disappeared when an `undefined` relay was added to the array passed to `_generateRelayTransactionForPendingDeposit`, for example when the relay is for the `Optimism` chain but its already sped up!

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
