### PR TITLE
feat: add transaction bundler to relayer for better batching

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pretty-quick": "^2.0.1",
     "secp256k1": "^3.7.1",
     "solc-0.8": "npm:solc@^0.8.4",
-    "typescript": "^4.3.5",
+    "typescript": "^4.5.4",
     "web3": "^1.6.0"
   },
   "resolutions": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^14.14.25",
     "@types/url-join": "^4.0.0",
     "@typescript-eslint/parser": "^4.24.0",
+    "axios": "^0.24.0",
     "ts-mocha": "^8.0.0",
     "ts-node": "^10.1.0"
   },

--- a/packages/api/src/services/collateral-prices.ts
+++ b/packages/api/src/services/collateral-prices.ts
@@ -124,7 +124,8 @@ export function CollateralPrices(config: Config, dependencies: Dependencies) {
     const addresses = await collateralAddresses.keys();
     await backfillHistories(addresses, startMs).then((results) => {
       results.forEach((result) => {
-        if (result.status === "rejected") console.error("Error backfilling prices: " + result.reason.message);
+        if (result.status === "rejected")
+          console.error("Error backfilling prices: " + (result.reason as Error).message);
       });
     });
   }

--- a/packages/api/src/services/synthetic-prices.ts
+++ b/packages/api/src/services/synthetic-prices.ts
@@ -161,14 +161,15 @@ export function SyntheticPrices(config: Config, appState: Dependencies, appClien
     // this gets raw synth price without regard to currency, stores them in table. not really useful until converted to usd.
     await updateLatestSynthPrices(empAddresses).then((results) => {
       results.forEach((result) => {
-        if (result.status === "rejected") console.error("Error updating synthetic price: " + result.reason.message);
+        if (result.status === "rejected")
+          console.error("Error updating synthetic price: " + (result.reason as Error).message);
       });
     });
     // this converts latest synth prices to a currency price, based on collateral price relationship
     await updateLatestPrices(empAddresses).then((results) => {
       results.forEach((result) => {
         if (result.status === "rejected")
-          console.error(`Error updating synthetic ${currency} price: ${result.reason.message}`);
+          console.error(`Error updating synthetic ${currency} price: ${(result.reason as Error).message}`);
       });
     });
     // this takes converted prices and creates a historical record

--- a/packages/bot-strategy-runner/src/BotEntryWrapper.ts
+++ b/packages/bot-strategy-runner/src/BotEntryWrapper.ts
@@ -68,7 +68,7 @@ async function _executeBot(
 
     return { financialContractAddress, botIdentifier, logs };
   } catch (error) {
-    return { financialContractAddress, botIdentifier, logs, error: error.toString() };
+    return { financialContractAddress, botIdentifier, logs, error: (error as Error).toString() };
   }
 }
 

--- a/packages/common/src/SolidityTestUtils.ts
+++ b/packages/common/src/SolidityTestUtils.ts
@@ -8,7 +8,7 @@ export async function didContractThrow<T>(promise: Promise<T>): Promise<boolean>
   try {
     await promise;
   } catch (error) {
-    return error.message.match(/[invalid opcode|out of gas|revert]/, "Expected throw, got '" + error + "' instead");
+    return !!(error as Error).message.match(/[invalid opcode|out of gas|revert]/);
   }
   return false;
 }

--- a/packages/common/src/TransactionUtils.ts
+++ b/packages/common/src/TransactionUtils.ts
@@ -114,8 +114,9 @@ export const runTransaction = async ({
       transaction.estimateGas({ from: transactionConfig.from }),
     ]);
   } catch (error) {
-    error.type = "call";
-    throw error;
+    const castedError = error as Error & { type?: string };
+    castedError.type = "call";
+    throw castedError;
   }
 
   // .call() succeeded, now broadcast transaction.
@@ -179,8 +180,9 @@ export const runTransaction = async ({
 
     return { receipt, transactionHash, returnValue, transactionConfig };
   } catch (error) {
-    error.type = "send";
-    throw error;
+    const castedError = error as Error & { type?: string };
+    castedError.type = "send";
+    throw castedError;
   }
 };
 

--- a/packages/core/contracts/common/test/MultiCallerTest.sol
+++ b/packages/core/contracts/common/test/MultiCallerTest.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.0;
+
+import "../implementation/MultiCaller.sol";
+
+contract MultiCallerTest is MultiCaller {
+    uint256 public value;
+
+    function call(bool shouldFail) public pure {
+        require(shouldFail, "shouldFail set to true");
+    }
+
+    function add(uint256 amount) public {
+        value += amount;
+    }
+}

