### PR TITLE
feat(pf-configs): Add default pf config for CVXUSD and USDCVX

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
@@ -984,6 +984,34 @@ export const defaultConfigs: { [name: string]: { type: string; [key: string]: an
     bridgeAdminAddress: "0x30B44C676A05F1264d1dE9cC31dB5F2A945186b6",
     rateModels: across.constants.RATE_MODELS,
   },
+  CVXUSD: {
+    type: "expression",
+    expression: ` 
+      convex_usd_sushi = ETHUSD * CVX_WETH_SUSHI;
+      convex_usd_uni = ETHUSD * CVX_WETH_UNI;
+      median( convex_usd_sushi, convex_usd_uni, CVX_USD_OKEX )
+    `,
+    lookback: 7200,
+    minTimeBetweenUpdates: 60,
+    customFeeds: {
+      CVX_WETH_SUSHI: {
+        type: "uniswap",
+        uniswapAddress: "0x05767d9EF41dC40689678fFca0608878fb3dE906",
+        twapLength: 300,
+      },
+      CVX_WETH_UNI: {
+        type: "uniswap",
+        version: "v3",
+        uniswapAddress: "0x2E4784446A0a06dF3D1A040b03e1680Ee266c35a",
+        twapLength: 300,
+      },
+      CVX_USD_OKEX: { type: "cryptowatch", exchange: "okex", pair: "cvxusdt", twapLength: 300 },
+    },
+  },
+  USDCVX: {
+    type: "expression",
+    expression: "1 / CVXUSD",
+  },
 };
 
 // Pull in the number of decimals for each identifier from the common getPrecisionForIdentifier. This is used within the


### PR DESCRIPTION
**Motivation**

The CVXUSD and USDCVX price identifiers from [UMIP-141](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-141.md) need default price feed configs.

**Summary**

Adds default price feed configs.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

NA
