### PR TITLE
feat: add functionality for relayer to run on multiple chainIds

### DIFF
--- a/packages/insured-bridge-relayer/package.json
+++ b/packages/insured-bridge-relayer/package.json
@@ -12,7 +12,8 @@
     "arb-ts": "^1.0.2",
     "async-retry": "^1.3.1",
     "dotenv": "^8.2.0",
-    "ethers": "^5.5.0"
+    "ethers": "^5.5.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@tsconfig/node14": "^1.0.0",

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -58,10 +58,10 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
     const relayers = await Promise.all(
       config.activatedChainIds.map(async (chainId: number) => {
         // Construct a web3 instance running on L2.
-        const l2Web3 = getWeb3ByChainId(config.activatedChainIds[0]);
+        const l2Web3 = getWeb3ByChainId(chainId);
         const latestL2BlockNumber = await l2Web3.eth.getBlockNumber();
         const l2StartBlock = Math.max(0, latestL2BlockNumber - config.l2BlockLookback);
-        const fallbackL2Web3s = getRetryWeb3sByChainId(config.activatedChainIds[0]);
+        const fallbackL2Web3s = getRetryWeb3sByChainId(chainId);
         // Note: This will not construct duplicate Web3 objects for URL's in the Retry config that are the same as the
         // one used to construct l2Web3.
         logger.debug({
@@ -71,8 +71,8 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
         const l2Client = new InsuredBridgeL2Client(
           logger,
           l2Web3,
-          await l1Client.getL2DepositBoxAddress(config.activatedChainIds[0]),
-          config.activatedChainIds[0],
+          await l1Client.getL2DepositBoxAddress(chainId),
+          chainId,
           l2StartBlock,
           null,
           fallbackL2Web3s
@@ -108,7 +108,7 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
           config.l2BlockLookback
         );
 
-        const canonicalBridgeAdapter = createBridgeAdapter(logger, l1Web3, l2Web3, config.activatedChainIds[0]);
+        const canonicalBridgeAdapter = createBridgeAdapter(logger, l1Web3, l2Web3, chainId);
         if (config.botModes.l1FinalizerEnabled) await canonicalBridgeAdapter.initialize();
 
         const crossDomainFinalizer = new CrossDomainFinalizer(

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -23,7 +23,7 @@ import { RelayerConfig } from "./RelayerConfig";
 config();
 
 function isErrorOutput<T>(input: PromiseSettledResult<T>): input is PromiseRejectedResult {
-  return "reason" in input;
+  return input.status === "rejected";
 }
 
 export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -2,7 +2,7 @@ import winston from "winston";
 import Web3 from "web3";
 import retry from "async-retry";
 import { config } from "dotenv";
-import assert from "assert";
+import lodash from "lodash";
 
 import { getWeb3, getWeb3ByChainId, processTransactionPromiseBatch, getRetryWeb3sByChainId } from "@uma/common";
 
@@ -21,6 +21,10 @@ import { CrossDomainFinalizer } from "./CrossDomainFinalizer";
 import { createBridgeAdapter } from "./canonical-bridge-adapters/CreateBridgeAdapter";
 import { RelayerConfig } from "./RelayerConfig";
 config();
+
+function isErrorOutput<T>(input: PromiseSettledResult<T>): input is PromiseRejectedResult {
+  return "reason" in input;
+}
 
 export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
   try {
@@ -51,129 +55,155 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
     // TODO: Add a method to fetch all registered chainIDs from bridge admin to let the bot default to all chains when
     // the config does not include activatedChainIds.
 
-    // For now, this bot only supports 1 L2 chain. In future we need to update the bot to create n number l2Clients for
-    // each L2 client. Then, create n instances of `Relayer`.
-    assert(config.activatedChainIds.length == 1, "bot only supports running on 1 l2 at a time for now");
+    const relayers = await Promise.all(
+      config.activatedChainIds.map(async (chainId: number) => {
+        // Construct a web3 instance running on L2.
+        const l2Web3 = getWeb3ByChainId(config.activatedChainIds[0]);
+        const latestL2BlockNumber = await l2Web3.eth.getBlockNumber();
+        const l2StartBlock = Math.max(0, latestL2BlockNumber - config.l2BlockLookback);
+        const fallbackL2Web3s = getRetryWeb3sByChainId(config.activatedChainIds[0]);
+        // Note: This will not construct duplicate Web3 objects for URL's in the Retry config that are the same as the
+        // one used to construct l2Web3.
+        logger.debug({
+          at: "AcrossRelayer#index",
+          message: `Constructed ${fallbackL2Web3s.length} fallback L2 web3 providers`,
+        });
+        const l2Client = new InsuredBridgeL2Client(
+          logger,
+          l2Web3,
+          await l1Client.getL2DepositBoxAddress(config.activatedChainIds[0]),
+          config.activatedChainIds[0],
+          l2StartBlock,
+          null,
+          fallbackL2Web3s
+        );
 
-    // Construct a web3 instance running on L2.
-    const l2Web3 = getWeb3ByChainId(config.activatedChainIds[0]);
-    const latestL2BlockNumber = await l2Web3.eth.getBlockNumber();
-    const l2StartBlock = Math.max(0, latestL2BlockNumber - config.l2BlockLookback);
-    const fallbackL2Web3s = getRetryWeb3sByChainId(config.activatedChainIds[0]);
-    // Note: This will not construct duplicate Web3 objects for URL's in the Retry config that are the same as the
-    // one used to construct l2Web3.
-    logger.debug({
-      at: "AcrossRelayer#index",
-      message: `Constructed ${fallbackL2Web3s.length} fallback L2 web3 providers`,
-    });
-    const l2Client = new InsuredBridgeL2Client(
-      logger,
-      l2Web3,
-      await l1Client.getL2DepositBoxAddress(config.activatedChainIds[0]),
-      config.activatedChainIds[0],
-      l2StartBlock,
-      null,
-      fallbackL2Web3s
-    );
+        // Update the L2 client and filter out tokens that are not whitelisted on the L2 from the whitelisted L1 relay list.
+        const filteredL1Whitelist = await pruneWhitelistedL1Tokens(
+          logger,
+          l1Client,
+          l2Client,
+          config.whitelistedRelayL1Tokens
+        );
 
-    // Update the L2 client and filter out tokens that are not whitelisted on the L2 from the whitelisted L1 relay list.
-    const filteredL1Whitelist = await pruneWhitelistedL1Tokens(
-      logger,
-      l1Client,
-      l2Client,
-      config.whitelistedRelayL1Tokens
+        // Construct the profitability calculator based on the filteredL1Whitelist and relayerDiscount.
+        const profitabilityCalculator = new ProfitabilityCalculator(
+          logger,
+          filteredL1Whitelist,
+          l1ChainId,
+          config.relayerDiscount
+        );
+
+        const relayer = new Relayer(
+          logger,
+          gasEstimator,
+          l1Client,
+          l2Client,
+          profitabilityCalculator,
+          filteredL1Whitelist,
+          accounts[0],
+          config.whitelistedChainIds,
+          config.l1DeployData,
+          config.l2DeployData,
+          config.l2BlockLookback
+        );
+
+        const canonicalBridgeAdapter = createBridgeAdapter(logger, l1Web3, l2Web3, config.activatedChainIds[0]);
+        if (config.botModes.l1FinalizerEnabled) await canonicalBridgeAdapter.initialize();
+
+        const crossDomainFinalizer = new CrossDomainFinalizer(
+          logger,
+          gasEstimator,
+          l1Client,
+          l2Client,
+          canonicalBridgeAdapter,
+          accounts[0],
+          config.l2DeployData,
+          config.crossDomainFinalizationThreshold
+        );
+
+        return {
+          relayer,
+          crossDomainFinalizer,
+          l2Client,
+          profitabilityCalculator,
+          filteredL1Whitelist,
+        };
+      })
     );
 
     // For all specified whitelisted L1 tokens that this relayer supports, approve the bridge pool to spend them. This
     // method will error if the bot runner has specified a L1 tokens that is not part of the Bridge Admin whitelist.
-    await approveL1Tokens(logger, l1Web3, gasEstimator, accounts[0], config.bridgeAdmin, filteredL1Whitelist);
-
-    // Construct the profitability calculator based on the filteredL1Whitelist and relayerDiscount.
-    const profitabilityCalculator = new ProfitabilityCalculator(
-      logger,
-      filteredL1Whitelist,
-      l1ChainId,
-      config.relayerDiscount
-    );
-
-    const relayer = new Relayer(
-      logger,
-      gasEstimator,
-      l1Client,
-      l2Client,
-      profitabilityCalculator,
-      filteredL1Whitelist,
-      accounts[0],
-      config.whitelistedChainIds,
-      config.l1DeployData,
-      config.l2DeployData,
-      config.l2BlockLookback
-    );
-
-    const canonicalBridgeAdapter = createBridgeAdapter(logger, l1Web3, l2Web3, config.activatedChainIds[0]);
-    if (config.botModes.l1FinalizerEnabled) await canonicalBridgeAdapter.initialize();
-
-    const crossDomainFinalizer = new CrossDomainFinalizer(
-      logger,
-      gasEstimator,
-      l1Client,
-      l2Client,
-      canonicalBridgeAdapter,
-      accounts[0],
-      config.l2DeployData,
-      config.crossDomainFinalizationThreshold
-    );
-
+    const combinedFilteredL1Whitelist = lodash.uniq(relayers.map((relayer) => relayer.filteredL1Whitelist).flat());
+    await approveL1Tokens(logger, l1Web3, gasEstimator, accounts[0], config.bridgeAdmin, combinedFilteredL1Whitelist);
     for (;;) {
-      await retry(
-        async () => {
-          // Update state.
-          await Promise.all([
-            gasEstimator.update(),
-            l1Client.update(),
-            l2Client.update(),
-            profitabilityCalculator.update(),
-          ]);
+      const outputs = await Promise.allSettled(
+        relayers.map(async ({ relayer, crossDomainFinalizer, l2Client, profitabilityCalculator }) => {
+          await retry(
+            async () => {
+              // Update state.
+              await Promise.all([
+                gasEstimator.update(),
+                l1Client.update(),
+                l2Client.update(),
+                profitabilityCalculator.update(),
+              ]);
 
-          // Start bots that are enabled.
-          if (config.botModes.relayerEnabled) await relayer.checkForPendingDepositsAndRelay();
-          else logger.debug({ at: "AcrossRelayer#Relayer", message: "Relayer disabled" });
+              // Start bots that are enabled.
+              if (config.botModes.relayerEnabled) await relayer.checkForPendingDepositsAndRelay();
+              else logger.debug({ at: "AcrossRelayer#Relayer", message: "Relayer disabled" });
 
-          if (config.botModes.disputerEnabled) await relayer.checkForPendingRelaysAndDispute();
-          else logger.debug({ at: "AcrossRelayer#Disputer", message: "Disputer disabled" });
+              if (config.botModes.disputerEnabled) await relayer.checkForPendingRelaysAndDispute();
+              else logger.debug({ at: "AcrossRelayer#Disputer", message: "Disputer disabled" });
 
-          if (config.botModes.settlerEnabled) await relayer.checkforSettleableRelaysAndSettle();
-          else logger.debug({ at: "AcrossRelayer#Finalizer", message: "Relay Settler disabled" });
+              if (config.botModes.settlerEnabled) await relayer.checkforSettleableRelaysAndSettle();
+              else logger.debug({ at: "AcrossRelayer#Finalizer", message: "Relay Settler disabled" });
 
-          if (config.botModes.l1FinalizerEnabled) await crossDomainFinalizer.checkForConfirmedL2ToL1RelaysAndFinalize();
-          else logger.debug({ at: "AcrossRelayer#CrossDomainFinalizer", message: "Confirmed L1 finalizer disabled" });
+              if (config.botModes.l1FinalizerEnabled)
+                await crossDomainFinalizer.checkForConfirmedL2ToL1RelaysAndFinalize();
+              else
+                logger.debug({
+                  at: "AcrossRelayer#CrossDomainFinalizer",
+                  message: "Confirmed L1 finalizer disabled",
+                });
 
-          if (config.botModes.l2FinalizerEnabled) await crossDomainFinalizer.checkForBridgeableL2TokensAndBridge();
-          else logger.debug({ at: "AcrossRelayer#CrossDomainFinalizer", message: "L2->L1 finalizer disabled" });
+              if (config.botModes.l2FinalizerEnabled) await crossDomainFinalizer.checkForBridgeableL2TokensAndBridge();
+              else logger.debug({ at: "AcrossRelayer#CrossDomainFinalizer", message: "L2->L1 finalizer disabled" });
 
-          // Each of the above code blocks could have produced transactions. If they did, their promises are stored
-          // in the executed transactions array. The method below awaits all these transactions to ensure they are
-          // correctly included in a block. if any submitted transactions contains an error then a log is produced.
-          await processTransactionPromiseBatch(
-            [...relayer.getExecutedTransactions(), ...crossDomainFinalizer.getExecutedTransactions()],
-            logger
+              // Each of the above code blocks could have produced transactions. If they did, their promises are stored
+              // in the executed transactions array. The method below awaits all these transactions to ensure they are
+              // correctly included in a block. if any submitted transactions contains an error then a log is produced.
+              await processTransactionPromiseBatch(
+                [...relayer.getExecutedTransactions(), ...crossDomainFinalizer.getExecutedTransactions()],
+                logger
+              );
+              relayer.resetExecutedTransactions(); // Purge the executed transactions array for next execution loop.
+            },
+
+            {
+              retries: config.errorRetries,
+              minTimeout: config.errorRetriesTimeout * 1000, // delay between retries in ms
+              randomize: false,
+              onRetry: (error) => {
+                logger.debug({
+                  at: "AcrossRelayer#index",
+                  message: "An error was thrown in the execution loop - retrying",
+                  error: typeof error === "string" ? new Error(error) : error,
+                });
+              },
+            }
           );
-          relayer.resetExecutedTransactions(); // Purge the executed transactions array for next execution loop.
-        },
-
-        {
-          retries: config.errorRetries,
-          minTimeout: config.errorRetriesTimeout * 1000, // delay between retries in ms
-          randomize: false,
-          onRetry: (error) => {
-            logger.debug({
-              at: "AcrossRelayer#index",
-              message: "An error was thrown in the execution loop - retrying",
-              error: typeof error === "string" ? new Error(error) : error,
-            });
-          },
-        }
+        })
       );
+
+      if (outputs.some(isErrorOutput))
+        throw new Error(
+          `Multiple errors: ${outputs
+            .filter(isErrorOutput)
+            .map((output) => output.reason)
+            .join("\n")}`
+        );
+
       // If the polling delay is set to 0 then the script will terminate the bot after one full run.
       if (config.pollingDelay === 0) {
         logger.debug({

--- a/packages/insured-bridge-relayer/test/index.ts
+++ b/packages/insured-bridge-relayer/test/index.ts
@@ -20,7 +20,13 @@ const startGanacheServer = (chainId: number, port: number) => {
 };
 
 // Helper contracts
-const chainId = 10;
+const networks = [
+  {
+    chainId: 10,
+    port: 7777,
+  },
+  { chainId: 11, port: 8888 },
+];
 const Messenger = getContract("MessengerMock");
 const BridgePool = getContract("BridgePool");
 const BridgeDepositBox = getContract("BridgeDepositBoxMock");
@@ -154,44 +160,48 @@ describe("index.js", function () {
       transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
     });
 
-    startGanacheServer(chainId, 7777);
-    const [l2Owner, l2BridgeAdminImpersonator] = await l2Web3.eth.getAccounts();
+    await Promise.all(
+      networks.map(async ({ chainId, port }) => {
+        startGanacheServer(chainId, port);
+        const [l2Owner, l2BridgeAdminImpersonator] = await l2Web3.eth.getAccounts();
 
-    // Deploy deposit box on L2 web3 so that L2 client can read its events.
-    const L2BridgeDepositBox = new l2Web3.eth.Contract(BridgeDepositBox.abi);
-    bridgeDepositBox = await L2BridgeDepositBox.deploy({
-      data: BridgeDepositBox.bytecode,
-      arguments: [l2BridgeAdminImpersonator, minimumBridgingDelay, ZERO_ADDRESS, ZERO_ADDRESS],
-    }).send({
-      from: l2Owner,
-      gas: 6000000,
-      gasPrice: toWei("1", "gwei"),
-    });
+        // Deploy deposit box on L2 web3 so that L2 client can read its events.
+        const L2BridgeDepositBox = new l2Web3.eth.Contract(BridgeDepositBox.abi);
+        bridgeDepositBox = await L2BridgeDepositBox.deploy({
+          data: BridgeDepositBox.bytecode,
+          arguments: [l2BridgeAdminImpersonator, minimumBridgingDelay, ZERO_ADDRESS, ZERO_ADDRESS],
+        }).send({
+          from: l2Owner,
+          gas: 6000000,
+          gasPrice: toWei("1", "gwei"),
+        });
 
-    await bridgeAdmin.methods
-      .setDepositContract(chainId, bridgeDepositBox.options.address, messenger.options.address)
-      .send({ from: owner });
+        await bridgeAdmin.methods
+          .setDepositContract(chainId, bridgeDepositBox.options.address, messenger.options.address)
+          .send({ from: owner });
 
-    // Add L1-L2 token mapping after deposit box address is set.
-    await bridgeAdmin.methods
-      .whitelistToken(
-        chainId,
-        l1Token.options.address,
-        l2Token,
-        bridgePool.options.address,
-        0,
-        defaultGasLimit,
-        defaultGasPrice,
-        0
-      )
-      .send({ from: owner });
-    await bridgeDepositBox.methods
-      .whitelistToken(l1Token.options.address, l2Token, bridgePool.options.address)
-      .send({ from: l2BridgeAdminImpersonator });
+        // Add L1-L2 token mapping after deposit box address is set.
+        await bridgeAdmin.methods
+          .whitelistToken(
+            chainId,
+            l1Token.options.address,
+            l2Token,
+            bridgePool.options.address,
+            0,
+            defaultGasLimit,
+            defaultGasPrice,
+            0
+          )
+          .send({ from: owner });
+        await bridgeDepositBox.methods
+          .whitelistToken(l1Token.options.address, l2Token, bridgePool.options.address)
+          .send({ from: l2BridgeAdminImpersonator });
+      })
+    );
   });
   it("Runs with no errors and correctly sets approvals for whitelisted L1 tokens", async function () {
     process.env.BRIDGE_ADMIN_ADDRESS = bridgeAdmin.options.address;
-    process.env.WHITELISTED_CHAIN_IDS = JSON.stringify([chainId]);
+    process.env.WHITELISTED_CHAIN_IDS = JSON.stringify([networks[0].chainId]);
     process.env.RELAYER_ENABLED = "1";
     process.env.DISPUTER_ENABLED = "1";
     process.env.FINALIZER_ENABLED = "1";
@@ -199,8 +209,27 @@ describe("index.js", function () {
     process.env.RATE_MODELS = JSON.stringify({
       [l1Token.options.address]: { UBar: toWei("0.65"), R0: toWei("0.00"), R1: toWei("0.08"), R2: toWei("1.00") },
     });
-    process.env.CHAIN_IDS = JSON.stringify([chainId]);
-    process.env[`NODE_URL_${chainId}`] = "http://localhost:7777";
+    process.env.CHAIN_IDS = JSON.stringify([networks[0].chainId]);
+    process.env[`NODE_URL_${networks[0].chainId}`] = "http://localhost:7777";
+
+    // Must not throw.
+    await run(spyLogger, web3);
+
+    // Approvals are set correctly
+    assert.notEqual((await l1Token.methods.allowance(owner, bridgePool.options.address)).toString(), "0");
+  });
+  it("Runs multiple chainIds with no errors", async function () {
+    process.env.BRIDGE_ADMIN_ADDRESS = bridgeAdmin.options.address;
+    process.env.WHITELISTED_CHAIN_IDS = JSON.stringify(networks.map(({ chainId }) => chainId));
+    process.env.RELAYER_ENABLED = "1";
+    process.env.DISPUTER_ENABLED = "1";
+    process.env.FINALIZER_ENABLED = "1";
+    process.env.POLLING_DELAY = "0";
+    process.env.RATE_MODELS = JSON.stringify({
+      [l1Token.options.address]: { UBar: toWei("0.65"), R0: toWei("0.00"), R1: toWei("0.08"), R2: toWei("1.00") },
+    });
+    process.env.CHAIN_IDS = JSON.stringify([networks.map(({ chainId }) => chainId)]);
+    networks.forEach(({ chainId, port }) => (process.env[`NODE_URL_${chainId}`] = `http://localhost:${port}`));
 
     // Must not throw.
     await run(spyLogger, web3);
@@ -210,7 +239,7 @@ describe("index.js", function () {
   });
   it("Filters L1 token whitelist on L2 whitelist events", async function () {
     process.env.BRIDGE_ADMIN_ADDRESS = bridgeAdmin.options.address;
-    process.env.WHITELISTED_CHAIN_IDS = JSON.stringify([chainId]);
+    process.env.WHITELISTED_CHAIN_IDS = JSON.stringify([networks[0].chainId]);
     process.env.RELAYER_ENABLED = "1";
     process.env.DISPUTER_ENABLED = "1";
     process.env.FINALIZER_ENABLED = "1";
@@ -222,8 +251,8 @@ describe("index.js", function () {
       [l1Token.options.address]: { UBar: toWei("0.65"), R0: toWei("0.00"), R1: toWei("0.08"), R2: toWei("1.00") },
       [unWhitelistedL1Token]: { UBar: toWei("0.75"), R0: toWei("0.00"), R1: toWei("0.06"), R2: toWei("2.00") },
     });
-    process.env.CHAIN_IDS = JSON.stringify([chainId]);
-    process.env[`NODE_URL_${chainId}`] = "http://localhost:7777";
+    process.env.CHAIN_IDS = JSON.stringify([networks[0].chainId]);
+    process.env[`NODE_URL_${networks[0].chainId}`] = "http://localhost:7777";
 
     // Must not throw.
     await run(spyLogger, web3);


### PR DESCRIPTION
**Motivation**

We would like to run the relayer for multiple chains in the same process to avoid nonce collisions and allow better batching.

**Summary**

Much of the code was already ready for this change. It only required a top-level Promise.allSettled to loop over all the chainIds we wanted to support.

Note: this should be backwards compatible with all existing configuration. It simply removes a restriction.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A