### PR TITLE
fix(sdk): fix pool withdraw validation

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -297,10 +297,6 @@ export class ReadPoolClient {
 export function validateWithdraw(pool: Pool, user: User, lpTokenAmount: BigNumberish) {
   const l1TokensToReturn = BigNumber.from(lpTokenAmount).mul(pool.exchangeRateCurrent).div(fixedPointAdjustment);
   assert(BigNumber.from(l1TokensToReturn).gt("0"), "Must withdraw amount greater than 0");
-  assert(
-    BigNumber.from(pool.liquidReserves).gte(l1TokensToReturn.add(pool.pendingReserves)),
-    "Utilization too high to remove that amount, try lowering withdraw amount"
-  );
   assert(BigNumber.from(lpTokenAmount).lte(user.lpTokens), "You cannot withdraw more than you have");
   return { lpTokenAmount, l1TokensToReturn: l1TokensToReturn.toString() };
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/3476/fix-bug-with-sdk-validatewithdraw-in-across-client

Someone who tried to withdraw a large lp position ran into an error and could not withdraw.  see [slack](https://risklabs.slack.com/archives/C02D94M08F7/p1638392549018600)

**Summary**

Removes the line that checks against `pool.liquidReserves`

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**
https://app.shortcut.com/uma-project/story/3476/fix-bug-with-sdk-validatewithdraw-in-across-client