### PR TITLE
feat: update mumbai lsp creator and add rinkeby fpl addresses

### DIFF
--- a/packages/core/networks/4.json
+++ b/packages/core/networks/4.json
@@ -90,5 +90,33 @@
   {
     "contractName": "LongShortPairCreator",
     "address": "0x8f584beEd8371757d520f7CEC06fF07de225371D"
+  },
+  {
+    "contractName": "BinaryOptionLongShortPairFinancialProductLibrary",
+    "address": "0x7a974Eb1F7D4bB49170aaed39C693A8daFe9E5B5"
+  },
+  {
+    "contractName": "CoveredCallLongShortPairFinancialProductLibrary",
+    "address": "0x01E5AD9B4Bc39504510C13C7A3B8352714011355"
+  },
+  {
+    "contractName": "LinearLongShortPairFinancialProductLibrary",
+    "address": "0x55e6CDd418F5Cf9Ba34f967c0Edc90E6dA606f2D"
+  },
+  {
+    "contractName": "RangeBondLongShortPairFinancialProductLibrary",
+    "address": "0x03f4600858CABa1ccff9c12351B984d956F1bA76"
+  },
+  {
+    "contractName": "SimpleSuccessTokenLongShortPairFinancialProductLibrary",
+    "address": "0x46130BF31fde58587392396dAA11aBe7dE80Ea02"
+  },
+  {
+    "contractName": "CappedYieldDollarLongShortPairFinancialProductLibrary",
+    "address": "0xBDed7E526fC0D581D6F62796118e64D885Cdf07d"
+  },
+  {
+    "contractName": "SuccessTokenLongShortPairFinancialProductLibrary",
+    "address": "0x40CD7eEc067279bDeb1a5069615569b5d43a3F0A"
   }
 ]

--- a/packages/core/networks/80001.json
+++ b/packages/core/networks/80001.json
@@ -49,7 +49,7 @@
   },
   {
     "contractName": "LongShortPairCreator",
-    "address": "0x57EE47829369e2EF62fBb423648bec70d0366204"
+    "address": "0xed3D3F90b8426E683b8d361ac7dDBbEa1a8A7Da8"
   },
   {
     "contractName": "BinaryOptionLongShortPairFinancialProductLibrary",


### PR DESCRIPTION
Signed-off-by: Alex Gaines <againes@umaproject.org>

**Motivation**

The new LSP creator has already been added to other networks. This adds the same contract version to Mumbai. This PR also includes FPL addresses for RInkeby.


**Summary**

Adds the deployed addresses to the networks file.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