--- a/packages/financial-templates-lib/src/index.ts
+++ b/packages/financial-templates-lib/src/index.ts
@@ -14,6 +14,7 @@ export * from "./helpers/GasEstimator";
 export * from "./helpers/AbiUtils";
 export * from "./logger/Logger";
 export * from "./logger/SpyTransport";
+export * from "./logger/ConsoleTransport";
 export * from "./price-feed/UniswapPriceFeed";
 export * from "./price-feed/CreatePriceFeed";
 export * from "./price-feed/Networker";

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -909,9 +909,8 @@ function getFinancialContractIdentifierAtAddress(web3: Web3, financialContractAd
   try {
     return new web3.eth.Contract(getAbi("ExpiringMultiParty"), financialContractAddress);
   } catch (error) {
-    const castedError = error as Error;
     throw new Error(
-      `Something went wrong in fetching the financial contract identifier ${castedError?.stack || castedError}`
+      `Something went wrong in fetching the financial contract identifier ${(error as Error)?.stack || error}`
     );
   }
 }

--- a/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CreatePriceFeed.ts
@@ -909,6 +909,9 @@ function getFinancialContractIdentifierAtAddress(web3: Web3, financialContractAd
   try {
     return new web3.eth.Contract(getAbi("ExpiringMultiParty"), financialContractAddress);
   } catch (error) {
-    throw new Error(`Something went wrong in fetching the financial contract identifier ${error?.stack || error}`);
+    const castedError = error as Error;
+    throw new Error(
+      `Something went wrong in fetching the financial contract identifier ${castedError?.stack || castedError}`
+    );
   }
 }

