### PR TITLE
feat(across-bots): Improve log quality in serverless

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -57,10 +57,8 @@ hub.post("/", async (req, res) => {
   // Use a custom logger if provided. Otherwise, initialize a local logger.
   // Note: no reason to put this into the try-catch since a logger is required to throw the error.
   const logger = customLogger || createNewLogger();
-  const configName = req?.body?.configFile.substring(0, req?.body?.configFile.length - 5); // remove .json from the end of the file name.
+  const configName = req?.body?.configFile.substring(0, req?.body?.configFile.length - 5) || "NO-NAME"; // remove .json from the end of the file name.
   try {
-    logger.debug({ at: "ServerlessHub", message: "Running Serverless hub query", configName, hubConfig });
-
     // Validate the post request has both the `bucket` and `configFile` params.
     if (!req.body.bucket || !req.body.configFile) {
       throw new Error("Body missing json bucket or file parameters!");

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -262,13 +262,10 @@ hub.post("/", async (req, res) => {
     }
 
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res
-      .status(500)
-      .send({
-        message:
-          errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
-        output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
-      });
+    res.status(500).send({
+      message: errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
+      output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
+    });
   }
 });
 

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -57,7 +57,7 @@ hub.post("/", async (req, res) => {
   // Use a custom logger if provided. Otherwise, initialize a local logger.
   // Note: no reason to put this into the try-catch since a logger is required to throw the error.
   const logger = customLogger || createNewLogger();
-  const configName = req.body.configFile.substring(0, req.body.configFile.length - 5); // remove .json from the end of the file name.
+  const configName = req?.body?.configFile.substring(0, req?.body?.configFile.length - 5); // remove .json from the end of the file name.
   try {
     logger.debug({ at: "ServerlessHub", message: "Running Serverless hub query", configName, hubConfig });
 
@@ -263,13 +263,10 @@ hub.post("/", async (req, res) => {
     }
 
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res
-      .status(500)
-      .send({
-        message:
-          errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
-        output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
-      });
+    res.status(500).send({
+      message: errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
+      output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
+    });
   }
 });
 

--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -67,11 +67,13 @@ spoke.post("/", async (req, res) => {
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
 
-    res.status(200).send({
-      message: "Process exited with no error",
-      childProcessIdentifier: _getChildProcessIdentifier(req),
-      execResponse,
-    });
+    res
+      .status(200)
+      .send({
+        message: "Process exited with no error",
+        childProcessIdentifier: _getChildProcessIdentifier(req),
+        execResponse,
+      });
   } catch (execResponse) {
     // If there is an error, send a debug log to the winston transport to capture in GCP. We dont want to trigger a
     // `logger.error` here as this will be dealt with one layer up in the Hub implementation.
@@ -83,11 +85,13 @@ spoke.post("/", async (req, res) => {
       execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res.status(500).send({
-      message: "Process exited with error",
-      childProcessIdentifier: _getChildProcessIdentifier(req),
-      execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
-    });
+    res
+      .status(500)
+      .send({
+        message: "Process exited with error",
+        childProcessIdentifier: _getChildProcessIdentifier(req),
+        execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
+      });
   }
 });
 
@@ -123,7 +127,7 @@ function _stripExecStdout(output, strategyRunnerSpoke = false) {
     // while preserving the individual bot execution logs within GCP when using the strategy runner.
     if (strategyRunnerSpoke) return logsArray.filter((logMessage) => logMessage.at == "BotStrategyRunner");
     // extract only the `message` field from each log to reduce how much is sent back to the hub and logged in GCP.
-    else return logsArray.map((logMessage) => logMessage["message"]);
+    else return logsArray.map((logMessage) => `${logMessage["at"]}:${logMessage["message"]}`);
   } catch (error) {
     return _regexStrip(output).replace(/\r?\n|\r/g, " "); // Remove escaped new line chars. Replace with space between each log output.
   }

--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -67,13 +67,11 @@ spoke.post("/", async (req, res) => {
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
 
-    res
-      .status(200)
-      .send({
-        message: "Process exited with no error",
-        childProcessIdentifier: _getChildProcessIdentifier(req),
-        execResponse,
-      });
+    res.status(200).send({
+      message: "Process exited with no error",
+      childProcessIdentifier: _getChildProcessIdentifier(req),
+      execResponse,
+    });
   } catch (execResponse) {
     // If there is an error, send a debug log to the winston transport to capture in GCP. We dont want to trigger a
     // `logger.error` here as this will be dealt with one layer up in the Hub implementation.
@@ -85,13 +83,11 @@ spoke.post("/", async (req, res) => {
       execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
     });
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res
-      .status(500)
-      .send({
-        message: "Process exited with error",
-        childProcessIdentifier: _getChildProcessIdentifier(req),
-        execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
-      });
+    res.status(500).send({
+      message: "Process exited with error",
+      childProcessIdentifier: _getChildProcessIdentifier(req),
+      execResponse: execResponse instanceof Error ? execResponse.message : execResponse,
+    });
   }
 });
 
@@ -127,7 +123,7 @@ function _stripExecStdout(output, strategyRunnerSpoke = false) {
     // while preserving the individual bot execution logs within GCP when using the strategy runner.
     if (strategyRunnerSpoke) return logsArray.filter((logMessage) => logMessage.at == "BotStrategyRunner");
     // extract only the `message` field from each log to reduce how much is sent back to the hub and logged in GCP.
-    else return logsArray.map((logMessage) => `${logMessage["at"]}:${logMessage["message"]}`);
+    else return logsArray.map((logMessage) => `${logMessage["at"] ?? ""}:${logMessage["message"]}`);
   } catch (error) {
     return _regexStrip(output).replace(/\r?\n|\r/g, " "); // Remove escaped new line chars. Replace with space between each log output.
   }

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -182,7 +182,7 @@ describe("ServerlessHub.js", function () {
     // read in hub configs and previous block numbers from the local storage of machine. This execution mode would be
     // used by a user running the hub-spoke on their local machine.
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {
@@ -218,7 +218,7 @@ describe("ServerlessHub.js", function () {
   it("ServerlessHub correctly deals with rejected spoke calls", async function () {
     // valid config to send but set the spoke to be off-line
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {
@@ -263,7 +263,7 @@ describe("ServerlessHub.js", function () {
   it("ServerlessHub correctly deals with timeout spoke calls", async function () {
     // valid config to send but set the spoke to be off-line.
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {
@@ -317,7 +317,7 @@ describe("ServerlessHub.js", function () {
     // read in hub configs and previous block numbers from the local storage of machine. This execution mode would be
     // used by a user running the hub-spoke on their local machine.
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {
@@ -383,7 +383,7 @@ describe("ServerlessHub.js", function () {
     // read in hub configs and previous block numbers from the local storage of machine. This execution mode would be
     // used by a user running the hub-spoke on their local machine.
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {
@@ -470,7 +470,7 @@ describe("ServerlessHub.js", function () {
   });
   it("ServerlessHub can correctly inject common config into child configs", async function () {
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {
@@ -552,7 +552,7 @@ describe("ServerlessHub.js", function () {
   });
   it("ServerlessHub can correctly deal with multiple providers", async function () {
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     // Temporarily spin up a new web3 provider with an overridden chain ID. The hub should be able to detect the
@@ -613,7 +613,7 @@ describe("ServerlessHub.js", function () {
     // read in hub configs and previous block numbers from the local storage of machine. This execution mode would be
     // used by a user running the hub-spoke on their local machine.
     const testBucket = "test-bucket"; // name of the config bucket.
-    const testConfigFile = "test-config-file"; // name of the config file.
+    const testConfigFile = "test-config-file.json"; // name of the config file.
     const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
 
     const hubConfig = {


### PR DESCRIPTION
**Motivation**

Serverless logs are somewhat hard to read now that we've got one unified relayer over all networks for across. See the sample logs below that show an example of these hard to read logs:

![image](https://user-images.githubusercontent.com/12886084/148402548-529de80f-9332-49e4-bdbe-2b4858478e6a.png)


**Summary**

This PR aims to fix this by doing two things:
1) Serverless redacted logs now include the `at` filed, as well as the previous `message` field.
2) the across bots were modified such that the `relayer.ts` now includes the chain name the relayer is connected to in the `at` field to make these logs more readable. 

Note that this wont impact almost all slack logs as slack logs are not produced from this part of the code. For example instant, speed up and slow relay logs are produced in the `MulticallBundler. See screenshot below:
![image](https://user-images.githubusercontent.com/12886084/148402869-9a3df91c-0eb5-402f-aa09-abdba21c55f3.png)


An additional thing this PR adds is the `configName` to the serverless hub execution. Using this, you can enrich GCP logs to with a flag to show you what config produced the execution output. this looks like this:
![image](https://user-images.githubusercontent.com/12886084/148403089-8960f769-8afe-497d-bc7d-d7f23ab778c2.png)


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [X]  Untested
