### PR TITLE
 (OO-monitor): Add UTF-8 fallback decoding to OO bot

### DIFF
--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -299,7 +299,7 @@ class OptimisticOracleContractMonitor {
       try {
         // If that fails, try to return the ancillary data UTF-8 decoded.
         return "Ancillary could not be parsed. UTF-8 decoded data: " + this.web3.utils.hexToUtf8(ancillaryData);
-      } catch (error) {
+      } catch (_) {
         return `Could not parse ancillary data nor UTF-8 decode: ${ancillaryData || "0x"}`;
       }
     }

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -300,7 +300,7 @@ class OptimisticOracleContractMonitor {
         // If that fails, try to return the ancillary data UTF-8 decoded.
         return "Ancillary could not be parsed. UTF-8 decoded data: " + this.web3.utils.hexToUtf8(ancillaryData);
       } catch (_) {
-        return `Could not parse ancillary data nor UTF-8 decode: ${ancillaryData || "0x"}`;
+        return "Could not parse ancillary data nor UTF-8 decode: " + ancillaryData || "0x";
       }
     }
   }

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -296,7 +296,12 @@ class OptimisticOracleContractMonitor {
       // Return the decoded ancillary data as a string. The `replace` syntax removes any escaped quotes from the string.
       return "Ancillary data: " + JSON.stringify(parseAncillaryData(ancillaryData)).replace(/"/g, "");
     } catch (_) {
-      return `Could not decode ancillary data: ${ancillaryData || "0x"}`;
+      try {
+        // If that fails, try to return the ancillary data UTF-8 decoded.
+        return "Ancillary could not be parsed. UTF-8 decoded data: " + this.web3.utils.hexToUtf8(ancillaryData);
+      } catch (error) {
+        return `Could not parse ancillary data nor UTF-8 decode: ${ancillaryData || "0x"}`;
+      }
     }
   }
 }


### PR DESCRIPTION
**Motivation**

Sometimes the OO monitor will fail to decode data. in this cae we need to still see the ancillary data within the price request. this PR adds a fallback to use utf-8 decoding in this case so the logs are still usable.

sample log that could not be decoded:
<img width="607" alt="image" src="https://user-images.githubusercontent.com/12886084/149170293-0c1f45cf-6edb-4627-adc9-88079efdd639.png">

Using `Web3.utils.hexToUtf8(ancillaryData)` this should be able to be decoded.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

