### PR TITLE
improve(optimistic-oracle-event-client): Support paginated block search config for Arbitrum Infura

### DIFF
--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -7,7 +7,7 @@ dotenv.config();
  * @notice Return average block-time for a period.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function averageBlockTimeSeconds(lookbackSeconds?: number, networkId?: number): Promise<number> {
+export async function averageBlockTimeSeconds(networkId?: number): Promise<number> {
   // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
   // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
   // since April 2016, although this value seems to spike periodically for a relatively short period of time.
@@ -17,9 +17,13 @@ export async function averageBlockTimeSeconds(lookbackSeconds?: number, networkI
   }
 
   switch (networkId) {
+    // Block time is irrelevant on Arbitrum since one transaction ~= 1 block, so this time value is based on empirical
+    // observation as of January 4 2022 of Arbitrum block propogation.
+    case 42161:
+      return 2.2;
     // Source: https://polygonscan.com/chart/blocktime
     case 137:
-      return 2.5;
+      return 2.2;
     case 1:
       return defaultBlockTimeSeconds;
     default:

--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -7,7 +7,7 @@ dotenv.config();
  * @notice Return average block-time for a period.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function averageBlockTimeSeconds(networkId?: number): Promise<number> {
+export async function averageBlockTimeSeconds(chainId?: number): Promise<number> {
   // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
   // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
   // since April 2016, although this value seems to spike periodically for a relatively short period of time.
@@ -16,7 +16,7 @@ export async function averageBlockTimeSeconds(networkId?: number): Promise<numbe
     throw "Missing default block time value";
   }
 
-  switch (networkId) {
+  switch (chainId) {
     // Block time is irrelevant on Arbitrum since one transaction ~= 1 block, so this time value is based on empirical
     // observation as of January 4 2022 of Arbitrum block propogation.
     case 42161:

--- a/packages/financial-templates-lib/src/clients/OptimisticOracleClient.ts
+++ b/packages/financial-templates-lib/src/clients/OptimisticOracleClient.ts
@@ -61,6 +61,7 @@ export class OptimisticOracleClient {
   // Store the last on-chain time the clients were updated to inform price request information.
   private lastUpdateTimestamp = 0;
   private hexToUtf8 = Web3.utils.hexToUtf8;
+  private chainId = -1;
 
   // Oracle Data structures & values to enable synchronous returns of the state seen by the client.
   private unproposedPriceRequests: RequestPriceReturnValues[] = [];
@@ -156,9 +157,9 @@ export class OptimisticOracleClient {
 
   public async update(): Promise<void> {
     // Determine earliest block to query events for based on lookback window:
-    const netId = await this.web3.eth.getChainId();
+    if (this.chainId === -1) this.chainId = await this.web3.eth.getChainId();
     const [averageBlockTime, currentBlock] = await Promise.all([
-      averageBlockTimeSeconds(netId),
+      averageBlockTimeSeconds(this.chainId),
       this.web3.eth.getBlock("latest"),
     ]);
     const lookbackBlocks = Math.ceil(this.lookback / averageBlockTime);

--- a/packages/financial-templates-lib/src/clients/OptimisticOracleEventClient.ts
+++ b/packages/financial-templates-lib/src/clients/OptimisticOracleEventClient.ts
@@ -43,7 +43,7 @@ export class OptimisticOracleEventClient {
   // Last block number to end the searching for events at.
   private lastBlockToSearchUntil: number | null;
 
-  private lookbackBlocks: number | null;
+  private blocksPerEventSearch: number | null;
 
   private lastUpdateTimestamp = 0;
 
@@ -59,7 +59,7 @@ export class OptimisticOracleEventClient {
    * "OptimisticOracle".
    * @param {Integer} startingBlockNumber Offset block number to index events from.
    * @param {Integer} endingBlockNumber Termination block number to index events until. If not defined runs to `latest`.
-   * @param {Integer} lookbackBlocks Amount of blocks to search per query. If not defined, then searches the max amount
+   * @param {Integer} blocksPerEventSearch Amount of blocks to search per query. If not defined, then searches the max amount
    * of blocks.
    * @return None or throws an Error.
    */
@@ -71,7 +71,7 @@ export class OptimisticOracleEventClient {
     public readonly oracleType: OptimisticOracleType = OptimisticOracleType.OptimisticOracle,
     startingBlockNumber = 0,
     endingBlockNumber: number | null = null,
-    lookbackBlocks: number | null = null
+    blocksPerEventSearch: number | null = null
   ) {
     this.optimisticOracleContract = (new this.web3.eth.Contract(
       optimisticOracleAbi,
@@ -79,7 +79,7 @@ export class OptimisticOracleEventClient {
     ) as unknown) as OptimisticOracleContract;
     this.firstBlockToSearch = startingBlockNumber;
     this.lastBlockToSearchUntil = endingBlockNumber;
-    this.lookbackBlocks = lookbackBlocks;
+    this.blocksPerEventSearch = blocksPerEventSearch;
   }
   // Delete all events within the client
   async clearState(): Promise<void> {
@@ -134,9 +134,9 @@ export class OptimisticOracleEventClient {
     let settlementEventsObj: (OptimisticOracleWeb3Events.Settle | SkinnyOptimisticOracleWeb3Events.Settle)[] = [];
 
     // If lookback blocks is defined, send multiple web3 requests, otherwise search all block history in one search.
-    let blockSearchConfig = { fromBlock: this.firstBlockToSearch, toBlock: lastBlockToSearch };
-    if (this.lookbackBlocks !== null) {
-      blockSearchConfig.toBlock = this.firstBlockToSearch + this.lookbackBlocks;
+    let blockSearchConfig = { fromBlock: Number(this.firstBlockToSearch), toBlock: Number(lastBlockToSearch) };
+    if (this.blocksPerEventSearch !== null) {
+      blockSearchConfig.toBlock = Number(this.firstBlockToSearch) + Number(this.blocksPerEventSearch);
     }
 
     while (blockSearchConfig.fromBlock <= lastBlockToSearch) {
@@ -168,7 +168,7 @@ export class OptimisticOracleEventClient {
       // cause the `while` loop to exit.
       blockSearchConfig = {
         fromBlock: blockSearchConfig.toBlock + 1,
-        toBlock: blockSearchConfig.toBlock + 1 + (this.lookbackBlocks ? this.lookbackBlocks : 0),
+        toBlock: blockSearchConfig.toBlock + 1 + (this.blocksPerEventSearch ? Number(this.blocksPerEventSearch) : 0),
       };
     }
 

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
@@ -138,11 +138,11 @@ describe("OptimisticOracleClient.js", function () {
         .send({ from: accounts[0] });
       await client.update();
 
-      // There should have been exactly 1 search.
+      // There should have been exactly 1 search each for the 4 events, so 4 web3 requests total.
       const blockSearchConfigLogs = spy
         .getCalls()
-        .filter((log) => log.lastArg.message.includes("Fetching events with block search config"));
-      assert.equal(blockSearchConfigLogs.length, 1);
+        .filter((log) => log.lastArg.message.includes("Queried past event requests"));
+      assert.equal(blockSearchConfigLogs[0].lastArg.eventRequestCount, 4);
     });
     it("If max blocks per search is set, makes multiple web3 requests to fetch all events", async function () {
       const chunkedClient = new OptimisticOracleClient(
@@ -171,11 +171,11 @@ describe("OptimisticOracleClient.js", function () {
         .send({ from: accounts[0] });
       await chunkedClient.update();
 
-      // There should have been > 1 searches.
+      // There should have been > 1 search each for the 4 events, so > 4 web3 requests total.
       const blockSearchConfigLogs = spy
         .getCalls()
-        .filter((log) => log.lastArg.message.includes("Fetching events with block search config"));
-      assert.isTrue(blockSearchConfigLogs.length > 1);
+        .filter((log) => log.lastArg.message.includes("Queried past event requests"));
+      assert.isTrue(blockSearchConfigLogs[0].lastArg.eventRequestCount > 4);
 
       result = chunkedClient.getUndisputedProposals();
       objectsInArrayInclude(result, []);

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
@@ -797,11 +797,11 @@ describe("OptimisticOracleEventClient.js", function () {
     await client.clearState();
     await client.update();
 
-    // There should have been exactly 1 search.
+    // There should have been exactly 1 search each for the 4 events, so 4 web3 requests total.
     const blockSearchConfigLogs = spy
       .getCalls()
-      .filter((log) => log.lastArg.message.includes("Fetching events with block search config"));
-    assert.equal(blockSearchConfigLogs.length, 1);
+      .filter((log) => log.lastArg.message.includes("Queried past event requests"));
+    assert.equal(blockSearchConfigLogs[0].lastArg.eventRequestCount, 4);
   });
   it("If max blocks per search is set, makes multiple web3 requests to fetch all events", async function () {
     const chunkedClient = new OptimisticOracleEventClient(
@@ -818,11 +818,11 @@ describe("OptimisticOracleEventClient.js", function () {
     await chunkedClient.clearState();
     await chunkedClient.update();
 
-    // There should have been > 1 searches.
+    // There should have been > 1 search each for the 4 events, so > 4 web3 requests total.
     const blockSearchConfigLogs = spy
       .getCalls()
-      .filter((log) => log.lastArg.message.includes("Fetching events with block search config"));
-    assert.isTrue(blockSearchConfigLogs.length > 1);
+      .filter((log) => log.lastArg.message.includes("Queried past event requests"));
+    assert.isTrue(blockSearchConfigLogs[0].lastArg.eventRequestCount > 4);
 
     // Now check that the events are stored correctly and exactly the same as in previous tests.
     objectsInArrayInclude(chunkedClient.getAllRequestPriceEvents(), [

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
@@ -138,10 +138,7 @@ describe("OptimisticOracleEventClient.js", function () {
     startTime = parseInt(await timer.methods.getCurrentTime().call());
     requestTime = startTime - 10;
 
-    // The Event client does not emit any info `level` events.  Therefore no need to test Winston outputs.
-    // DummyLogger will not print anything to console as only capture `info` level events.
     dummyLogger = winston.createLogger({ level: "info", transports: [new winston.transports.Console()] });
-
     spy = sinon.spy();
 
     client = new OptimisticOracleEventClient(

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
@@ -138,6 +138,8 @@ describe("OptimisticOracleEventClient.js", function () {
     startTime = parseInt(await timer.methods.getCurrentTime().call());
     requestTime = startTime - 10;
 
+    // The OptimisticOracleEventClient does not emit any info `level` events. DummyLogger will not print anything
+    // to console as only capture `info` level events. The spy logger is used to test for `debug` level events.
     dummyLogger = winston.createLogger({ level: "info", transports: [new winston.transports.Console()] });
     spy = sinon.spy();
 
@@ -791,7 +793,7 @@ describe("OptimisticOracleEventClient.js", function () {
     objectsInArrayInclude([], offSetClient.getAllDisputePriceEvents());
     objectsInArrayInclude([], offSetClient.getAllSettlementEvents());
   });
-  it("Update with no lookback blocks set", async function () {
+  it("Update with no max blocks per search set", async function () {
     await client.clearState();
     await client.update();
 
@@ -801,7 +803,7 @@ describe("OptimisticOracleEventClient.js", function () {
       .filter((log) => log.lastArg.message.includes("Fetching events with block search config"));
     assert.equal(blockSearchConfigLogs.length, 1);
   });
-  it("If lookback blocks is set, makes multiple web3 requests to fetch all events", async function () {
+  it("If max blocks per search is set, makes multiple web3 requests to fetch all events", async function () {
     const chunkedClient = new OptimisticOracleEventClient(
       winston.createLogger({ level: "debug", transports: [new SpyTransport({ level: "debug" }, { spy: spy })] }),
       OptimisticOracle.abi,

--- a/packages/fx-tunnel-relayer/src/index.ts
+++ b/packages/fx-tunnel-relayer/src/index.ts
@@ -24,7 +24,7 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
     const polygonWeb3 = polygonNodeUrl !== "" ? new Web3(polygonNodeUrl) : web3;
     const polygonNetworkId = await polygonWeb3.eth.net.getId();
     const [polygonAverageBlockTime, polygonCurrentBlock] = await Promise.all([
-      averageBlockTimeSeconds(undefined, polygonNetworkId),
+      averageBlockTimeSeconds(polygonNetworkId),
       polygonWeb3.eth.getBlock("latest"),
     ]);
     const polygonLookbackBlocks = Math.ceil(config.lookback / polygonAverageBlockTime);

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -49,7 +49,7 @@ const {
  *     from. If 0 will look for all events back to deployment of the Financial Contract. If set to null uses current block number.
  * @param {Number} endingBlock Termination block number to define where the monitor bot should end searching for events.
  *     If `null` then will search up until the latest block number in each loop.
- * @param {Number} lookbackBlocks Amount of blocks to search per web3 request.
+ * @param {Number} blocksPerEventSearch Amount of blocks to search per web3 request.
  * @param {Object} monitorConfig Configuration object to parameterize all monitor modules.
  * @param {Object} tokenPriceFeedConfig Configuration to construct the tokenPriceFeed (balancer or uniswap) price feed object.
  * @param {Object} medianizerPriceFeedConfig Configuration to construct the reference price feed object.
@@ -67,7 +67,7 @@ async function run({
   errorRetriesTimeout,
   startingBlock,
   endingBlock,
-  lookbackBlocks,
+  blocksPerEventSearch,
   monitorConfig,
   tokenPriceFeedConfig,
   medianizerPriceFeedConfig,
@@ -89,7 +89,7 @@ async function run({
       errorRetriesTimeout,
       startingBlock,
       endingBlock,
-      lookbackBlocks,
+      blocksPerEventSearch,
       monitorConfig,
       tokenPriceFeedConfig,
       medianizerPriceFeedConfig,
@@ -223,7 +223,7 @@ async function run({
         eventsFromBlockNumber,
         endingBlock,
         monitorConfig.contractType
-        // TODO: Should use `lookbackBlocks` in this event client as well, but this is not added currently as only the
+        // TODO: Should use `blocksPerEventSearch` in this event client as well, but this is not added currently as only the
         // Arbitrum Infura provider requires this chunking logic and the FinancialContractEventClient won't be used on
         // Arbitrum initially.
       );
@@ -338,7 +338,7 @@ async function run({
         optimisticOracleType,
         eventsFromBlockNumber,
         endingBlock,
-        lookbackBlocks
+        blocksPerEventSearch
       );
 
       const contractProps = { networkId };
@@ -439,7 +439,7 @@ async function Poll(callback) {
       // Amount of blocks to search per web3 request to fetch events. This can be used with providers that limit the
       // amount of blocks that can be fetched per request, including Arbitrum Infura nodes. Defaults to null which
       // searches the maximum amount of blocks.
-      lookbackBlocks: process.env.LOOKBACK_BLOCKS,
+      blocksPerEventSearch: process.env.MAX_BLOCKS_PER_EVENT_SEARCH,
       // Monitor config contains all configuration settings for all monitor modules. This includes the following:
       // MONITOR_CONFIG={
       //  "botsToMonitor": [{ name: "Liquidator Bot",       // Friendly bot name

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -336,9 +336,9 @@ async function run({
         web3,
         optimisticOracleAddress,
         optimisticOracleType,
-        eventsFromBlockNumber,
-        endingBlock,
-        blocksPerEventSearch
+        Number(eventsFromBlockNumber),
+        Number(endingBlock),
+        Number(blocksPerEventSearch)
       );
 
       const contractProps = { networkId };

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -337,8 +337,8 @@ async function run({
         optimisticOracleAddress,
         optimisticOracleType,
         Number(eventsFromBlockNumber),
-        Number(endingBlock),
-        Number(blocksPerEventSearch)
+        endingBlock ? Number(endingBlock) : null,
+        blocksPerEventSearch ? Number(blocksPerEventSearch) : null
       );
 
       const contractProps = { networkId };

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -49,6 +49,7 @@ const {
  *     from. If 0 will look for all events back to deployment of the Financial Contract. If set to null uses current block number.
  * @param {Number} endingBlock Termination block number to define where the monitor bot should end searching for events.
  *     If `null` then will search up until the latest block number in each loop.
+ * @param {Number} lookbackBlocks Amount of blocks to search per web3 request.
  * @param {Object} monitorConfig Configuration object to parameterize all monitor modules.
  * @param {Object} tokenPriceFeedConfig Configuration to construct the tokenPriceFeed (balancer or uniswap) price feed object.
  * @param {Object} medianizerPriceFeedConfig Configuration to construct the reference price feed object.
@@ -66,6 +67,7 @@ async function run({
   errorRetriesTimeout,
   startingBlock,
   endingBlock,
+  lookbackBlocks,
   monitorConfig,
   tokenPriceFeedConfig,
   medianizerPriceFeedConfig,
@@ -87,6 +89,7 @@ async function run({
       errorRetriesTimeout,
       startingBlock,
       endingBlock,
+      lookbackBlocks,
       monitorConfig,
       tokenPriceFeedConfig,
       medianizerPriceFeedConfig,
@@ -220,6 +223,9 @@ async function run({
         eventsFromBlockNumber,
         endingBlock,
         monitorConfig.contractType
+        // TODO: Should use `lookbackBlocks` in this event client as well, but this is not added currently as only the
+        // Arbitrum Infura provider requires this chunking logic and the FinancialContractEventClient won't be used on
+        // Arbitrum initially.
       );
 
       const contractMonitor = new ContractMonitor({
@@ -331,7 +337,8 @@ async function run({
         optimisticOracleAddress,
         optimisticOracleType,
         eventsFromBlockNumber,
-        endingBlock
+        endingBlock,
+        lookbackBlocks
       );
 
       const contractProps = { networkId };
@@ -429,6 +436,10 @@ async function Poll(callback) {
       // Block number to search for events to. If set, acts to limit from where the monitor bot will search for events up
       // until. If not set the default to null which indicates that the bot should search up to 'latest'.
       endingBlock: process.env.ENDING_BLOCK_NUMBER,
+      // Amount of blocks to search per web3 request to fetch events. This can be used with providers that limit the
+      // amount of blocks that can be fetched per request, including Arbitrum Infura nodes. Defaults to null which
+      // searches the maximum amount of blocks.
+      lookbackBlocks: process.env.LOOKBACK_BLOCKS,
       // Monitor config contains all configuration settings for all monitor modules. This includes the following:
       // MONITOR_CONFIG={
       //  "botsToMonitor": [{ name: "Liquidator Bot",       // Friendly bot name

--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -21,10 +21,12 @@ const { getAbi, getAddress } = require("@uma/contracts-node");
 // as input into getAbi and getAddress.
 const OracleType = {
   Voting: "Voting", // Used on mainnet when optimistic oracle directly submits price requests to Voting.
-  OracleChildTunnel: "OracleChildTunnel", // Used in production when running proposer bot on sidechain that needs to
+  OracleChildTunnel: "OracleChildTunnel", // Used in production when running proposer bot on Polygon that needs to
   // bridge price requests back to L1.
   MockOracleAncillary: "MockOracleAncillary", // Used for testing when caller wants to be able to manually push prices
-  // to resolve requests
+  // to resolve requests.
+  OracleSpoke: "OracleSpoke", // Used in production for non-Polygon L2s to bridge price requests to L1.
+  SkinnyOptimisticOracle: "SkinnyOptimisticOracle", // Gas-lite version of Optimistic oracle.
 };
 
 /**
@@ -52,6 +54,7 @@ async function run({
   oracleType = OracleType.Voting,
   optimisticOracleType = OptimisticOracleType.OptimisticOracle,
 }) {
+  if (!Object.keys(OracleType).includes(oracleType)) throw new Error("Unexpected OracleType");
   try {
     const [accounts, networkId] = await Promise.all([web3.eth.getAccounts(), web3.eth.net.getId()]);
     const optimisticOracleAddress = await getAddress(optimisticOracleType, networkId);

--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -87,7 +87,7 @@ async function run({
       await getAddress(oracleType, networkId),
       604800, // default lookback setting for this client
       optimisticOracleType,
-      Number(blocksPerEventSearch)
+      blocksPerEventSearch ? Number(blocksPerEventSearch) : null
     );
     const gasEstimator = new GasEstimator(logger, 60, networkId);
 

--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -87,7 +87,7 @@ async function run({
       await getAddress(oracleType, networkId),
       604800, // default lookback setting for this client
       optimisticOracleType,
-      blocksPerEventSearch
+      Number(blocksPerEventSearch)
     );
     const gasEstimator = new GasEstimator(logger, 60, networkId);
 

--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -38,6 +38,7 @@ const OracleType = {
  * @param {Number} errorRetries The number of times the execution loop will re-try before throwing if an error occurs.
  * @param {Number} errorRetriesTimeout The amount of milliseconds to wait between re-try iterations on failed loops.
  * @param {Object} [commonPriceFeedConfig] Common configuration to pass to all PriceFeeds constructed by proposer.
+ * @param {Number} [blocksPerEventSearch] Amount of blocks to search per web3 request.
  * @param {Object} [optimisticOracleProposerConfig] Configuration to construct the OptimisticOracle proposer.
  * @param {OracleType} [oracleType] Type of "Oracle" for this network, defaults to "Voting"
  * @param {OptimisticOracleType} [optimisticOracleType] Type of "OptimisticOracle" for this network, defaults to "OptimisticOracle"
@@ -50,6 +51,7 @@ async function run({
   errorRetries,
   errorRetriesTimeout,
   commonPriceFeedConfig,
+  blocksPerEventSearch,
   optimisticOracleProposerConfig,
   oracleType = OracleType.Voting,
   optimisticOracleType = OptimisticOracleType.OptimisticOracle,
@@ -68,6 +70,7 @@ async function run({
       errorRetries,
       errorRetriesTimeout,
       commonPriceFeedConfig,
+      blocksPerEventSearch,
       optimisticOracleProposerConfig,
       oracleType,
       optimisticOracleType,
@@ -83,7 +86,8 @@ async function run({
       optimisticOracleAddress,
       await getAddress(oracleType, networkId),
       604800, // default lookback setting for this client
-      optimisticOracleType
+      optimisticOracleType,
+      blocksPerEventSearch
     );
     const gasEstimator = new GasEstimator(logger, 60, networkId);
 
@@ -156,6 +160,10 @@ async function Poll(callback) {
       errorRetries: process.env.ERROR_RETRIES ? Number(process.env.ERROR_RETRIES) : 3,
       // Default to 10 seconds in between error re-tries.
       errorRetriesTimeout: process.env.ERROR_RETRIES_TIMEOUT ? Number(process.env.ERROR_RETRIES_TIMEOUT) : 1,
+      // Amount of blocks to search per web3 request to fetch events. This can be used with providers that limit the
+      // amount of blocks that can be fetched per request, including Arbitrum Infura nodes. Defaults to null which
+      // searches the maximum amount of blocks.
+      blocksPerEventSearch: process.env.MAX_BLOCKS_PER_EVENT_SEARCH,
       // Common price feed configuration passed along to all those constructed by proposer.
       commonPriceFeedConfig: process.env.COMMON_PRICE_FEED_CONFIG
         ? JSON.parse(process.env.COMMON_PRICE_FEED_CONFIG)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Event querying on Arbitrum cannot look at more than 10,000 blocks at a time. This PR defines a new environment variable `process.env.MAX_BLOCKS_PER_EVENT_SEARCH` that can be used to control the amount of blocks to search in a single event web3 query

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
