### PR TITLE
feat(sdk): add timestamp search for lp fee pct calculation

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/utils.ts
+++ b/packages/financial-templates-lib/src/price-feed/utils.ts
@@ -1,8 +1,8 @@
 import lodash from "lodash";
 import assert from "assert";
-import { averageBlockTimeSeconds, MAX_SAFE_JS_INT, estimateBlocksElapsed } from "@uma/common";
+import { averageBlockTimeSeconds, MAX_SAFE_JS_INT } from "@uma/common";
 import type { BN } from "../types";
-export { BlockFinder} from '@uma/sdk'
+export { BlockFinder } from "@uma/sdk";
 
 type WithoutStringTimestamp<T extends { timestamp: number | string }> = T & { timestamp: number };
 

--- a/packages/financial-templates-lib/src/price-feed/utils.ts
+++ b/packages/financial-templates-lib/src/price-feed/utils.ts
@@ -2,6 +2,7 @@ import lodash from "lodash";
 import assert from "assert";
 import { averageBlockTimeSeconds, MAX_SAFE_JS_INT, estimateBlocksElapsed } from "@uma/common";
 import type { BN } from "../types";
+export { BlockFinder} from '@uma/sdk'
 
 type WithoutStringTimestamp<T extends { timestamp: number | string }> = T & { timestamp: number };
 
@@ -198,103 +199,6 @@ export const PriceHistory = <T>(
     list,
   };
 };
-
-export class BlockFinder<T extends { number: number; timestamp: number | string }> {
-  constructor(
-    private readonly requestBlock: (requestedBlock: string | number) => Promise<T>,
-    private readonly blocks: T[] = []
-  ) {
-    assert(requestBlock, "requestBlock function must be provided");
-  }
-
-  /**
-   * @notice Gets the latest block whose timestamp is <= the provided timestamp.
-   * @param {number} timestamp timestamp to search.
-   */
-  public async getBlockForTimestamp(timestamp: number | string): Promise<T> {
-    timestamp = Number(timestamp);
-    assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
-    // If the last block we have stored is too early, grab the latest block.
-    if (this.blocks.length === 0 || this.blocks[this.blocks.length - 1].timestamp < timestamp) {
-      const block = await this.getLatestBlock();
-      if (timestamp >= block.timestamp) return block;
-    }
-
-    // Check the first block. If it's grater than our timestamp, we need to find an earlier block.
-    if (this.blocks[0].timestamp > timestamp) {
-      const initialBlock = this.blocks[0] as WithoutStringTimestamp<T>;
-      const cushion = 1.1;
-      // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
-      const incrementDistance = Math.max(await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion), 1);
-
-      // Search backwards by a constant increment until we find a block before the timestamp or hit block 0.
-      for (let multiplier = 1; ; multiplier++) {
-        const distance = multiplier * incrementDistance;
-        const blockNumber = Math.max(0, initialBlock.number - distance);
-        const block = await this.getBlock(blockNumber);
-        if (block.timestamp <= timestamp) break; // Found an earlier block.
-        assert(blockNumber > 0, "timestamp is before block 0"); // Block 0 was not earlier than this timestamp. Throw.
-      }
-    }
-
-    // Find the index where the block would be inserted and use that as the end block (since it is >= the timestamp).
-    const index = lodash.sortedIndexBy(this.blocks, { timestamp } as T, "timestamp");
-    return this.findBlock(this.blocks[index - 1], this.blocks[index], timestamp);
-  }
-
-  // Grabs the most recent block and caches it.
-  private async getLatestBlock() {
-    const block = await this.requestBlock("latest");
-    const index = lodash.sortedIndexBy(this.blocks, block, "number");
-    if (this.blocks[index]?.number !== block.number) this.blocks.splice(index, 0, block);
-    return this.blocks[index];
-  }
-
-  // Grabs the block for a particular number and caches it.
-  private async getBlock(number: number) {
-    const index = lodash.sortedIndexBy(this.blocks, { number } as T, "number");
-    if (this.blocks[index]?.number === number) return this.blocks[index]; // Return early if block already exists.
-    const block = await this.requestBlock(number);
-    this.blocks.splice(index, 0, block); // A simple insert at index.
-    return block;
-  }
-
-  // Return the latest block, between startBlock and endBlock, whose timestamp is <= timestamp.
-  // Effectively, this is an interpolation search algorithm to minimize block requests.
-  // Note: startBlock and endBlock _must_ be different blocks.
-  private async findBlock(_startBlock: T, _endBlock: T, timestamp: number): Promise<T> {
-    const [startBlock, endBlock] = [_startBlock, _endBlock] as WithoutStringTimestamp<T>[];
-    // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
-    // timestamp.
-    if (endBlock.timestamp === timestamp) return endBlock;
-
-    // If there's no equality, but the blocks are adjacent, return the startBlock, since we want the returned block's
-    // timestamp to be <= the requested timestamp.
-    if (endBlock.number === startBlock.number + 1) return startBlock;
-
-    assert(endBlock.number !== startBlock.number, "startBlock cannot equal endBlock");
-    assert(
-      timestamp < endBlock.timestamp && timestamp > startBlock.timestamp,
-      "timestamp not in between start and end blocks"
-    );
-
-    // Interpolating the timestamp we're searching for to block numbers.
-    const totalTimeDifference = endBlock.timestamp - startBlock.timestamp;
-    const totalBlockDistance = endBlock.number - startBlock.number;
-    const blockPercentile = (timestamp - startBlock.timestamp) / totalTimeDifference;
-    const estimatedBlock = startBlock.number + Math.round(blockPercentile * totalBlockDistance);
-
-    // Clamp ensures the estimated block is strictly greater than the start block and strictly less than the end block.
-    const newBlock = await this.getBlock(lodash.clamp(estimatedBlock, startBlock.number + 1, endBlock.number - 1));
-
-    // Depending on whether the new block is below or above the timestamp, narrow the search space accordingly.
-    if (newBlock.timestamp < timestamp) {
-      return this.findBlock(newBlock, endBlock, timestamp);
-    } else {
-      return this.findBlock(startBlock, newBlock, timestamp);
-    }
-  }
-}
 
 type TwapEvent = [timestamp: number, price: BN | null];
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,6 @@
     "@types/lodash-es": "^4.17.5",
     "@uma/contracts-frontend": "^0.1.13",
     "@uma/contracts-node": "^0.1.13",
