### PR TITLE
fix: [C01] fixes issue where disputes are impossible in the OptimisticRewarder

### DIFF
--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -195,7 +195,8 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
         // This automatically checks that redemptions[redemptionId] != 0.
         // Check that it has not passed liveness.
         Redemption storage redemption = redemptions[redemptionId];
-        require(getCurrentTime() < redemption.expiryTime, "redemption expired or nonexistent");
+        uint256 currentTime = getCurrentTime();
+        require(currentTime < redemption.expiryTime, "redemption expired or nonexistent");
 
         // Final fees don't match to those in the current store, which means the bond the initial caller provided was
         // incorrect. Cancel the request to allow the requester to resubmit with the correct params.
@@ -247,7 +248,7 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
                     settled: false,
                     proposedPrice: int256(1e18),
                     resolvedPrice: 0,
-                    expirationTime: redemption.expiryTime,
+                    expirationTime: currentTime + liveness,
                     reward: 0,
                     finalFee: redemption.finalFee,
                     bond: bond,

--- a/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
+++ b/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
@@ -385,8 +385,7 @@ describe("OptimisticRewarder", () => {
     await optimisticRewarder.methods.requestRedemption(tokenId, redemptions).send({ from: submitter });
 
     // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
-    const currentTime = await optimisticRewarder.methods.getCurrentTime().call();
-    await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
+    await advanceTime(100);
 
     const disputeReceipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
     const { request, timestamp, ancillaryData } = (
@@ -439,8 +438,7 @@ describe("OptimisticRewarder", () => {
     await store.methods.setFinalFee(bondToken.options.address, { rawValue: toWei("1") }).send({ from: owner });
 
     // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
-    const currentTime = await optimisticRewarder.methods.getCurrentTime().call();
-    await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
+    await advanceTime(100);
 
     receipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
     await assertEventEmitted(receipt, optimisticRewarder, "Canceled");
@@ -476,8 +474,7 @@ describe("OptimisticRewarder", () => {
     await collateralWhitelist.methods.removeFromWhitelist(bondToken.options.address).send({ from: owner });
 
     // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
-    const currentTime = await optimisticRewarder.methods.getCurrentTime().call();
-    await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
+    await advanceTime(100);
 
     receipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
     await assertEventEmitted(receipt, optimisticRewarder, "Canceled");

--- a/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
+++ b/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
@@ -383,6 +383,11 @@ describe("OptimisticRewarder", () => {
     const redemptions = [{ token: redemptionToken.options.address, amount: toWei("100") }];
     assert(await didContractThrow(optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer })));
     await optimisticRewarder.methods.requestRedemption(tokenId, redemptions).send({ from: submitter });
+
+    // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
+    const currentTime = optimisticRewarder.methods.getCurrentTime().call();
+    await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
+
     const disputeReceipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
     const { request, timestamp, ancillaryData } = (
       await findEvent(disputeReceipt, optimisticOracle, "DisputePrice")
@@ -432,6 +437,11 @@ describe("OptimisticRewarder", () => {
     assert(await didContractThrow(optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer })));
     await optimisticRewarder.methods.requestRedemption(tokenId, redemptions).send({ from: submitter });
     await store.methods.setFinalFee(bondToken.options.address, { rawValue: toWei("1") }).send({ from: owner });
+
+    // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
+    const currentTime = optimisticRewarder.methods.getCurrentTime().call();
+    await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
+
     receipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
     await assertEventEmitted(receipt, optimisticRewarder, "Canceled");
 
@@ -464,6 +474,11 @@ describe("OptimisticRewarder", () => {
     assert(await didContractThrow(optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer })));
     await optimisticRewarder.methods.requestRedemption(tokenId, redemptions).send({ from: submitter });
     await collateralWhitelist.methods.removeFromWhitelist(bondToken.options.address).send({ from: owner });
+
+    // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
+    const currentTime = optimisticRewarder.methods.getCurrentTime().call();
+    await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
+
     receipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
     await assertEventEmitted(receipt, optimisticRewarder, "Canceled");
 

--- a/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
+++ b/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
@@ -385,7 +385,7 @@ describe("OptimisticRewarder", () => {
     await optimisticRewarder.methods.requestRedemption(tokenId, redemptions).send({ from: submitter });
 
     // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
-    const currentTime = optimisticRewarder.methods.getCurrentTime().call();
+    const currentTime = await optimisticRewarder.methods.getCurrentTime().call();
     await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
 
     const disputeReceipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
@@ -439,7 +439,7 @@ describe("OptimisticRewarder", () => {
     await store.methods.setFinalFee(bondToken.options.address, { rawValue: toWei("1") }).send({ from: owner });
 
     // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
-    const currentTime = optimisticRewarder.methods.getCurrentTime().call();
+    const currentTime = await optimisticRewarder.methods.getCurrentTime().call();
     await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
 
     receipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });
@@ -476,7 +476,7 @@ describe("OptimisticRewarder", () => {
     await collateralWhitelist.methods.removeFromWhitelist(bondToken.options.address).send({ from: owner });
 
     // Add 100 seconds to the current time so the dispute occurs at a different time than the proposal.
-    const currentTime = optimisticRewarder.methods.getCurrentTime().call();
+    const currentTime = await optimisticRewarder.methods.getCurrentTime().call();
     await optimisticRewarder.methods.setCurrentTime(parseInt(currentTime) + 100).send({ from: owner });
 
     receipt = await optimisticRewarder.methods.dispute(tokenId, redemptions).send({ from: disputer });


### PR DESCRIPTION
**Motivation**

```
When disputing a reward request, the OptimisticRewardBase contract first triggers a proposal on the
SkinnyOptimisticOracle and then disputes that proposal. However, the proposal sets the expiration
time as an offset from the current (dispute) time, while the dispute specifies the expiration as an offset
from the time of the original reward request. In most cases, this discrepancy will prevent the oracle
from identifying the proposal to be disputed, which means valid disputes will not be processed and
invalid reward requests will be accepted.

Consider updating the dispute invocation to correctly specify the proposal to be disputed.
```

**Summary**

This changes the timestamp passed into the Request object provided to the dispute function to match what the SkinnyOptimisticOracle sets.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass (updated existing tests to cover this case by modifying the dispute timestamps)
- [ ]  Untested


**Issue(s)**

N/A
