### PR TITLE
fix: deployment scripts don't skip when already deployed

### DIFF
--- a/packages/core/deploy/001_deploy_finder.js
+++ b/packages/core/deploy/001_deploy_finder.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("Finder", { from: deployer });
+  await deploy("Finder", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["Finder", "dvm"];

--- a/packages/core/deploy/002_deploy_timer.js
+++ b/packages/core/deploy/002_deploy_timer.js
@@ -9,7 +9,7 @@ const func = async function (hre) {
 
   // If live === false, don't deploy a timer.
   if (live === false) {
-    await deploy("Timer", { from: deployer, log: true });
+    await deploy("Timer", { from: deployer, log: true, skipIfAlreadyDeployed: true });
   }
 };
 module.exports = func;

--- a/packages/core/deploy/003_deploy_registry.js
+++ b/packages/core/deploy/003_deploy_registry.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("Registry", { from: deployer, log: true });
+  await deploy("Registry", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["Registry", "dvm"];

--- a/packages/core/deploy/004_deploy_voting_token.js
+++ b/packages/core/deploy/004_deploy_voting_token.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("VotingToken", { from: deployer, log: true });
+  await deploy("VotingToken", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["dvm"];

--- a/packages/core/deploy/005_deploy_identifier_whitelist.js
+++ b/packages/core/deploy/005_deploy_identifier_whitelist.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("IdentifierWhitelist", { from: deployer, log: true });
+  await deploy("IdentifierWhitelist", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["IdentifierWhitelist", "dvm"];

--- a/packages/core/deploy/006_deploy_voting.js
+++ b/packages/core/deploy/006_deploy_voting.js
@@ -34,6 +34,7 @@ const func = async function (hre) {
       Timer.address,
     ],
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/007_deploy_financial_contracts_admin.js
+++ b/packages/core/deploy/007_deploy_financial_contracts_admin.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("FinancialContractsAdmin", { from: deployer, log: true });
+  await deploy("FinancialContractsAdmin", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["FinancialContractsAdmin", "dvm"];

--- a/packages/core/deploy/008_deploy_store.js
+++ b/packages/core/deploy/008_deploy_store.js
@@ -14,6 +14,7 @@ const func = async function (hre) {
     from: deployer,
     args: [initialFixedOracleFeePerSecondPerPfc, initialWeeklyDelayFeePerSecondPerPfc, Timer.address],
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/009_deploy_governor.js
+++ b/packages/core/deploy/009_deploy_governor.js
@@ -9,7 +9,12 @@ const func = async function (hre) {
 
   const startingProposalId = 0;
 
-  await deploy("Governor", { from: deployer, args: [Finder.address, startingProposalId, Timer.address], log: true });
+  await deploy("Governor", {
+    from: deployer,
+    args: [Finder.address, startingProposalId, Timer.address],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["Governor", "dvm"];

--- a/packages/core/deploy/010_deploy_designated_voting_factory.js
+++ b/packages/core/deploy/010_deploy_designated_voting_factory.js
@@ -5,7 +5,12 @@ const func = async function (hre) {
   const { deployer } = await getNamedAccounts();
   const Finder = await deployments.get("Finder");
 
-  await deploy("DesignatedVotingFactory", { from: deployer, args: [Finder.address], log: true });
+  await deploy("DesignatedVotingFactory", {
+    from: deployer,
+    args: [Finder.address],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["DesignatedVotingFactory", "dvm"];

--- a/packages/core/deploy/011_deploy_address_whitelist.js
+++ b/packages/core/deploy/011_deploy_address_whitelist.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("AddressWhitelist", { from: deployer, log: true });
+  await deploy("AddressWhitelist", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["AddressWhitelist", "dvm"];

--- a/packages/core/deploy/012_deploy_optimistic_oracle.js
+++ b/packages/core/deploy/012_deploy_optimistic_oracle.js
@@ -14,6 +14,7 @@ const func = async function (hre) {
     from: deployer,
     args: [defaultLiveness, Finder.address, Timer.address],
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/013_deploy_mock_oracle.js
+++ b/packages/core/deploy/013_deploy_mock_oracle.js
@@ -10,7 +10,7 @@ const func = async function (hre) {
   const Timer = (await deployments.getOrNull("Timer")) || { address: ZERO_ADDRESS };
 
   const args = [Finder.address, Timer.address];
-  await deploy("MockOracleAncillary", { from: deployer, args, log: true });
+  await deploy("MockOracleAncillary", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["MockOracle", "test"];

--- a/packages/core/deploy/014_deploy_token_factory.js
+++ b/packages/core/deploy/014_deploy_token_factory.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("TokenFactory", { from: deployer, log: true });
+  await deploy("TokenFactory", { from: deployer, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["TokenFactory", "emp"];

--- a/packages/core/deploy/015_deploy_emp_creator.js
+++ b/packages/core/deploy/015_deploy_emp_creator.js
@@ -9,12 +9,13 @@ const func = async function (hre) {
   const TokenFactory = await deployments.get("TokenFactory");
   const Timer = (await deployments.getOrNull("Timer")) || ZERO_ADDRESS;
 
-  const EMPLib = await deploy("ExpiringMultiPartyLib", { from: deployer, log: true });
+  const EMPLib = await deploy("ExpiringMultiPartyLib", { from: deployer, log: true, skipIfAlreadyDeployed: true });
   await deploy("ExpiringMultiPartyCreator", {
     from: deployer,
     args: [Finder.address, TokenFactory.address, Timer.address],
     libraries: { ExpiringMultiPartyLib: EMPLib.address },
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/016_deploy_perpetual_creator.js
+++ b/packages/core/deploy/016_deploy_perpetual_creator.js
@@ -9,12 +9,13 @@ const func = async function (hre) {
   const TokenFactory = await deployments.get("TokenFactory");
   const Timer = (await deployments.getOrNull("Timer")) || ZERO_ADDRESS;
 
-  const PerpetualLib = await deploy("PerpetualLib", { from: deployer, log: true });
+  const PerpetualLib = await deploy("PerpetualLib", { from: deployer, log: true, skipIfAlreadyDeployed: true });
   await deploy("PerpetualCreator", {
     from: deployer,
     args: [Finder.address, TokenFactory.address, Timer.address],
     libraries: { PerpetualLib: PerpetualLib.address },
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/017_deploy_bridge.js
+++ b/packages/core/deploy/017_deploy_bridge.js
@@ -15,7 +15,7 @@ const func = async function (hre) {
     0, // Deposit fee
     100, // # of blocks after which a proposal expires
   ];
-  await deploy("Bridge", { from: deployer, args, log: true });
+  await deploy("Bridge", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["Bridge", "bridge-l2", "bridge-l1"];

--- a/packages/core/deploy/018_deploy_generic_handler.js
+++ b/packages/core/deploy/018_deploy_generic_handler.js
@@ -7,7 +7,7 @@ const func = async function (hre) {
   const Bridge = await deployments.get("Bridge");
 
   const args = [Bridge.address, [], [], [], []];
-  await deploy("GenericHandler", { from: deployer, args, log: true });
+  await deploy("GenericHandler", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["GenericHandler", "bridge-l2", "bridge-l1"];

--- a/packages/core/deploy/019_deploy_sink_oracle.js
+++ b/packages/core/deploy/019_deploy_sink_oracle.js
@@ -18,7 +18,7 @@ const func = async function (hre) {
     bridgeId, // Current chain ID.
     SOURCE_ORACLE_CHAIN_ID, // Chain ID where SourceOracle is located that this SinkOracle will make price requests to.
   ];
-  await deploy("SinkOracle", { from: deployer, args, log: true });
+  await deploy("SinkOracle", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["SinkOracle", "l2-chainbridge"];

--- a/packages/core/deploy/020_deploy_source_oracle.js
+++ b/packages/core/deploy/020_deploy_source_oracle.js
@@ -14,7 +14,7 @@ const func = async function (hre) {
     Finder.address,
     bridgeId, // Current chain ID.
   ];
-  await deploy("SourceOracle", { from: deployer, args, log: true });
+  await deploy("SourceOracle", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["SourceOracle", "l1-chainbridge"];

--- a/packages/core/deploy/021_deploy_sink_governor.js
+++ b/packages/core/deploy/021_deploy_sink_governor.js
@@ -6,7 +6,7 @@ const func = async function (hre) {
 
   const Finder = await deployments.get("Finder");
 
-  await deploy("SinkGovernor", { from: deployer, args: [Finder.address], log: true });
+  await deploy("SinkGovernor", { from: deployer, args: [Finder.address], log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["SinkGovernor", "l2-chainbridge"];

--- a/packages/core/deploy/022_deploy_source_governor.js
+++ b/packages/core/deploy/022_deploy_source_governor.js
@@ -11,7 +11,12 @@ const func = async function (hre) {
 
   const Finder = await deployments.get("Finder");
 
-  await deploy("SourceGovernor", { from: deployer, args: [Finder.address, bridgeId], log: true });
+  await deploy("SourceGovernor", {
+    from: deployer,
+    args: [Finder.address, bridgeId],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["SourceGovernor", "l1-chainbridge"];

--- a/packages/core/deploy/023_deploy_state_sync_mock.js
+++ b/packages/core/deploy/023_deploy_state_sync_mock.js
@@ -3,7 +3,7 @@ const func = async function (hre) {
   const { deploy } = deployments;
 
   const { deployer } = await getNamedAccounts();
-  await deploy("StateSyncMock", { from: deployer, args: [], log: true });
+  await deploy("StateSyncMock", { from: deployer, args: [], log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["StateSyncMock", "test"];

--- a/packages/core/deploy/024_deploy_fx_root_mock.js
+++ b/packages/core/deploy/024_deploy_fx_root_mock.js
@@ -6,7 +6,7 @@ const func = async function (hre) {
 
   const StateSyncMock = await deployments.get("StateSyncMock");
 
-  await deploy("FxRootMock", { from: deployer, args: [StateSyncMock.address], log: true });
+  await deploy("FxRootMock", { from: deployer, args: [StateSyncMock.address], log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["FxRootMock", "test"];

--- a/packages/core/deploy/025_deploy_fx_child_mock.js
+++ b/packages/core/deploy/025_deploy_fx_child_mock.js
@@ -8,6 +8,7 @@ const func = async function (hre) {
     from: deployer,
     args: [deployer], // Set deployer as the systemSuperUser.
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/026_deploy_oracle_root_tunnel.js
+++ b/packages/core/deploy/026_deploy_oracle_root_tunnel.js
@@ -28,7 +28,7 @@ const func = async function (hre) {
     args = [deployer, FxRootMock.address, Finder.address]; // Note: uses deployer as the checkpoint manager.
   }
 
-  await deploy("OracleRootTunnel", { from: deployer, args, log: true });
+  await deploy("OracleRootTunnel", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["OracleRootTunnel", "l1-polygon"];

--- a/packages/core/deploy/027_deploy_oracle_child_tunnel.js
+++ b/packages/core/deploy/027_deploy_oracle_child_tunnel.js
@@ -22,7 +22,7 @@ const func = async function (hre) {
     args = [FxChildMock.address, Finder.address];
   }
 
-  await deploy("OracleChildTunnel", { from: deployer, args, log: true });
+  await deploy("OracleChildTunnel", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["OracleChildTunnel", "l2-polygon"];

--- a/packages/core/deploy/028_deploy_governor_child_tunnel.js
+++ b/packages/core/deploy/028_deploy_governor_child_tunnel.js
@@ -21,7 +21,7 @@ const func = async function (hre) {
     args = [FxChildMock.address];
   }
 
-  await deploy("GovernorChildTunnel", { from: deployer, args, log: true });
+  await deploy("GovernorChildTunnel", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["GovernorChildTunnel", "l2-polygon"];

--- a/packages/core/deploy/029_deploy_governor_root_tunnel.js
+++ b/packages/core/deploy/029_deploy_governor_root_tunnel.js
@@ -27,7 +27,7 @@ const func = async function (hre) {
     args = [deployer, FxRootMock.address]; // Note: uses deployer as the checkpoint manager.
   }
 
-  await deploy("GovernorRootTunnel", { from: deployer, args, log: true });
+  await deploy("GovernorRootTunnel", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["GovernorRootTunnel", "l1-polygon"];

--- a/packages/core/deploy/030_deploy_long_short_pair_creator.js
+++ b/packages/core/deploy/030_deploy_long_short_pair_creator.js
@@ -13,6 +13,7 @@ const func = async function (hre) {
     from: deployer,
     args: [Finder.address, TokenFactory.address, Timer.address],
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/031_deploy_long_short_pair_libraries_covered_call.js
+++ b/packages/core/deploy/031_deploy_long_short_pair_libraries_covered_call.js
@@ -4,7 +4,11 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("CoveredCallLongShortPairFinancialProductLibrary", { from: deployer, log: true });
+  await deploy("CoveredCallLongShortPairFinancialProductLibrary", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["LongShortPairLibraries", "lsplib", "CoveredCallLongShortPairLibrary"];

--- a/packages/core/deploy/032_deploy_long_short_pair_libraries_range_bond.js
+++ b/packages/core/deploy/032_deploy_long_short_pair_libraries_range_bond.js
@@ -4,7 +4,11 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("RangeBondLongShortPairFinancialProductLibrary", { from: deployer, log: true });
+  await deploy("RangeBondLongShortPairFinancialProductLibrary", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["LongShortPairLibraries", "lsplib", "RangeBondLongShortPairLibrary"];

--- a/packages/core/deploy/033_deploy_long_short_pair_library_binary.js
+++ b/packages/core/deploy/033_deploy_long_short_pair_library_binary.js
@@ -4,7 +4,11 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("BinaryOptionLongShortPairFinancialProductLibrary", { from: deployer, log: true });
+  await deploy("BinaryOptionLongShortPairFinancialProductLibrary", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["LongShortPairLibraries", "lsplib", "BinaryLongShortPairLibrary"];

--- a/packages/core/deploy/034_deploy_long_short_pair_library_linear.js
+++ b/packages/core/deploy/034_deploy_long_short_pair_library_linear.js
@@ -4,7 +4,11 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("LinearLongShortPairFinancialProductLibrary", { from: deployer, log: true });
+  await deploy("LinearLongShortPairFinancialProductLibrary", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["LongShortPairLibraries", "lsplib", "LinearLongShortPairLibrary"];

--- a/packages/core/deploy/035_deploy_skinny_optimistic_oracle.js
+++ b/packages/core/deploy/035_deploy_skinny_optimistic_oracle.js
@@ -14,6 +14,7 @@ const func = async function (hre) {
     from: deployer,
     args: [defaultLiveness, Finder.address, Timer.address],
     log: true,
+    skipIfAlreadyDeployed: true,
   });
 };
 module.exports = func;

--- a/packages/core/deploy/036_deploy_across_bridge_admin.js
+++ b/packages/core/deploy/036_deploy_across_bridge_admin.js
@@ -16,7 +16,7 @@ const func = async function (hre) {
     hre.web3.utils.padRight(hre.web3.utils.utf8ToHex("IS_CROSS_CHAIN_RELAY_VALID"), 64), // price identifier to validate bridging action
   ];
 
-  await deploy("BridgeAdmin", { from: deployer, args, log: true });
+  await deploy("BridgeAdmin", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["BridgeAdmin"];

--- a/packages/core/deploy/037_deploy_across_optimism_messenger.js
+++ b/packages/core/deploy/037_deploy_across_optimism_messenger.js
@@ -12,7 +12,12 @@ const func = async function (hre) {
     1: "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1", // mainnet
   };
 
-  await deploy("Optimism_Messenger", { from: deployer, args: [l1ChainIdToMessenger[chainId]], log: true });
+  await deploy("Optimism_Messenger", {
+    from: deployer,
+    args: [l1ChainIdToMessenger[chainId]],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
 };
 module.exports = func;
 func.tags = ["Optimism_Messenger"];

--- a/packages/core/deploy/038_deploy_across_ovm_bridge_deposit_box.js
+++ b/packages/core/deploy/038_deploy_across_ovm_bridge_deposit_box.js
@@ -27,7 +27,7 @@ const func = async function (hre) {
     ZERO_ADDRESS, // timer address
   ];
 
-  await deploy("OVM_BridgeDepositBox", { from: deployer, args, log: true });
+  await deploy("OVM_BridgeDepositBox", { from: deployer, args, log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["OVM_BridgeDepositBox"];

--- a/packages/core/deploy/040_deploy_rate_model_store.js
+++ b/packages/core/deploy/040_deploy_rate_model_store.js
@@ -4,7 +4,7 @@ const func = async function (hre) {
 
   const { deployer } = await getNamedAccounts();
 
-  await deploy("RateModelStore", { from: deployer, args: [], log: true });
+  await deploy("RateModelStore", { from: deployer, args: [], log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
 func.tags = ["RateModelStore"];

--- a/packages/core/networks/4.json
+++ b/packages/core/networks/4.json
@@ -78,5 +78,17 @@
   {
     "contractName": "GovernorHub",
     "address": "0x5A361C68c0F6605F44e564469Ff68826DAA3A36E"
+  },
+  {
+    "contractName": "OptimisticOracle",
+    "address": "0x3746badD4d6002666dacd5d7bEE19f60019A8433"
+  },
+  {
+    "contractName": "TokenFactory",
+    "address": "0xcB69d8dAb9b1F1D9dF8A42a1001fd0ce7A8fFB5B"
+  },
+  {
+    "contractName": "LongShortPairCreator",
+    "address": "0x8f584beEd8371757d520f7CEC06fF07de225371D"
   }
 ]

--- a/packages/core/networks/4.json
+++ b/packages/core/networks/4.json
@@ -78,17 +78,5 @@
   {
     "contractName": "GovernorHub",
     "address": "0x5A361C68c0F6605F44e564469Ff68826DAA3A36E"
-  },
-  {
-    "contractName": "OptimisticOracle",
-    "address": "0x3746badD4d6002666dacd5d7bEE19f60019A8433"
-  },
-  {
-    "contractName": "TokenFactory",
-    "address": "0xcB69d8dAb9b1F1D9dF8A42a1001fd0ce7A8fFB5B"
-  },
-  {
-    "contractName": "LongShortPairCreator",
-    "address": "0x8f584beEd8371757d520f7CEC06fF07de225371D"
   }
 ]


### PR DESCRIPTION
**Motivation**

Currently, if a deployment already exists, the deployment scripts replace it whenever a deployment is run.

**Summary**

With this PR, as long as the deployments are loaded (during `yarn build` or `yarn load-addresses`), they will not redeploy any contract that already has an address.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
