### PR TITLE
feat (across-docs): small nit relayer config

### DIFF
--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -49,7 +49,6 @@ export class RelayerConfig {
   readonly errorRetries: number;
   readonly errorRetriesTimeout: number;
 
-  readonly whitelistedRelayL1Tokens: string[] = [];
   readonly whitelistedChainIds: number[] = [];
   readonly activatedChainIds: number[];
   readonly l2BlockLookback: number;


### PR DESCRIPTION
**Motivation**

There is a redundant veriable within the RelayerConfig that is a bit confusing. This PR removes this.

**Summary**

This viarable `whitelistedRelayL1Tokens` is constructed using `pruneWhitelistedL1Tokens` and should not be within the config.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
