### PR TITLE
fix: [C02] Proposer cannot pay rewards out multiple times for the same proposal

### DIFF
--- a/packages/core/contracts/oracle/implementation/Proposer.sol
+++ b/packages/core/contracts/oracle/implementation/Proposer.sol
@@ -86,6 +86,7 @@ contract Proposer is Ownable, Testable, Lockable {
             token.safeTransfer(finder.getImplementationAddress(OracleInterfaces.Store), bondedProposal.lockedBond);
             emit ProposalResolved(id, false);
         }
+        delete bondedProposals[id];
     }
 
     /**


### PR DESCRIPTION
**Motivation**

```
The resolveProposal function of the Proposer contract simply validates that the oracle has resolved,
but does not check if the bond has been distributed. This means the same proposal can be resolved
multiple times, resulting in duplicate bond payments. Consider flagging or deleting existing proposals
when they are resolved.
```

**Summary**

This PR deletes the proposal after it is resolved to avoid re-resolution.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A