### PR TITLE
feat(sdk): add generic state machine runner

### DIFF
--- a/packages/sdk/src/oracle/services/index.ts
+++ b/packages/sdk/src/oracle/services/index.ts
@@ -1,2 +1,3 @@
 export * as erc20 from "./erc20";
 export * as optimisticOracle from "./optimisticOracle";
+export * as statemachine from "./statemachine";

--- a/packages/sdk/src/oracle/services/statemachine.ts
+++ b/packages/sdk/src/oracle/services/statemachine.ts
@@ -39,7 +39,7 @@ export class StateMachine<P = undefined, M extends Memory = undefined> {
     try {
       assert(this.handlers[context.state], "No handler for state: " + context.state);
       const handler = this.handlers[context.state];
-      // handlers take in params and return a new state or nothin
+      // handlers take in params and return a new state or nothing
       const state = await handler(context.params, context.memory);
 
       // update context state

--- a/packages/sdk/src/oracle/services/statemachine.ts
+++ b/packages/sdk/src/oracle/services/statemachine.ts
@@ -1,0 +1,108 @@
+import assert from "assert";
+import type { Context, Handlers, Memory, Emit, ContextProps } from "../types/statemachine";
+import uid from "lodash/uniqueId";
+
+export { Context, Handlers, Emit };
+
+/**
+ * StateMachine. This class will be used to handle all change requests by the user, including setting state which
+ * may require triggering fetching data from chain, or initiating transactions that require tracking.
+ *
+ * This class is meant to step through states of a Context object. This object can have variable
+ * parameters and memory. There are several concepts to understand before using this class:
+ *
+ * 1. Handlers - This is the state machine state handlers, it is an objected keyed by each state, with a function handler.
+ * 2. Params - These are common parameters set by the caller, passed into each handler function.
+ * 3. Memory - This is a writing space within the state machine handlers that accumulates through states.
+ * 4. Context - This is the sum of all data needed to transition through the state machine states. It includes params, memory and metadata about the runtime.
+ * 5. Context.done - This is a special property on context.done which represents that the state machine is done transitioning this context.
+ * 6. Context.state = "done" - This is a reserved state on context.state, if set to "done" its the same thing as done = true.
+ * 7. Context.state = "error" - This is a reserved state on context.state, if set to "error" it means the context is done, but also there is an context.error object.
+ * 8. Interval - This is a property on the context which specifies the maximum rate in MS this context will transition, based on the current timestamp.
+ */
+export class StateMachine<P = undefined, M extends Memory = undefined> {
+  private pending: Record<string, Context<P, M>> = {};
+  constructor(public type: string, private handlers: Handlers<P, M>, private emit: Emit<P, M>) {}
+  private remove(id: string): void {
+    delete this.pending[id];
+  }
+  private shouldStep(context: Context<P, M>, now: number): boolean {
+    if (context.updated === undefined) return true;
+    if (!context?.interval) return true;
+    return now - context.updated >= context.interval;
+  }
+  public hasPending(): boolean {
+    return Object.values(this.pending).length > 0;
+  }
+  private async step(context: Context<P, M>, now: number): Promise<Context<P, M>> {
+    assert(!context.done, "Context has ended");
+    try {
+      assert(this.handlers[context.state], "No handler for state: " + context.state);
+      const handler = this.handlers[context.state];
+      // handlers take in params and return a new state or nothin
+      const state = await handler(context.params, context.memory);
+
+      // update context state
+      if (state) context.state = state;
+      // check for done
+      if (state === "done") context.done = true;
+    } catch (err) {
+      context.error = err as Error;
+      context.state = "error";
+      context.done = true;
+    }
+    context.updated = now;
+    return context;
+  }
+  /**
+   * tick. Process all pending contexts, move them to done if needed
+   *
+   * @param {} now - Specify the timestamp this tick is running on.
+   * @returns {Promise<boolean>} - Returns if there are still any pending contexts to run.
+   */
+  async tick(now = Date.now()): Promise<boolean> {
+    for (const context of Object.values(this.pending)) {
+      if (this.shouldStep(context, now)) {
+        const next = await this.step(context, now);
+        if (next.done) this.remove(context.id);
+        this.emit(next);
+      }
+    }
+    return this.hasPending();
+  }
+  /**
+   * create. This creates a new context to run in the state machine.
+   *
+   * @param {P} params - User defined parameters needed to pass into the state handlers.
+   * @param {M} memory - User defined memory needed to accumulate data to pass into state handlers.
+   * @param {Partial} override - Override any of the default properties in the context, should not be used often.
+   * @param {} now - Specify the current time as a number, by default Date.now();
+   * @returns {string} - Returns the ID of this context.
+   */
+  create(params: P, memory: M, override: Partial<ContextProps> = {}, now = Date.now()): string {
+    const { type } = this;
+    const context: Context<P, M> = {
+      id: uid(type),
+      state: "start",
+      done: false,
+      updated: undefined,
+      created: now,
+      type,
+      // override any part of the context, not recommended for most cases
+      ...override,
+      params,
+      memory,
+    };
+    this.pending[context.id] = context;
+    this.emit(context);
+    return context.id;
+  }
+  /**
+   * get. Lookup a context by id.
+   *
+   * @param {} id
+   */
+  get(id: string) {
+    return this.pending[id];
+  }
+}

--- a/packages/sdk/src/oracle/services/tests/statemachine.test.ts
+++ b/packages/sdk/src/oracle/services/tests/statemachine.test.ts
@@ -1,0 +1,131 @@
+import assert from "assert";
+import { Context, StateMachine } from "../statemachine";
+
+const handler1 = {
+  start() {
+    return "two";
+  },
+  two() {
+    return "three";
+  },
+  three() {
+    return "done";
+  },
+};
+const handler2 = {
+  start() {
+    throw new Error("fail");
+  },
+};
+type Counter = { count?: number };
+const handler3 = {
+  start(endCount: number, memory: Counter) {
+    if (memory.count == undefined) memory.count = 0;
+    memory.count++;
+    if (memory.count >= endCount) return "done";
+    return undefined;
+  },
+};
+describe("Oracle Statemachine", () => {
+  describe("handler1", () => {
+    let sm: StateMachine;
+    const state: Record<string, Context> = {};
+    beforeAll(() => {
+      sm = new StateMachine("handler1", handler1, (context: Context) => {
+        state[context.id] = context;
+      });
+    });
+    test("create", () => {
+      sm.create(undefined, undefined, { id: "a" }, 1);
+      assert.ok(state.a);
+    });
+    test("tick", async () => {
+      await sm.tick();
+      assert.ok(state.a);
+      assert.equal(state.a.state, "two");
+      assert.equal(state.a.done, false);
+    });
+    test("tick", async () => {
+      await sm.tick();
+      assert.equal(state.a.state, "three");
+      assert.equal(state.a.done, false);
+    });
+    test("tick", async () => {
+      await sm.tick();
+      assert.equal(state.a.state, "done");
+      assert.equal(state.a.done, true);
+    });
+  });
+  describe("handler2", () => {
+    let sm: StateMachine;
+    const state: Record<string, Context> = {};
+    beforeAll(() => {
+      sm = new StateMachine("handler2", handler2, (context: Context) => {
+        state[context.id] = context;
+      });
+    });
+    test("create", () => {
+      sm.create(undefined, undefined, { id: "b" }, 1);
+      assert.ok(state.b);
+    });
+    test("tick", async () => {
+      await sm.tick();
+      assert.ok(state.b);
+      assert.equal(state.b.done, true);
+      assert.equal(state.b.state, "error");
+      assert.ok(state.b.error, "error");
+    });
+  });
+  describe("handler3", () => {
+    let sm: StateMachine<number, Counter>;
+    const state: Record<string, Context<number, Counter>> = {};
+    let id: string;
+    beforeAll(() => {
+      sm = new StateMachine<number, Counter>("handler3", handler3, (context: Context<number, Counter>) => {
+        state[context.id] = context;
+      });
+    });
+    test("create", () => {
+      id = sm.create(3, {}, { interval: 10 }, 0);
+      assert.equal(Object.values(state).length, 1);
+    });
+    test("tick", async () => {
+      // first tick at time 0, initialize memory and increment 1
+      await sm.tick(0);
+      let ctx = state[id];
+      assert.ok(ctx);
+      assert.equal(ctx.done, false);
+      assert.equal(ctx.memory?.count, 1);
+      assert.equal(ctx.updated, 0);
+
+      // second tick at 5, is before the interval of 10, should not count
+      await sm.tick(5);
+      ctx = state[id];
+      assert.ok(ctx);
+      assert.equal(ctx.done, false);
+      assert.equal(ctx.memory?.count, 1);
+      assert.equal(ctx.updated, 0);
+
+      // third tick at 10 is on the interval, tick and increment
+      await sm.tick(10);
+      ctx = state[id];
+      assert.equal(ctx.done, false);
+      assert.equal(ctx.memory?.count, 2);
+      assert.equal(ctx.updated, 10);
+
+      // fourth tick before interval of 10, no increment
+      await sm.tick(15);
+      ctx = state[id];
+      assert.equal(ctx.memory?.count, 2);
+      assert.equal(ctx.updated, 10);
+
+      // last tick increments value to 3, which triggers end state, find in done table.
+      await sm.tick(20);
+      ctx = state[id];
+      assert.ok(ctx);
+      assert.equal(ctx.memory?.count, 3);
+      assert.equal(ctx.done, true);
+      assert.equal(ctx.updated, 20);
+    });
+  });
+});

--- a/packages/sdk/src/oracle/store/store.ts
+++ b/packages/sdk/src/oracle/store/store.ts
@@ -32,6 +32,12 @@ export default class Store<S> {
     // Once state is changed, an event is emitted, this is how we get changes out of the client and also allow for change detection.
     this.emit(this.state, prevState);
   }
+  // same as write
+  async writeAsync(cb: WriteCallback<S>): Promise<void> {
+    const prevState = this.state;
+    this.state = await produce(this.state, cb);
+    this.emit(this.state, prevState);
+  }
   read(): S {
     return this.state;
   }

--- a/packages/sdk/src/oracle/types/index.ts
+++ b/packages/sdk/src/oracle/types/index.ts
@@ -1,3 +1,4 @@
 export * as state from "./state";
 export * as ethers from "./ethers";
 export * as misc from "./misc";
+export * as statemachine from "./statemachine";

--- a/packages/sdk/src/oracle/types/statemachine.ts
+++ b/packages/sdk/src/oracle/types/statemachine.ts
@@ -1,0 +1,22 @@
+// memory can be any non primitive type or undefined
+// eslint-disable-next-line
+export type Memory = object | undefined;
+
+export type ContextProps = {
+  id: string;
+  type: string;
+  state: string;
+  done: boolean;
+  created: number;
+  updated: number | undefined;
+  error?: Error;
+  interval?: number;
+};
+
+export type Context<P = undefined, M extends Memory = undefined> = ContextProps & {
+  memory: M;
+  params: P;
+};
+export type Handler<P, M extends Memory> = (params: P, memory: M) => string | undefined;
+export type Handlers<P, M extends Memory> = Record<string, Handler<P, M>>;
+export type Emit<P, M extends Memory> = (context: Context<P, M>) => void;


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/3974/add-statemachine-runner-to-oo-client-for-handling-all-change-requests

**Summary**

This is a generic state machine implementation which will be used for triggering and tracking transactions, as well as fetching state on chain in reaction to user requests.  It has some features useful to tracking transactions, such as an interval value to prevent over querying, automatic error managament, and an optional memory space used for accumulating data across state transitions. 

**Details**
A statemachine is really useful for asyncronous tasks, like waiting for a pending transaction, or fetching several pieces of state conditionally or in series which may cause branching cases.  We can construct a simple transaction manager as an example:

1. Validate parameters to send transaction, send transaction, store hash in memory -> transition to 2, or end with error
2. check for transaction receipt with memory.hash , if found, transition to done, else stay in 2 and check on interval.

If we needed to execute other transactions after this one we could transition to another state, rather than ending. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
