### PR TITLE
fix(slack-logger/relay-logs): small logger fixes

### DIFF
--- a/packages/common/src/FormattingUtils.ts
+++ b/packages/common/src/FormattingUtils.ts
@@ -104,7 +104,7 @@ export function createEtherscanLinkFromtx(networkId: NetworkId): string {
 // Convert either an address or transaction to a shorter version.
 // 0x772871a444c6e4e9903d8533a5a13101b74037158123e6709470f0afbf6e7d94 -> 0x7787...7d94
 export function createShortHexString(hex: string): string {
-  return hex.substring(0, 5) + "..." + hex.substring(hex.length - 6, hex.length - 1);
+  return hex.substring(0, 5) + "..." + hex.substring(hex.length - 6, hex.length);
 }
 
 // Take in either a transaction or an account and generate an etherscan link for the corresponding

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -777,11 +777,11 @@ export class Relayer {
     return (
       "Relayed " +
       this._generateMrkdwnDepositIdNetworkSizeFromTo(deposit) +
-      "slowRelayFeePct " +
+      "slowRelayFee " +
       createFormatFunction(2, 4, false, 18)(toBN(deposit.slowRelayFeePct).muln(100)) +
-      "%, instantRelayFeePct " +
+      "%, instantRelayFee " +
       createFormatFunction(2, 4, false, 18)(toBN(deposit.instantRelayFeePct).muln(100)) +
-      "%, realizedLpFeePct " +
+      "%, realizedLpFee " +
       createFormatFunction(2, 4, false, 18)(realizedLpFeePct.muln(100)) +
       "%."
     );
@@ -817,7 +817,7 @@ export class Relayer {
       deposit.depositId +
       " on " +
       PublicNetworks[this.l2Client.chainId]?.name +
-      " of size " +
+      " of " +
       createFormatFunction(2, 4, false, collateralDecimals)(deposit.amount) +
       " " +
       collateralSymbol +


### PR DESCRIPTION
**Motivation**

This PR makes two logs changes:
1) slack logs sent by the relayer should not wrap to a extra line. to solve this I removed the `pct` from some logs, which was redundant, the make the logs take up a little bit less space
2) there was a subtle bug in the slack markdown creator that removed the last char from the markdown text. see example below:

this slack message:
<img width="190" alt="image" src="https://user-images.githubusercontent.com/12886084/145576765-5e7a4ae1-39ac-4532-8ef7-3b7410304229.png">
shows the address as 0xb1A...A68aD but the address ends in a 4, having lost the last param. hovering shows this loss:
<img width="409" alt="image" src="https://user-images.githubusercontent.com/12886084/145576828-8f80b461-f897-45be-a42c-9734bb4f288b.png">

this was also fixed.
