### PR TITLE
feat(sdk): basic erc20 and erc20 multicall client

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.ts
+++ b/packages/sdk/src/across/clients/bridgePool.ts
@@ -93,7 +93,13 @@ class PoolState {
       address: this.address,
       l1Token: this.l1Token,
       exchangeRatePrevious,
-      ...(await this.batchRead([
+      ...(await this.batchRead<{
+        exchangeRateCurrent: BigNumber;
+        liquidityUtilizationCurrent: BigNumber;
+        liquidReserves: BigNumber;
+        pendingReserves: BigNumber;
+        utilizedReserves: BigNumber;
+      }>([
         // its important exchangeRateCurrent is called first, as it calls _sync under the hood which updates the contract
         // and gives more accurate values for the following properties.
         ["exchangeRateCurrent"],

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,7 @@ export * as stores from "./stores";
 export * as tables from "./tables";
 export * as utils from "./utils";
 export * as across from "./across";
+export * as oracle from "./oracle";
 export { default as Coingecko } from "./coingecko";
 export { default as Multicall } from "./multicall";
 export { default as Multicall2 } from "./multicall2";

--- a/packages/sdk/src/oracle/index.ts
+++ b/packages/sdk/src/oracle/index.ts
@@ -1,0 +1,1 @@
+export * as services from "./services";

--- a/packages/sdk/src/oracle/services/erc20.ts
+++ b/packages/sdk/src/oracle/services/erc20.ts
@@ -1,0 +1,43 @@
+import { erc20 } from "../../clients";
+import Multicall2 from "../../multicall2";
+import { BatchReadWithErrors, BatchReadWithErrorsType, Calls } from "../../utils";
+import { BigNumber, Provider } from "../types/ethers";
+
+const batchProps: Calls = [["symbol"], ["name"], ["decimals"], ["totalSupply"]];
+type Props = {
+  symbol: string;
+  name: string;
+  decimals: number;
+  totalSupply: BigNumber;
+};
+export class Erc20 {
+  public contract: erc20.Instance;
+  constructor(protected provider: Provider, protected address: string) {
+    this.contract = erc20.connect(address, provider);
+  }
+  async getProps(): Promise<Props> {
+    const { contract } = this;
+    return {
+      symbol: await contract.callStatic.symbol(),
+      name: await contract.callStatic.name(),
+      decimals: await contract.callStatic.decimals(),
+      totalSupply: await contract.callStatic.totalSupply(),
+    };
+  }
+}
+export class Erc20Multicall extends Erc20 {
+  private multicall: Multicall2;
+  private batchRead: BatchReadWithErrorsType;
+  constructor(provider: Provider, address: string, private multicallAddress: string) {
+    super(provider, address);
+    this.multicall = new Multicall2(multicallAddress, this.provider);
+    this.batchRead = BatchReadWithErrors(this.multicall)(this.contract);
+  }
+  async getProps(): Promise<Props> {
+    return this.batchRead<Props>(batchProps);
+  }
+}
+export function factory(provider: Provider, address: string, multicallAddress?: string) {
+  if (!multicallAddress) return new Erc20(provider, address);
+  return new Erc20Multicall(provider, address, multicallAddress);
+}

--- a/packages/sdk/src/oracle/services/index.ts
+++ b/packages/sdk/src/oracle/services/index.ts
@@ -1,0 +1,1 @@
+export * as erc20 from "./erc20";

--- a/packages/sdk/src/oracle/services/tests/erc20.e2e.ts
+++ b/packages/sdk/src/oracle/services/tests/erc20.e2e.ts
@@ -1,0 +1,44 @@
+import dotenv from "dotenv";
+import assert from "assert";
+import { ethers } from "ethers";
+import { Provider } from "@ethersproject/providers";
+import { factory, Erc20 } from "../erc20";
+import { MULTICALL2_ADDRESS } from "../../constants";
+
+dotenv.config();
+
+const wethAddress = "0x7355Efc63Ae731f584380a9838292c7046c1e433";
+
+describe("Erc20 E2E", function () {
+  let provider: Provider;
+  let erc20: Erc20;
+  beforeAll(async () => {
+    provider = ethers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+  });
+  describe("Erc20", function () {
+    beforeAll(async () => {
+      erc20 = factory(provider, wethAddress);
+    });
+    test("getProps", async function () {
+      jest.setTimeout(30000);
+      const result = await erc20.getProps();
+      assert.ok(result.symbol);
+      assert.ok(result.name);
+      assert.ok(result.decimals);
+      assert.ok(result.totalSupply.toString());
+    });
+  });
+  describe("Erc20Multicall", function () {
+    beforeAll(async () => {
+      erc20 = factory(provider, wethAddress, MULTICALL2_ADDRESS);
+    });
+    test("getProps", async function () {
+      jest.setTimeout(30000);
+      const result = await erc20.getProps();
+      assert.ok(result.symbol);
+      assert.ok(result.name);
+      assert.ok(result.decimals);
+      assert.ok(result.totalSupply.toString());
+    });
+  });
+});

--- a/packages/sdk/src/oracle/types/ethers.ts
+++ b/packages/sdk/src/oracle/types/ethers.ts
@@ -1,0 +1,3 @@
+export type { Signer, BigNumber, BigNumberish, Contract } from "ethers";
+export type { Overrides } from "@ethersproject/contracts";
+export { Provider } from "@ethersproject/providers";

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -72,9 +72,12 @@ export async function loop(fn: (...args: any[]) => any, delay: number, ...args: 
   } while (true);
 }
 
-type Call = [string, ...any[]];
-type Calls = Call[];
-export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contract) => async (calls: Calls) => {
+export type Call = [string, ...BigNumberish[]];
+export type Calls = Call[];
+export type BatchReadWithErrorsType = ReturnType<ReturnType<typeof BatchReadWithErrors>>;
+export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contract) => async <R>(
+  calls: Calls
+): Promise<R> => {
   // multicall batch takes array of {method} objects
   const results = await multicall2
     .batch(


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/3779/add-basic-erc20-service-for-oo-in-sdk


**Summary**

This basic client will be used during the approval flow in the full oracle client eventually. Factory creates a client with or without multicall as multicall is not available on all chains.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