-    "@uma/common": "^2.14.0",
     "axios": "^0.21.4",
     "bn.js": "^4.11.9",
     "decimal.js": "^10.3.1",
@@ -48,6 +47,8 @@
     "web3": "^1.6.0"
   },
   "peerDependencies": {
+    "@eth-optimism/contracts": "^0.5.5",
+    "@eth-optimism/core-utils": "^0.7.3",
     "ethers": "^5.4.2"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
     "@types/lodash-es": "^4.17.5",
     "@uma/contracts-frontend": "^0.1.13",
     "@uma/contracts-node": "^0.1.13",
-    "@uma/financial-templates-lib": "^2.19.0",
+    "@uma/common": "^2.14.0",
     "axios": "^0.21.4",
     "bn.js": "^4.11.9",
     "decimal.js": "^10.3.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,6 +39,7 @@
     "@types/lodash-es": "^4.17.5",
     "@uma/contracts-frontend": "^0.1.13",
     "@uma/contracts-node": "^0.1.13",
+    "@uma/financial-templates-lib": "^2.19.0",
     "axios": "^0.21.4",
     "bn.js": "^4.11.9",
     "decimal.js": "^10.3.1",

--- a/packages/sdk/src/across/README.md
+++ b/packages/sdk/src/across/README.md
@@ -142,7 +142,7 @@ const tokenAddress = // token address on L1 to transfer from l2 to l1
 const bridgePoolAddress = // bridge pool address on L1 with the liquidity pool
 const amount = // amount in wei for user to send across
 const timestamp = // timestamp in seconds of latest block on L2 chain
-const const percent = await calculator.getLpFeePct(tokenAddress, bridgePoolAddress, amount, timestamp)
+const percent = await calculator.getLpFeePct(tokenAddress, bridgePoolAddress, amount, timestamp)
 
 
 ```

--- a/packages/sdk/src/across/README.md
+++ b/packages/sdk/src/across/README.md
@@ -126,6 +126,27 @@ const result = utils.calculateGasFees(gas, gasPrice)
 const userDisplay = fromWei(result)
 ```
 
+### LP Fee Calculator
+
+Get lp fee calculations by timestamp.
+
+```ts
+import * as uma from "@uma/sdk"
+
+const LpFeeCalculator = uma.across.LpFeeCalculator
+
+// pass in L1 read only provider. You should only have a single instance of the calculator.
+const calculator = new LpFeeCalculator(provider)
+
+const tokenAddress = // token address on L1 to transfer from l2 to l1
+const bridgePoolAddress = // bridge pool address on L1 with the liquidity pool
+const amount = // amount in wei for user to send across
+const timestamp = // timestamp in seconds of latest block on L2 chain
+const const percent = await calculator.getLpFeePct(tokenAddress, bridgePoolAddress, amount, timestamp)
+
+
+```
+
 ### Contract Clients
 
 - [BridgePool Client](./clients/README.md)

--- a/packages/sdk/src/across/index.ts
+++ b/packages/sdk/src/across/index.ts
@@ -1,4 +1,5 @@
 export * as feeCalculator from "./feeCalculator";
+export { default as LpFeeCalculator } from "./lpFeeCalculator";
 export { default as gasFeeCalculator } from "./gasFeeCalculator";
 export * as utils from "./utils";
 export * as constants from "./constants";

--- a/packages/sdk/src/across/lpFeeCalculator.ts
+++ b/packages/sdk/src/across/lpFeeCalculator.ts
@@ -5,7 +5,8 @@ import { bridgePool } from "../clients";
 import { RATE_MODELS } from "./constants";
 import { BigNumberish } from "./utils";
 import { calculateRealizedLpFeePct } from "./feeCalculator";
-import { exists, BlockFinder } from "../utils";
+import { exists } from "../utils";
+import BlockFinder from "../blockFinder";
 
 export default class LpFeeCalculator {
   private blockFinder: BlockFinder<Block>;

--- a/packages/sdk/src/across/lpFeeCalculator.ts
+++ b/packages/sdk/src/across/lpFeeCalculator.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { Provider, Block } from "@ethersproject/providers";
+import { ethers, BigNumber } from "ethers";
+import { bridgePool } from "../clients";
+import { RATE_MODELS } from "./constants";
+import { BigNumberish } from "./utils";
+import { calculateRealizedLpFeePct } from "./feeCalculator";
+import { exists, BlockFinder } from "../utils";
+
+export default class LpFeeCalculator {
+  private blockFinder: BlockFinder<Block>;
+  constructor(private provider: Provider) {
+    this.blockFinder = new BlockFinder<Block>(provider.getBlock.bind(provider));
+  }
+  async getLpFeePct(tokenAddress: string, bridgePoolAddress: string, amount: BigNumberish, timestamp?: number) {
+    const rateModel = RATE_MODELS[ethers.utils.getAddress(tokenAddress)];
+    assert(rateModel, "No rate model for token: " + tokenAddress);
+
+    amount = BigNumber.from(amount);
+    assert(amount.gt(0), "Amount must be greater than 0");
+
+    const { blockFinder, provider } = this;
+
+    const bridgePoolInstance = bridgePool.connect(bridgePoolAddress, provider);
+
+    const targetBlock = exists(timestamp)
+      ? await blockFinder.getBlockForTimestamp(timestamp)
+      : await provider.getBlock("latest");
+    assert(exists(targetBlock), "Unable to find target block for timestamp: " + timestamp || "latest");
+    const blockTag = targetBlock.number;
+
+    const [currentUt, nextUt] = await Promise.all([
+      bridgePoolInstance.callStatic.liquidityUtilizationCurrent({ blockTag } as any),
+      bridgePoolInstance.callStatic.liquidityUtilizationPostRelay(amount, { blockTag } as any),
+    ]);
+    return calculateRealizedLpFeePct(rateModel, currentUt, nextUt);
+  }
+}

--- a/packages/sdk/src/across/test/lpFeeCalculator.e2e.ts
+++ b/packages/sdk/src/across/test/lpFeeCalculator.e2e.ts
@@ -1,0 +1,25 @@
+import dotenv from "dotenv";
+import assert from "assert";
+import { ethers } from "ethers";
+import { LpFeeCalculator } from "..";
+import { Provider } from "@ethersproject/providers";
+import { toWei } from "../utils";
+
+dotenv.config();
+
+const wethAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const wethPool = "0x7355Efc63Ae731f584380a9838292c7046c1e433";
+
+describe("Relay Client", function () {
+  let provider: Provider;
+  beforeAll(async () => {
+    provider = ethers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+  });
+  test("get fees", async () => {
+    const calculator = new LpFeeCalculator(provider);
+    const timestamp = Math.floor(Date.now() / 1000) - 60 * 10;
+    const amount = toWei(10);
+    const result = await calculator.getLpFeePct(wethAddress, wethPool, amount, timestamp);
+    assert.ok(result);
+  });
+});

--- a/packages/sdk/src/across/utils.test.ts
+++ b/packages/sdk/src/across/utils.test.ts
@@ -31,7 +31,7 @@ test("estimate usdc slow", async function () {
   const result = utils.calculateGasFees(gas, gasPrice, tokenPrice, decimals);
   const userDisplay = utils.fromWei(result, decimals);
   assert.ok(userDisplay);
-}, 10000);
+});
 test("estimate uma slow", async function () {
   const gas = constants.SLOW_UMA_GAS;
   const gasPrice = estimatedGasPrice;

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -1,0 +1,103 @@
+import assert from "assert";
+import sortedIndexBy from "lodash/sortedIndexBy";
+import clamp from "lodash/clamp";
+import { estimateBlocksElapsed } from "./utils";
+
+type WithoutStringTimestamp<T extends { timestamp: number | string }> = T & { timestamp: number };
+
+export default class BlockFinder<T extends { number: number; timestamp: number | string }> {
+  constructor(
+    private readonly requestBlock: (requestedBlock: string | number) => Promise<T>,
+    private readonly blocks: T[] = []
+  ) {
+    assert(requestBlock, "requestBlock function must be provided");
+  }
+
+  /**
+   * @notice Gets the latest block whose timestamp is <= the provided timestamp.
+   * @param {number} timestamp timestamp to search.
+   */
+  public async getBlockForTimestamp(timestamp: number | string): Promise<T> {
+    timestamp = Number(timestamp);
+    assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
+    // If the last block we have stored is too early, grab the latest block.
+    if (this.blocks.length === 0 || this.blocks[this.blocks.length - 1].timestamp < timestamp) {
+      const block = await this.getLatestBlock();
+      if (timestamp >= block.timestamp) return block;
+    }
+
+    // Check the first block. If it's grater than our timestamp, we need to find an earlier block.
+    if (this.blocks[0].timestamp > timestamp) {
+      const initialBlock = this.blocks[0] as WithoutStringTimestamp<T>;
+      const cushion = 1.1;
+      // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
+      const incrementDistance = Math.max(await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion), 1);
+
+      // Search backwards by a constant increment until we find a block before the timestamp or hit block 0.
+      for (let multiplier = 1; ; multiplier++) {
+        const distance = multiplier * incrementDistance;
+        const blockNumber = Math.max(0, initialBlock.number - distance);
+        const block = await this.getBlock(blockNumber);
+        if (block.timestamp <= timestamp) break; // Found an earlier block.
+        assert(blockNumber > 0, "timestamp is before block 0"); // Block 0 was not earlier than this timestamp. The row.
+      }
+    }
+
+    // Find the index where the block would be inserted and use that as the end block (since it is >= the timestamp).
+    const index = sortedIndexBy(this.blocks, { timestamp } as T, "timestamp");
+    return this.findBlock(this.blocks[index - 1], this.blocks[index], timestamp);
+  }
+
+  // Grabs the most recent block and caches it.
+  private async getLatestBlock() {
+    const block = await this.requestBlock("latest");
+    const index = sortedIndexBy(this.blocks, block, "number");
+    if (this.blocks[index]?.number !== block.number) this.blocks.splice(index, 0, block);
+    return this.blocks[index];
+  }
+
+  // Grabs the block for a particular number and caches it.
+  private async getBlock(number: number) {
+    const index = sortedIndexBy(this.blocks, { number } as T, "number");
+    if (this.blocks[index]?.number === number) return this.blocks[index]; // Return early if block already exists.
+    const block = await this.requestBlock(number);
+    this.blocks.splice(index, 0, block); // A simple insert at index.
+    return block;
+  }
+
+  // Return the latest block, between startBlock and endBlock, whose timestamp is <= timestamp.
+  // Effectively, this is an interpolation search algorithm to minimize block requests.
+  // Note: startBlock and endBlock _must_ be different blocks.
+  private async findBlock(_startBlock: T, _endBlock: T, timestamp: number): Promise<T> {
+    const [startBlock, endBlock] = [_startBlock, _endBlock] as WithoutStringTimestamp<T>[];
+    // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
+    // timestamp.
+    if (endBlock.timestamp === timestamp) return endBlock;
+
+    // If there's no equality, but the blocks are adjacent, return the startBlock, since we want the returned block's
+    // timestamp to be <= the requested timestamp.
+    if (endBlock.number === startBlock.number + 1) return startBlock;
+
+    assert(endBlock.number !== startBlock.number, "startBlock cannot equal endBlock");
+    assert(
+      timestamp < endBlock.timestamp && timestamp > startBlock.timestamp,
+      "timestamp not in between start and end blocks"
+    );
+
+    // Interpolating the timestamp we're searching for to block numbers.
+    const totalTimeDifference = endBlock.timestamp - startBlock.timestamp;
+    const totalBlockDistance = endBlock.number - startBlock.number;
+    const blockPercentile = (timestamp - startBlock.timestamp) / totalTimeDifference;
+    const estimatedBlock = startBlock.number + Math.round(blockPercentile * totalBlockDistance);
+
+    // Clamp ensures the estimated block is strictly greater than the start block and strictly less than the end block.
+    const newBlock = await this.getBlock(clamp(estimatedBlock, startBlock.number + 1, endBlock.number - 1));
+
+    // Depending on whether the new block is below or above the timestamp, narrow the search space accordingly.
+    if (newBlock.timestamp < timestamp) {
+      return this.findBlock(newBlock, endBlock, timestamp);
+    } else {
+      return this.findBlock(startBlock, newBlock, timestamp);
+    }
+  }
+}

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import clamp from "lodash/clamp";
-import { estimateBlocksElapsed } from "./utils";
+import { estimateBlocksElapsed } from "@uma/common";
 
-type WithoutStringTimestamp<T extends { timestamp: number | string }> = T & { timestamp: number };
+export type WithoutStringTimestamp<T extends { timestamp: number | string }> = T & { timestamp: number };
 
 export default class BlockFinder<T extends { number: number; timestamp: number | string }> {
   constructor(

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import clamp from "lodash/clamp";
-import { estimateBlocksElapsed } from "@uma/common";
+import { estimateBlocksElapsed } from "./utils";
 
 export type WithoutStringTimestamp<T extends { timestamp: number | string }> = T & { timestamp: number };
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,12 +10,19 @@ export { default as BlockFinder } from "./blockFinder";
 
 // types
 import type { TypedEventFilterEthers as TypedEventFilter, TypedEventEthers as TypedEvent } from "@uma/contracts-node";
-import { Contract, ethers, Signer, providers, Event } from "ethers";
+import { Contract, ethers, providers, Event } from "ethers";
 import { Provider } from "@ethersproject/providers";
+import { Signer } from "@ethersproject/abstract-signer";
 
 type Result = ethers.utils.Result;
 
-export type SignerOrProvider = providers.BaseProvider | Signer | Provider;
+export type SignerOrProvider =
+  | providers.Provider
+  | providers.BaseProvider
+  | Signer
+  | Provider
+  | providers.JsonRpcProvider
+  | ethers.Signer;
 
 export interface MakeId<I, D> {
   (d: D): I;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,6 +6,7 @@ export * as across from "./across";
 export { default as Coingecko } from "./coingecko";
 export { default as Multicall } from "./multicall";
 export { default as Multicall2 } from "./multicall2";
+export { default as BlockFinder } from "./blockFinder";
 
 // types
 import type { TypedEventFilterEthers as TypedEventFilter, TypedEventEthers as TypedEvent } from "@uma/contracts-node";

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -92,3 +92,33 @@ export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contra
     })
   );
 };
