### PR TITLE
feat(sdk): add basic state reader to oo client

### DIFF
--- a/packages/sdk/src/oracle/services/erc20.ts
+++ b/packages/sdk/src/oracle/services/erc20.ts
@@ -37,7 +37,7 @@ export class Erc20Multicall extends Erc20 {
     return this.batchRead<Props>(batchProps);
   }
 }
-export function factory(provider: Provider, address: string, multicallAddress?: string) {
+export function factory(provider: Provider, address: string, multicallAddress?: string): Erc20 {
   if (!multicallAddress) return new Erc20(provider, address);
   return new Erc20Multicall(provider, address, multicallAddress);
 }

--- a/packages/sdk/src/oracle/store/index.ts
+++ b/packages/sdk/src/oracle/store/index.ts
@@ -1,15 +1,17 @@
 import Write from "./write";
+import Read from "./read";
+
 import Store, { WriteCallback, Emit } from "./store";
 import { State } from "../types/state";
 
-export { Write, Store };
+export { Write, Store, Read };
 
 /**
  * OracleStore. Wraps the store with a specific state shape and passes the Write client through to end user.
  */
 export default class OracleStore {
   private store: Store<State>;
-  constructor(private emit: Emit<State>, private state: State = {}) {
+  constructor(private emit: Emit<State> = () => undefined, private state: State = {}) {
     this.store = new Store(emit, state);
   }
   /**
@@ -17,7 +19,24 @@ export default class OracleStore {
    *
    * @param {WriteCallback} cb - Sends a write client to the caller for safer and easier state mutations rather than the raw object.
    */
-  write(cb: WriteCallback<Write>) {
+  write = (cb: WriteCallback<Write>): void => {
     this.store.write((state) => cb(new Write(state)));
-  }
+  };
+  /**
+   * read - Function for reading from state. Returns a read client to the user.
+   *
+   * @returns {Read}
+   */
+  read = (): Read => {
+    return new Read(this.store.read());
+  };
+  /**
+   * get - Function for getting access to the raw state object, not wrapped by the reader class.
+   * State should not be modified directly and treated as read only.
+   *
+   * @returns {State}
+   */
+  get = (): State => {
+    return this.store.read();
+  };
 }

--- a/packages/sdk/src/oracle/store/read.ts
+++ b/packages/sdk/src/oracle/store/read.ts
@@ -1,0 +1,52 @@
+import assert from "assert";
+
+import type { State, Chain, Inputs, Request } from "../types/state";
+import type { Signer } from "../types/ethers";
+
+// This is a typescript compatible way of pulling out values from the global state object, essentially
+// forming a basic API. Most calls are parameterless, requiring first setting state which determines, the
+// user/chain, etc of the query.
+
+export default class Read {
+  constructor(private state: State) {}
+  chainId(): number {
+    const chainId = this.state?.user?.chainId;
+    assert(chainId, "ChainId is not set");
+    return chainId;
+  }
+  chain(): Partial<Chain> {
+    const chainId = this.chainId();
+    const chain = this.state?.chains?.[chainId];
+    assert(chain, "Chain not set");
+    return chain;
+  }
+  userAddress(): string {
+    const address = this.state?.user?.address;
+    assert(address, "User address is not set");
+    return address;
+  }
+  oracleAddress(): string {
+    const chain = this.chain();
+    const address = chain?.optimisticOracle?.address;
+    assert(address, "Optimistic oracle address not set");
+    return address;
+  }
+  signer(): Signer {
+    const signer = this.state?.user?.signer;
+    assert(signer, "Signer is not set");
+    return signer;
+  }
+  inputRequest(): Inputs["request"] {
+    const input = this.state?.inputs?.request;
+    assert(input, "Input request is not set");
+    return input;
+  }
+  request(): Request {
+    const chain = this.chain();
+    const input = this.inputRequest();
+    const id = [input.requester, input.identifier, input.timestamp, input.ancillaryData].join("!");
+    const request = chain?.optimisticOracle?.requests?.[id];
+    assert(request, "Request has not been fetched");
+    return request;
+  }
+}

--- a/packages/sdk/src/oracle/store/store.ts
+++ b/packages/sdk/src/oracle/store/store.ts
@@ -21,7 +21,7 @@ export default class Store<S> {
    *
    * @param {WriteCallback} cb
    */
-  write(cb: WriteCallback<S>) {
+  write(cb: WriteCallback<S>): void {
     const prevState = this.state;
 
     // immer's produce method, takes an object, and passes a draft of that object to the callback. Any changes to the draft
@@ -31,5 +31,8 @@ export default class Store<S> {
 
     // Once state is changed, an event is emitted, this is how we get changes out of the client and also allow for change detection.
     this.emit(this.state, prevState);
+  }
+  read(): S {
+    return this.state;
   }
 }

--- a/packages/sdk/src/oracle/store/test/store.test.ts
+++ b/packages/sdk/src/oracle/store/test/store.test.ts
@@ -43,4 +43,12 @@ describe("Oracle Store", function () {
     });
     store.write((write) => write.chains(1).erc20s("test").allowance("user1", "oracle", BigNumber.from(1)));
   });
+  test("get chainId", function () {
+    const result = store.read().chainId();
+    assert.equal(result, 1);
+  });
+  test("get inputRequest", function () {
+    const result = store.read().inputRequest();
+    assert.deepEqual(result, { requester: "a", identifier: "b", timestamp: 1, ancillaryData: "d" });
+  });
 });

--- a/packages/sdk/src/oracle/types/state.ts
+++ b/packages/sdk/src/oracle/types/state.ts
@@ -24,6 +24,7 @@ export type Erc20Props = {
   decimals: string;
   totalSupply: string;
 };
+
 export type Erc20 = {
   props: Partial<Erc20Props>;
   allowances: Record<string, Balances>;


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/3810/add-ability-to-read-from-global-state


**Summary**
This adds a basic way to simplify calls to read global state by creating a type safe class with some common calls. Calls are automatically scoped based on the users current input, ie which request they are currently looking at. This means though that reads for some calls wont work unless the input is set ahead of time.  This is mainly meant as an example of how to add calls as needed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
