### PR TITLE
fix(cross-chain-oracle): [L03] fixed wrong commenting

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -45,9 +45,7 @@ contract GovernorSpoke is Lockable, ChildMessengerConsumerInterface {
 
     // Note: this snippet of code is copied from Governor.sol.
     function _executeCall(address to, bytes memory data) private returns (bool) {
-        // Note: this snippet of code is copied from Governor.sol.
-        // solhint-disable-next-line max-line-length
-        // https://github.com/gnosis/safe-contracts/blob/59cfdaebcd8b87a0a32f87b50fead092c10d3a05/contracts/base/Executor.sol#L23-L31
+        // Note: this snippet of code is copied from Governor.sol and modified to not include any "value" field.
         // solhint-disable-next-line no-inline-assembly
 
         bool success;

--- a/packages/core/contracts/cross-chain-oracle/interfaces/ChildMessengerConsumerInterface.sol
+++ b/packages/core/contracts/cross-chain-oracle/interfaces/ChildMessengerConsumerInterface.sol
@@ -2,6 +2,6 @@
 pragma solidity ^0.8.0;
 
 interface ChildMessengerConsumerInterface {
-    // Called on L2 by parent messenger.
+    // Called on L2 by child messenger.
     function processMessageFromParent(bytes memory data) external;
 }


### PR DESCRIPTION
OZ identified the following issues:
_Here are some misleading comments we identified during our review:
ChildMessengerConsumerInterface.sol:
Line 5 says "parent messenger" instead of "child messenger"
GovernorSpoke.sol:
Lines 49-51 links to a Gnosis file even though the comment says the snippet was copied
from Governor.sol. Additionally, the snippet is not identical to the one in Governor.sol_

This PR addresses these misleading comments.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested