### PR TITLE
feat(sdk): add preview flags for proposing for oo

### DIFF
--- a/packages/sdk/src/oracle/client.ts
+++ b/packages/sdk/src/oracle/client.ts
@@ -2,6 +2,7 @@ import Store, { Emit } from "./store";
 import type { state } from "./types";
 import { Inputs } from "./types/state";
 import { Signer } from "./types/ethers";
+import * as utils from "./utils";
 
 export class Client {
   public readonly update: Update;
@@ -14,6 +15,9 @@ export class Client {
   setActiveRequest(params: Inputs["request"]): void {
     const { requester, identifier, timestamp, ancillaryData, chainId } = params;
     this.store.write((write) => write.inputs().request(requester, identifier, timestamp, ancillaryData, chainId));
+  }
+  previewProposal() {
+    return utils.previewProposal(this.store.get());
   }
 }
 

--- a/packages/sdk/src/oracle/tests/client.e2e.ts
+++ b/packages/sdk/src/oracle/tests/client.e2e.ts
@@ -4,6 +4,7 @@ import assert from "assert";
 import factory, { Client } from "../client";
 import Store from "../store";
 import * as types from "../types";
+import { ProposalFlags } from "../utils";
 
 dotenv.config();
 assert(process.env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
@@ -60,5 +61,10 @@ describe("Oracle Client", function () {
     assert.ok(store.read().userCollateralAllowance());
     assert.ok(store.read().collateralProps());
     assert.ok(store.read().request());
+  });
+  test("previewProposal", function () {
+    const result = client.previewProposal();
+    assert.ok(result[ProposalFlags.InvalidContractState]);
+    assert.ok(result[ProposalFlags.InsufficientApproval]);
   });
 });

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -1,0 +1,39 @@
+import { State } from "./types/state";
+import { Read } from "./store";
+
+export enum RequestState {
+  Invalid = 0, // Never requested.
+  Requested, // Requested, no other actions taken.
+  Proposed, // Proposed, but not expired or disputed yet.
+  Expired, // Proposed, not disputed, past liveness.
+  Disputed, // Disputed, but no DVM price returned yet.
+  Resolved, // Disputed and DVM price is available.
+  Settled, // Final price has been set in the contract (can get here from Expired or Resolved).
+}
+
+export enum ProposalFlags {
+  WrongChain = 0,
+  InvalidContractState,
+  InsufficientBalance,
+  InsufficientApproval,
+  TransactionInProgress,
+}
+export function previewProposal(state: State) {
+  const read = new Read(state);
+  const flags = [false, false, false, false, false];
+  if (read.userChainId() != read.requestChainId()) {
+    flags[ProposalFlags.WrongChain] = true;
+  }
+  if (read.request()?.state !== RequestState.Requested) {
+    flags[ProposalFlags.InvalidContractState] = true;
+  }
+  const totalBond = read.request().bond.add(read.request().finalFee);
+
+  if (read.userCollateralBalance().lt(totalBond)) {
+    flags[ProposalFlags.InsufficientBalance] = true;
+  }
+  if (read.userCollateralAllowance().lt(totalBond)) {
+    flags[ProposalFlags.InsufficientApproval] = true;
+  }
+  return flags;
+}


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/3781/add-approval-checking-logic

**Summary**

Adds a way to flag important errors the user has when trying to propose. This takes the shape as an array of booleans, which are keyed by an enum type which is self explanatory.  This way you can check on the frontend something like 

`if(flags[ProposalFlags.InvalidContractState]) ...`


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


