### PR TITLE
fix: [bots] remove wait for logger

### DIFF
--- a/packages/bot-strategy-runner/src/index.ts
+++ b/packages/bot-strategy-runner/src/index.ts
@@ -104,7 +104,7 @@ async function runStrategies(strategyRunnerConfig: strategyRunnerConfig) {
           message: "End of execution loop - terminating process",
         });
 
-      await delay(5);
+      await delay(5); // Set a delay to let the transports flush fully.
       break;
     }
     if (strategyRunnerConfig.emitRunnerLogs)

--- a/packages/bot-strategy-runner/src/index.ts
+++ b/packages/bot-strategy-runner/src/index.ts
@@ -110,7 +110,7 @@ async function runStrategies(strategyRunnerConfig: strategyRunnerConfig) {
     if (strategyRunnerConfig.emitRunnerLogs)
       Logger.debug({
         at: "BotStrategyRunner",
-        message: "End of execution loop - ting polling delay",
+        message: "End of execution loop - waiting polling delay",
         pollingDelay: `${strategyRunnerConfig.pollingDelay} (s)`,
       });
     await delay(Number(strategyRunnerConfig.pollingDelay));

--- a/packages/bot-strategy-runner/src/index.ts
+++ b/packages/bot-strategy-runner/src/index.ts
@@ -104,13 +104,13 @@ async function runStrategies(strategyRunnerConfig: strategyRunnerConfig) {
           message: "End of execution loop - terminating process",
         });
 
-      await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+      await delay(5);
       break;
     }
     if (strategyRunnerConfig.emitRunnerLogs)
       Logger.debug({
         at: "BotStrategyRunner",
-        message: "End of execution loop - waiting polling delay",
+        message: "End of execution loop - ting polling delay",
         pollingDelay: `${strategyRunnerConfig.pollingDelay} (s)`,
       });
     await delay(Number(strategyRunnerConfig.pollingDelay));

--- a/packages/contract-notifier/index.js
+++ b/packages/contract-notifier/index.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 const retry = require("async-retry");
 
 // Helpers:
-const { Networker, Logger, waitForLogger, delay } = require("@uma/financial-templates-lib");
+const { Networker, Logger, delay } = require("@uma/financial-templates-lib");
 
 const { ContractNotifier } = require("./src/ContractNotifier");
 
@@ -65,8 +65,7 @@ async function run({ logger, pollingDelay, errorRetries, errorRetriesTimeout, no
           at: "ContractNotifier#index",
           message: "End of serverless execution loop - terminating process",
         });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({
@@ -115,7 +114,7 @@ async function Poll(callback) {
       error: typeof error === "string" ? new Error(error) : error,
       notificationPath: "infrastructure-error",
     });
-    await waitForLogger(Logger);
+    await delay(5); // Set a delay to let the transports flush fully.
     callback(error);
   }
   callback();

