### PR TITLE
feat: add proposer address and deployment script

### DIFF
--- a/packages/core/deploy/051_deploy_proposer.js
+++ b/packages/core/deploy/051_deploy_proposer.js
@@ -1,0 +1,25 @@
+const { ZERO_ADDRESS } = require("@uma/common");
+
+const func = async function (hre) {
+  const { deployments, getNamedAccounts, web3 } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+
+  const Finder = await deployments.get("Finder");
+  const Governor = await deployments.get("Governor");
+  const VotingToken = await deployments.get("VotingToken");
+  const Timer = (await deployments.getOrNull("Timer")) || { address: ZERO_ADDRESS };
+
+  const defaultBond = web3.utils.toWei("5000");
+
+  await deploy("Proposer", {
+    from: deployer,
+    args: [VotingToken.address, defaultBond, Governor.address, Finder.address, Timer.address],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
+};
+module.exports = func;
+func.tags = ["Proposer", "dvm"];
+func.dependencies = ["Finder", "VotingToken", "Governor", "Timer"];

--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -198,5 +198,9 @@
     "contractName": "BridgePoolProd",
     "deploymentName": "WBTC_BridgePool",
     "address": "0x02fbb64517E1c6ED69a6FAa3ABf37Db0482f1152"
+  },
+  {
+    "contractName": "Proposer",
+    "address": "0x226726Ac52e6e948D1B7eA9168F9Ff2E27DbcbB5"
   }
 ]


### PR DESCRIPTION
**Motivation**

To move to a decentralized proposal system, we need to deploy a proposer contract.


**Summary**

Adds simple proposer deployment script and a deployed proposer address.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
