### PR TITLE
improve(across-relayer): Remove hardcoded deployment data maps

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -52,11 +52,16 @@ export interface InstantRelay {
 
 export interface BridgePoolData {
   contract: BridgePoolWeb3;
+  earliestValidDepositQuoteTime: number;
   l2Token: { [chainId: string]: string }; // chainID=>L2TokenAddress
   currentTime: number;
   relayNonce: number;
   poolCollateralDecimals: number;
   poolCollateralSymbol: string;
+}
+
+export interface BridgePoolDeploymentData {
+  [key: string]: { timestamp: number };
 }
 
 export class InsuredBridgeL1Client {
@@ -129,6 +134,14 @@ export class InsuredBridgeL1Client {
     return this.relays[l1Token][deposit.depositHash];
   }
 
+  getBridgePoolDeployData(): BridgePoolDeploymentData {
+    this._throwIfNotInitialized();
+    const deployTimestamps: BridgePoolDeploymentData = {};
+    Object.keys(this.bridgePools).map((l1Token: string) => {
+      deployTimestamps[l1Token] = { timestamp: this.bridgePools[l1Token].earliestValidDepositQuoteTime };
+    });
+    return deployTimestamps;
+  }
   getWhitelistedTokensForChainId(chainId: string): { [l1TokenAddress: string]: string } {
     this._throwIfNotInitialized();
     return this.whitelistedTokens[chainId];
@@ -309,12 +322,25 @@ export class InsuredBridgeL1Client {
 
       const l1Token = toChecksumAddress(whitelistedTokenEvent.returnValues.l1Token);
       const l2Tokens = this.bridgePools[l1Token]?.l2Token;
+
+      // Store the WhitelistToken event timestamp as the earliest allowable deposit quote time for relays that will go
+      // through this bridge pool. If any relays have a quote time that is before the bridge pool was whitelisted,
+      // then it is by default invalid.
+      // Note: Only update this deployment time if the bridge pool address is reset.
+      const existingBridgePoolAddress = this.bridgePools[l1Token]?.contract.options.address;
+      const earliestValidDepositQuoteTime = Number(
+        (await this.l1Web3.eth.getBlock(whitelistedTokenEvent.blockNumber)).timestamp
+      );
       this.bridgePools[l1Token] = {
         l2Token: l2Tokens, // Re-use existing L2 token array and update after resetting other state.
         contract: (new this.l1Web3.eth.Contract(
           getAbi("BridgePool"),
           whitelistedTokenEvent.returnValues.bridgePool
         ) as unknown) as BridgePoolWeb3,
+        earliestValidDepositQuoteTime:
+          whitelistedTokenEvent.returnValues.bridgePool === existingBridgePoolAddress
+            ? this.bridgePools[l1Token].earliestValidDepositQuoteTime
+            : earliestValidDepositQuoteTime,
         // We'll set the following params when fetching bridge pool state in parallel.
         currentTime: 0,
         relayNonce: 0,

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -314,10 +314,9 @@ export class InsuredBridgeL1Client {
     // Lookup timestamp for each event block number in parallel instead of once per loop. We are ok fetching these
     // upfront because there shouldn't be that many WhitelistToken events in production, so the max number of web3
     // requests to send is anticipated to be low to lookup block numbers.
-    const getWhitelistedTokenEventBlockPromises = whitelistedTokenEvents.map((e) =>
-      this.l1Web3.eth.getBlock(e.blockNumber)
+    const whitelistedTokenBlocks = await Promise.all(
+      whitelistedTokenEvents.map((e) => this.l1Web3.eth.getBlock(e.blockNumber))
     );
-    const whitelistedTokenBlocks = await Promise.all(getWhitelistedTokenEventBlockPromises);
     for (let i = 0; i < whitelistedTokenEvents.length; i++) {
       const whitelistedTokenEvent = whitelistedTokenEvents[i];
       // Add L1=>L2 token mapping to whitelisted dictionary for this chain ID.

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -327,20 +327,17 @@ export class InsuredBridgeL1Client {
       // through this bridge pool. If any relays have a quote time that is before the bridge pool was whitelisted,
       // then it is by default invalid.
       // Note: Only update this deployment time if the bridge pool address is reset.
-      const existingBridgePoolAddress = this.bridgePools[l1Token]?.contract.options.address;
-      const earliestValidDepositQuoteTime = Number(
-        (await this.l1Web3.eth.getBlock(whitelistedTokenEvent.blockNumber)).timestamp
-      );
+      const earliestValidDepositQuoteTime =
+        whitelistedTokenEvent.returnValues.bridgePool === this.bridgePools[l1Token]?.contract.options.address
+          ? this.bridgePools[l1Token].earliestValidDepositQuoteTime
+          : Number((await this.l1Web3.eth.getBlock(whitelistedTokenEvent.blockNumber)).timestamp);
       this.bridgePools[l1Token] = {
         l2Token: l2Tokens, // Re-use existing L2 token array and update after resetting other state.
         contract: (new this.l1Web3.eth.Contract(
           getAbi("BridgePool"),
           whitelistedTokenEvent.returnValues.bridgePool
         ) as unknown) as BridgePoolWeb3,
-        earliestValidDepositQuoteTime:
-          whitelistedTokenEvent.returnValues.bridgePool === existingBridgePoolAddress
-            ? this.bridgePools[l1Token].earliestValidDepositQuoteTime
-            : earliestValidDepositQuoteTime,
+        earliestValidDepositQuoteTime,
         // We'll set the following params when fetching bridge pool state in parallel.
         currentTime: 0,
         relayNonce: 0,

--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -8,6 +8,7 @@ const fixedPointAdjustment = toBNWei(1);
 import { createEtherscanLinkMarkdown, createFormatFunction, PublicNetworks } from "@uma/common";
 import {
   InsuredBridgeL1Client,
+  BridgePoolDeploymentData,
   InsuredBridgeL2Client,
   GasEstimator,
   Deposit,
@@ -64,7 +65,7 @@ export class Relayer {
     readonly whitelistedRelayL1Tokens: string[],
     readonly account: string,
     readonly whitelistedChainIds: number[],
-    readonly l1DeployData: { [key: string]: { timestamp: number } },
+    readonly l1DeployData: BridgePoolDeploymentData,
     readonly l2DeployData: { [key: string]: { blockNumber: number } },
     readonly l2LookbackWindow: number,
     readonly multicallBundler: MulticallBundler

--- a/packages/insured-bridge-relayer/src/RelayerConfig.ts
+++ b/packages/insured-bridge-relayer/src/RelayerConfig.ts
@@ -1,8 +1,6 @@
 import Web3 from "web3";
 const { toChecksumAddress } = Web3.utils;
 
-import { replaceAddressCase } from "@uma/common";
-
 // These are the block heights at which deposit box contracts were deployed on-chain. We use this in the fallback
 // search for a FundsDeposited L2 event to optimize how we search for the event. We don't need to search for events
 // earlier than the BridgeDepositBox's deployment block. We could try to automatically fetch this from on-chain
@@ -43,7 +41,6 @@ export class RelayerConfig {
   readonly relayerDiscount: number;
   readonly botModes: BotModes;
 
-  readonly l1DeployData: { [key: string]: { timestamp: number } };
   readonly l2DeployData: { [key: string]: { blockNumber: number } };
 
   constructor(env: ProcessEnv) {
@@ -63,7 +60,6 @@ export class RelayerConfig {
       L1_FINALIZER_ENABLED,
       L2_FINALIZER_ENABLED,
       WHITELISTED_CHAIN_IDS,
-      L1_DEPLOY_DATA,
       L2_DEPLOY_DATA,
     } = env;
 
@@ -108,7 +104,6 @@ export class RelayerConfig {
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;
     this.errorRetriesTimeout = ERROR_RETRIES_TIMEOUT ? Number(ERROR_RETRIES_TIMEOUT) : 1;
 
-    this.l1DeployData = replaceAddressCase(L1_DEPLOY_DATA ? JSON.parse(L1_DEPLOY_DATA) : bridgePoolDeployData);
     this.l2DeployData = L2_DEPLOY_DATA ? JSON.parse(L2_DEPLOY_DATA) : bridgeDepositBoxDeployData;
 
     // CHAIN_IDS sets the active chain ID's for this bot. Note how this is distinct from WHITELISTED_CHAIN_IDS which

--- a/packages/insured-bridge-relayer/src/index.ts
+++ b/packages/insured-bridge-relayer/src/index.ts
@@ -99,7 +99,7 @@ export async function run(logger: winston.Logger, l1Web3: Web3): Promise<void> {
           filteredL1Whitelist,
           accounts[0],
           config.whitelistedChainIds,
-          config.l1DeployData,
+          l1Client.getBridgePoolDeployData(),
           config.l2DeployData,
           config.l2BlockLookback,
           multicallBundler


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Its easy to forget to update this map of L1 tokens to bridge pool deployment times, and moreover its trivial to approximate these deployment times using on-chain data.


**Summary**

This adds no additional web3 requests to each bot run, it just stores extra data from the existing web3 requests.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested