### PR TITLE
improve(cross-chain-oracle): Clarify comments for refundL2Address

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
@@ -70,8 +70,7 @@ contract Arbitrum_ParentMessenger is
      * ticket reverts.
      * @dev The caller of this function must be the owner, which should be set to the DVM governor.
      * @param newRefundl2Address the new refund address to set. This should be set to an L2 address that is trusted by
-     * the owner and that can spend the funds by generating a signature for its address. For example, an EOA or a
-     * custom contract.
+     * the owner as it can spend Arbitrum L2 refunds for excess gas when sending transactions on Arbitrum.
      */
     function setRefundL2Address(address newRefundl2Address) public onlyOwner nonReentrant() {
         refundL2Address = newRefundl2Address;

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
@@ -68,8 +68,9 @@ contract Arbitrum_ParentMessenger is
     /**
      * @notice Changes the refund address on L2 that receives excess gas or the full msg.value if the retryable
      * ticket reverts.
-     * @dev The caller of this function must be the owner. This should be set to the DVM governor.
-     * @param newRefundl2Address the new refund address to set.
+     * @dev The caller of this function must be the owner, which should be set to the DVM governor.
+     * @param newRefundl2Address the new refund address to set. This should be set to an L2 EOA that is trusted by the
+     * owner.
      */
     function setRefundL2Address(address newRefundl2Address) public onlyOwner nonReentrant() {
         refundL2Address = newRefundl2Address;
@@ -78,7 +79,7 @@ contract Arbitrum_ParentMessenger is
 
     /**
      * @notice Changes the default gas limit that is sent along with transactions to Arbitrum.
-     * @dev The caller of this function must be the owner. This should be set to the DVM governor.
+     * @dev The caller of this function must be the owner, which should be set to the DVM governor.
      * @param newDefaultGasLimit the new L2 gas limit to be set.
      */
     function setDefaultGasLimit(uint32 newDefaultGasLimit) public onlyOwner nonReentrant() {
@@ -88,7 +89,7 @@ contract Arbitrum_ParentMessenger is
 
     /**
      * @notice Changes the default gas price that is sent along with transactions to Arbitrum.
-     * @dev The caller of this function must be the owner. This should be set to the DVM governor.
+     * @dev The caller of this function must be the owner, which should be set to the DVM governor.
      * @param newDefaultGasPrice the new L2 gas price to be set.
      */
     function setDefaultGasPrice(uint256 newDefaultGasPrice) public onlyOwner nonReentrant() {
@@ -98,7 +99,7 @@ contract Arbitrum_ParentMessenger is
 
     /**
      * @notice Changes the default max submission cost that is sent along with transactions to Arbitrum.
-     * @dev The caller of this function must be the owner. This should be set to the DVM governor.
+     * @dev The caller of this function must be the owner, which should be set to the DVM governor.
      * @param newDefaultMaxSubmissionCost the new L2 max submission cost to be set.
      */
     function setDefaultMaxSubmissionCost(uint256 newDefaultMaxSubmissionCost) public onlyOwner nonReentrant() {
@@ -108,7 +109,7 @@ contract Arbitrum_ParentMessenger is
 
     /**
      * @notice Changes the address of the oracle spoke on L2 via the child messenger.
-     * @dev The caller of this function must be the owner. This should be set to the DVM governor.
+     * @dev The caller of this function must be the owner, which should be set to the DVM governor.
      * @dev This function will only succeed if this contract has enough ETH to cover the approximate L1 call value.
      * @param newOracleSpoke the new oracle spoke address set on L2.
      */
@@ -119,7 +120,7 @@ contract Arbitrum_ParentMessenger is
 
     /**
      * @notice Changes the address of the parent messenger on L2 via the child messenger.
-     * @dev The caller of this function must be the owner. This should be set to the DVM governor.
+     * @dev The caller of this function must be the owner, which should be set to the DVM governor.
      * @dev This function will only succeed if this contract has enough ETH to cover the approximate L1 call value.
      * @param newParentMessenger the new parent messenger contract to be set on L2.
      */

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Arbitrum_ParentMessenger.sol
@@ -69,8 +69,9 @@ contract Arbitrum_ParentMessenger is
      * @notice Changes the refund address on L2 that receives excess gas or the full msg.value if the retryable
      * ticket reverts.
      * @dev The caller of this function must be the owner, which should be set to the DVM governor.
-     * @param newRefundl2Address the new refund address to set. This should be set to an L2 EOA that is trusted by the
-     * owner.
+     * @param newRefundl2Address the new refund address to set. This should be set to an L2 address that is trusted by
+     * the owner and that can spend the funds by generating a signature for its address. For example, an EOA or a
+     * custom contract.
      */
     function setRefundL2Address(address newRefundl2Address) public onlyOwner nonReentrant() {
         refundL2Address = newRefundl2Address;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Comments are misleading about what the `refundL2Address` should be set to. Clarifies that address should be set to an EOA or contract that can spend the funds.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
