### PR TITLE
feat: add bot redundancy to fx-tunnel-relayer

### DIFF
--- a/packages/fx-tunnel-relayer/src/RelayerConfig.ts
+++ b/packages/fx-tunnel-relayer/src/RelayerConfig.ts
@@ -7,14 +7,14 @@ export class RelayerConfig {
   readonly errorRetries: number;
   readonly errorRetriesTimeout: number;
   // User will pass in a node url to connect to Polygon network with.
-  readonly polygonNodeUrl: string;
+  readonly chainId: string;
   // Any events older than now minus this value (in seconds) will be ignored.
   readonly lookback: number;
 
   constructor(env: ProcessEnv) {
-    const { POLYGON_CUSTOM_NODE_URL, POLLING_DELAY, ERROR_RETRIES, ERROR_RETRIES_TIMEOUT, LOOKBACK } = env;
+    const { POLLING_DELAY, ERROR_RETRIES, ERROR_RETRIES_TIMEOUT, LOOKBACK, CHAIN_ID } = env;
 
-    this.polygonNodeUrl = POLYGON_CUSTOM_NODE_URL ? POLYGON_CUSTOM_NODE_URL : "";
+    this.chainId = CHAIN_ID || "";
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;
     this.errorRetriesTimeout = ERROR_RETRIES_TIMEOUT ? Number(ERROR_RETRIES_TIMEOUT) : 1;

--- a/packages/fx-tunnel-relayer/src/index.ts
+++ b/packages/fx-tunnel-relayer/src/index.ts
@@ -3,7 +3,7 @@ import Web3 from "web3";
 import retry from "async-retry";
 import { config } from "dotenv";
 import MaticJs from "@maticnetwork/maticjs";
-import { averageBlockTimeSeconds, getWeb3 } from "@uma/common";
+import { averageBlockTimeSeconds, getWeb3, getWeb3ByChainId } from "@uma/common";
 import { getAddress, getAbi } from "@uma/contracts-node";
 import { GasEstimator, Logger, delay } from "@uma/financial-templates-lib";
 
@@ -20,8 +20,8 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
 
     // Set up polygon web3. If polygon node URL is undefined, then default to setting it equal to the web3 instance.
     // This facilitates local testing where contracts are deployed to the same local network.
-    const polygonNodeUrl = config.polygonNodeUrl;
-    const polygonWeb3 = polygonNodeUrl !== "" ? new Web3(polygonNodeUrl) : web3;
+    const polygonChainId = config.chainId;
+    const polygonWeb3 = polygonChainId !== "" ? getWeb3ByChainId(Number(polygonChainId)) : web3;
     const polygonNetworkId = await polygonWeb3.eth.net.getId();
     const [polygonAverageBlockTime, polygonCurrentBlock] = await Promise.all([
       averageBlockTimeSeconds(undefined, polygonNetworkId),


### PR DESCRIPTION
**Motivation**

Currently, the fx-tunnel-relayer has no node redundancy. If its node fails, it throws.


**Summary**

Make fx-tunnel-relayer use getWeb3 for all of its nodes, so it can take advantage of retry configs for more redundancy.

This meant we needed a way to provide the chain id that it should use for its polygon node so it can provide it to getWeb3.. This adds a CHAIN_ID env variable for this purpose. Happy to consider other options for how to pull in mainnet and polygon nodes via getWeb3.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
