### PR TITLE
improve(cross-chain-oracle): Use Finder in PolygonChildMessenger

### DIFF
--- a/packages/common/src/Constants.ts
+++ b/packages/common/src/Constants.ts
@@ -14,6 +14,8 @@ export const interfaceName = {
   SinkOracle: "Oracle",
   SkinnyOptimisticOracle: "SkinnyOptimisticOracle",
   ChildMessenger: "ChildMessenger",
+  OracleSpoke: "OracleSpoke",
+  OracleHub: "OracleHub",
 };
 
 // These enforce the maximum number of transactions that can fit within one batch-commit and batch-reveal.

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
@@ -16,13 +16,7 @@ import "../../oracle/implementation/Constants.sol";
  */
 contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, Lockable {
     FinderInterface public finder;
-    // The only child network contract that can send messages over the bridge via the messenger is the OracleSpoke.
-    address public oracleSpoke;
-    // Store oracle hub address that OracleSpoke can send messages to via `sendMessageToParent`.
-    address public oracleHub;
 
-    event SetOracleSpoke(address newOracleSpoke);
-    event SetOracleHub(address newOracleHub);
     event MessageSentToParent(bytes data, address indexed targetHub, address indexed oracleSpoke);
     event MessageReceivedFromParent(address indexed targetSpoke, bytes dataToSendToTarget);
 
@@ -44,9 +38,9 @@ contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, L
      * @param data data message sent to the L1 messenger. Should be an encoded function call or packed data.
      */
     function sendMessageToParent(bytes memory data) public override nonReentrant() {
-        require(msg.sender == oracleSpoke, "Only callable by oracleSpoke");
-        _sendMessageToRoot(abi.encode(data, oracleHub));
-        emit MessageSentToParent(data, oracleHub, oracleSpoke);
+        require(msg.sender == getOracleSpoke(), "Only callable by oracleSpoke");
+        _sendMessageToRoot(abi.encode(data, getOracleHub()));
+        emit MessageSentToParent(data, getOracleHub(), getOracleSpoke());
     }
 
     /**

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
@@ -5,6 +5,8 @@ import "../../external/polygon/tunnel/FxBaseChildTunnel.sol";
 import "../interfaces/ChildMessengerInterface.sol";
 import "../interfaces/ChildMessengerConsumerInterface.sol";
 import "../../common/implementation/Lockable.sol";
+import "../../oracle/interfaces/FinderInterface.sol";
+import "../../oracle/implementation/Constants.sol";
 
 /**
  * @notice Sends cross chain messages from Polygon to Ethereum network.
@@ -13,6 +15,7 @@ import "../../common/implementation/Lockable.sol";
  * the internal `_processMessageFromRoot` function is only callable indirectly by the `Polygon_ParentMessenger`.
  */
 contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, Lockable {
+    FinderInterface public finder;
     // The only child network contract that can send messages over the bridge via the messenger is the OracleSpoke.
     address public oracleSpoke;
     // Store oracle hub address that OracleSpoke can send messages to via `sendMessageToParent`.
@@ -25,32 +28,12 @@ contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, L
 
     /**
      * @notice Construct the Polygon_ChildMessenger contract.
+     * @param _finder Used to locate contracts for this network.
      * @param _fxChild Polygon system contract deployed on Mainnet, required to construct new FxBaseRootTunnel
      * that can send messages via native Polygon data tunnel.
      */
-    constructor(address _fxChild) FxBaseChildTunnel(_fxChild) {}
-
-    /**
-     * @notice Set OracleSpoke address, which is the only address that can call `sendMessageToParent`.
-     * @dev Can only reset this address once.
-     * @param _oracleSpoke address of the new OracleSpoke, deployed on this network.
-     */
-    function setOracleSpoke(address _oracleSpoke) public nonReentrant() {
-        require(oracleSpoke == address(0x0), "OracleSpoke already set");
-        oracleSpoke = _oracleSpoke;
-        emit SetOracleSpoke(oracleSpoke);
-    }
-
-    /**
-     * @notice Set OracleHub address, which is always the target address for messages sent from this network to
-     * the parent network.
-     * @dev Can only reset this address once.
-     * @param _oracleHub address of the new OracleHub, deployed on the parent network.
-     */
-    function setOracleHub(address _oracleHub) public nonReentrant() {
-        require(oracleHub == address(0x0), "OracleHub already set");
-        oracleHub = _oracleHub;
-        emit SetOracleHub(oracleHub);
+    constructor(address _fxChild, address _finder) FxBaseChildTunnel(_fxChild) {
+        finder = FinderInterface(_finder);
     }
 
     /**
@@ -83,5 +66,13 @@ contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, L
         (bytes memory dataToSendToTarget, address target) = abi.decode(data, (bytes, address));
         ChildMessengerConsumerInterface(target).processMessageFromParent(dataToSendToTarget);
         emit MessageReceivedFromParent(target, dataToSendToTarget);
+    }
+
+    function getOracleSpoke() public view returns (address) {
+        return finder.getImplementationAddress(OracleInterfaces.OracleSpoke);
+    }
+
+    function getOracleHub() public view returns (address) {
+        return finder.getImplementationAddress(OracleInterfaces.OracleHub);
     }
 }

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/test/Polygon_ChildMessengerMock.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/test/Polygon_ChildMessengerMock.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "../Polygon_ChildMessenger.sol";
 
 contract Polygon_ChildMessengerMock is Polygon_ChildMessenger {
-    constructor(address _fxChild) Polygon_ChildMessenger(_fxChild) {}
+    constructor(address _fxChild, address _finder) Polygon_ChildMessenger(_fxChild, _finder) {}
 
     function processMessageFromRoot(address sender, bytes memory data) external {
         _processMessageFromRoot(

--- a/packages/core/contracts/oracle/implementation/Constants.sol
+++ b/packages/core/contracts/oracle/implementation/Constants.sol
@@ -16,6 +16,8 @@ library OracleInterfaces {
     bytes32 public constant GenericHandler = "GenericHandler";
     bytes32 public constant SkinnyOptimisticOracle = "SkinnyOptimisticOracle";
     bytes32 public constant ChildMessenger = "ChildMessenger";
+    bytes32 public constant OracleHub = "OracleHub";
+    bytes32 public constant OracleSpoke = "OracleSpoke";
 }
 
 /**


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently the `ChildMessenger` doesn't allow upgradeability of the `OracleHub` and `OracleSpoke`. This contract instead can easily implement upgradeability by reading these addresses from the `Finder` for the child network, which can be modified by L1 governance.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
