### PR TITLE
fix: [across] address issue with nested BN

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -196,7 +196,6 @@ export class InsuredBridgeL1Client {
       quoteBlockNumber,
       liquidityUtilizationCurrent: liquidityUtilizationCurrent.toString(),
       liquidityUtilizationPostRelay: liquidityUtilizationPostRelay.toString(),
-      rateModel: this.rateModels[deposit.l1Token],
     });
 
     return calculateRealizedLpFeePct(

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -28,10 +28,14 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
 
     // If pollingDelay === 0 then the bot is running in serverless mode and should send a `debug` level log.
     // Else, if running in loop mode (pollingDelay != 0), then it should send a `info` level log.
+
+    // The logger is having issues with logging nested BNs. Remove this for now. Is indirectly fixed in PR https://github.com/UMAprotocol/protocol/pull/3656
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    const { rateModels, ...logableConfig } = config;
     logger[config.pollingDelay === 0 ? "debug" : "info"]({
       at: "AcrossRelayer#index",
       message: "Relayer started 🌉",
-      config,
+      logableConfig,
     });
 
     const [accounts] = await Promise.all([l1Web3.eth.getAccounts()]);


### PR DESCRIPTION
**Motivation**

There is a common issue in the across bots producing irritating logs in slack and making some bots timeout under some conditions. See the screenshot below for the common log.


<img width="1002" alt="image" src="https://user-images.githubusercontent.com/12886084/146250577-0973c9d4-4e8c-4edd-9e47-1ad6c7e2a1bf.png">


The cause of this is logging nested JS objects, containing BigNumbers, using the `@google-cloud/logging-winston` package. 


**Summary**

This PR fixes this until a more perminat solution can be implemented.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
