### PR TITLE
fix(optimistic-rewarder): [N07] addressed unused imports

### DIFF
--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -9,6 +9,7 @@ import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/MultiCaller.sol";
 import "../../oracle/interfaces/StoreInterface.sol";
 import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
+import "../../oracle/implementation/Constants.sol";
 import "../../oracle/interfaces/SkinnyOptimisticOracleInterface.sol";
 import "../../common/implementation/AncillaryData.sol";
 import "../../common/interfaces/AddressWhitelistInterface.sol";

--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -9,7 +9,6 @@ import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/MultiCaller.sol";
 import "../../oracle/interfaces/StoreInterface.sol";
 import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
-import "../../oracle/implementation/Constants.sol";
 import "../../oracle/interfaces/SkinnyOptimisticOracleInterface.sol";
 import "../../common/implementation/AncillaryData.sol";
 import "../../common/interfaces/AddressWhitelistInterface.sol";

--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderCreator.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderCreator.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../../common/implementation/Lockable.sol";
-import "../../common/implementation/Testable.sol";
 
 import "../../oracle/interfaces/FinderInterface.sol";
 import "./OptimisticRewarder.sol";

--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderToken.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderToken.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "./OptimisticRewarder.sol";
 
 contract OptimisticRewarderToken is ERC721 {
     string public baseUri;

--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticStaker.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticStaker.sol
@@ -6,8 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/MultiCaller.sol";
-import "./OptimisticRewarder.sol";
-import "./OptimisticRewarderToken.sol";
+import "./OptimisticRewarderBase.sol";
 
 /**
  * @notice An example use case of the OptimisticRewarder in use by a contract that allows users to stake an ERC20 to


### PR DESCRIPTION

**Motivation**
OZ identified the following issue: 

To improve readability of the code, consider removing the following unused imports:
- The OptimisticRewarderBase contract imports the unused Constants contract
- The OptimisticRewarderToken contract imports unused OptimisticRewarder contract
- The OptimisticRewarderCreator contract imports unused ERC721 and Testable contracts
- the OptimisticStaker contract imports usused OptimisticRewarder andOptimisticRewarderToken contracts

This PR addresses this by removing these imports.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
