### PR TITLE
improve(across-relayer): Additional logging when computing realized LP fee %

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -184,6 +184,16 @@ export class InsuredBridgeL1Client {
       bridgePool.methods.liquidityUtilizationPostRelay(deposit.amount.toString()).call(undefined, quoteBlockNumber),
     ]);
 
+    this.logger.debug({
+      at: "InsuredBridgeL1Client",
+      message: "Computed realized LP fee % for deposit",
+      deposit,
+      quoteBlockNumber,
+      liquidityUtilizationCurrent: liquidityUtilizationCurrent.toString(),
+      liquidityUtilizationPostRelay: liquidityUtilizationPostRelay.toString(),
+      rateModel: this.rateModels[deposit.l1Token],
+    });
+
     return calculateRealizedLpFeePct(
       this.rateModels[deposit.l1Token],
       toBN(liquidityUtilizationCurrent),

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -187,6 +187,7 @@ export class InsuredBridgeL1Client {
     this.logger.debug({
       at: "InsuredBridgeL1Client",
       message: "Computed realized LP fee % for deposit",
+      deposit,
       quoteBlockNumber,
       liquidityUtilizationCurrent: liquidityUtilizationCurrent.toString(),
       liquidityUtilizationPostRelay: liquidityUtilizationPostRelay.toString(),

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -187,7 +187,6 @@ export class InsuredBridgeL1Client {
     this.logger.debug({
       at: "InsuredBridgeL1Client",
       message: "Computed realized LP fee % for deposit",
-      deposit,
       quoteBlockNumber,
       liquidityUtilizationCurrent: liquidityUtilizationCurrent.toString(),
       liquidityUtilizationPostRelay: liquidityUtilizationPostRelay.toString(),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This log will be helpful to determine which block was used to compute realized LP fee %, which is derived from the `deposit.quoteTime`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
