### PR TITLE
feat(sdk): add detailed gas deposit fees for across

### DIFF
--- a/packages/sdk/src/across/README.md
+++ b/packages/sdk/src/across/README.md
@@ -70,7 +70,7 @@ Quickest way to get up and running.
 - Mainnet Ethers provider
 - Address of erc20 token on mainnet, if transfering a token, or `ethers.constants.AddressZero` for ETH.
 
-#### Example
+#### Basic Fees Example
 
 Calculate fees for calling deposit for initiating a relay.
 
@@ -81,7 +81,13 @@ const { gasFeeCalculator, constants, utils } = uma.across
 const totalRelayed = utils.toWei(10)
 const provider = ethers.providers.getDefaultProvider()
 const umaAddress = constants.ADDRESSES.UMA
-const { slowPct, instantPct } = await gasFeecalculator.getDepositFees(provider, totalRelayed, umaAddress)
+const optionalDiscountPercent = 25 // we may decide to discount gas fees by this percent, optionally omit this param
+const { slowPct, instantPct } = await gasFeecalculator.getDepositFees(
+  provider,
+  totalRelayed,
+  umaAddress,
+  optionalDiscountPercent
+)
 
 // example call to deposit, uses the slow/instant percentages from getDepositFees call
 // const tx = await depositBox.deposit(
