### PR TITLE
fix: [L06] fix Residual allowance

### DIFF
--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -207,7 +207,7 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
             return;
         } else {
             uint256 totalBond = bond + redemption.finalFee;
-            bondToken.safeApprove(address(optimisticOracle), totalBond * 2);
+            bondToken.safeIncreaseAllowance(address(optimisticOracle), totalBond * 2);
             bytes memory ancillaryData =
                 AncillaryData.appendKeyValueBytes32(customAncillaryData, "redemptionId", redemptionId);
             uint32 requestTimestamp = uint32(redemption.expiryTime - liveness);
@@ -236,6 +236,7 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
                 // 4. The money bond + final fee is larger than approved or in the contract's balance. This should also
                 //    be impossible in this contract.
                 _cancelRedemption(tokenId, redemptionId);
+                bondToken.safeDecreaseAllowance(address(optimisticOracle), totalBond * 2);
                 return;
             }
 

--- a/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
+++ b/packages/core/contracts/financial-templates/optimistic-rewarder/OptimisticRewarderBase.sol
@@ -236,7 +236,7 @@ abstract contract OptimisticRewarderBase is Lockable, MultiCaller {
                 // 4. The money bond + final fee is larger than approved or in the contract's balance. This should also
                 //    be impossible in this contract.
                 _cancelRedemption(tokenId, redemptionId);
-                bondToken.safeDecreaseAllowance(address(optimisticOracle), totalBond * 2);
+                bondToken.safeApprove(address(optimisticOracle), 0); // Reset allowance.
                 return;
             }
 


### PR DESCRIPTION
**Motivation**
```
In order to invoke the Optimistic Oracle, the OptimisticRewarderBase contract grants it a tokenallowance, so it can pull the bond payments. If the proposal fails, the reward redemption is cancelledbut the allowance is not reset. Therefore, the Optimistic Oracle will retain an unnecessary residualallowance until the next time a dispute is triggered. Consider revoking the allowance if the proposalfails.
```

This PR addresses this by decreasing the allowance granted before proposing the price request. Additionally, `safeApprove` was replaced with `safeIncreaseAllowance` to more correctly use the `safeERC20` lib.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
