### PR TITLE
feat(across): Add RateModelStore contract

### DIFF
--- a/packages/core/contracts/insured-bridge/RateModelStore.sol
+++ b/packages/core/contracts/insured-bridge/RateModelStore.sol
@@ -13,52 +13,17 @@ import "../common/implementation/MultiCaller.sol";
  * the structure in the future.
  */
 contract RateModelStore is Ownable, MultiCaller {
-    struct RateModel {
-        uint256 startBlock; // When the new rate model becomes active.
-        string oldRateModel; // Store old rate model so that public getter method does not need to modify state to
-        // return correct rate model based on current block
-        string newRateModel; // New rate model that becomes active when current block >= start block.
-    }
-    mapping(address => RateModel) public l1TokenRateModels;
+    mapping(address => string) public l1TokenRateModels;
 
-    event UpdatedRateModel(address indexed l1Token, string oldRateModel, string newRateModel, uint256 startBlock);
+    event UpdatedRateModel(address indexed l1Token, string rateModel);
 
     /**
      * @notice Updates rate model string for L1 token.
      * @param l1Token the l1 token rate model to update.
      * @param rateModel the updated rate model.
-     * @param startBlock determines when `rateModel` officially becomes active.
      */
-    function updateRateModel(
-        address l1Token,
-        string memory rateModel,
-        uint256 startBlock
-    ) external onlyOwner {
-        // If current block >= existing rate model's start block, then the new "old" rate model is the existing
-        // "new" rate model. Otherwise, the existing rate model has not updated to the "new" rate model yet and the new
-        // "old" rate model gets carried over.
-        string memory oldRateModel =
-            (block.number >= l1TokenRateModels[l1Token].startBlock)
-                ? l1TokenRateModels[l1Token].newRateModel
-                : l1TokenRateModels[l1Token].oldRateModel;
-        l1TokenRateModels[l1Token] = RateModel({
-            startBlock: startBlock,
-            oldRateModel: oldRateModel,
-            newRateModel: rateModel
-        });
-        emit UpdatedRateModel(l1Token, oldRateModel, rateModel, startBlock);
-    }
-
-    /**
-     * @notice Designed to be called by off-chain clien to get latest rate model for L1 token.
-     * @param l1Token the l1 token rate model to fetch rate model for.
-     * @return rateModel the latest rate model.
-     */
-    function getRateModel(address l1Token) external view returns (string memory) {
-        if (block.number >= l1TokenRateModels[l1Token].startBlock) {
-            return l1TokenRateModels[l1Token].newRateModel;
-        } else {
-            return l1TokenRateModels[l1Token].oldRateModel;
-        }
+    function updateRateModel(address l1Token, string memory rateModel) external onlyOwner {
+        l1TokenRateModels[l1Token] = rateModel;
+        emit UpdatedRateModel(l1Token, rateModel);
     }
 }

--- a/packages/core/contracts/insured-bridge/RateModelStore.sol
+++ b/packages/core/contracts/insured-bridge/RateModelStore.sol
@@ -37,6 +37,9 @@ contract RateModelStore is Ownable, MultiCaller {
         // If current block >= existing rate model's start block, then the new "old" rate model is the existing
         // "new" rate model. Otherwise, the existing rate model has not updated to the "new" rate model yet and the new
         // "old" rate model gets carried over.
+        // Note: If current block >= existing rate model's start block, then the new rate model will immediately take
+        // effect. This is a potentially useful feature for the admin who has the responsibility for determining when
+        // the rate model should update.
         string memory oldRateModel =
             (block.number >= l1TokenRateModels[l1Token].startBlock)
                 ? l1TokenRateModels[l1Token].newRateModel

--- a/packages/core/contracts/insured-bridge/RateModelStore.sol
+++ b/packages/core/contracts/insured-bridge/RateModelStore.sol
@@ -13,17 +13,52 @@ import "../common/implementation/MultiCaller.sol";
  * the structure in the future.
  */
 contract RateModelStore is Ownable, MultiCaller {
-    mapping(address => string) public l1TokenRateModels;
+    struct RateModel {
+        uint256 startBlock; // When the new rate model becomes active.
+        string oldRateModel; // Store old rate model so that public getter method does not need to modify state to
+        // return correct rate model based on current block
+        string newRateModel; // New rate model that becomes active when current block >= start block.
+    }
+    mapping(address => RateModel) public l1TokenRateModels;
 
-    event UpdatedRateModel(address indexed l1Token, string rateModel);
+    event UpdatedRateModel(address indexed l1Token, string oldRateModel, string newRateModel, uint256 startBlock);
 
     /**
      * @notice Updates rate model string for L1 token.
      * @param l1Token the l1 token rate model to update.
      * @param rateModel the updated rate model.
+     * @param startBlock determines when `rateModel` officially becomes active.
      */
-    function updateRateModel(address l1Token, string memory rateModel) external onlyOwner {
-        l1TokenRateModels[l1Token] = rateModel;
-        emit UpdatedRateModel(l1Token, rateModel);
+    function updateRateModel(
+        address l1Token,
+        string memory rateModel,
+        uint256 startBlock
+    ) external onlyOwner {
+        // If current block >= existing rate model's start block, then the new "old" rate model is the existing
+        // "new" rate model. Otherwise, the existing rate model has not updated to the "new" rate model yet and the new
+        // "old" rate model gets carried over.
+        string memory oldRateModel =
+            (block.number >= l1TokenRateModels[l1Token].startBlock)
+                ? l1TokenRateModels[l1Token].newRateModel
+                : l1TokenRateModels[l1Token].oldRateModel;
+        l1TokenRateModels[l1Token] = RateModel({
+            startBlock: startBlock,
+            oldRateModel: oldRateModel,
+            newRateModel: rateModel
+        });
+        emit UpdatedRateModel(l1Token, oldRateModel, rateModel, startBlock);
+    }
+
+    /**
+     * @notice Designed to be called by off-chain clien to get latest rate model for L1 token.
+     * @param l1Token the l1 token rate model to fetch rate model for.
+     * @return rateModel the latest rate model.
+     */
+    function getRateModel(address l1Token) external view returns (string memory) {
+        if (block.number >= l1TokenRateModels[l1Token].startBlock) {
+            return l1TokenRateModels[l1Token].newRateModel;
+        } else {
+            return l1TokenRateModels[l1Token].oldRateModel;
+        }
     }
 }

--- a/packages/core/contracts/insured-bridge/RateModelStore.sol
+++ b/packages/core/contracts/insured-bridge/RateModelStore.sol
@@ -37,9 +37,6 @@ contract RateModelStore is Ownable, MultiCaller {
         // If current block >= existing rate model's start block, then the new "old" rate model is the existing
         // "new" rate model. Otherwise, the existing rate model has not updated to the "new" rate model yet and the new
         // "old" rate model gets carried over.
-        // Note: If current block >= existing rate model's start block, then the new rate model will immediately take
-        // effect. This is a potentially useful feature for the admin who has the responsibility for determining when
-        // the rate model should update.
         string memory oldRateModel =
             (block.number >= l1TokenRateModels[l1Token].startBlock)
                 ? l1TokenRateModels[l1Token].newRateModel

--- a/packages/core/contracts/insured-bridge/RateModelStore.sol
+++ b/packages/core/contracts/insured-bridge/RateModelStore.sol
@@ -2,14 +2,17 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "../common/implementation/MultiCaller.sol";
 
 /**
  * @title Maps rate model objects to L1 token.
  * @dev This contract is designed to be queried by off-chain relayers that need to compute realized LP fee %'s before
  * submitting relay transactions to a BridgePool contract. Therefore, this contract does not perform any validation on
- * the shape of the rate model. The validation step is left as a responsibility to off-chain relayers.
+ * the shape of the rate model, which is stored as a string to enable arbitrary data encoding via a stringified JSON
+ * object. This leaves this contract unopionated on the parameters within the rate model, enabling governance to adjust
+ * the structure in the future.
  */
-contract RateModelStore is Ownable {
+contract RateModelStore is Ownable, MultiCaller {
     mapping(address => string) public l1TokenRateModels;
 
     event UpdatedRateModel(address indexed l1Token, string rateModel);

--- a/packages/core/contracts/insured-bridge/RateModelStore.sol
+++ b/packages/core/contracts/insured-bridge/RateModelStore.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title Maps rate model objects to L1 token.
+ * @dev This contract is designed to be queried by off-chain relayers that need to compute realized LP fee %'s before
+ * submitting relay transactions to a BridgePool contract. Therefore, this contract does not perform any validation on
+ * the shape of the rate model. The validation step is left as a responsibility to off-chain relayers.
+ */
+contract RateModelStore is Ownable {
+    mapping(address => string) public l1TokenRateModels;
+
+    event UpdatedRateModel(address indexed l1Token, string rateModel);
+
+    /**
+     * @notice Updates rate model string for L1 token.
+     * @param l1Token the l1 token rate model to update.
+     * @param rateModel the updated rate model.
+     */
+    function updateRateModel(address l1Token, string memory rateModel) external onlyOwner {
+        l1TokenRateModels[l1Token] = rateModel;
+        emit UpdatedRateModel(l1Token, rateModel);
+    }
+}

--- a/packages/core/test/insured-bridge/RateModelStore.js
+++ b/packages/core/test/insured-bridge/RateModelStore.js
@@ -20,60 +20,23 @@ describe("RateModelStore", function () {
   });
 
   it("Update rate model for L1 token", async function () {
+    console.log(await store.methods.l1TokenRateModels(l1Token).call());
     assert.equal(
-      await store.methods.getRateModel(l1Token).call(),
+      await store.methods.l1TokenRateModels(l1Token).call(),
       "" // Empty string
     );
 
-    const rateModel = JSON.stringify({ key: "value" });
-    const startBlock = 0; // Set start block so that rate model updates immediately.
+    const newRateModel = JSON.stringify({ key: "value" });
 
-    const updateRateModel = store.methods.updateRateModel(l1Token, rateModel, startBlock);
+    const updateRateModel = store.methods.updateRateModel(l1Token, newRateModel);
 
     // Only owner can update.
     assert(await didContractThrow(updateRateModel.send({ from: user })));
 
     const txn = await updateRateModel.send({ from: owner });
-    assert.equal(await store.methods.getRateModel(l1Token).call(), rateModel);
+    assert.equal(await store.methods.l1TokenRateModels(l1Token).call(), newRateModel);
     assertEventEmitted(txn, store, "UpdatedRateModel", (ev) => {
-      return (
-        ev.newRateModel === rateModel &&
-        ev.l1Token === l1Token &&
-        ev.oldRateModel === "" &&
-        ev.startBlock.toString() === startBlock.toString()
-      );
-    });
-
-    // Now call update rate model again with a new rate model but a start block very far into the future so that the
-    // new rate model does not update yet.
-    const rateModel2 = JSON.stringify({ key: "newValue" });
-    const startBlock2 = 999999;
-    const txn2 = await store.methods.updateRateModel(l1Token, rateModel2, startBlock2).send({ from: owner });
-    assert.equal(await store.methods.getRateModel(l1Token).call(), rateModel); // Latest rate model doesn't change.
-    assertEventEmitted(txn2, store, "UpdatedRateModel", (ev) => {
-      return (
-        ev.newRateModel === rateModel2 &&
-        ev.l1Token === l1Token &&
-        ev.oldRateModel === rateModel && // Old rate model is the recently updated rate model
-        ev.startBlock.toString() === startBlock2.toString()
-      );
-    });
-
-    // Finally, call rate model again with a start block set lower than the recently updated start block. Check that the
-    // "old" rate model remains the same.
-    const rateModel3 = JSON.stringify({ key: "evenNewerValue" });
-    const startBlock3 = startBlock; // This means that this rate model should immediately take effect, effectively
-    // erasing rateModel2.
-    const txn3 = await store.methods.updateRateModel(l1Token, rateModel3, startBlock3).send({ from: owner });
-    assert.equal(await store.methods.getRateModel(l1Token).call(), rateModel3);
-    assertEventEmitted(txn3, store, "UpdatedRateModel", (ev) => {
-      return (
-        ev.newRateModel === rateModel3 &&
-        ev.l1Token === l1Token &&
-        ev.oldRateModel === rateModel && // Old rate model remains the same after the last update because the rateModel2
-        // hasn't updated yet.
-        ev.startBlock.toString() === startBlock3.toString()
-      );
+      return ev.rateModel === newRateModel && ev.l1Token === l1Token;
     });
   });
 });

--- a/packages/core/test/insured-bridge/RateModelStore.js
+++ b/packages/core/test/insured-bridge/RateModelStore.js
@@ -20,23 +20,60 @@ describe("RateModelStore", function () {
   });
 
   it("Update rate model for L1 token", async function () {
-    console.log(await store.methods.l1TokenRateModels(l1Token).call());
     assert.equal(
-      await store.methods.l1TokenRateModels(l1Token).call(),
+      await store.methods.getRateModel(l1Token).call(),
       "" // Empty string
     );
 
-    const newRateModel = JSON.stringify({ key: "value" });
+    const rateModel = JSON.stringify({ key: "value" });
+    const startBlock = 0; // Set start block so that rate model updates immediately.
 
-    const updateRateModel = store.methods.updateRateModel(l1Token, newRateModel);
+    const updateRateModel = store.methods.updateRateModel(l1Token, rateModel, startBlock);
 
     // Only owner can update.
     assert(await didContractThrow(updateRateModel.send({ from: user })));
 
     const txn = await updateRateModel.send({ from: owner });
-    assert.equal(await store.methods.l1TokenRateModels(l1Token).call(), newRateModel);
+    assert.equal(await store.methods.getRateModel(l1Token).call(), rateModel);
     assertEventEmitted(txn, store, "UpdatedRateModel", (ev) => {
-      return ev.rateModel === newRateModel && ev.l1Token === l1Token;
+      return (
+        ev.newRateModel === rateModel &&
+        ev.l1Token === l1Token &&
+        ev.oldRateModel === "" &&
+        ev.startBlock.toString() === startBlock.toString()
+      );
+    });
+
+    // Now call update rate model again with a new rate model but a start block very far into the future so that the
+    // new rate model does not update yet.
+    const rateModel2 = JSON.stringify({ key: "newValue" });
+    const startBlock2 = 999999;
+    const txn2 = await store.methods.updateRateModel(l1Token, rateModel2, startBlock2).send({ from: owner });
+    assert.equal(await store.methods.getRateModel(l1Token).call(), rateModel); // Latest rate model doesn't change.
+    assertEventEmitted(txn2, store, "UpdatedRateModel", (ev) => {
+      return (
+        ev.newRateModel === rateModel2 &&
+        ev.l1Token === l1Token &&
+        ev.oldRateModel === rateModel && // Old rate model is the recently updated rate model
+        ev.startBlock.toString() === startBlock2.toString()
+      );
+    });
+
+    // Finally, call rate model again with a start block set lower than the recently updated start block. Check that the
+    // "old" rate model remains the same.
+    const rateModel3 = JSON.stringify({ key: "evenNewerValue" });
+    const startBlock3 = startBlock; // This means that this rate model should immediately take effect, effectively
+    // erasing rateModel2.
+    const txn3 = await store.methods.updateRateModel(l1Token, rateModel3, startBlock3).send({ from: owner });
+    assert.equal(await store.methods.getRateModel(l1Token).call(), rateModel3);
+    assertEventEmitted(txn3, store, "UpdatedRateModel", (ev) => {
+      return (
+        ev.newRateModel === rateModel3 &&
+        ev.l1Token === l1Token &&
+        ev.oldRateModel === rateModel && // Old rate model remains the same after the last update because the rateModel2
+        // hasn't updated yet.
+        ev.startBlock.toString() === startBlock3.toString()
+      );
     });
   });
 });

--- a/packages/core/test/insured-bridge/RateModelStore.js
+++ b/packages/core/test/insured-bridge/RateModelStore.js
@@ -1,0 +1,42 @@
+const hre = require("hardhat");
+const { getContract, assertEventEmitted } = hre;
+const { didContractThrow } = require("@uma/common");
+const { assert } = require("chai");
+
+const RateModelStore = getContract("RateModelStore");
+
+describe("RateModelStore", function () {
+  let accounts;
+  let owner;
+  let user;
+
+  let store;
+  let l1Token;
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+    [owner, user, l1Token] = accounts;
+
+    store = await RateModelStore.new().send({ from: owner });
+  });
+
+  it("Update rate model for L1 token", async function () {
+    console.log(await store.methods.l1TokenRateModels(l1Token).call());
+    assert.equal(
+      await store.methods.l1TokenRateModels(l1Token).call(),
+      "" // Empty string
+    );
+
+    const newRateModel = JSON.stringify({ key: "value" });
+
+    const updateRateModel = store.methods.updateRateModel(l1Token, newRateModel);
+
+    // Only owner can update.
+    assert(await didContractThrow(updateRateModel.send({ from: user })));
+
+    const txn = await updateRateModel.send({ from: owner });
+    assert.equal(await store.methods.l1TokenRateModels(l1Token).call(), newRateModel);
+    assertEventEmitted(txn, store, "UpdatedRateModel", (ev) => {
+      return ev.rateModel === newRateModel && ev.l1Token === l1Token;
+    });
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Storing the RATE_MODEL dictionary on-chain provides a trustless, transparent single-source of truth for all clients of this dictionary including the relayer bot, and the across front-end.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