--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -85,7 +85,7 @@ export class Relayer {
     } catch (error) {
       // If event block hasn't been checkpointed to Mainnet yet, then don't emit error level log.
       let logLevel = "error";
-      if (error.message.includes("transaction has not been checkpointed")) logLevel = "debug";
+      if ((error as Error)?.message.includes("transaction has not been checkpointed")) logLevel = "debug";
       this.logger[logLevel]({
         at: "Relayer#relayMessage",
         message: "Failed to derive proof for MessageSent transaction hash 📛",
@@ -118,7 +118,7 @@ export class Relayer {
     } catch (error) {
       // If the proof was already submitted, then don't emit an error level log.
       let logLevel = "error";
-      if (error.message.includes("EXIT_ALREADY_PROCESSED")) logLevel = "debug";
+      if ((error as Error)?.message.includes("EXIT_ALREADY_PROCESSED")) logLevel = "debug";
       this.logger[logLevel]({
         at: "Relayer#relayMessage",
         message: "Failed to submit proof to root tunnel🚨",

--- a/packages/insured-bridge-relayer/src/MulticallBundler.ts
+++ b/packages/insured-bridge-relayer/src/MulticallBundler.ts
@@ -1,0 +1,179 @@
+import winston from "winston";
+import Web3 from "web3";
+
+import { runTransaction, createEtherscanLinkMarkdown } from "@uma/common";
+import { MultiCallerWeb3 } from "@uma/contracts-node";
+import { GasEstimator } from "@uma/financial-templates-lib";
+
+import type { TransactionType, ExecutedTransaction } from "@uma/common";
+import type { Contract } from "web3-eth-contract";
+import type { TransactionReceipt } from "web3-core";
+
+import lodash from "lodash";
+
+interface BaseCall<T extends TransactionType> {
+  transaction: T;
+  message?: string;
+  mrkdwn?: string;
+  level?: string;
+}
+
+type Call = BaseCall<TransactionType>;
+type ExtendedTransasction = TransactionType & { _parent: Contract };
+type ExtendedCall = BaseCall<ExtendedTransasction>;
+
+function isErrorSettlement<T>(input: PromiseSettledResult<T>): input is PromiseRejectedResult {
+  return input.status === "rejected";
+}
+
+async function allSettledOrError<T>(promises: T[], errorPrefix: string): Promise<Awaited<T>[]> {
+  // Allow all transactions to finish before propagating any errors.
+  const results = await Promise.allSettled(promises);
+  const errors = results.filter(isErrorSettlement).map((errorResult) => errorResult.reason);
+
+  // Throw if there are any errors.
+  if (errors.length > 0) throw new Error(`${errorPrefix}:\n${errors.join("\n")}`);
+
+  // Cast results to the fulfilled result because we know that there were no errors due to the above check.
+  return (results as PromiseFulfilledResult<Awaited<T>>[]).map((element) => element.value);
+}
+
+export class MulticallBundler {
+  public calls: ExtendedCall[] = [];
+  public sentTransactions: ExecutedTransaction[] = [];
+
+  /**
+   * @notice Constructs new MulticallBundler instance.
+   * @param {Object} logger Module used to send logs.
+   * @param {Object} gasEstimator used to estimate gas prices for the receiving chainId.
+   * @param {Object} web3 web3 instance containing permissions to send with the provided account.
+   * @param {string} account Unlocked web3 account to send transactions.
+   */
+  constructor(
+    readonly logger: winston.Logger,
+    readonly gasEstimator: GasEstimator,
+    readonly web3: Web3,
+    readonly account: string
+  ) {}
+
+  public addTransactions(...calls: Call[]): void {
+    // Cast just allows us to access nonpublic fields on the transaction.
+    const castedCalls = calls as ExtendedCall[];
+    this.calls.push(...castedCalls);
+  }
+
+  public async send(): Promise<void> {
+    const callGroups = lodash.groupBy(this.calls, (call) =>
+      this.web3.utils.toChecksumAddress(call.transaction._parent.options.address)
+    );
+
+    await allSettledOrError(
+      Object.values(callGroups).map(async (calls) => {
+        if (calls.length === 1) {
+          return await this.sendTransaction(calls[0]);
+        } else {
+          return await this.batchTransactions(calls);
+        }
+      }),
+      "Error sending batches"
+    ).catch((error) => {
+      this.logger.error({
+        at: "MulticallBundler#send",
+        message: "One or more errors sending transaction batches",
+        error,
+      });
+    });
+
+    // After sending, set the calls to an empty array (even if some produced errors).
+    this.calls = [];
+  }
+
+  public async waitForMine(): Promise<TransactionReceipt[]> {
+    try {
+      return await allSettledOrError(
+        this.sentTransactions.map((transaction) => transaction.receipt),
+        "MulticallBundler#waitForMine: some transactions failed to mine"
+      );
+    } finally {
+      // This always gets executed after the return/error.
+      this.sentTransactions = [];
+    }
+  }
+
+  private async sendTransaction(call: ExtendedCall) {
+    await this.gasEstimator.update();
+
+    // Run the transaction provided. Note that waitForMine is set to false. This means the function will return as
+    // soon as the transaction has been included in the mem pool, but is not yet mined. This is important as we want
+    // to be able to fire off as many transactions as quickly as posable. Note that as soon as the transaction is
+    // in the mem pool we will produces a transaction hash for logging.
+    const executionResult = await runTransaction({
+      web3: this.web3,
+      transaction: call.transaction,
+      transactionConfig: { ...this.gasEstimator.getCurrentFastPrice(), from: this.account },
+      availableAccounts: 1,
+      waitForMine: false,
+    });
+
+    if (!executionResult.receipt) throw new Error("MulticallBundler#sendTransaction: No receipt returned");
+
+    const receiptMarkdown = `tx: ${createEtherscanLinkMarkdown(executionResult.transactionHash)}`;
+    this.logger.log({
+      at: "MulticallBundler#sendTransaction",
+      message: call.message || "No message",
+      mrkdwn: call.mrkdwn ? `${call.mrkdwn} ${receiptMarkdown}` : receiptMarkdown,
+      level: call.level || "info",
+    });
+
+    // Just append the execution result. No need to return.
+    // Note: appending this way ensures _every_ successful transaction ends up in this array.
+    this.sentTransactions.push(executionResult);
+  }
+
+  private async batchTransactions(calls: ExtendedCall[]) {
+    const multicaller: MultiCallerWeb3 = (calls[0].transaction._parent as unknown) as MultiCallerWeb3;
+
+    let markdownBlock = "*Transactions sent in batch:*\n";
+    calls.forEach(({ message, mrkdwn }) => {
+      markdownBlock += `  • ${message || "No message"}:\n`;
+      markdownBlock += `      ◦ ${mrkdwn || "No markdown"}\n`;
+    });
+
+    try {
+      // First try as a batch.
+      const executionResult = await this.sendTransaction({
+        transaction: (multicaller.methods.multicall(
+          calls.map(({ transaction }) => transaction.encodeABI())
+        ) as unknown) as ExtendedTransasction,
+        message: "Multicall batch sent!🧙",
+        mrkdwn: markdownBlock,
+        level: await this.getMaxLevel(calls),
+      });
+
+      // Return the successful result as a single element array.
+      return [executionResult];
+    } catch (error) {
+      // If the batch failed, try sending the transactions individually.
+      this.logger.info({
+        at: "MulticallBundler#batchTransactions",
+        message: "Sending batched transactions individually😷",
+        error,
+      });
+
+      // Allow all transactions to finish before propagating any errors.
+      await allSettledOrError(
+        calls.map((call) => this.sendTransaction(call)),
+        "Errors sending transactions individually"
+      );
+    }
+  }
+
+  private getMaxLevel(calls: ExtendedCall[]) {
+    if (!calls.every((call) => call.level === undefined)) return "info"; // default if no log level is provided.
+    if (calls.some((call) => call.level === "error")) return "error";
+    if (calls.some((call) => call.level === "warn")) return "warn";
+    if (calls.some((call) => call.level === "info")) return "info";
+    if (calls.some((call) => call.level === "debug")) return "debug";
+    return "info"; // Default to info if no others are found.
+  }
+}

--- a/packages/insured-bridge-relayer/src/MulticallBundler.ts
+++ b/packages/insured-bridge-relayer/src/MulticallBundler.ts
@@ -4,6 +4,7 @@ import Web3 from "web3";
 import { runTransaction, createEtherscanLinkMarkdown } from "@uma/common";
 import { MultiCallerWeb3 } from "@uma/contracts-node";
 import { GasEstimator } from "@uma/financial-templates-lib";
+import { isErrorOutput } from "./helpers";
 
 import type { TransactionType, ExecutedTransaction } from "@uma/common";
 import type { Contract } from "web3-eth-contract";
@@ -22,14 +23,10 @@ type Call = BaseCall<TransactionType>;
 type ExtendedTransasction = TransactionType & { _parent: Contract };
 type ExtendedCall = BaseCall<ExtendedTransasction>;
 
-function isErrorSettlement<T>(input: PromiseSettledResult<T>): input is PromiseRejectedResult {
-  return input.status === "rejected";
-}
-
 async function allSettledOrError<T>(promises: T[], errorPrefix: string): Promise<Awaited<T>[]> {
   // Allow all transactions to finish before propagating any errors.
   const results = await Promise.allSettled(promises);
-  const errors = results.filter(isErrorSettlement).map((errorResult) => errorResult.reason);
+  const errors = results.filter(isErrorOutput).map((errorResult) => errorResult.reason);
 
   // Throw if there are any errors.
   if (errors.length > 0) throw new Error(`${errorPrefix}:\n${errors.join("\n")}`);

--- a/packages/insured-bridge-relayer/src/helpers.ts
+++ b/packages/insured-bridge-relayer/src/helpers.ts
@@ -1,0 +1,3 @@
+export function isErrorOutput<T>(input: PromiseSettledResult<T>): input is PromiseRejectedResult {
+  return input.status === "rejected";
+}

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -21,11 +21,8 @@ import { CrossDomainFinalizer } from "./CrossDomainFinalizer";
 import { createBridgeAdapter } from "./canonical-bridge-adapters/CreateBridgeAdapter";
 import { RelayerConfig } from "./RelayerConfig";
 import { MulticallBundler } from "./MulticallBundler";
+import { isErrorOutput } from "./helpers";
 config();
-
-function isErrorOutput<T>(input: PromiseSettledResult<T>): input is PromiseRejectedResult {
-  return input.status === "rejected";
-}
 
 export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
   try {

--- a/packages/insured-bridge-relayer/test/MulticallBundler.ts
+++ b/packages/insured-bridge-relayer/test/MulticallBundler.ts
@@ -1,0 +1,73 @@
+import { SpyTransport, GasEstimator } from "@uma/financial-templates-lib";
+import { MultiCallerTestWeb3 } from "@uma/contracts-node";
+import winston from "winston";
+import sinon, { SinonSpy } from "sinon";
+import hre from "hardhat";
+import { assert } from "chai";
+import { MulticallBundler } from "../src/MulticallBundler";
+import { HRE, TransactionType } from "@uma/common";
+
+const { web3, getContract } = hre as HRE;
+const Multicaller = getContract("MultiCallerTest");
+
+describe("MulticallBundler.ts", function () {
+  let spyLogger: winston.Logger | undefined;
+  let spy: SinonSpy | undefined;
+  let gasEstimator: GasEstimator | undefined;
+  let owner = "";
+  let multicallBundler: MulticallBundler | undefined;
+  let multicaller: MultiCallerTestWeb3 | undefined;
+
+  const txnCast = <T>(input: T) => (input as unknown) as TransactionType;
+
+  before(async function () {
+    [owner] = await web3.eth.getAccounts();
+  });
+
+  beforeEach(async function () {
+    spy = sinon.spy();
+    spyLogger = winston.createLogger({
+      level: "debug",
+      transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
+    });
+
+    gasEstimator = new GasEstimator(spyLogger!);
+
+    multicallBundler = new MulticallBundler(spyLogger!, gasEstimator, web3, owner);
+
+    multicaller = ((await Multicaller.new().send({ from: owner })) as unknown) as MultiCallerTestWeb3;
+  });
+  it("Sends single transaction", async function () {
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+    await multicallBundler!.send();
+    console.log(await multicallBundler!.waitForMine());
+    assert.equal((await multicaller!.methods.value().call()).toString(), "1");
+  });
+
+  it("Sends multiple transactions", async function () {
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+    await multicallBundler!.send();
+    await multicallBundler!.waitForMine();
+    assert.equal((await multicaller!.methods.value().call()).toString(), "2");
+  });
+
+  it("Handles single transaction failure", async function () {
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.call(true)) });
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+
+    await multicallBundler!.send();
+    await multicallBundler!.waitForMine();
+    assert.equal((await multicaller!.methods.value().call()).toString(), "2");
+  });
+
+  it("Transactions not sent until send is called", async function () {
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+    multicallBundler!.addTransactions({ transaction: txnCast(multicaller!.methods.add("1")) });
+
+    assert.equal((await multicaller!.methods.value().call()).toString(), "0");
+    await multicallBundler!.send();
+    await multicallBundler!.waitForMine();
+  });
+});

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
     "@types/lodash-es": "^4.17.5",
     "@uma/contracts-frontend": "^0.1.17",
     "@uma/contracts-node": "^0.1.17",
-    "axios": "^0.21.4",
+    "axios": "^0.24.0",
     "bn.js": "^4.11.9",
     "decimal.js": "^10.3.1",
     "highland": "^2.13.5",

--- a/packages/sdk/src/across/transactionManager.ts
+++ b/packages/sdk/src/across/transactionManager.ts
@@ -39,7 +39,7 @@ export default (config: Config, signer: Signer, emit: Emit = () => null) => {
       submissions.set(key, sent.hash);
       emit("submitted", key, sent.hash);
     } catch (err) {
-      emit("error", key, err);
+      emit("error", key, err as Error);
     }
   }
   async function processSubmission(key: string) {

--- a/packages/sdk/src/tables/base/table.ts
+++ b/packages/sdk/src/tables/base/table.ts
@@ -30,7 +30,7 @@ export default function Table<I, D, S extends stores.Store<I, D>>(
   }
   async function get(id: I) {
     assert(await store.has(id), `${type} does not exist`);
-    return (await store.get(id)) as D & { id: I };
+    return ((await store.get(id)) as unknown) as D & { id: I };
   }
   async function has(id: I) {
     return store.has(id);

--- a/packages/trader/src/exchange-adapters/UniswapV2Trader.ts
+++ b/packages/trader/src/exchange-adapters/UniswapV2Trader.ts
@@ -47,7 +47,7 @@ export class UniswapV2Trader implements ExchangeAdapterInterface {
     try {
       return await this.dsProxyManager.callFunctionOnNewlyDeployedLibrary(callCode, callData);
     } catch (error) {
-      return error;
+      return error as Error;
     }
   }
 }

--- a/packages/trader/src/exchange-adapters/UniswapV3Trader.ts
+++ b/packages/trader/src/exchange-adapters/UniswapV3Trader.ts
@@ -41,7 +41,7 @@ export class UniswapV3Trader implements ExchangeAdapterInterface {
     try {
       return await this.dsProxyManager.callFunctionOnNewlyDeployedLibrary(callCode, callData);
     } catch (error) {
-      return error;
+      return error as Error;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7197,12 +7197,12 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@^0.21.4:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.4"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -12692,10 +12692,10 @@ follow-redirects@^1.10.0, follow-redirects@^1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
-follow-redirects@^1.14.0:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
-  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
+follow-redirects@^1.14.4:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
+  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23951,10 +23951,15 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.3.4, typescript@^4.3.5:
+typescript@^4.3.4:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+typescript@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
**Motivation**

We'd like the relayer bot to do as much batching as possible.

**Summary**

Rather than doing the batching within the transaction-producing code, this adds a separate bundler that transactions are added to over the course of the bot run. Then, the bundler sorts the transactions by target and fires off batches that are as large as possible.

Note: this upgrades the typescript version to get access to the `Awaited` generic type. This caused some issues with compilation elsewhere in the repo, which were fixed in this PR.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
