### PR TITLE
fix: throw errors when transaction fails pre tx hash

### DIFF
--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -154,8 +154,10 @@ export const runTransaction = async ({
           maxFeePerGas: parseInt(transactionConfig.maxFeePerGas.toString()) * 2,
           type: "0x2",
         } as SendOptions) as unknown) as PromiEvent<TransactionReceipt>;
-        transactionHash = await new Promise((resolve) => {
-          (receipt as any).on("transactionHash", (transactionHash: any) => resolve(transactionHash));
+        transactionHash = await new Promise((resolve, reject) => {
+          const _receipt = receipt as PromiEvent<TransactionReceipt>;
+          _receipt.on("transactionHash", (transactionHash) => resolve(transactionHash));
+          _receipt.on("error", (error) => reject(error));
         });
       }
 

--- a/packages/common/test/TransactionUtils.js
+++ b/packages/common/test/TransactionUtils.js
@@ -30,7 +30,7 @@ describe("TransactionUtils.js", function () {
     // TODO: Figure out how to test situations where the `transaction.send()` fails but `.call()` does not
     it("waitForMine = false doesn't hang if transaction hash errors", async function () {
       const erc20Contract = await ERC20.new("1").send({ from: accounts[0] });
-      // Allowance is not set for accounts[0] so this should fail on .call()
+      // This transaction should be successful since the sender has 1 wei.
       const transaction = erc20Contract.methods.transfer(accounts[1], "1");
 
       // Should fail pre-transaction hash because gas prices cannot be negative.


### PR DESCRIPTION
**Motivation**

Certain types of transaction errors cause the bot to hang.

**Summary**

This catches errors that are thrown before we get a transaction hash back.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
