### PR TITLE
fix(api): allow both http and ws providers

### DIFF
--- a/packages/api/src/apps/serverless_write/app.ts
+++ b/packages/api/src/apps/serverless_write/app.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import { ethers } from "ethers";
 import { tables, Coingecko, Multicall2 } from "@uma/sdk";
 import { Datastore } from "@google-cloud/datastore";
 
@@ -18,7 +17,7 @@ import {
   tvl,
 } from "../../tables";
 import Zrx from "../../libs/zrx";
-import { Profile, parseEnvArray, getWeb3 } from "../../libs/utils";
+import { Profile, parseEnvArray, getWeb3, getEthers } from "../../libs/utils";
 
 import type { AppClients, AppServices, AppState, OrchestratorServices, ProcessEnv, Channels } from "../../types";
 
@@ -31,7 +30,7 @@ export default async (env: ProcessEnv) => {
   // debug flag for more verbose logs
   const debug = Boolean(env.debug);
   const profile = Profile(debug);
-  const provider = new ethers.providers.JsonRpcProvider(env.CUSTOM_NODE_URL);
+  const provider = getEthers(env.CUSTOM_NODE_URL);
   // we need web3 for syth price feeds
   const web3 = getWeb3(env.CUSTOM_NODE_URL);
   const datastoreClient = new Datastore();

--- a/packages/api/src/libs/utils.ts
+++ b/packages/api/src/libs/utils.ts
@@ -1,7 +1,7 @@
 import lodash from "lodash";
 import { Obj } from "../types";
 import * as uma from "@uma/sdk";
-import { utils, BigNumber, Contract } from "ethers";
+import { utils, BigNumber, Contract, ethers } from "ethers";
 import assert from "assert";
 import Web3 from "web3";
 const { parseUnits, parseBytes32String } = utils;
@@ -203,6 +203,13 @@ export function getWeb3(url: string, options: Obj = {}) {
   if (url.startsWith("http")) return getWeb3Http(url);
 
   throw new Error("Web3 provider URLs not supported");
+}
+
+export function getEthers(url: string) {
+  if (url.startsWith("ws")) return new ethers.providers.WebSocketProvider(url);
+  if (url.startsWith("http")) return new ethers.providers.JsonRpcProvider(url);
+
+  throw new Error("Unsupported ethers provider url");
 }
 
 // this just maintains the start/endblock given sporadic updates with a latest block number


### PR DESCRIPTION

**Motivation**

Quick PR for allowing the serverless api to use both http and ws url providers for ethers

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX