### PR TITLE
WIP(across): Improve L2 client provider redundancy

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -72,10 +72,9 @@ export class InsuredBridgeL2Client {
 
   async update(): Promise<void> {
     // Define a config to bound the queries by.
-    const latestBlockNumbers = await Promise.all(this.l2Web3s.map((l2Web3) => l2Web3.eth.getBlockNumber()));
     const blockSearchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.endingBlockNumber || Math.min.apply(null, latestBlockNumbers),
+      toBlock: this.endingBlockNumber || (await this.l2Web3s[0].eth.getBlockNumber()),
     };
     if (blockSearchConfig.fromBlock > blockSearchConfig.toBlock) {
       this.logger.debug({

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -98,6 +98,7 @@ export class InsuredBridgeL2Client {
       fundsDepositedEvents = fundsDepositedEvents.concat(_fundsDepositedEvents);
       whitelistedTokenEvents = whitelistedTokenEvents.concat(_whitelistedTokenEvents);
     }
+    // TODO: filter out redundant events
 
     // We assume that whitelisted token events are searched from oldest to newest so we'll just store the most recently
     // whitelisted token mappings.

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -503,7 +503,7 @@ export async function createPriceFeed(
     const currentL2Block = await l2Web3.eth.getBlockNumber();
     const l2Client = new InsuredBridgeL2Client(
       logger,
-      l2Web3,
+      [l2Web3],
       await l1Client.getL2DepositBoxAddress(config.l2NetId),
       config.l2NetId,
       currentL2Block - l2BlockLookback

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
@@ -77,7 +77,7 @@ describe("InsuredBridgeL2Client", () => {
     // DummyLogger will not print anything to console as only capture `info` level events.
     const dummyLogger = winston.createLogger({ level: "info", transports: [new winston.transports.Console()] });
 
-    client = new InsuredBridgeL2Client(dummyLogger, web3, depositBox.options.address);
+    client = new InsuredBridgeL2Client(dummyLogger, [web3], depositBox.options.address);
   });
 
   it("Correctly returns deposit event information", async () => {

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -866,6 +866,7 @@ export class Relayer {
           ]);
           fundsDepositedEvents = fundsDepositedEvents.concat(_fundsDepositedEvents);
         }
+        // TODO: Filter out redundant events
         // For any found deposits, try to match it with the relay:
         for (const fundsDepositedEvent of fundsDepositedEvents) {
           const _deposit: Deposit = {

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -56,7 +56,7 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
 
     const l2Client = new InsuredBridgeL2Client(
       logger,
-      l2Web3,
+      [l2Web3],
       await l1Client.getL2DepositBoxAddress(config.activatedChainIds[0]),
       config.activatedChainIds[0],
       l2StartBlock

--- a/packages/insured-bridge-relayer/test/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/test/CrossDomainFinalizer.ts
@@ -201,7 +201,7 @@ describe("CrossDomainFinalizer.ts", function () {
     // Create the rate models for the one and only l1Token, set to the single rateModel defined in the constants.
     const rateModels = { [l1Token.options.address]: rateModel };
     l1Client = new InsuredBridgeL1Client(spyLogger, web3, bridgeAdmin.options.address, rateModels);
-    l2Client = new InsuredBridgeL2Client(spyLogger, web3, bridgeDepositBox.options.address, chainId);
+    l2Client = new InsuredBridgeL2Client(spyLogger, [web3], bridgeDepositBox.options.address, chainId);
 
     gasEstimator = new GasEstimator(spyLogger);
     crossDomainFinalizer = new CrossDomainFinalizer(

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -218,7 +218,7 @@ describe("Relayer.ts", function () {
     // Create the rate models for the one and only l1Token, set to the single rateModel defined in the constants.
     const rateModels = { [l1Token.options.address]: rateModel };
     l1Client = new InsuredBridgeL1Client(spyLogger, web3, bridgeAdmin.options.address, rateModels);
-    l2Client = new InsuredBridgeL2Client(spyLogger, web3, bridgeDepositBox.options.address, chainId);
+    l2Client = new InsuredBridgeL2Client(spyLogger, [web3], bridgeDepositBox.options.address, chainId);
 
     gasEstimator = new GasEstimator(spyLogger);
     relayer = new Relayer(
@@ -1101,7 +1101,7 @@ describe("Relayer.ts", function () {
       // Next, create a new L2 client that trivially sets its block range such that it can't find the deposit.
       l2Client = new InsuredBridgeL2Client(
         spyLogger,
-        web3,
+        [web3],
         bridgeDepositBox.options.address,
         chainId,
         0,
@@ -1609,7 +1609,7 @@ describe("Relayer.ts", function () {
       // Create new Relayer that is aware of new L1 token:
       const rateModels = { [l1Token.options.address]: rateModel, [newL1Token.options.address]: rateModel };
       l1Client = new InsuredBridgeL1Client(spyLogger, web3, bridgeAdmin.options.address, rateModels);
-      l2Client = new InsuredBridgeL2Client(spyLogger, web3, bridgeDepositBox.options.address, chainId);
+      l2Client = new InsuredBridgeL2Client(spyLogger, [web3], bridgeDepositBox.options.address, chainId);
       relayer = new Relayer(
         spyLogger,
         gasEstimator,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Explain the motivation for making this change.
What existing problem does the pull request solve?
It may be sufficient to just link to an issue, but please explain if more details are needed.


**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
