### PR TITLE
fix: [M01] fixes incorrect event parameters

### DIFF
--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -173,14 +173,14 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
         // transaction would not.
         require(cumulativeRedemptions.length <= 100, "too many token transfers");
 
-        uint256 time = getCurrentTime();
+        uint256 expiryTime = getCurrentTime() + liveness;
 
         totalBond = finalFee + bond;
         bondToken.safeTransferFrom(msg.sender, address(this), totalBond);
 
-        redemptions[redemptionId] = Redemption({ finalFee: finalFee, expiryTime: time + liveness });
+        redemptions[redemptionId] = Redemption({ finalFee: finalFee, expiryTime: expiryTime });
 
-        emit Requested(tokenId, redemptionId, cumulativeRedemptions, time);
+        emit Requested(tokenId, redemptionId, cumulativeRedemptions, expiryTime);
     }
 
     /**
@@ -308,9 +308,9 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
         // Return the bond to the owner.
         bondToken.safeTransfer(msg.sender, bond + redemptions[redemptionId].finalFee);
 
-        delete redemptions[redemptionId];
-
         emit Redeemed(tokenId, redemptionId, redemptions[redemptionId].expiryTime);
+
+        delete redemptions[redemptionId];
     }
 
     /**


### PR DESCRIPTION
**Motivation**

```
The OptimisticRewarderBase contract defines a Requested event which is emitted from the
requestRedemption function when a redemption is requested. This event is defined to emit the expiry
time of the redemption as its last parameter. However, when the event is emitted, its last parameter is
incorrectly set to the current time.
Similarly the Redeemed event reads the expiry time after the record is deleted, so it will be incorrectly
set to zero.

Given that this event can be used to trigger off-chain computations, consider updating the emitted
value appropriately.
```

**Summary**

Corrected as suggested in the Motivation.

Added tests for these events.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
