### PR TITLE
fix(cross-chain-oracle): [L02] add more nonReentrant() modifiers

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
@@ -112,7 +112,7 @@ contract Arbitrum_ParentMessenger is
      * @dev This function will only succeed if this contract has enough ETH to cover the approximate L1 call value.
      * @param newOracleSpoke the new oracle spoke address set on L2.
      */
-    function setChildOracleSpoke(address newOracleSpoke) public onlyOwner {
+    function setChildOracleSpoke(address newOracleSpoke) public onlyOwner nonReentrant() {
         bytes memory dataSentToChild = abi.encodeWithSignature("setOracleSpoke(address)", newOracleSpoke);
         _sendMessageToChild(dataSentToChild, childMessenger);
     }
@@ -123,7 +123,7 @@ contract Arbitrum_ParentMessenger is
      * @dev This function will only succeed if this contract has enough ETH to cover the approximate L1 call value.
      * @param newParentMessenger the new parent messenger contract to be set on L2.
      */
-    function setChildParentMessenger(address newParentMessenger) public onlyOwner {
+    function setChildParentMessenger(address newParentMessenger) public onlyOwner nonReentrant() {
         bytes memory dataSentToChild = abi.encodeWithSignature("setParentMessenger(address)", newParentMessenger);
         _sendMessageToChild(dataSentToChild, childMessenger);
     }

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ParentMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ParentMessenger.sol
@@ -44,7 +44,7 @@ contract Optimism_ParentMessenger is CrossDomainEnabled, ParentMessengerInterfac
      * @dev The caller of this function must be the owner. This should be set to the DVM governor.
      * @param newOracleSpoke the new oracle spoke address set on L2.
      */
-    function setChildOracleSpoke(address newOracleSpoke) public onlyOwner {
+    function setChildOracleSpoke(address newOracleSpoke) public onlyOwner nonReentrant() {
         bytes memory dataSentToChild = abi.encodeWithSignature("setOracleSpoke(address)", newOracleSpoke);
         sendCrossDomainMessage(childMessenger, defaultGasLimit, dataSentToChild);
         emit MessageSentToChild(dataSentToChild, address(0), defaultGasLimit, childMessenger);
@@ -55,7 +55,7 @@ contract Optimism_ParentMessenger is CrossDomainEnabled, ParentMessengerInterfac
      * @dev The caller of this function must be the owner. This should be set to the DVM governor.
      * @param newParentMessenger the new parent messenger contract to be set on L2.
      */
-    function setChildParentMessenger(address newParentMessenger) public onlyOwner {
+    function setChildParentMessenger(address newParentMessenger) public onlyOwner nonReentrant() {
         bytes memory dataSentToChild = abi.encodeWithSignature("setParentMessenger(address)", newParentMessenger);
         sendCrossDomainMessage(childMessenger, defaultGasLimit, dataSentToChild);
         emit MessageSentToChild(dataSentToChild, address(0), defaultGasLimit, childMessenger);
@@ -66,7 +66,7 @@ contract Optimism_ParentMessenger is CrossDomainEnabled, ParentMessengerInterfac
      * @dev The caller of this function must be the owner. This should be set to the DVM governor.
      * @param newDefaultGasLimit the new default gas limit set on L2.
      */
-    function setChildDefaultGasLimit(uint32 newDefaultGasLimit) public onlyOwner {
+    function setChildDefaultGasLimit(uint32 newDefaultGasLimit) public onlyOwner nonReentrant() {
         bytes memory dataSentToChild = abi.encodeWithSignature("setDefaultGasLimit(uint32)", newDefaultGasLimit);
         sendCrossDomainMessage(childMessenger, defaultGasLimit, dataSentToChild);
         emit MessageSentToChild(dataSentToChild, address(0), defaultGasLimit, childMessenger);


### PR DESCRIPTION
Signed-off-by: chrismaree <christopher.maree@gmail.com>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ identified the following issue:
_The Optimism_ParentMessenger and Arbitrum_ParentMessenger contracts inconsistently apply the
nonReentrant modifier. Consider including it on all public functions._

This PR fixes this by consistently applying nonReentrant modifiers to all public functions.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
