### PR TITLE
fix(cross-chain-oracle): [N03] address incorrect interface

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./interfaces/ChildMessengerConsumerInterface.sol";
+import "./interfaces/ChildMessengerInterface.sol";
 import "../common/implementation/Lockable.sol";
 
 /**
@@ -10,12 +11,12 @@ import "../common/implementation/Lockable.sol";
  */
 contract GovernorSpoke is Lockable, ChildMessengerConsumerInterface {
     // Messenger contract that receives messages from root chain.
-    ChildMessengerConsumerInterface public messenger;
+    ChildMessengerInterface public messenger;
 
     event ExecutedGovernanceTransaction(address indexed to, bytes data);
     event SetChildMessenger(address indexed childMessenger);
 
-    constructor(ChildMessengerConsumerInterface _messengerAddress) {
+    constructor(ChildMessengerInterface _messengerAddress) {
         messenger = _messengerAddress;
         emit SetChildMessenger(address(messenger));
     }


### PR DESCRIPTION
**Motivation**

OZ identified the following issue: _The GovernorSpoke contract incorrectly uses the ChildMessengerConsumerInterface type to describe its messenger variable. Consider using the ChildMessengerInterface instead._

This PR fixes this by using the correct interface.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
