### PR TITLE
fix(core-contracts): [N06] fix some typographical errors

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -27,7 +27,7 @@ contract GovernorSpoke is Lockable, ChildMessengerConsumerInterface {
 
     /**
      * @notice Executes governance transaction created on Ethereum.
-     * @dev Can only called by ChildMessenger contract that wants to execute governance action on this child chain that
+     * @dev Can only be called by ChildMessenger contract that wants to execute governance action on this child chain that
      * originated from DVM voters on root chain. ChildMessenger should only receive communication from ParentMessenger
      * on mainnet.
 

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
@@ -10,7 +10,7 @@ import "../../common/implementation/Lockable.sol";
  * @notice A version of the child messenger that allows an admin to relay messages on its behalf.
  * @dev No parent messenger is needed for this case, as the admin could be trusted to manually send DVM requests on
  * mainnet. This is intended to be used as a "beta" deployment compatible with any EVM-compatible chains before
- * impleenting a full bridge adapter. Put simply, it is meant as a stop-gap.
+ * implementing a full bridge adapter. Put simply, it is meant as a stop-gap.
  */
 contract Admin_ChildMessenger is Ownable, Lockable, ChildMessengerInterface {
     // The only child network contract that can send messages over the bridge via the messenger is the oracle spoke.

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ChildMessenger.sol
@@ -9,7 +9,7 @@ import "../../common/implementation/Lockable.sol";
 
 /**
  * @notice Sends cross chain messages from Optimism L2 to Ethereum L1 network.
- * @dev This contract is ownable via the onlyCrossDomainAccount modifier, restricting ownership to the cross-domain
+ * @dev This contract is ownable via the onlyFromCrossDomainAccount. modifier, restricting ownership to the cross-domain
  * parent messenger contract that lives on L1.
  */
 contract Optimism_ChildMessenger is CrossDomainEnabled, ChildMessengerInterface, Lockable {
@@ -95,7 +95,7 @@ contract Optimism_ChildMessenger is CrossDomainEnabled, ChildMessengerInterface,
      * @dev The caller must be the the parent messenger, sent over the canonical message bridge.
      * @param data data message sent from the L1 messenger. Should be an encoded function call or packed data.
      * @param target desired recipient of `data`. Target must implement the `processMessageFromParent` function. Having
-     * this as a param enables the L1 Messenger to send messages to arbitrary addresses on the L1. This is primarily
+     * this as a param enables the L1 Messenger to send messages to arbitrary addresses on the L2. This is primarily
      * used to send messages to the OracleSpoke and GovernorSpoke on L2.
      */
     function processMessageFromCrossChainParent(bytes memory data, address target)

--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -149,7 +149,7 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
      * @dev if called by someone who doesn't own the token, they are effectively gifting their bond to the owner.
      * @param tokenId the tokenId the redemption is for.
      * @param cumulativeRedemptions the cumulative token addresses and amounts that this tokenId is eligible for
-     * at the current timestap. cumulative redemptions that are too low should be considered to be valid.
+     * at the current timestamp. cumulative redemptions that are too low should be considered to be valid.
      */
     function requestRedemption(uint256 tokenId, RedemptionAmount[] memory cumulativeRedemptions)
         public
@@ -185,7 +185,7 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
         bytes32 redemptionId = getRedemptionId(tokenId, cumulativeRedemptions);
 
         // This automatically checks that redemptions[redemptionId] != 0.
-        // Check that it has not passed liveness liveness.
+        // Check that it has not passed liveness.
         Redemption storage redemption = redemptions[redemptionId];
         require(getCurrentTime() < redemption.expiryTime, "redemption expired or nonexistent");
 


### PR DESCRIPTION
**Motivation**

OZ identified a number of typographical errors:
In the Admin_ChildMessenger contract, impleenting should be implementing
In the OptimisticRewarderBase contract, timestap should be timestamp.
In the OptimisticRewarderBase contract, liveness liveness should be liveness.
In the GovernorSpoke contract, only called should be only be called.
In the Optimism_ChildMessenger contract:onlyCrossDomainAccount should be onlyFromCrossDomainAccount.addresses on the L1 should be addresses on the L2

This PR addresses these.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [X]  Untested
