### PR TITLE
improve(across-relayer): Reduce default L2_BLOCK_LOOKBACK

### DIFF
--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -125,7 +125,12 @@ export class RelayerConfig {
     // L2 start block must be explicitly set unlike L1 due to how L2 nodes work. For best practices, we also should
     // constrain L1 start blocks but this hasn't been an issue empirically. As a data point, Arbitrum Infura has a
     // query limit of up to 100,000 blocks into the past.
-    this.l2BlockLookback = L2_BLOCK_LOOKBACK ? Number(L2_BLOCK_LOOKBACK) : 99999;
+    // Note: Set this to some buffer below the 100,000 limit based on how the `index.ts` file computes the start block
+    // to set in the L2 client. It takes the L2 latest block and then subtracts `L2_BLOCK_LOOKBACK` to get the start
+    // block. A little after, the L2 client updates and sets its own `toBlock` to the latest L2 block at the update
+    // time. Therefore, its possible that block height increases enough between the initial L2 latest block query and
+    // the second one that more than 100,000 blocks are queried and the API throws an error.
+    this.l2BlockLookback = L2_BLOCK_LOOKBACK ? Number(L2_BLOCK_LOOKBACK) : 99900;
 
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
The default should be set to some buffer below the 100,000 limit based on how the `index.ts` file computes the start block to set in the L2 client. It takes the L2 latest block and then subtracts `L2_BLOCK_LOOKBACK` to get the start
block. A little after, the L2 client updates and sets its own `toBlock` to the latest L2 block at the update time. Therefore, its possible that block height increases enough between the initial L2 latest block query and
the second one that more than 100,000 blocks are queried and the API throws an error.

This fix was inspired by this error which occurs inconsistently:

![Screen Shot 2021-12-06 at 09 03 19](https://user-images.githubusercontent.com/9457025/144859627-d27ffc56-d97d-4435-9108-5f4bcfbba5d0.png)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
