### PR TITLE
feat: make hub respect bot retry configs

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -33,6 +33,7 @@ const { Storage } = require("@google-cloud/storage"); // Used to get global conf
 const storage = new Storage();
 const { Datastore } = require("@google-cloud/datastore"); // Used to read/write the last block number the monitor used.
 const datastore = new Datastore();
+const { createBasicProvider } = require("@uma/common");
 
 // Web3 instance to get current block numbers of polling loops.
 const Web3 = require("web3");
@@ -92,8 +93,8 @@ hub.post("/", async (req, res) => {
     };
     for (const botName in configObject) {
       // Check if bot is running on a non-default chain, and fetch last block number seen on this or the default chain.
-      const spokeCustomNodeUrl = configObject[botName]?.environmentVariables?.CUSTOM_NODE_URL;
-      const chainId = await _getChainId(spokeCustomNodeUrl);
+      const [botWeb3, spokeCustomNodeUrl] = _getWeb3AndUrlForBot(configObject[botName]);
+      const chainId = await _getChainId(botWeb3);
       nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
 
       // If we've seen this chain ID already we can skip it:
@@ -104,7 +105,7 @@ hub.post("/", async (req, res) => {
 
       // Next, get the head block for the chosen chain, which we'll use to override the last queried block number
       // stored in GCP at the end of this hub execution.
-      let latestBlockNumber = await _getLatestBlockNumber(spokeCustomNodeUrl);
+      let latestBlockNumber = await _getLatestBlockNumber(botWeb3);
 
       // If the last queried block number stored on GCP Data Store is undefined, then its possible that this is
       // the first time that the hub is being run for this chain. Therefore, try setting it to the head block number
@@ -142,7 +143,7 @@ hub.post("/", async (req, res) => {
     let promiseArray = [];
     let botConfigs = {};
     for (const botName in configObject) {
-      const spokeCustomNodeUrl = configObject[botName]?.environmentVariables?.CUSTOM_NODE_URL;
+      const [, spokeCustomNodeUrl] = _getWeb3AndUrlForBot(configObject[botName]);
       const chainId = nodeUrlToChainIdCache[spokeCustomNodeUrl];
       const lastQueriedBlockNumber = blockNumbersForChain[chainId].lastQueriedBlockNumber;
       const latestBlockNumber = blockNumbersForChain[chainId].latestBlockNumber;
@@ -397,15 +398,23 @@ async function _getLastQueriedBlockNumber(configIdentifier, chainId, logger) {
   );
 }
 
+function _getWeb3AndUrlForBot(botConfig) {
+  const retryConfig = botConfig?.environmentVariables?.NODE_RETRY_CONFIG;
+  if (retryConfig) {
+    return [new Web3(createBasicProvider(retryConfig)), retryConfig[0].url];
+  } else {
+    const url = botConfig?.environmentVariables?.CUSTOM_NODE_URL || customNodeUrl;
+    return [new Web3(url), url];
+  }
+}
+
 // Get the latest block number from either `overrideNodeUrl` or `CUSTOM_NODE_URL`. Used to update the `
 // lastSeenBlockNumber` after each run.
-async function _getLatestBlockNumber(overrideNodeUrl) {
-  const web3 = new Web3(overrideNodeUrl || customNodeUrl);
+async function _getLatestBlockNumber(web3) {
   return await web3.eth.getBlockNumber();
 }
 
-async function _getChainId(overrideNodeUrl) {
-  const web3 = new Web3(overrideNodeUrl || customNodeUrl);
+async function _getChainId(web3) {
   return await web3.eth.getChainId();
 }
 


### PR DESCRIPTION
**Motivation**

The hub doesn't have any capacity to retry its requests. This causes it to sometimes be flaky.


**Summary**

This allows the hub to pull in the spoke's retry config to allow it to construct a retry provider.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
