### PR TITLE
improve(across-relayer): Remove redundant L1 event query

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -256,7 +256,10 @@ export class InsuredBridgeL1Client {
     // while the bot is running.
     const whitelistedTokenEvents = await this.bridgeAdmin.getPastEvents("WhitelistToken", blockSearchConfig);
     for (const whitelistedTokenEvent of whitelistedTokenEvents) {
+      // Add L1=>L2 token mapping to whitelisted dictionary for this chain ID.
+      const whitelistedTokenMappingsForChainId = this.whitelistedTokens[whitelistedTokenEvent.returnValues.chainId];
       this.whitelistedTokens[whitelistedTokenEvent.returnValues.chainId] = {
+        ...whitelistedTokenMappingsForChainId,
         [this.l1Web3.utils.toChecksumAddress(
           whitelistedTokenEvent.returnValues.l1Token
         )]: this.l1Web3.utils.toChecksumAddress(whitelistedTokenEvent.returnValues.l2Token),

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -1,5 +1,5 @@
 import Web3 from "web3";
-const { toBN, soliditySha3 } = Web3.utils;
+const { toBN, soliditySha3, toChecksumAddress } = Web3.utils;
 
 import { BlockFinder } from "../price-feed/utils";
 import { getAbi } from "@uma/contracts-node";
@@ -260,9 +260,9 @@ export class InsuredBridgeL1Client {
       const whitelistedTokenMappingsForChainId = this.whitelistedTokens[whitelistedTokenEvent.returnValues.chainId];
       this.whitelistedTokens[whitelistedTokenEvent.returnValues.chainId] = {
         ...whitelistedTokenMappingsForChainId,
-        [this.l1Web3.utils.toChecksumAddress(
-          whitelistedTokenEvent.returnValues.l1Token
-        )]: this.l1Web3.utils.toChecksumAddress(whitelistedTokenEvent.returnValues.l2Token),
+        [toChecksumAddress(whitelistedTokenEvent.returnValues.l1Token)]: toChecksumAddress(
+          whitelistedTokenEvent.returnValues.l2Token
+        ),
       };
 
       const l1Token = whitelistedTokenEvent.returnValues.l1Token;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

CrossDomainFinalizer queries for `WhitelistTokenEvents` but L1 client does the same thing in its `update()` method. We should cache all such events in the L1 client and read them from the CrossDomainFinalizer.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
