### PR TITLE
improve(cross-chain-oracle): Stamp ancillary data in hasPrice and getPrice

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
@@ -104,7 +104,7 @@ contract OracleSpoke is
         uint256 time,
         bytes memory ancillaryData
     ) public view override nonReentrantView() onlyRegisteredContract() returns (bool) {
-        bytes32 priceRequestId = _encodePriceRequest(identifier, time, ancillaryData);
+        bytes32 priceRequestId = _encodePriceRequest(identifier, time, _stampAncillaryData(ancillaryData));
         return prices[priceRequestId].state == RequestState.Resolved;
     }
 
@@ -136,7 +136,7 @@ contract OracleSpoke is
         uint256 time,
         bytes memory ancillaryData
     ) public view override nonReentrantView() onlyRegisteredContract() returns (int256) {
-        bytes32 priceRequestId = _encodePriceRequest(identifier, time, ancillaryData);
+        bytes32 priceRequestId = _encodePriceRequest(identifier, time, _stampAncillaryData(ancillaryData));
         Price storage lookup = prices[priceRequestId];
         require(lookup.state == RequestState.Resolved, "Price has not been resolved");
         return lookup.price;

--- a/packages/core/test/cross-chain-oracle/OracleSpoke.js
+++ b/packages/core/test/cross-chain-oracle/OracleSpoke.js
@@ -103,20 +103,18 @@ describe("OracleSpoke.js", async () => {
     assert.equal(pushPriceEvents.length, 1);
     assert.isTrue(
       await oracleSpoke.methods
-        .hasPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData)
+        .hasPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
         .call({ from: owner })
     );
   });
   it("hasPrice", async function () {
-    let expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData).call();
-
     assert.isFalse(
       await oracleSpoke.methods
-        .hasPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData)
+        .hasPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
         .call({ from: owner })
     );
 
-    expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData).call();
+    let expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData).call();
     await messenger.methods
       .publishPrice(
         oracleSpoke.options.address,
@@ -130,13 +128,13 @@ describe("OracleSpoke.js", async () => {
     // Only registered caller can call
     assert(
       await didContractThrow(
-        oracleSpoke.methods.hasPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData).call({ from: rando })
+        oracleSpoke.methods.hasPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData).call({ from: rando })
       )
     );
 
     assert.isTrue(
       await oracleSpoke.methods
-        .hasPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData)
+        .hasPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
         .call({ from: owner })
     );
 
@@ -155,16 +153,14 @@ describe("OracleSpoke.js", async () => {
     assert.isTrue(await oracleSpoke.methods.hasPrice(defaultIdentifier, defaultTimestamp).call({ from: owner }));
   });
   it("getPrice", async function () {
-    let expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData).call();
-
     // Reverts if price not available
     assert(
       await didContractThrow(
-        oracleSpoke.methods.getPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData).call({ from: owner })
+        oracleSpoke.methods.getPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData).call({ from: owner })
       )
     );
 
-    expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData).call();
+    let expectedAncillaryData = await oracleSpoke.methods.stampAncillaryData(defaultAncillaryData).call();
     await messenger.methods
       .publishPrice(
         oracleSpoke.options.address,
@@ -178,13 +174,13 @@ describe("OracleSpoke.js", async () => {
     // Only registered caller can call
     assert(
       await didContractThrow(
-        oracleSpoke.methods.getPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData).call({ from: rando })
+        oracleSpoke.methods.getPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData).call({ from: rando })
       )
     );
 
     assert.equal(
       await oracleSpoke.methods
-        .getPrice(defaultIdentifier, defaultTimestamp, expectedAncillaryData)
+        .getPrice(defaultIdentifier, defaultTimestamp, defaultAncillaryData)
         .call({ from: owner }),
       defaultPrice
     );

--- a/packages/core/test/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.js
+++ b/packages/core/test/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.js
@@ -88,7 +88,7 @@ describe("Admin_ChildMessenger", function () {
     // Encode price response data.
     const dataToSend = web3.eth.abi.encodeParameters(
       ["bytes32", "uint256", "bytes", "int256"],
-      [identifier, timestamp, ancillaryData, "100"]
+      [identifier, timestamp, await oracleSpokeReal.methods.stampAncillaryData(ancillaryData).call(), "100"]
     );
 
     // Only the owner can send a message to the spoke contracts.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

I believe we should stamp ancillary data in these public methods. I originally removed this stamping logic in [this PR](https://github.com/UMAprotocol/protocol/pull/3627) because the previous `stampAncillaryData` implementation stamped the `msg.sender` address, which means that only the original requester could call `has/getPrice`, but now that we removed it we can add stamping for the caller’s convenience. 

This improves the caller's experience as they only need to pass the original ancillary data that was passed into `requestPrice`.

This PR is possible because `stampAncillaryData` now only stamps the `block.chainId` which is not affected by who the `msg.sender` is.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