@@ -92,6 +98,30 @@ const { slowPct, instantPct } = await gasFeecalculator.getDepositFees(provider, 
 //   instantPct,
 //   latestl2Block.timestamp,
 // );
+```
+
+#### Detailed Fees Example
+
+This uses the same underlying logic as the basic example, but returns omre information useful for display purposes.
+
+```ts
+import * as uma from "@uma/sdk"
+const { gasFeeCalculator, constants, utils } = uma.across
+
+const totalRelayed = utils.toWei(10)
+const provider = ethers.providers.getDefaultProvider()
+const umaAddress = constants.ADDRESSES.UMA
+const optionalDiscountPercent = 25 // we may decide to discount gas fees by this percent, optionally omit this param
+const optionalFeeLimitPercent = 25 // this checks if fees are too high as a percentage of total amount to relay, omit to disable check
+const feeDetails: gasFeeCalculator.DepositFeeDetails = await gasFeecalculator.getDepositFeesDetails(
+  provider,
+  totalRelayed,
+  umaAddress,
+  optionalDiscountPercent,
+  optionalFeeLimitPercent
+)
+
+// see the DepositFeeDetails type for the shape of return data.
 ```
 
 ### LP Fee Calculator

--- a/packages/sdk/src/across/README.md
+++ b/packages/sdk/src/across/README.md
@@ -81,13 +81,7 @@ const { gasFeeCalculator, constants, utils } = uma.across
 const totalRelayed = utils.toWei(10)
 const provider = ethers.providers.getDefaultProvider()
 const umaAddress = constants.ADDRESSES.UMA
-const optionalDiscountPercent = 25 // we may decide to discount gas fees by this percent, optionally omit this param
-const { slowPct, instantPct } = await gasFeecalculator.getDepositFees(
-  provider,
-  totalRelayed,
-  umaAddress,
-  optionalDiscountPercent
-)
+const { slowPct, instantPct } = await gasFeecalculator.getDepositFees(provider, totalRelayed, umaAddress)
 
 // example call to deposit, uses the slow/instant percentages from getDepositFees call
 // const tx = await depositBox.deposit(
@@ -111,13 +105,11 @@ const { gasFeeCalculator, constants, utils } = uma.across
 const totalRelayed = utils.toWei(10)
 const provider = ethers.providers.getDefaultProvider()
 const umaAddress = constants.ADDRESSES.UMA
-const optionalDiscountPercent = 25 // we may decide to discount gas fees by this percent, optionally omit this param
 const optionalFeeLimitPercent = 25 // this checks if fees are too high as a percentage of total amount to relay, omit to disable check
 const feeDetails: gasFeeCalculator.DepositFeeDetails = await gasFeecalculator.getDepositFeesDetails(
   provider,
   totalRelayed,
   umaAddress,
-  optionalDiscountPercent,
   optionalFeeLimitPercent
 )
 

--- a/packages/sdk/src/across/constants.ts
+++ b/packages/sdk/src/across/constants.ts
@@ -13,7 +13,7 @@ export const SPEED_UP_ETH_GAS = 195288;
 export const SPEED_UP_ERC_GAS = 203011;
 export const SPEED_UP_UMA_GAS = 227341;
 
-// Bots offer a discount on gas costs when batching mulitple transactions, this roughly estimates the savings
+// Bots incur lower than expected costs due to batching mulitple transactions, this roughly estimates the savings
 export const DEFAULT_GAS_DISCOUNT = 25;
 
 export interface RateModel {

--- a/packages/sdk/src/across/constants.ts
+++ b/packages/sdk/src/across/constants.ts
@@ -13,6 +13,9 @@ export const SPEED_UP_ETH_GAS = 195288;
 export const SPEED_UP_ERC_GAS = 203011;
 export const SPEED_UP_UMA_GAS = 227341;
 
+// Bots offer a discount on gas costs when batching mulitple transactions, this roughly estimates the savings
+export const DEFAULT_GAS_DISCOUNT = 25;
+
 export interface RateModel {
   UBar: string; // denote the utilization kink along the rate model where the slope of the interest rate model changes.
   R0: string; // is the interest rate charged at 0 utilization

--- a/packages/sdk/src/across/gasFeeCalculator.e2e.ts
+++ b/packages/sdk/src/across/gasFeeCalculator.e2e.ts
@@ -36,4 +36,22 @@ describe("gasFeeCalculator", function () {
       });
     });
   });
+  describe("gasFeeCalculator.getDepositFeesDetails", function () {
+    test(`deposit fee details eth no discount`, async function () {
+      const address = ADDRESSES.ETH;
+      const amount = toWei("1");
+      const discount = 0;
+      const feeLimit = 5;
+      const result = await across.gasFeeCalculator.getDepositFeesDetails(provider, amount, address, discount, feeLimit);
+      assert.ok(result.isAmountTooLow);
+    });
+    test(`deposit fee details eth with discount`, async function () {
+      const address = ADDRESSES.ETH;
+      const amount = toWei("1");
+      const discount = 25;
+      const feeLimit = 25;
+      const result = await across.gasFeeCalculator.getDepositFeesDetails(provider, amount, address, discount, feeLimit);
+      assert.ok(!result.isAmountTooLow);
+    });
+  });
 });

--- a/packages/sdk/src/across/gasFeeCalculator.e2e.ts
+++ b/packages/sdk/src/across/gasFeeCalculator.e2e.ts
@@ -42,7 +42,7 @@ describe("gasFeeCalculator", function () {
       const amount = toWei("1");
       const discount = 0;
       const feeLimit = 5;
-      const result = await across.gasFeeCalculator.getDepositFeesDetails(provider, amount, address, discount, feeLimit);
+      const result = await across.gasFeeCalculator.getDepositFeesDetails(provider, amount, address, feeLimit, discount);
       assert.ok(result.isAmountTooLow);
     });
     test(`deposit fee details eth with discount`, async function () {
@@ -50,7 +50,7 @@ describe("gasFeeCalculator", function () {
       const amount = toWei("1");
       const discount = 25;
       const feeLimit = 25;
-      const result = await across.gasFeeCalculator.getDepositFeesDetails(provider, amount, address, discount, feeLimit);
+      const result = await across.gasFeeCalculator.getDepositFeesDetails(provider, amount, address, feeLimit, discount);
       assert.ok(!result.isAmountTooLow);
     });
   });

--- a/packages/sdk/src/across/gasFeeCalculator.ts
+++ b/packages/sdk/src/across/gasFeeCalculator.ts
@@ -87,7 +87,8 @@ export type DepositFees = {
  * @param {Provider} ethersProvider - Read provider on mainnet
  * @param {BigNumberish} amountToRelay - Amount in wei of token to relay
  * @param {string} tokenAddress = 0 - Mainnet address of token to relay. Defaults to ETH which is constants.ADDRESSES.ETH.
- * @param {string} discountPercent = 0 - Percent as a value 0-100 of gas fee discount. 0 means no discount. Typically 25 for a 25% gas fee reduction.
+ * @param {string} discountPercent = DEFAULT_GAS_DISCOUNT- Percent as a value 0-100 of gas fee discount. 0 means no discount. Typically 25 for a 25% gas fee reduction.
+ * No need to override this as the values are hardcoded in the sdk.
  * @returns {Promise<DepositFees>} - Returns the fee parameters to the deposit function on the deposit box contract.
  * These are percentages in wei. For example 50% is represented as 0.5 * 1e18.
  */
@@ -95,7 +96,7 @@ export async function getDepositFees(
   ethersProvider: Provider,
   amountToRelay: BigNumberish,
   tokenAddress: string = constants.ADDRESSES.ETH,
-  discountPercent = 0
+  discountPercent: number = constants.DEFAULT_GAS_DISCOUNT
 ): Promise<DepositFees> {
   assert(discountPercent >= 0 && discountPercent <= 100, "discountPercent must be between 0 and 100 percent");
   const slowGas = getSlowGasByAddress(tokenAddress);
@@ -133,17 +134,18 @@ export type DepositFeeDetails = {
  * @param {Provider} ethersProvider - Read provider on mainnet
  * @param {BigNumberish} amountToRelay - Amount in wei of token to relay
  * @param {string} tokenAddress = 0 - Mainnet address of token to relay, for ETH specify constants.ADDRESSES.ETH
- * @param {string} discountPercent = 0 - Percent as a value 0-100 of gas fee discount. 0 means no discount. Typically 25 for a 25% gas fee reduction.
  * @param {number} feeLimitPercent? - Optional, percent as a value 0-100 of how much to limit fees as a percentage of the total relayed. Typically 25 or 25% of fees are acceptable out of the total relay amount.
  * For instance 25 means fees can be up to 25% of the total amount to send, fees above this will cause isAmountTooLow to be true.
+ * @param {string} discountPercent = DEFAULT_GAS_DISCOUNT - Percent as a value 0-100 of gas fee discount. 0 means no discount. Typically 25 for a 25% gas fee reduction.
+ * No need to override this as the values are hardcoded in the sdk.
  * @returns {DepositFeeDetails}
  */
 export async function getDepositFeesDetails(
   ethersProvider: Provider,
   amountToRelay: BigNumberish,
   tokenAddress: string = constants.ADDRESSES.ETH,
-  discountPercent = 0,
-  feeLimitPercent?: number
+  feeLimitPercent?: number,
+  discountPercent: number = constants.DEFAULT_GAS_DISCOUNT
 ): Promise<DepositFeeDetails> {
   const { slowPct, instantPct } = await getDepositFees(ethersProvider, amountToRelay, tokenAddress, discountPercent);
   const slowTotal = BigNumber.from(slowPct).mul(amountToRelay).div(fixedPointAdjustment).toString();

--- a/packages/sdk/src/across/gasFeeCalculator.ts
+++ b/packages/sdk/src/across/gasFeeCalculator.ts
@@ -1,10 +1,11 @@
-import { calculateGasFees, percent, BigNumberish } from "./utils";
+import assert from "assert";
+import { calculateGasFees, percent, BigNumberish, toBNWei, fixedPointAdjustment } from "./utils";
 import { exists } from "../utils";
 import { Provider } from "@ethersproject/providers";
 import { connect as erc20Connect } from "../clients/erc20";
 import { Etherchain } from "../clients/etherchain";
 import Coingecko from "../coingecko";
-import { ethers } from "ethers";
+import { ethers, BigNumber } from "ethers";
 import * as constants from "./constants";
 
 /**
@@ -74,7 +75,7 @@ const GetGasByAddress = (gasTable: GasTable) => (tokenAddress: string): number =
 export const getInstantGasByAddress = GetGasByAddress(makeInstantGasTable());
 export const getSlowGasByAddress = GetGasByAddress(makeSlowGasTable());
 
-type DepositFees = {
+export type DepositFees = {
   slowPct: string;
   instantPct: string;
 };
@@ -85,21 +86,90 @@ type DepositFees = {
  *
  * @param {Provider} ethersProvider - Read provider on mainnet
  * @param {BigNumberish} amountToRelay - Amount in wei of token to relay
- * @param {string} tokenAddress - Mainnet address of token to relay, for ETH specify constants.ADDRESSES.ETH
+ * @param {string} tokenAddress = 0 - Mainnet address of token to relay. Defaults to ETH which is constants.ADDRESSES.ETH.
+ * @param {string} discountPercent = 0 - Percent as a value 0-100 of gas fee discount. 0 means no discount. Typically 25 for a 25% gas fee reduction.
  * @returns {Promise<DepositFees>} - Returns the fee parameters to the deposit function on the deposit box contract.
  * These are percentages in wei. For example 50% is represented as 0.5 * 1e18.
  */
 export async function getDepositFees(
   ethersProvider: Provider,
   amountToRelay: BigNumberish,
-  tokenAddress: string = constants.ADDRESSES.ETH
+  tokenAddress: string = constants.ADDRESSES.ETH,
+  discountPercent = 0
 ): Promise<DepositFees> {
+  assert(discountPercent >= 0 && discountPercent <= 100, "discountPercent must be between 0 and 100 percent");
   const slowGas = getSlowGasByAddress(tokenAddress);
+  const slowGasDiscounted = Math.floor((1 - discountPercent / 100) * slowGas);
+  const slowGasFee = await getGasFee(ethersProvider, slowGasDiscounted, tokenAddress);
+
   const instantGas = getInstantGasByAddress(tokenAddress);
-  const slowGasFee = await getGasFee(ethersProvider, slowGas, tokenAddress);
-  const instantGasFee = await getGasFee(ethersProvider, instantGas, tokenAddress);
+  const instantGasDiscounted = Math.floor((1 - discountPercent / 100) * instantGas);
+  const instantGasFee = await getGasFee(ethersProvider, instantGasDiscounted, tokenAddress);
+
   return {
     slowPct: percent(slowGasFee, amountToRelay).toString(),
     instantPct: percent(instantGasFee, amountToRelay).toString(),
+  };
+}
+
+export type DepositFeeDetails = {
+  tokenAddress: string;
+  amountToRelay: string;
+  discountPercent: number;
+  feeLimitPercent?: number;
+  instant: {
+    pct: string;
+    total: string;
+  };
+  slow: {
+    pct: string;
+    total: string;
+  };
+  isAmountTooLow: boolean;
+};
+/**
+ * getDepositFeesDetails. Same as deposit fees, but returns more information, useful for a frontend display.
+ *
+ * @param {Provider} ethersProvider - Read provider on mainnet
+ * @param {BigNumberish} amountToRelay - Amount in wei of token to relay
+ * @param {string} tokenAddress = 0 - Mainnet address of token to relay, for ETH specify constants.ADDRESSES.ETH
+ * @param {string} discountPercent = 0 - Percent as a value 0-100 of gas fee discount. 0 means no discount. Typically 25 for a 25% gas fee reduction.
+ * @param {number} feeLimitPercent? - Optional, percent as a value 0-100 of how much to limit fees as a percentage of the total relayed. Typically 25 or 25% of fees are acceptable out of the total relay amount.
+ * For instance 25 means fees can be up to 25% of the total amount to send, fees above this will cause isAmountTooLow to be true.
+ * @returns {DepositFeeDetails}
+ */
+export async function getDepositFeesDetails(
+  ethersProvider: Provider,
+  amountToRelay: BigNumberish,
+  tokenAddress: string = constants.ADDRESSES.ETH,
+  discountPercent = 0,
+  feeLimitPercent?: number
+): Promise<DepositFeeDetails> {
+  const { slowPct, instantPct } = await getDepositFees(ethersProvider, amountToRelay, tokenAddress, discountPercent);
+  const slowTotal = BigNumber.from(slowPct).mul(amountToRelay).div(fixedPointAdjustment).toString();
+  const instantTotal = BigNumber.from(instantPct).mul(amountToRelay).div(fixedPointAdjustment).toString();
+  let isAmountTooLow = false;
+
+  if (feeLimitPercent) {
+    assert(feeLimitPercent >= 0 && feeLimitPercent <= 100, "feeLimitPercent must be between 0 and 100 percent");
+    isAmountTooLow = BigNumber.from(slowPct)
+      .add(instantPct)
+      .gt(toBNWei(feeLimitPercent / 100));
+  }
+
+  return {
+    amountToRelay: amountToRelay.toString(),
+    discountPercent,
+    feeLimitPercent,
+    tokenAddress,
+    instant: {
+      pct: instantPct,
+      total: instantTotal,
+    },
+    slow: {
+      pct: slowPct,
+      total: slowTotal,
+    },
+    isAmountTooLow,
   };
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/3644/improve-gas-fee-calculator-in-sdk-to-add-frontend-functionality

**Summary**

This adds a wrapper function to the previous bare bones fee estimator. This roughly matches the output in frontend specific function, but will require some changes for integration. This also adds a "discount" parameter which is optional, to reduce gas costs by the discount rate. 

current frontend definition:
![image](https://user-images.githubusercontent.com/4429761/146438571-dc79a881-d076-423f-b819-dcaa2d5ca9d5.png)

sdk definition 
![image](https://user-images.githubusercontent.com/4429761/146438649-e0f40ed8-32ac-4bbf-9bdb-c8b6ae21ebf5.png)


**Details**
output of this function with the same params as frontend is returning `0.053160704612800294` in eth transfer fees vs across showing `0.0506`, so its in the same ballpark                                                                                      

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

https://app.shortcut.com/uma-project/story/3644/improve-gas-fee-calculator-in-sdk-to-add-frontend-functionality