+
+/**
+ * @notice Return average block-time for a period.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function averageBlockTimeSeconds(lookbackSeconds?: number, networkId?: number): Promise<number> {
+  // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
+  // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
+  // since April 2016, although this value seems to spike periodically for a relatively short period of time.
+  const defaultBlockTimeSeconds = 13.5;
+  if (!defaultBlockTimeSeconds) {
+    throw "Missing default block time value";
+  }
+
+  switch (networkId) {
+    // Source: https://polygonscan.com/chart/blocktime
+    case 137:
+      return 2.5;
+    case 1:
+      return defaultBlockTimeSeconds;
+    default:
+      return defaultBlockTimeSeconds;
+  }
+}
+
+export async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0): Promise<number> {
+  const cushionMultiplier = cushionPercentage + 1.0;
+  const averageBlockTime = await averageBlockTimeSeconds();
+  return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
+}

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -95,3 +95,33 @@ export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contra
     })
   );
 };
+
+/**
+ * @notice Return average block-time for a period.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function averageBlockTimeSeconds(lookbackSeconds?: number, networkId?: number): Promise<number> {
+  // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
+  // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
+  // since April 2016, although this value seems to spike periodically for a relatively short period of time.
+  const defaultBlockTimeSeconds = 13.5;
+  if (!defaultBlockTimeSeconds) {
+    throw "Missing default block time value";
+  }
+
+  switch (networkId) {
+    // Source: https://polygonscan.com/chart/blocktime
+    case 137:
+      return 2.5;
+    case 1:
+      return defaultBlockTimeSeconds;
+    default:
+      return defaultBlockTimeSeconds;
+  }
+}
+
+export async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0): Promise<number> {
+  const cushionMultiplier = cushionPercentage + 1.0;
+  const averageBlockTime = await averageBlockTimeSeconds();
+  return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
+}

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,8 +1,10 @@
 import assert from "assert";
-import { BigNumber } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import type Multicall2 from "./multicall2";
-import type { Contract } from "ethers";
 import zip from "lodash/zip";
+
+// re-use this class, its compatible with FE and BE
+export { BlockFinder } from "@uma/financial-templates-lib/dist/price-feed/utils";
 
 export type BigNumberish = number | string | BigNumber;
 // check if a value is not null or undefined, useful for numbers which could be 0.

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -3,9 +3,6 @@ import { BigNumber, Contract } from "ethers";
 import type Multicall2 from "./multicall2";
 import zip from "lodash/zip";
 
-// re-use this class, its compatible with FE and BE
-export { BlockFinder } from "@uma/financial-templates-lib/dist/price-feed/utils";
-
 export type BigNumberish = number | string | BigNumber;
 // check if a value is not null or undefined, useful for numbers which could be 0.
 // "is" syntax: https://stackoverflow.com/questions/40081332/what-does-the-is-keyword-do-in-typescript

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -95,33 +95,3 @@ export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contra
     })
   );
 };
-
-/**
- * @notice Return average block-time for a period.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function averageBlockTimeSeconds(lookbackSeconds?: number, networkId?: number): Promise<number> {
-  // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
-  // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
-  // since April 2016, although this value seems to spike periodically for a relatively short period of time.
-  const defaultBlockTimeSeconds = 13.5;
-  if (!defaultBlockTimeSeconds) {
-    throw "Missing default block time value";
-  }
-
-  switch (networkId) {
-    // Source: https://polygonscan.com/chart/blocktime
-    case 137:
-      return 2.5;
-    case 1:
-      return defaultBlockTimeSeconds;
-    default:
-      return defaultBlockTimeSeconds;
-  }
-}
-
-export async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0): Promise<number> {
-  const cushionMultiplier = cushionPercentage + 1.0;
-  const averageBlockTime = await averageBlockTimeSeconds();
-  return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,9 +3962,9 @@
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
 "@napi-rs/triples@^1.0.3":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.1.0.tgz#88c35b72e79a20b79bb4c9b3e2817241a1c9f4f9"
-  integrity sha512-XQr74QaLeMiqhStEhLn1im9EOMnkypp7MZOwQhGzqp2Weu5eQJbpPxWxixxlYRKWPOmJjsk6qYfYH9kq43yc2w==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
+  integrity sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA==
 
 "@node-rs/crc32-android-arm64@^1.0.0":
   version "1.2.2"
@@ -26681,3 +26681,4 @@ zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+  

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,9 +3962,9 @@
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
 "@napi-rs/triples@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
-  integrity sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.1.0.tgz#88c35b72e79a20b79bb4c9b3e2817241a1c9f4f9"
+  integrity sha512-XQr74QaLeMiqhStEhLn1im9EOMnkypp7MZOwQhGzqp2Weu5eQJbpPxWxixxlYRKWPOmJjsk6qYfYH9kq43yc2w==
 
 "@node-rs/crc32-android-arm64@^1.0.0":
   version "1.2.2"
@@ -26681,4 +26681,3 @@ zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
-  


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/3307/add-support-for-l2s-that-are-more-than-10-mintues-behind-in-sdk

**Summary**

Wraps the lpfee calculation to add an optional timestamp with the query. The timestamp does a block lookup using BlockFinder code in financial-templates-lib.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.shortcut.com/uma-project/story/3307/add-support-for-l2s-that-are-more-than-10-mintues-behind-in-sdk
