### PR TITLE
feat (across-docs): add chain ID to state disagreement log

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -120,6 +120,7 @@ export class InsuredBridgeL2Client {
       this.logger.error({
         at: "InsuredBridgeL2Client",
         message: "L2 RPC endpoint state disagreement! 🤺",
+        chainId: this.chainId,
         eventName,
         eventSearchOptions,
         countMissingEvents: eventsData.missingEvents.length,


### PR DESCRIPTION
**Motivation**

When there is state disagreement having chain ID is useful in the context of the batch relayer. This PR adds this.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
