### PR TITLE
fix: fix profitability module

### DIFF
--- a/packages/insured-bridge-relayer/src/ProfitabilityCalculator.ts
+++ b/packages/insured-bridge-relayer/src/ProfitabilityCalculator.ts
@@ -26,7 +26,7 @@ const costConstants = {
 };
 
 export class ProfitabilityCalculator {
-  public l1TokenInfo: { [token: string]: { tokenType: TokenType; tokenEthPrice: BN; tokenDecimals: BN } } = {};
+  public l1TokenInfo: { [token: string]: { tokenType: TokenType; tokenEthPrice: BN; decimals: BN } } = {};
 
   public relayerDiscount: BN;
 
@@ -64,7 +64,7 @@ export class ProfitabilityCalculator {
         await getAddress("WETH9", this.l1ChainId),
       ]);
       for (const l1Token of this.l1Tokens) {
-        this.l1TokenInfo[l1Token] = { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("1") };
+        this.l1TokenInfo[l1Token] = { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("1"), decimals: toBN("18") };
         if (l1Token == toChecksumAddress(umaAddress)) this.l1TokenInfo[l1Token].tokenType = TokenType.UMA;
         else if (l1Token == toChecksumAddress(wethAddress)) this.l1TokenInfo[l1Token].tokenType = TokenType.WETH;
       }
@@ -97,12 +97,14 @@ export class ProfitabilityCalculator {
       }
     }
 
