### PR TITLE
refactor(cross-chain-oracle): Add HasFinder base contract

### DIFF
--- a/packages/core/contracts/common/implementation/HasFinder.sol
+++ b/packages/core/contracts/common/implementation/HasFinder.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.8.9;
+
+// SPDX-License-Identifier: UNLICENSED
+import "../../oracle/interfaces/FinderInterface.sol";
+
+// Contract stores a reference to the DVM Finder contract which can be used to locate other important DVM contracts.
+contract HasFinder {
+    FinderInterface public finder;
+
+    constructor(address _finder) {
+        finder = FinderInterface(_finder);
+    }
+}

--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -10,12 +10,17 @@ import "./SpokeBase.sol";
  * @notice Governor contract deployed on L2 that receives governance actions from Ethereum.
  */
 contract GovernorSpoke is Lockable, SpokeBase, ChildMessengerConsumerInterface {
+    // Added as a convenient view method to determine this contract's set Finder address. The finder address stored
+    // in the SpokeBase is private for reasons specific to that contract, see its comments.
+    address public finder;
     struct Call {
         address to;
         bytes data;
     }
 
-    constructor(address _finderAddress) SpokeBase(_finderAddress) {}
+    constructor(address _finderAddress) SpokeBase(_finderAddress) {
+        finder = _finderAddress;
+    }
 
     event ExecutedGovernanceTransaction(address indexed to, bytes data);
 

--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -23,12 +23,12 @@ contract GovernorSpoke is Lockable, SpokeBase, ChildMessengerConsumerInterface {
      * @notice Executes governance transaction created on Ethereum.
      * @dev Can only be called by ChildMessenger contract that wants to execute governance action on this child chain
      * that originated from DVM voters on root chain. ChildMessenger should only receive communication from
-     * ParentMessenger on mainnet. See the SpokeBase for the onlyMessenger modifier.
+     * ParentMessenger on mainnet. See the SpokeBase for the onlyChildMessenger modifier.
 
      * @param data Contains the target address and the encoded function selector + ABI encoded params to include in
      * delegated transaction.
      */
-    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyMessenger() {
+    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyChildMessenger() {
         Call[] memory calls = abi.decode(data, (Call[]));
 
         for (uint256 i = 0; i < calls.length; i++) {

--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -23,12 +23,12 @@ contract GovernorSpoke is Lockable, SpokeBase, ChildMessengerConsumerInterface {
      * @notice Executes governance transaction created on Ethereum.
      * @dev Can only be called by ChildMessenger contract that wants to execute governance action on this child chain
      * that originated from DVM voters on root chain. ChildMessenger should only receive communication from
-     * ParentMessenger on mainnet. See the SpokeBase for the onlyChildMessenger modifier.
+     * ParentMessenger on mainnet. See the SpokeBase for the onlyMessenger modifier.
 
      * @param data Contains the target address and the encoded function selector + ABI encoded params to include in
      * delegated transaction.
      */
-    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyChildMessenger() {
+    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyMessenger() {
         Call[] memory calls = abi.decode(data, (Call[]));
 
         for (uint256 i = 0; i < calls.length; i++) {

--- a/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/GovernorSpoke.sol
@@ -10,17 +10,12 @@ import "./SpokeBase.sol";
  * @notice Governor contract deployed on L2 that receives governance actions from Ethereum.
  */
 contract GovernorSpoke is Lockable, SpokeBase, ChildMessengerConsumerInterface {
-    // Added as a convenient view method to determine this contract's set Finder address. The finder address stored
-    // in the SpokeBase is private for reasons specific to that contract, see its comments.
-    address public finder;
     struct Call {
         address to;
         bytes data;
     }
 
-    constructor(address _finderAddress) SpokeBase(_finderAddress) {
-        finder = _finderAddress;
-    }
+    constructor(address _finderAddress) HasFinder(_finderAddress) {}
 
     event ExecutedGovernanceTransaction(address indexed to, bytes data);
 

--- a/packages/core/contracts/cross-chain-oracle/OracleBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleBase.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.0;
 
 import "../oracle/interfaces/FinderInterface.sol";
 import "../oracle/implementation/Constants.sol";
+import "./SpokeBase.sol";
 
 /**
  * @title Cross-chain Oracle L1 Oracle Base.
  * @notice Enforces lifecycle of price requests for deriving contract.
  */
-abstract contract OracleBase {
+abstract contract OracleBase is SpokeBase {
     enum RequestState { NeverRequested, Requested, Resolved }
 
     struct Price {
@@ -18,9 +19,6 @@ abstract contract OracleBase {
 
     // Mapping of encoded price requests {identifier, time, ancillaryData} to Price objects.
     mapping(bytes32 => Price) internal prices;
-
-    // Finder to provide addresses for DVM system contracts.
-    FinderInterface public finder;
 
     event PriceRequestAdded(bytes32 indexed identifier, uint256 time, bytes ancillaryData, bytes32 indexed requestHash);
     event PushedPrice(
@@ -35,9 +33,7 @@ abstract contract OracleBase {
      * @notice Constructor.
      * @param _finderAddress finder to use to get addresses of DVM contracts.
      */
-    constructor(address _finderAddress) {
-        finder = FinderInterface(_finderAddress);
-    }
+    constructor(address _finderAddress) SpokeBase(_finderAddress) {}
 
     /**
      * @notice Enqueues a request (if a request isn't already present) for the given (identifier, time,

--- a/packages/core/contracts/cross-chain-oracle/OracleBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleBase.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.0;
 
 import "../oracle/interfaces/FinderInterface.sol";
 import "../oracle/implementation/Constants.sol";
+import "../common/implementation/HasFinder.sol";
 
 /**
  * @title Cross-chain Oracle L1 Oracle Base.
  * @notice Enforces lifecycle of price requests for deriving contract.
  */
-abstract contract OracleBase {
+abstract contract OracleBase is HasFinder {
     enum RequestState { NeverRequested, Requested, Resolved }
 
     struct Price {
@@ -19,9 +20,6 @@ abstract contract OracleBase {
     // Mapping of encoded price requests {identifier, time, ancillaryData} to Price objects.
     mapping(bytes32 => Price) internal prices;
 
-    // Finder to provide addresses for DVM system contracts.
-    FinderInterface public finder;
-
     event PriceRequestAdded(bytes32 indexed identifier, uint256 time, bytes ancillaryData, bytes32 indexed requestHash);
     event PushedPrice(
         bytes32 indexed identifier,
@@ -30,14 +28,6 @@ abstract contract OracleBase {
         int256 price,
         bytes32 indexed requestHash
     );
-
-    /**
-     * @notice Constructor.
-     * @param _finderAddress finder to use to get addresses of DVM contracts.
-     */
-    constructor(address _finderAddress) {
-        finder = FinderInterface(_finderAddress);
-    }
 
     /**
      * @notice Enqueues a request (if a request isn't already present) for the given (identifier, time,

--- a/packages/core/contracts/cross-chain-oracle/OracleBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleBase.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.8.0;
 
 import "../oracle/interfaces/FinderInterface.sol";
 import "../oracle/implementation/Constants.sol";
-import "./SpokeBase.sol";
 
 /**
  * @title Cross-chain Oracle L1 Oracle Base.
  * @notice Enforces lifecycle of price requests for deriving contract.
  */
-abstract contract OracleBase is SpokeBase {
+abstract contract OracleBase {
     enum RequestState { NeverRequested, Requested, Resolved }
 
     struct Price {
@@ -19,6 +18,9 @@ abstract contract OracleBase is SpokeBase {
 
     // Mapping of encoded price requests {identifier, time, ancillaryData} to Price objects.
     mapping(bytes32 => Price) internal prices;
+
+    // Finder to provide addresses for DVM system contracts.
+    FinderInterface public finder;
 
     event PriceRequestAdded(bytes32 indexed identifier, uint256 time, bytes ancillaryData, bytes32 indexed requestHash);
     event PushedPrice(
@@ -33,7 +35,9 @@ abstract contract OracleBase is SpokeBase {
      * @notice Constructor.
      * @param _finderAddress finder to use to get addresses of DVM contracts.
      */
-    constructor(address _finderAddress) SpokeBase(_finderAddress) {}
+    constructor(address _finderAddress) {
+        finder = FinderInterface(_finderAddress);
+    }
 
     /**
      * @notice Enqueues a request (if a request isn't already present) for the given (identifier, time,

--- a/packages/core/contracts/cross-chain-oracle/OracleHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleHub.sol
@@ -37,7 +37,7 @@ contract OracleHub is OracleBase, ParentMessengerConsumerInterface, Ownable, Loc
         token = _token;
     }
 
-    modifier onlyMessenger(uint256 chainId) {
+    modifier onlyParentMessenger(uint256 chainId) {
         require(msg.sender == address(messengers[chainId]), "Caller must be messenger for network");
         _;
     }
@@ -108,7 +108,7 @@ contract OracleHub is OracleBase, ParentMessengerConsumerInterface, Ownable, Loc
         public
         override
         nonReentrant()
-        onlyMessenger(chainId)
+        onlyParentMessenger(chainId)
     {
         (bytes32 identifier, uint256 time, bytes memory ancillaryData) = abi.decode(data, (bytes32, uint256, bytes));
         bool newPriceRequested = _requestPrice(identifier, time, ancillaryData);

--- a/packages/core/contracts/cross-chain-oracle/OracleHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleHub.sol
@@ -33,7 +33,7 @@ contract OracleHub is OracleBase, ParentMessengerConsumerInterface, Ownable, Loc
 
     event SetParentMessenger(uint256 indexed chainId, address indexed parentMessenger);
 
-    constructor(address _finderAddress, IERC20 _token) OracleBase(_finderAddress) {
+    constructor(address _finderAddress, IERC20 _token) HasFinder(_finderAddress) {
         token = _token;
     }
 

--- a/packages/core/contracts/cross-chain-oracle/OracleHub.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleHub.sol
@@ -37,7 +37,7 @@ contract OracleHub is OracleBase, ParentMessengerConsumerInterface, Ownable, Loc
         token = _token;
     }
 
-    modifier onlyParentMessenger(uint256 chainId) {
+    modifier onlyMessenger(uint256 chainId) {
         require(msg.sender == address(messengers[chainId]), "Caller must be messenger for network");
         _;
     }
@@ -108,7 +108,7 @@ contract OracleHub is OracleBase, ParentMessengerConsumerInterface, Ownable, Loc
         public
         override
         nonReentrant()
-        onlyParentMessenger(chainId)
+        onlyMessenger(chainId)
     {
         (bytes32 identifier, uint256 time, bytes memory ancillaryData) = abi.decode(data, (bytes32, uint256, bytes));
         bool newPriceRequested = _requestPrice(identifier, time, ancillaryData);

--- a/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
@@ -23,13 +23,12 @@ import "./SpokeBase.sol";
  */
 contract OracleSpoke is
     OracleBase,
-    SpokeBase,
     OracleAncillaryInterface,
     OracleInterface,
     ChildMessengerConsumerInterface,
     Lockable
 {
-    constructor(address _finderAddress) OracleBase(_finderAddress) SpokeBase(_finderAddress) {}
+    constructor(address _finderAddress) OracleBase(_finderAddress) {}
 
     // This assumes that the local network has a Registry that resembles the mainnet registry.
     modifier onlyRegisteredContract() {
@@ -75,10 +74,10 @@ contract OracleSpoke is
     /**
      * @notice Resolves a price request originating from a message sent by the DVM on the parent chain.
      * @dev Can only be called by the ChildMessenger contract which is designed to communicate only with the
-     * ParentMessenger contract on Mainnet. See the SpokeBase for the onlyMessenger modifier.
+     * ParentMessenger contract on Mainnet. See the SpokeBase for the onlyChildMessenger modifier.
      * @param data ABI encoded params with which to call `_publishPrice`.
      */
-    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyMessenger() {
+    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyChildMessenger() {
         (bytes32 identifier, uint256 time, bytes memory ancillaryData, int256 price) =
             abi.decode(data, (bytes32, uint256, bytes, int256));
         _publishPrice(identifier, time, ancillaryData, price);

--- a/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
@@ -23,12 +23,13 @@ import "./SpokeBase.sol";
  */
 contract OracleSpoke is
     OracleBase,
+    SpokeBase,
     OracleAncillaryInterface,
     OracleInterface,
     ChildMessengerConsumerInterface,
     Lockable
 {
-    constructor(address _finderAddress) OracleBase(_finderAddress) {}
+    constructor(address _finderAddress) OracleBase(_finderAddress) SpokeBase(_finderAddress) {}
 
     // This assumes that the local network has a Registry that resembles the mainnet registry.
     modifier onlyRegisteredContract() {
@@ -74,10 +75,10 @@ contract OracleSpoke is
     /**
      * @notice Resolves a price request originating from a message sent by the DVM on the parent chain.
      * @dev Can only be called by the ChildMessenger contract which is designed to communicate only with the
-     * ParentMessenger contract on Mainnet. See the SpokeBase for the onlyChildMessenger modifier.
+     * ParentMessenger contract on Mainnet. See the SpokeBase for the onlyMessenger modifier.
      * @param data ABI encoded params with which to call `_publishPrice`.
      */
-    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyChildMessenger() {
+    function processMessageFromParent(bytes memory data) public override nonReentrant() onlyMessenger() {
         (bytes32 identifier, uint256 time, bytes memory ancillaryData, int256 price) =
             abi.decode(data, (bytes32, uint256, bytes, int256));
         _publishPrice(identifier, time, ancillaryData, price);

--- a/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
+++ b/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol
@@ -29,7 +29,7 @@ contract OracleSpoke is
     ChildMessengerConsumerInterface,
     Lockable
 {
-    constructor(address _finderAddress) OracleBase(_finderAddress) SpokeBase(_finderAddress) {}
+    constructor(address _finderAddress) HasFinder(_finderAddress) {}
 
     // This assumes that the local network has a Registry that resembles the mainnet registry.
     modifier onlyRegisteredContract() {

--- a/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
@@ -13,6 +13,8 @@ import "../oracle/implementation/Constants.sol";
  */
 
 contract SpokeBase {
+    // Note: This is private because `OracleSpoke` inherits both `OracleBase` and this contract and there cannot be
+    // two public `finder` global variables.
     FinderInterface private finder;
 
     constructor(address _finderAddress) {

--- a/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
@@ -13,13 +13,13 @@ import "../oracle/implementation/Constants.sol";
  */
 
 contract SpokeBase {
-    FinderInterface private finder;
+    FinderInterface public finder;
 
     constructor(address _finderAddress) {
         finder = FinderInterface(_finderAddress);
     }
 
-    modifier onlyMessenger() {
+    modifier onlyChildMessenger() {
         require(msg.sender == address(getChildMessenger()), "Caller must be messenger");
         _;
     }

--- a/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
@@ -1,26 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
-
-import "../oracle/interfaces/FinderInterface.sol";
-
 import "./interfaces/ChildMessengerInterface.sol";
 
 import "../oracle/implementation/Constants.sol";
+import "../common/implementation/HasFinder.sol";
 
 /**
  * @title Cross-chain Oracle L2 Spoke Base.
  * @notice Provides access control to Governance and Oracle spoke L2 contracts.
  */
 
-contract SpokeBase {
-    // Note: This is private because `OracleSpoke` inherits both `OracleBase` and this contract and there cannot be
-    // two public `finder` global variables.
-    FinderInterface private finder;
-
-    constructor(address _finderAddress) {
-        finder = FinderInterface(_finderAddress);
-    }
-
+abstract contract SpokeBase is HasFinder {
     modifier onlyMessenger() {
         require(msg.sender == address(getChildMessenger()), "Caller must be messenger");
         _;

--- a/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
+++ b/packages/core/contracts/cross-chain-oracle/SpokeBase.sol
@@ -13,13 +13,13 @@ import "../oracle/implementation/Constants.sol";
  */
 
 contract SpokeBase {
-    FinderInterface public finder;
+    FinderInterface private finder;
 
     constructor(address _finderAddress) {
         finder = FinderInterface(_finderAddress);
     }
 
-    modifier onlyChildMessenger() {
+    modifier onlyMessenger() {
         require(msg.sender == address(getChildMessenger()), "Caller must be messenger");
         _;
     }

--- a/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
+++ b/packages/core/contracts/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.sol
@@ -7,6 +7,7 @@ import "../interfaces/ChildMessengerConsumerInterface.sol";
 import "../../common/implementation/Lockable.sol";
 import "../../oracle/interfaces/FinderInterface.sol";
 import "../../oracle/implementation/Constants.sol";
+import "../../common/implementation/HasFinder.sol";
 
 /**
  * @notice Sends cross chain messages from Polygon to Ethereum network.
@@ -14,9 +15,7 @@ import "../../oracle/implementation/Constants.sol";
  * `FxBaseRootTunnel` extended by the `Polygon_ParentMessenger` contract deployed on Polygon. This mapping ensures that
  * the internal `_processMessageFromRoot` function is only callable indirectly by the `Polygon_ParentMessenger`.
  */
-contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, Lockable {
-    FinderInterface public finder;
-
+contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, Lockable, HasFinder {
     event MessageSentToParent(bytes data, address indexed targetHub, address indexed oracleSpoke);
     event MessageReceivedFromParent(address indexed targetSpoke, bytes dataToSendToTarget);
 
@@ -26,9 +25,7 @@ contract Polygon_ChildMessenger is FxBaseChildTunnel, ChildMessengerInterface, L
      * @param _fxChild Polygon system contract deployed on Mainnet, required to construct new FxBaseRootTunnel
      * that can send messages via native Polygon data tunnel.
      */
-    constructor(address _fxChild, address _finder) FxBaseChildTunnel(_fxChild) {
-        finder = FinderInterface(_finder);
-    }
+    constructor(address _fxChild, address _finder) FxBaseChildTunnel(_fxChild) HasFinder(_finder) {}
 
     /**
      * @notice Sends a message to the OracleSpoke via the parent messenger and the canonical message bridge.

--- a/packages/core/contracts/cross-chain-oracle/test/OracleBaseMock.sol
+++ b/packages/core/contracts/cross-chain-oracle/test/OracleBaseMock.sol
@@ -7,7 +7,7 @@ import "../OracleBase.sol";
  * @title Test implementation of OracleBase enabling unit tests on internal methods.
  */
 contract OracleBaseMock is OracleBase {
-    constructor(address _finderAddress) OracleBase(_finderAddress) {}
+    constructor(address _finderAddress) HasFinder(_finderAddress) {}
 
     function requestPrice(
         bytes32 identifier,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

I discovered while testing out contracts on live test networks that the `GovernorSpoke` does not make its `finder` address public. This is because the `GovernorSpoke` inherits the `SpokeBase` who's `finder` global variable is private. 

I found this a puzzling design choice so I flipped it to `public`, only to run into compile errors. This is because `OracleBase` also has a `finder` global variable that is `public`, and the `OracleSpoke` inherits both `OracleBase` and `SpokeBase`.

The very simple but naive fix was to add a `finder` public variable to the one contract that _only_ inherits `SpokeBase` but not `OracleBase`: the `GovernorSpoke` contract.

However, it feels weird (cc @mrice32 ) to keep having to declare `finder` in contracts that inherit one another. Instead, we should add a `HasFinder` contract that any contract can inherit and share the same `finder` variable.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
