### PR TITLE
fix: [across] address issue log mapping

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -67,13 +67,11 @@ spoke.post("/", async (req, res) => {
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
 
-    res
-      .status(200)
-      .send({
-        message: "Process exited with no error",
-        childProcessIdentifier: _getChildProcessIdentifier(req),
-        execResponse,
-      });
+    res.status(200).send({
+      message: "Process exited with no error",
+      childProcessIdentifier: _getChildProcessIdentifier(req),
+      execResponse,
+    });
   } catch (execResponse) {
     // If there is an error, send a debug log to the winston transport to capture in GCP. We dont want to trigger a
     // `logger.error` here as this will be dealt with one layer up in the Hub implementation.
@@ -85,13 +83,11 @@ spoke.post("/", async (req, res) => {
       execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res
-      .status(500)
-      .send({
-        message: "Process exited with error",
-        childProcessIdentifier: _getChildProcessIdentifier(req),
-        execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
-      });
+    res.status(500).send({
+      message: "Process exited with error",
+      childProcessIdentifier: _getChildProcessIdentifier(req),
+      execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
+    });
   }
 });
 

--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -59,7 +59,6 @@ spoke.post("/", async (req, res) => {
     if (execResponse.error) {
       throw execResponse;
     }
-    // Log the full execResponse in this log. This enables you to retrieve the full output of the child process.
     logger.debug({
       at: "ServerlessSpoke",
       message: "Process exited with no error",
@@ -68,19 +67,13 @@ spoke.post("/", async (req, res) => {
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
 
-    // Send back a redacted log to the hub, if possible. This is done to decrease the amount of logs that are sent to
-    // the hub. extract only the `message` filed from the logs. This is the main log headline without any details.
-    res.status(200).send({
-      message: "Process exited with no error",
-      childProcessIdentifier: _getChildProcessIdentifier(req),
-      execResponse: {
-        error: execResponse.error,
-        stderr: execResponse.stderr,
-        stdout: Array.isArray(execResponse.stdout)
-          ? execResponse.stdout.map((logMessage) => logMessage["message"])
-          : execResponse.stdout,
-      },
-    });
+    res
+      .status(200)
+      .send({
+        message: "Process exited with no error",
+        childProcessIdentifier: _getChildProcessIdentifier(req),
+        execResponse,
+      });
   } catch (execResponse) {
     // If there is an error, send a debug log to the winston transport to capture in GCP. We dont want to trigger a
     // `logger.error` here as this will be dealt with one layer up in the Hub implementation.
@@ -92,11 +85,13 @@ spoke.post("/", async (req, res) => {
       execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res.status(500).send({
-      message: "Process exited with error",
-      childProcessIdentifier: _getChildProcessIdentifier(req),
-      execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
-    });
+    res
+      .status(500)
+      .send({
+        message: "Process exited with error",
+        childProcessIdentifier: _getChildProcessIdentifier(req),
+        execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
+      });
   }
 });
 
@@ -131,7 +126,8 @@ function _stripExecStdout(output, strategyRunnerSpoke = false) {
     // done to clean up the upstream logs produced by the bots so the serverless hub can still produce meaningful logs
     // while preserving the individual bot execution logs within GCP when using the strategy runner.
     if (strategyRunnerSpoke) return logsArray.filter((logMessage) => logMessage.at == "BotStrategyRunner");
-    else return logsArray;
+    // extract only the `message` field from each log to reduce how much is sent back to the hub and logged in GCP.
+    else return logsArray.map((logMessage) => logMessage["message"]);
   } catch (error) {
     return _regexStrip(output).replace(/\r?\n|\r/g, " "); // Remove escaped new line chars. Replace with space between each log output.
   }


### PR DESCRIPTION
**Motivation**

We are producing logs too big to fit into GCP's stack driver. This PR cuts down on the logs sent all in one go. Screenshot below shows the issue attempted to be fixed in this PR:

![image](https://user-images.githubusercontent.com/12886084/146271037-5e94fddf-4c7e-4a3d-ad59-99b3aeb72996.png)


**Summary**

decreases log bloat.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