-    // Get decimals for each token.
-    const tokenDecimals = await Promise.all(
-      this.l1Tokens.map((l1Token) => new this.l1Web3.eth.Contract(getAbi("ERC20"), l1Token).methods.decimals().call())
+    // Set decimals for each token.
+    await Promise.all(
+      this.l1Tokens.map(async (l1Token) => {
+        const erc20 = new this.l1Web3.eth.Contract(getAbi("ERC20"), l1Token);
+        const decimals = await erc20.methods.decimals().call();
+        this.l1TokenInfo[l1Token].decimals = toBN(decimals.toString());
+      })
     );
-
-    tokenDecimals.forEach();
 
     this.logger.debug({
       at: "ProfitabilityCalculator",
@@ -122,7 +124,7 @@ export class ProfitabilityCalculator {
   ): RelaySubmitType {
     this._throwIfNotInitialized();
     if (!this.l1TokenInfo[l1Token]) throw new Error("Token info not found. Ensure to construct correctly");
-    const { tokenType, tokenEthPrice } = this.l1TokenInfo[l1Token];
+    const { tokenType, tokenEthPrice, decimals } = this.l1TokenInfo[l1Token];
 
     // If the relayer discount is 100% then we can relay tokens with a price of 0. Else, if the price is zero then there
     // is no way that this is a profitable relay. In this case, error out.
@@ -147,7 +149,7 @@ export class ProfitabilityCalculator {
     const ethSubmissionCost = this.getRelayEthSubmissionCost(cumulativeGasPrice, tokenType);
 
     // Calculate the expected revenue, in ETH, based on the amount of tokens being offered in fees.
-    const ethRevenue = this.getEthRevenue(tokenEthPrice, slowRevenue, speedUpRevenue, instantRevenue);
+    const ethRevenue = this.getEthRevenue(tokenEthPrice, slowRevenue, speedUpRevenue, instantRevenue, decimals);
 
     // Calculate the relay profitability as the difference between revenue and cost.
     const ethProfitability = this.getProfit(ethSubmissionCost, ethRevenue);
@@ -198,16 +200,18 @@ export class ProfitabilityCalculator {
     tokenPrice: BN,
     slowRevenue: BN,
     speedUpRevenue: BN,
-    instantRevenue: BN
+    instantRevenue: BN,
+    tokenDecimals: BN
   ): {
     slowEthRevenue: BN;
     speedUpEthRevenue: BN;
     instantEthRevenue: BN;
   } {
+    const tokenDecimalMultiplier = toBN(10).pow(tokenDecimals);
     return {
-      slowEthRevenue: slowRevenue.mul(tokenPrice).div(fixedPoint),
-      speedUpEthRevenue: speedUpRevenue.mul(tokenPrice).div(fixedPoint),
-      instantEthRevenue: instantRevenue.mul(tokenPrice).div(fixedPoint),
+      slowEthRevenue: slowRevenue.mul(tokenPrice).div(tokenDecimalMultiplier),
+      speedUpEthRevenue: speedUpRevenue.mul(tokenPrice).div(tokenDecimalMultiplier),
+      instantEthRevenue: instantRevenue.mul(tokenPrice).div(tokenDecimalMultiplier),
     };
   }
 

--- a/packages/insured-bridge-relayer/src/ProfitabilityCalculator.ts
+++ b/packages/insured-bridge-relayer/src/ProfitabilityCalculator.ts
@@ -137,6 +137,7 @@ export class ProfitabilityCalculator {
       l1Token,
       tokenType: TokenType[tokenType],
       tokenEthPrice: fromWei(tokenEthPrice),
+      tokenDecimals: decimals.toString(),
       cumulativeGasPrice: cumulativeGasPrice.toString(),
       relayerDiscount: fromWei(this.relayerDiscount),
       slowRevenue: slowRevenue.toString(),

--- a/packages/insured-bridge-relayer/src/ProfitabilityCalculator.ts
+++ b/packages/insured-bridge-relayer/src/ProfitabilityCalculator.ts
@@ -6,7 +6,7 @@ const fixedPoint = toBNWei(1);
 
 import { objectMap } from "@uma/common";
 import { Coingecko, across } from "@uma/sdk";
-import { getAddress } from "@uma/contracts-node";
+import { getAddress, getAbi } from "@uma/contracts-node";
 
 import { RelaySubmitType } from "./Relayer";
 
@@ -26,7 +26,7 @@ const costConstants = {
 };
 
 export class ProfitabilityCalculator {
-  public l1TokenInfo: { [token: string]: { tokenType: TokenType; tokenEthPrice: BN } } = {};
+  public l1TokenInfo: { [token: string]: { tokenType: TokenType; tokenEthPrice: BN; tokenDecimals: BN } } = {};
 
   public relayerDiscount: BN;
 
@@ -44,6 +44,7 @@ export class ProfitabilityCalculator {
     readonly logger: winston.Logger,
     readonly l1Tokens: string[],
     readonly l1ChainId: number,
+    readonly l1Web3: Web3,
     readonly relayerDiscountNumber: number = 0
   ) {
     this.relayerDiscount = toBNWei(Math.floor(relayerDiscountNumber)).div(toBN("100"));
@@ -95,6 +96,14 @@ export class ProfitabilityCalculator {
         });
       }
     }
+
+    // Get decimals for each token.
+    const tokenDecimals = await Promise.all(
+      this.l1Tokens.map((l1Token) => new this.l1Web3.eth.Contract(getAbi("ERC20"), l1Token).methods.decimals().call())
+    );
+
+    tokenDecimals.forEach();
+
     this.logger.debug({
       at: "ProfitabilityCalculator",
       message: "Updated prices",

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -91,6 +91,7 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
           logger,
           filteredL1Whitelist,
           l1ChainId,
+          l1Web3,
           config.relayerDiscount
         );
 

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -1642,8 +1642,8 @@ describe("Relayer.ts", function () {
         100 // 100% discount (ignores profitability calculator)
       );
       profitabilityCalculator.setL1TokenInfo({
-        [l1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1") },
-        [newL1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1") },
+        [l1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1"), decimals: toBN(18) },
+        [newL1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1"), decimals: toBN(18) },
       });
       relayer = new Relayer(
         spyLogger,

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -233,7 +233,7 @@ describe("Relayer.ts", function () {
     // Create the profitabilityCalculator. Set the discount rate to 100% so that the calculator does not consider the
     // cost of the l1 token. In doing so, we only test the relayer directly, ignoring profitability. The calculator will
     // return the relay type that produces the most revenue, irrespective of cost.
-    profitabilityCalculator = new MockProfitabilityCalculator(spyLogger, [l1Token.options.address], 1, 100);
+    profitabilityCalculator = new MockProfitabilityCalculator(spyLogger, [l1Token.options.address], 1, web3, 100);
     profitabilityCalculator.setL1TokenInfo({
       [l1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1") },
     });
@@ -1638,6 +1638,7 @@ describe("Relayer.ts", function () {
         spyLogger,
         [l1Token.options.address, newL1Token.options.address],
         1,
+        web3,
         100 // 100% discount (ignores profitability calculator)
       );
       profitabilityCalculator.setL1TokenInfo({

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -235,7 +235,7 @@ describe("Relayer.ts", function () {
     // return the relay type that produces the most revenue, irrespective of cost.
     profitabilityCalculator = new MockProfitabilityCalculator(spyLogger, [l1Token.options.address], 1, web3, 100);
     profitabilityCalculator.setL1TokenInfo({
-      [l1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1") },
+      [l1Token.options.address]: { tokenType: TokenType.ERC20, tokenEthPrice: toBNWei("0.1"), decimals: toBN(18) },
     });
 
     relayer = new Relayer(

--- a/packages/insured-bridge-relayer/test/mocks/MockProfitabilityCalculator.ts
+++ b/packages/insured-bridge-relayer/test/mocks/MockProfitabilityCalculator.ts
@@ -5,7 +5,7 @@ import { ProfitabilityCalculator } from "../../src/ProfitabilityCalculator";
 import type { TokenType } from "../../src/ProfitabilityCalculator";
 
 export class MockProfitabilityCalculator extends ProfitabilityCalculator {
-  setL1TokenInfo(l1TokenInfo: { [token: string]: { tokenType: TokenType; tokenEthPrice: BN } }) {
+  setL1TokenInfo(l1TokenInfo: { [token: string]: { tokenType: TokenType; tokenEthPrice: BN; decimals: BN } }) {
     this.l1TokenInfo = l1TokenInfo;
   }
   async update() {


### PR DESCRIPTION
**Motivation**

There is a bug in the profitability module that affects tokens whose decimals are != 18.


**Summary**

The profitability module now uses the token's decimals to convert between the amount of the token and its corresponding value in ETH.

Note: this doesn't add new tests. Rather, it modifies existing tests to take decimals into account.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
