### PR TITLE
improve(across-relayer): Exit early if block search period is < 0

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -237,7 +237,7 @@ export class InsuredBridgeL1Client {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.endingBlockNumber || (await this.l1Web3.eth.getBlockNumber()),
     };
-    if (blockSearchConfig.fromBlock >= blockSearchConfig.toBlock) {
+    if (blockSearchConfig.fromBlock > blockSearchConfig.toBlock) {
       this.logger.debug({
         at: "InsuredBridgeL1Client",
         message: "All blocks are searched, returning early",

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -237,6 +237,14 @@ export class InsuredBridgeL1Client {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.endingBlockNumber || (await this.l1Web3.eth.getBlockNumber()),
     };
+    if (blockSearchConfig.fromBlock >= blockSearchConfig.toBlock) {
+      this.logger.debug({
+        at: "InsuredBridgeL1Client",
+        message: "All blocks are searched, returning early",
+        toBlock: blockSearchConfig.toBlock,
+      });
+      return;
+    }
 
     // Check for new bridgePools deployed. This acts as the initial setup and acts to more pools if they are deployed
     // while the bot is running.

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -69,7 +69,7 @@ export class InsuredBridgeL2Client {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.endingBlockNumber || (await this.l2Web3.eth.getBlockNumber()),
     };
-    if (blockSearchConfig.fromBlock >= blockSearchConfig.toBlock) {
+    if (blockSearchConfig.fromBlock > blockSearchConfig.toBlock) {
       this.logger.debug({
         at: "InsuredBridgeL2Client",
         message: "All blocks are searched, returning early",

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -69,6 +69,15 @@ export class InsuredBridgeL2Client {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.endingBlockNumber || (await this.l2Web3.eth.getBlockNumber()),
     };
+    if (blockSearchConfig.fromBlock >= blockSearchConfig.toBlock) {
+      this.logger.debug({
+        at: "InsuredBridgeL2Client",
+        message: "All blocks are searched, returning early",
+        toBlock: blockSearchConfig.toBlock,
+      });
+      return;
+    }
+
     // TODO: update this state retrieval to include looking for L2 liquidity in the deposit box that can be sent over
     // the bridge. This should consider the minimumBridgingDelay and the lastBridgeTime for a respective L2Token.
     const [fundsDepositedEvents, whitelistedTokenEvents] = await Promise.all([


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

After each loop iteration, `fromBlock` gets set to `toBlock + 1`, while `toBlock` gets set to the latest block height. If latest block height doesn't advance fast enough between `update()` calls, then its possible that `toBlock > fromBlock`, so we should exit early in this case.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
