### PR TITLE
fix(bots): correct optimism toBlock issue

### DIFF
--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -6,6 +6,7 @@ const argv = minimist(process.argv.slice(), {});
 
 import winston from "winston";
 
+import { across } from "@uma/sdk";
 import {
   createEtherscanLinkMarkdown,
   createFormatFunction,
@@ -238,7 +239,9 @@ export class CrossDomainFinalizer {
     // canonical L1 StateCommitmentChain. 5000 blocks is ~ 3 hours at current Optimism rate. This is only applied if we
     // are not running in test mode.
     const blockOffset =
-      argv._.indexOf("test") !== -1 || argv._.filter((arg) => arg.includes("mocha")).length > 0 ? 0 : 5000;
+      argv._.indexOf("test") !== -1 || argv._.filter((arg) => arg.includes("mocha")).length > 0
+        ? 0
+        : across.constants.L2_STATE_COMMITMENT_DELAY_BLOCKS;
     const tokensBridgedEvents = await this.l2Client.bridgeDepositBox.getPastEvents("TokensBridged", {
       fromBlock: this.l2DeployData[this.l2Client.chainId].blockNumber,
       toBlock: (await this.l2Client.l2Web3.eth.getBlockNumber()) - blockOffset,

--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -1,6 +1,9 @@
 import Web3 from "web3";
 const { toBN } = Web3.utils;
 
+import minimist from "minimist";
+const argv = minimist(process.argv.slice(), {});
+
 import winston from "winston";
 
 import {
@@ -230,9 +233,15 @@ export class CrossDomainFinalizer {
     // Note that the query below only works on particular RPC endpoints. Infura, for example, is limited to a 100k look
     // back. This means that to use this module you need to use an endpoint that supports longer lookbacks, such as
     // alchemy, which supports arbitrary long loobacks. In future, Infura will support arbitrary long lookbacks.
+    // Note2: the blockOffset is added to limit how far forward we look. We want to ideally ignore the newest blocks
+    // as these can causes errors in the Bridge Adapters if the L2 transactions are not yet checkpointed on the
+    // canonical L1 StateCommitmentChain. 5000 blocks is ~ 3 hours at current Optimism rate. This is only applied if we
+    // are not running in test mode.
+    const blockOffset =
+      argv._.indexOf("test") !== -1 || argv._.filter((arg) => arg.includes("mocha")).length > 0 ? 0 : 5000;
     const tokensBridgedEvents = await this.l2Client.bridgeDepositBox.getPastEvents("TokensBridged", {
       fromBlock: this.l2DeployData[this.l2Client.chainId].blockNumber,
-      toBlock: await this.l2Client.l2Web3.eth.getBlockNumber(),
+      toBlock: (await this.l2Client.l2Web3.eth.getBlockNumber()) - blockOffset,
     });
     for (const tokensBridgedEvent of tokensBridgedEvents) {
       // If this is the first time we are seeing this L2 token then create the array.

--- a/packages/sdk/src/across/constants.ts
+++ b/packages/sdk/src/across/constants.ts
@@ -16,6 +16,11 @@ export const SPEED_UP_UMA_GAS = 227341;
 // Bots incur lower than expected costs due to batching mulitple transactions, this roughly estimates the savings
 export const DEFAULT_GAS_DISCOUNT = 25;
 
+// Amount of blocks to wait following a `TokensBridged` L2 event until we check the L1 state commitment contracts. This
+// offset provides a buffer to allow for any time delay between L2 state changing and L1 state updating. For example,
+// Optimism has a several hour delay.
+export const L2_STATE_COMMITMENT_DELAY_BLOCKS = 5000;
+
 export interface RateModel {
   UBar: string; // denote the utilization kink along the rate model where the slope of the interest rate model changes.
   R0: string; // is the interest rate charged at 0 utilization


### PR DESCRIPTION
**Motivation**

If the cross-domain finaliser looks forward to the current block the OptimismBridgeAdapter will error out as L2 transactions have not yet been included in the L1 StateCommitmentChain. This makes the bot throw errors every time a L2->L1 transfer is initiated until the `StateCommitmentChain` has been updated.

The solution is to add an offset on how new the blocks should be that we look at, thereby avoiding the above situation.

**Summary**

Fixes an issue with fresh blocks in the Optimism finaliser.
