### PR TITLE
improve(cryptowatch-pricefeed): Use twapLength from parsed ancillary data

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -91,11 +91,11 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
 
     let twapLength = this.twapLength;
     // Ancillary data might contain parameters that affect how we compute the historical price, such as the twapLength.
-    try {
+    if (ancillaryData) {
       const parsedAncillaryData = (parseAncillaryData(ancillaryData) as unknown) as SimplePriceAncillaryData;
-      twapLength = Number(parsedAncillaryData.twapLength);
-    } catch (err) {
-      // Could not parse ancillary data into utf8 dictionary, use default parameters.
+      if (parsedAncillaryData.twapLength) {
+        twapLength = Number(parsedAncillaryData.twapLength);
+      }
     }
 
     // Return early if computing a TWAP.

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -89,12 +89,16 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
       throw new Error(`${this.uuid}: undefined lastUpdateTime`);
     }
 
+    let twapLength = this.twapLength;
     // Ancillary data might contain parameters that affect how we compute the historical price, such as the twapLength.
-    const parsedAncillaryData = (parseAncillaryData(ancillaryData) as unknown) as SimplePriceAncillaryData;
-    const ancillaryDataTwapLength = Number(parsedAncillaryData.twapLength);
+    try {
+      const parsedAncillaryData = (parseAncillaryData(ancillaryData) as unknown) as SimplePriceAncillaryData;
+      twapLength = Number(parsedAncillaryData.twapLength);
+    } catch (err) {
+      // Could not parse ancillary data into utf8 dictionary, use default parameters.
+    }
 
     // Return early if computing a TWAP.
-    const twapLength = ancillaryDataTwapLength ? ancillaryDataTwapLength : this.twapLength;
     if (twapLength) {
       const twapPrice = this._computeTwap(time, this.historicalPricePeriods, twapLength);
       if (!twapPrice) {

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.ts
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.ts
@@ -5,6 +5,7 @@ export abstract class PriceFeedInterface {
   // Updates the internal state of the price feed. Should pull in any async data so the get*Price methods can be called.
   // Will use the optional ancillary data parameter to customize what kind of data get*Price returns.
   // Note: derived classes *must* override this method.
+  // Note: Eventually `update` will be removed in favor of folding its logic into `getCurrentPrice`.
   public abstract update(ancillaryData?: string): Promise<void>;
 
   // Gets the current price (as a BN) for this feed synchronously from the in-memory state of this price feed object.

--- a/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.ts
+++ b/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.ts
@@ -3,12 +3,14 @@ import { BN } from "../types";
 // Price feed interface -- all price feed implementations should override all functions (except for _abstractFunctionCalled).
 export abstract class PriceFeedInterface {
   // Updates the internal state of the price feed. Should pull in any async data so the get*Price methods can be called.
+  // Will use the optional ancillary data parameter to customize what kind of data get*Price returns.
   // Note: derived classes *must* override this method.
-  public abstract update(): Promise<void>;
+  public abstract update(ancillaryData?: string): Promise<void>;
 
   // Gets the current price (as a BN) for this feed synchronously from the in-memory state of this price feed object.
-  // This price should be up-to-date as of the last time `update()` was called. If `update()` has never been called,
-  // this should return `null` or `undefined`. If no price could be retrieved, it should return `null` or `undefined`.
+  // This price should be up-to-date as of the last time that `update(ancillaryData)` was called, using any parameters
+  // specified in the ancillary data passed as input. If `update()` has never been called, this should return `null` or
+  // `undefined`. If no price could be retrieved, it should return `null` or `undefined`.
   // Note: derived classes *must* override this method.
   public abstract getCurrentPrice(): BN | null;
 

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -418,10 +418,19 @@ describe("CryptoWatchPriceFeed.js", function () {
 
     // When passing in ancillary data that doesn't specify TWAP length, pricefeed default twapLength is used. In this
     // case, the default TWAP length is 0 so it should return the current price for the timestamp.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376460, "")).toString(), web3.utils.toWei("1.2"));
     assert.equal(
       (await cryptoWatchPriceFeed.getHistoricalPrice(1588376460, utf8ToHex("key:value"))).toString(),
       web3.utils.toWei("1.2")
     );
+
+    // If ancillary data can't be parsed to UTF8, then it should throw.
+    try {
+      await cryptoWatchPriceFeed.getHistoricalPrice(1588376460, "0xabcd");
+      assert.isTrue(false);
+    } catch (e) {
+      assert.isTrue(e.message.includes("Cannot parse ancillary data bytes to UTF-8"));
+    }
   });
 
   it("TWAP fails if period ends before data", async function () {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The CryptoWatchPriceFeed should be able to read `twapLength` as a parameter specified in ancillary data if available.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested