### PR TITLE
fix(across-relayer): Prune L1 token whitelist using L1 contract state instead of L2 event data

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -120,11 +120,6 @@ export class InsuredBridgeL1Client {
     return this.whitelistedTokens[chainId];
   }
 
-  isWhitelistedToken(l1TokenAddress: string, chainId: string): boolean {
-    this._throwIfNotInitialized();
-    return this.whitelistedTokens[chainId][toChecksumAddress(l1TokenAddress)] !== undefined;
-  }
-
   hasInstantRelayer(l1Token: string, depositHash: string, realizedLpFeePct: string): boolean {
     this._throwIfNotInitialized();
     return this.getInstantRelayer(l1Token, depositHash, realizedLpFeePct) !== undefined;

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -120,6 +120,11 @@ export class InsuredBridgeL1Client {
     return this.whitelistedTokens[chainId];
   }
 
+  isWhitelistedToken(l1TokenAddress: string, chainId: string): boolean {
+    this._throwIfNotInitialized();
+    return this.whitelistedTokens[chainId][toChecksumAddress(l1TokenAddress)] !== undefined;
+  }
+
   hasInstantRelayer(l1Token: string, depositHash: string, realizedLpFeePct: string): boolean {
     this._throwIfNotInitialized();
     return this.getInstantRelayer(l1Token, depositHash, realizedLpFeePct) !== undefined;

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -4,6 +4,7 @@
 import { getAbi } from "@uma/contracts-node";
 import type { BridgeDepositBoxWeb3 } from "@uma/contracts-node";
 import Web3 from "web3";
+const { toChecksumAddress } = Web3.utils;
 import type { Logger } from "winston";
 
 export interface Deposit {
@@ -53,7 +54,7 @@ export class InsuredBridgeL2Client {
   }
 
   isWhitelistedToken(l1TokenAddress: string) {
-    return this.whitelistedTokens[this.l2Web3.utils.toChecksumAddress(l1TokenAddress)] !== undefined;
+    return this.whitelistedTokens[toChecksumAddress(l1TokenAddress)] !== undefined;
   }
 
   getDepositByHash(depositHash: string) {
@@ -88,9 +89,9 @@ export class InsuredBridgeL2Client {
     // We assume that whitelisted token events are searched from oldest to newest so we'll just store the most recently
     // whitelisted token mappings.
     for (const whitelistedTokenEvent of whitelistedTokenEvents) {
-      this.whitelistedTokens[
-        this.l2Web3.utils.toChecksumAddress(whitelistedTokenEvent.returnValues.l1Token)
-      ] = this.l2Web3.utils.toChecksumAddress(whitelistedTokenEvent.returnValues.l2Token);
+      this.whitelistedTokens[toChecksumAddress(whitelistedTokenEvent.returnValues.l1Token)] = toChecksumAddress(
+        whitelistedTokenEvent.returnValues.l2Token
+      );
     }
 
     for (const fundsDepositedEvent of fundsDepositedEvents) {

--- a/packages/insured-bridge-relayer/src/RelayerHelpers.ts
+++ b/packages/insured-bridge-relayer/src/RelayerHelpers.ts
@@ -4,7 +4,7 @@ const { toBN } = Web3.utils;
 import winston from "winston";
 import { getAbi } from "@uma/contracts-node";
 import { ZERO_ADDRESS } from "@uma/common";
-import { GasEstimator, setAllowance, InsuredBridgeL2Client } from "@uma/financial-templates-lib";
+import { GasEstimator, setAllowance, InsuredBridgeL1Client, InsuredBridgeL2Client } from "@uma/financial-templates-lib";
 
 import type { BN } from "@uma/common";
 
@@ -41,12 +41,13 @@ export async function approveL1Tokens(
 // dictionary will be whitelisted for all L2 deposit boxes.
 export async function pruneWhitelistedL1Tokens(
   logger: winston.Logger,
+  l1Client: InsuredBridgeL1Client,
   l2Client: InsuredBridgeL2Client,
   whitelistedRelayL1Tokens: string[]
 ): Promise<string[]> {
-  await l2Client.update();
+  await l1Client.update();
   const filteredWhitelistedRelayL1Tokens = whitelistedRelayL1Tokens.filter((l1TokenAddress: string) => {
-    return l2Client.isWhitelistedToken(l1TokenAddress);
+    return l1Client.isWhitelistedToken(l1TokenAddress, l2Client.chainId.toString());
   });
   logger.debug({
     at: "AcrossRelayer#index",

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -64,7 +64,6 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
 
     // Update the L2 client and filter out tokens that are not whitelisted on the L2 from the whitelisted
     // L1 relay list.
-    await l2Client.update();
     const filteredL1Whitelist = await pruneWhitelistedL1Tokens(
       logger,
       l1Client,

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -65,7 +65,12 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
     // Update the L2 client and filter out tokens that are not whitelisted on the L2 from the whitelisted
     // L1 relay list.
     await l2Client.update();
-    const filteredL1Whitelist = await pruneWhitelistedL1Tokens(logger, l2Client, config.whitelistedRelayL1Tokens);
+    const filteredL1Whitelist = await pruneWhitelistedL1Tokens(
+      logger,
+      l1Client,
+      l2Client,
+      config.whitelistedRelayL1Tokens
+    );
 
     // For all specified whitelisted L1 tokens that this relayer supports, approve the bridge pool to spend them. This
     // method will error if the bot runner has specified a L1 tokens that is not part of the Bridge Admin whitelist.

--- a/packages/insured-bridge-relayer/test/index.ts
+++ b/packages/insured-bridge-relayer/test/index.ts
@@ -241,7 +241,7 @@ describe("index.js", function () {
     const targetLog = spy.getCalls().filter((_log: any) => {
       return _log.lastArg.message.includes("Filtered out tokens that are not whitelisted on L2");
     })[0];
-    assert.equal(targetLog.lastArg.filteredWhitelistedRelayL1Tokens.length, 1);
-    assert.equal(targetLog.lastArg.filteredWhitelistedRelayL1Tokens[0], l1Token.options.address);
+    assert.equal(targetLog.lastArg.prunedWhitelist.length, 1);
+    assert.equal(targetLog.lastArg.prunedWhitelist[0], l1Token.options.address);
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

L2 event data is less reliable than L1 event data and even less so than querying L1 contracts directly. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
