### PR TITLE
fix: [L01] uses the declared Disputed event

### DIFF
--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -266,6 +266,8 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
                 msg.sender,
                 address(this)
             );
+
+            emit Disputed(tokenId, redemptionId, redemption.expiryTime);
         }
 
         delete redemptions[redemptionId];

--- a/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
+++ b/packages/core/test/financial-templates/optimistic-rewarder/OptimisticRewarder.js
@@ -387,6 +387,12 @@ describe("OptimisticRewarder", () => {
     const { request, timestamp, ancillaryData } = (
       await findEvent(disputeReceipt, optimisticOracle, "DisputePrice")
     ).match.returnValues;
+    await assertEventEmitted(
+      disputeReceipt,
+      optimisticRewarder,
+      "Disputed",
+      (event) => event.tokenId === tokenId && request.expirationTime.toString() === event.expiryTime.toString()
+    );
 
     const [dvmRequest] = await mockOracle.methods.getPendingQueries().call();
     await mockOracle.methods


### PR DESCRIPTION
**Motivation**

```
The OptimisticRewarderBase contract defines a Disputed event that is intended to be triggered if a
redemption is disputed. However, this event is not emitted within or outside of the
OptimisticRewarderBase contract.

Consider emitting the event after sensitive changes take place in the dispute function, to facilitate
tracking and notify off-chain clients following the contracts' activity.
```

**Summary**

This PR uses and tests the new event.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
