### PR TITLE
fix(optimistic-rewarder): fixed child messenger interface issue

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Admin_ChildMessenger.sol
@@ -50,7 +50,12 @@ contract Admin_ChildMessenger is Ownable, Lockable, ChildMessengerInterface {
      * this as a param enables the Admin to send messages to arbitrary addresses from the messenger contract. This is
      * primarily used to send messages to the OracleSpoke and GovernorSpoke.
      */
-    function processMessageFromCrossChainParent(bytes memory data, address target) public onlyOwner nonReentrant() {
+    function processMessageFromCrossChainParent(bytes memory data, address target)
+        public
+        override
+        onlyOwner
+        nonReentrant()
+    {
         ChildMessengerConsumerInterface(target).processMessageFromParent(data);
         emit MessageReceivedFromParent(data, target, msg.sender);
     }

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ChildMessenger.sol
@@ -78,6 +78,7 @@ contract Arbitrum_ChildMessenger is AVM_CrossDomainEnabled, ChildMessengerInterf
      */
     function processMessageFromCrossChainParent(bytes memory data, address target)
         public
+        override
         onlyFromCrossDomainAccount(parentMessenger)
         nonReentrant()
     {

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Optimism_ChildMessenger.sol
@@ -100,6 +100,7 @@ contract Optimism_ChildMessenger is CrossDomainEnabled, ChildMessengerInterface,
      */
     function processMessageFromCrossChainParent(bytes memory data, address target)
         public
+        override
         onlyFromCrossDomainAccount(parentMessenger)
         nonReentrant()
     {

--- a/packages/core/contracts/cross-chain-oracle/interfaces/ChildMessengerInterface.sol
+++ b/packages/core/contracts/cross-chain-oracle/interfaces/ChildMessengerInterface.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.0;
 
 interface ChildMessengerInterface {
-    // Should send cross-chain message to Parent messenger contract or revert.
+    // Should send cross-chain message to parent messenger contract or revert.
     function sendMessageToParent(bytes memory data) external;
+
+    // Processes a message recived from the parent messanger, calling `target` with `data`.
+    function processMessageFromCrossChainParent(bytes memory data, address target) external;
 }


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

_The ChildMessengerInterface does not specify a processMessageFromCrossChainParent function,even though it is assumed to exist by parent messengers. Consider including it for completeness._

This PR addresses this issue.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
