### PR TITLE
feat: governor spoke is able to execute multiple transactions atomically

### DIFF
--- a/packages/core/contracts/cross-chain-oracle/GovernorHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorHub.sol
@@ -41,7 +41,7 @@ contract GovernorHub is Ownable, Lockable, MultiCaller {
      * @notice This should be called in order to relay a governance request to the `GovernorSpoke` contract deployed to
      * the child chain associated with `chainId`.
      * @param chainId network that messenger contract will communicate with
-     * @param calls the calls to be made by the GovernorSpoke.
+     * @param calls the calls to be made by the GovernorSpoke. Should encode a `to` and `data` prop for each call.
      * @dev Only callable by the owner (presumably the UMA DVM Governor contract, on L1 Ethereum).
      */
     function relayGovernance(uint256 chainId, GovernorSpoke.Call[] memory calls) external nonReentrant() onlyOwner {

--- a/packages/core/contracts/cross-chain-oracle/GovernorHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorHub.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "../common/implementation/Lockable.sol";
 import "../common/implementation/MultiCaller.sol";
 import "./interfaces/ParentMessengerInterface.sol";
+import "./GovernorSpoke.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
@@ -20,9 +21,8 @@ contract GovernorHub is Ownable, Lockable, MultiCaller {
     event RelayedGovernanceRequest(
         uint256 indexed chainId,
         address indexed messenger,
-        address indexed to,
-        bytes dataFromGovernor,
-        bytes dataSentToChild
+        GovernorSpoke.Call[] calls,
+        bytes dataSentToChilds
     );
     event SetParentMessenger(uint256 indexed chainId, address indexed parentMessenger);
 
@@ -41,17 +41,12 @@ contract GovernorHub is Ownable, Lockable, MultiCaller {
      * @notice This should be called in order to relay a governance request to the `GovernorSpoke` contract deployed to
      * the child chain associated with `chainId`.
      * @param chainId network that messenger contract will communicate with
-     * @param to Contract on child chain to send message to
-     * @param dataFromGovernor Message to send. Should contain the encoded function selector and params.
+     * @param calls the calls to be made by the GovernorSpoke.
      * @dev Only callable by the owner (presumably the UMA DVM Governor contract, on L1 Ethereum).
      */
-    function relayGovernance(
-        uint256 chainId,
-        address to,
-        bytes memory dataFromGovernor
-    ) external nonReentrant() onlyOwner {
-        bytes memory dataSentToChild = abi.encode(to, dataFromGovernor);
+    function relayGovernance(uint256 chainId, GovernorSpoke.Call[] memory calls) external nonReentrant() onlyOwner {
+        bytes memory dataSentToChild = abi.encode(calls);
         messengers[chainId].sendMessageToChild(dataSentToChild);
-        emit RelayedGovernanceRequest(chainId, address(messengers[chainId]), to, dataFromGovernor, dataSentToChild);
+        emit RelayedGovernanceRequest(chainId, address(messengers[chainId]), calls, dataSentToChild);
     }
 }

--- a/packages/core/contracts/cross-chain-oracle/GovernorHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorHub.sol
@@ -22,7 +22,7 @@ contract GovernorHub is Ownable, Lockable, MultiCaller {
         uint256 indexed chainId,
         address indexed messenger,
         GovernorSpoke.Call[] calls,
-        bytes dataSentToChilds
+        bytes dataSentToChild
     );
     event SetParentMessenger(uint256 indexed chainId, address indexed parentMessenger);
 

--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -10,6 +10,11 @@ import "../common/implementation/Lockable.sol";
  * @notice Governor contract deployed on L2 that receives governance actions from Ethereum.
  */
 contract GovernorSpoke is Lockable, ChildMessengerConsumerInterface {
+    struct Call {
+        address to;
+        bytes data;
+    }
+
     // Messenger contract that receives messages from root chain.
     ChildMessengerInterface public messenger;
 
@@ -36,12 +41,15 @@ contract GovernorSpoke is Lockable, ChildMessengerConsumerInterface {
      * delegated transaction.
      */
     function processMessageFromParent(bytes memory data) public override nonReentrant() onlyMessenger() {
-        (address to, bytes memory inputData) = abi.decode(data, (address, bytes));
+        Call[] memory calls = abi.decode(data, (Call[]));
         // TODO: Consider calling this via <address>.call(): https://docs.soliditylang.org/en/v0.8.10/units-and-global-variables.html?highlight=low%20level%20call#members-of-address-types
         // to avoid inline assembly.
 
-        require(_executeCall(to, inputData), "execute call failed");
-        emit ExecutedGovernanceTransaction(to, inputData);
+        for (uint256 i = 0; i < calls.length; i++) {
+            (address to, bytes memory inputData) = (calls[i].to, calls[i].data);
+            require(_executeCall(to, inputData), "execute call failed");
+            emit ExecutedGovernanceTransaction(to, inputData);
+        }
     }
 
     // Note: this snippet of code is copied from Governor.sol.

--- a/packages/core/contracts/cross-chain-oracle/test/GovernorMessengerMock.sol
+++ b/packages/core/contracts/cross-chain-oracle/test/GovernorMessengerMock.sol
@@ -1,16 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "../GovernorSpoke.sol";
+
 /**
  * @notice Can be used as either a Parent or Child messenger mock in unit tests for the Governor Hub and Spoke
  * cross-chain contracts. The reason that this can't also be used for the Oracle Hub and Spoke is that the
  * sendMessageToChild is called with different encoded data in the Oracle versus the Governor.
  */
 contract GovernorMessengerMock {
-    bytes public latestData;
-    address public latestTo;
+    GovernorSpoke.Call[] private _latestCalls;
+
+    function latestCalls() external view returns (GovernorSpoke.Call[] memory) {
+        return _latestCalls;
+    }
 
     function sendMessageToChild(bytes memory data) external {
-        (latestTo, latestData) = abi.decode(data, (address, bytes));
+        delete _latestCalls;
+        GovernorSpoke.Call[] memory calls = abi.decode(data, (GovernorSpoke.Call[]));
+        for (uint256 i = 0; i < calls.length; i++) _latestCalls.push(calls[i]);
     }
 }

--- a/packages/core/test/cross-chain-oracle/GovernorSpoke.js
+++ b/packages/core/test/cross-chain-oracle/GovernorSpoke.js
@@ -41,7 +41,7 @@ describe("GovernorSpoke.js", async () => {
     await addressWhitelist.methods.transferOwnership(governorSpoke.options.address).send({ from: owner });
 
     identifierWhitelist = await IdentifierWhitelist.new().send({ from: owner });
-    await addressWhitelist.methods.transferOwnership(governorSpoke.options.address).send({ from: owner });
+    await identifierWhitelist.methods.transferOwnership(governorSpoke.options.address).send({ from: owner });
   });
 
   it("Can delegate call if called by Messenger", async function () {
@@ -92,7 +92,18 @@ describe("GovernorSpoke.js", async () => {
     let inputDataBytes = finder.methods
       .changeImplementationAddress(utf8ToHex(interfaceName.ChildMessenger), owner)
       .encodeABI();
-    let messageBytes = web3.eth.abi.encodeParameters(["address", "bytes"], [targetAddress, inputDataBytes]);
+    let messageBytes = web3.eth.abi.encodeParameters(
+      [
+        {
+          type: "tuple[]",
+          components: [
+            { name: "to", type: "address" },
+            { name: "data", type: "bytes" },
+          ],
+        },
+      ],
+      [[{ to: targetAddress, data: inputDataBytes }]]
+    );
 
     let txn = await governorSpoke.methods.processMessageFromParent(messageBytes).send({ from: messenger });
     await assertEventEmitted(

--- a/packages/core/test/cross-chain-oracle/GovernorSpoke.js
+++ b/packages/core/test/cross-chain-oracle/GovernorSpoke.js
@@ -1,10 +1,12 @@
 const hre = require("hardhat");
-const { getContract, assertEventEmitted } = hre;
+const { getContract, assertEventEmitted, web3 } = hre;
 const { didContractThrow } = require("@uma/common");
 const { assert } = require("chai");
+const { utf8ToHex } = web3.utils;
 
 const GovernorSpoke = getContract("GovernorSpoke");
 const AddressWhitelist = getContract("AddressWhitelist");
+const IdentifierWhitelist = getContract("IdentifierWhitelist");
 
 describe("GovernorSpoke.js", async () => {
   let accounts;
@@ -13,6 +15,7 @@ describe("GovernorSpoke.js", async () => {
 
   let governor;
   let addressWhitelist;
+  let identifierWhitelist;
 
   before(async function () {
     accounts = await web3.eth.getAccounts();
@@ -25,16 +28,37 @@ describe("GovernorSpoke.js", async () => {
     // Deploy contract that Governor should be able to delegate execution to:
     addressWhitelist = await AddressWhitelist.new().send({ from: owner });
     await addressWhitelist.methods.transferOwnership(governor.options.address).send({ from: owner });
+
+    identifierWhitelist = await IdentifierWhitelist.new().send({ from: owner });
+    await identifierWhitelist.methods.transferOwnership(governor.options.address).send({ from: owner });
   });
   it("Constructor", async function () {
     const setChildMessengerEvents = await governor.getPastEvents("SetChildMessenger", { fromBlock: 0 });
     assert.equal(setChildMessengerEvents.length, 1);
     assert.equal(setChildMessengerEvents[0].returnValues.childMessenger, messenger);
   });
+
   it("Can delegate call if called by Messenger", async function () {
-    let targetAddress = addressWhitelist.options.address;
-    let inputDataBytes = addressWhitelist.methods.addToWhitelist(messenger).encodeABI();
-    let messageBytes = web3.eth.abi.encodeParameters(["address", "bytes"], [targetAddress, inputDataBytes]);
+    const calls = [
+      { to: addressWhitelist.options.address, data: addressWhitelist.methods.addToWhitelist(messenger).encodeABI() },
+      {
+        to: identifierWhitelist.options.address,
+        data: identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex("Messenger")).encodeABI(),
+      },
+    ];
+
+    let messageBytes = web3.eth.abi.encodeParameters(
+      [
+        {
+          type: "tuple[]",
+          components: [
+            { name: "to", type: "address" },
+            { name: "data", type: "bytes" },
+          ],
+        },
+      ],
+      [calls]
+    );
 
     // Only messenger can call.
     assert(await didContractThrow(governor.methods.processMessageFromParent(messageBytes).send({ from: owner })));
@@ -44,9 +68,16 @@ describe("GovernorSpoke.js", async () => {
       txn,
       governor,
       "ExecutedGovernanceTransaction",
-      (event) => event.to === targetAddress && event.data === inputDataBytes
+      (event) => event.data === calls[0].data && event.to === calls[0].to
+    );
+    await assertEventEmitted(
+      txn,
+      governor,
+      "ExecutedGovernanceTransaction",
+      (event) => event.data === calls[1].data && event.to === calls[1].to
     );
 
     assert.isTrue(await addressWhitelist.methods.isOnWhitelist(messenger).call());
+    assert.isTrue(await identifierWhitelist.methods.isIdentifierSupported(utf8ToHex("Messenger")).call());
   });
 });


### PR DESCRIPTION
**Motivation**

The `GovernorSpoke` contract should be able to execute multiple transactions atomically keep the Governance system from losing control of the sequencing of important actions.

**Summary**

This adds a more complex structure for cross-chain messages so that they can contain multiple transactions rather than one.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