--- a/packages/disputer/index.js
+++ b/packages/disputer/index.js
@@ -20,7 +20,6 @@ const {
   Logger,
   Networker,
   delay,
-  waitForLogger,
   createReferencePriceFeedForFinancialContract,
   setAllowance,
   DSProxyManager,
@@ -245,8 +244,7 @@ async function run({
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (pollingDelay === 0) {
         logger.debug({ at: "Disputer#index", message: "End of serverless execution loop - terminating process" });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({
@@ -318,7 +316,7 @@ async function Poll(callback) {
       error: typeof error === "string" ? new Error(error) : error,
       notificationPath: "infrastructure-error",
     });
-    await waitForLogger(Logger);
+    await delay(5); // Set a delay to let the transports flush fully.
     callback(error);
   }
   callback();

--- a/packages/funding-rate-proposer/index.js
+++ b/packages/funding-rate-proposer/index.js
@@ -5,7 +5,6 @@ const retry = require("async-retry");
 
 const {
   Logger,
-  waitForLogger,
   delay,
   FinancialContractFactoryClient,
   GasEstimator,
@@ -116,8 +115,8 @@ async function run({
           at: "PerpetualFundingRateProposer#index",
           message: "End of serverless execution loop - terminating process",
         });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({
@@ -171,7 +170,7 @@ async function Poll(callback) {
       message: "Perpetual funding rate proposer execution error🚨",
       error: typeof error === "string" ? new Error(error) : error,
     });
-    await waitForLogger(Logger);
+    await delay(5); // Set a delay to let the transports flush fully.
     callback(error);
   }
   callback();

--- a/packages/fx-tunnel-relayer/src/index.ts
+++ b/packages/fx-tunnel-relayer/src/index.ts
@@ -5,7 +5,7 @@ import { config } from "dotenv";
 import MaticJs from "@maticnetwork/maticjs";
 import { averageBlockTimeSeconds, getWeb3 } from "@uma/common";
 import { getAddress, getAbi } from "@uma/contracts-node";
-import { GasEstimator, Logger, waitForLogger, delay } from "@uma/financial-templates-lib";
+import { GasEstimator, Logger, delay } from "@uma/financial-templates-lib";
 
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
@@ -102,8 +102,7 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
           at: "FxTunnelRelayer#index",
           message: "End of serverless execution loop - terminating process",
         });
-        await waitForLogger(logger);
-        await delay(2);
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -9,7 +9,6 @@ import { getWeb3, getWeb3ByChainId, processTransactionPromiseBatch, getRetryWeb3
 import {
   GasEstimator,
   Logger,
-  waitForLogger,
   delay,
   InsuredBridgeL1Client,
   InsuredBridgeL2Client,
@@ -166,8 +165,7 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
           at: "AcrossRelayer#index",
           message: "End of serverless execution loop - terminating process",
         });
-        await delay(5);
-        await waitForLogger(logger);
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({

--- a/packages/liquidator/index.js
+++ b/packages/liquidator/index.js
@@ -19,7 +19,6 @@ const {
   Networker,
   Logger,
   createReferencePriceFeedForFinancialContract,
-  waitForLogger,
   delay,
   setAllowance,
   DSProxyManager,
@@ -329,8 +328,7 @@ async function run({
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (pollingDelay === 0) {
         logger.debug({ at: "Liquidator#index", message: "End of serverless execution loop - terminating process" });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({
@@ -416,7 +414,7 @@ async function Poll(callback) {
       error: typeof error === "string" ? new Error(error) : error,
       notificationPath: "infrastructure-error",
     });
-    await waitForLogger(Logger);
+    await delay(5); // Set a delay to let the transports flush fully.
     callback(error);
   }
   callback();

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -13,7 +13,6 @@ const {
   Logger,
   createReferencePriceFeedForFinancialContract,
   createTokenPriceFeedForFinancialContract,
-  waitForLogger,
   delay,
   multicallAddressMap,
   OptimisticOracleType,
@@ -384,8 +383,7 @@ async function run({
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (pollingDelay === 0) {
         logger.debug({ at: "Monitor#index", message: "End of serverless execution loop - terminating process" });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({ at: "Monitor#index", message: "End of execution loop - waiting polling delay" });
@@ -485,7 +483,7 @@ async function Poll(callback) {
       error: typeof error === "string" ? new Error(error) : error,
       notificationPath: "infrastructure-error",
     });
-    await waitForLogger(Logger);
+    await delay(5); // Set a delay to let the transports flush fully.
     callback(error);
   }
   callback();

--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -5,7 +5,6 @@ const retry = require("async-retry");
 
 const {
   Logger,
-  waitForLogger,
   delay,
   OptimisticOracleClient,
   GasEstimator,
@@ -127,8 +126,7 @@ async function run({
           at: "OptimisticOracle#index",
           message: "End of serverless execution loop - terminating process",
         });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({
@@ -186,7 +184,7 @@ async function Poll(callback) {
       error: typeof error === "string" ? new Error(error) : error,
       notificationPath: "infrastructure-error",
     });
-    await waitForLogger(Logger);
+    await delay(5); // Set a delay to let the transports flush fully.
     callback(error);
   }
   callback();

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -37,7 +37,7 @@ const datastore = new Datastore();
 // Web3 instance to get current block numbers of polling loops.
 const Web3 = require("web3");
 
-const { delay, createNewLogger, waitForLogger } = require("@uma/financial-templates-lib");
+const { delay, createNewLogger } = require("@uma/financial-templates-lib");
 let customLogger;
 let spokeUrl;
 let customNodeUrl;
@@ -211,7 +211,6 @@ hub.post("/", async (req, res) => {
       output: { errorOutputs, validOutputs, retriedOutputs },
     });
 
-    await waitForLogger(logger);
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
     res
       .status(200)
@@ -256,7 +255,6 @@ hub.post("/", async (req, res) => {
       });
     }
 
-    await waitForLogger(logger);
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
     res.status(500).send({
       message: errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",

--- a/packages/trader/src/index.ts
+++ b/packages/trader/src/index.ts
@@ -11,7 +11,6 @@ import {
   Logger,
   createReferencePriceFeedForFinancialContract,
   createTokenPriceFeedForFinancialContract,
-  waitForLogger,
   delay,
   DSProxyManager,
 } from "@uma/financial-templates-lib";
@@ -121,8 +120,7 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
           at: "Trader#index",
           message: "End of serverless execution loop - terminating process",
         });
-        await waitForLogger(logger);
-        await delay(2); // waitForLogger does not always work 100% correctly in serverless. add a delay to ensure logs are captured upstream.
+        await delay(5); // Set a delay to let the transports flush fully.
         break;
       }
       logger.debug({


### PR DESCRIPTION
**Motivation**

The `waitForLogger` utility is extremely inconsistant in production and has proven to be dangerous to use. If this utility is called before all GCP logs have fully flushed out of the stream the process will hang until it times out, producing no logs. This makes it very difficult to figure out what's going wrong with the bots and to debug.

Unfortunately, there is no easy solution to this. Ideally, we want a utility that can halt code execution until all streams have been fully flushed (i.e all upstream messages sent). This is not posible with Winston. Note that their documentation claims this is posible but in practice it just does not work. See [this](https://github.com/winstonjs/winston/issues/1250) PR for the best solution I've found (which inspired the original implementation of `waitForLogger`). Note that the code here does not work any more with GCP's `@google-cloud/logging-winston` package.

There are a number of people complaining about the same issue with `@google-cloud/logging-winston`. see issue [502](https://github.com/googleapis/nodejs-logging-winston/issues/502 ) and issue [598](https://github.com/googleapis/nodejs-logging-winston/issues/598) and there is no clear solution for now.


**Details**

Removes all usage of `waitForLogger` instances and replaces with a `delay`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested