### PR TITLE
feat: allow bot to settle on behalf of other accounts

### DIFF
--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -170,9 +170,10 @@ async function Poll(callback) {
         : {},
       // If there is an optimistic oracle config, add it. Else, set to null. Example config:
       // {
-      //   "disputePriceErrorPercent":0.05 -> Proposal prices that do not equal the dispute price
+      //   "disputePriceErrorPercent":0.05, -> Proposal prices that do not equal the dispute price
       //                                      within this error % will be disputed.
       //                                      e.g. 0.05 implies 5% margin of error.
+      //   "otherAccountsToSettle": ["0x1234", "0x5678"] -> Other accounts for which this bot will call settle.
       //  }
       optimisticOracleProposerConfig: process.env.OPTIMISTIC_ORACLE_PROPOSER_CONFIG
         ? JSON.parse(process.env.OPTIMISTIC_ORACLE_PROPOSER_CONFIG)

--- a/packages/optimistic-oracle/test/proposer.js
+++ b/packages/optimistic-oracle/test/proposer.js
@@ -84,9 +84,9 @@ describe("OptimisticOracle: proposer.js", function () {
   ];
   let collateralCurrenciesForIdentifier;
 
-  const verifyState = async (state, identifier, ancillaryData = "0x") => {
+  const verifyState = async (state, identifier, ancillaryData = "0x", time = requestTime) => {
     assert.equal(
-      (await optimisticOracle.methods.getState(requester, identifier, requestTime, ancillaryData).call()).toString(),
+      (await optimisticOracle.methods.getState(requester, identifier, time, ancillaryData).call()).toString(),
       state
     );
   };
@@ -209,7 +209,7 @@ describe("OptimisticOracle: proposer.js", function () {
       };
       // For this test, we'll dispute any proposals that are not equal to historical price up to a
       // 10% margin of error
-      let optimisticOracleProposerConfig = { disputePriceErrorPercent: 0.1 };
+      let optimisticOracleProposerConfig = { disputePriceErrorPercent: 0.1, otherAccountsToSettle: [randoProposer] };
       proposer = new OptimisticOracleProposer({
         logger: spyLogger,
         optimisticOracleClient: client,
@@ -461,6 +461,33 @@ describe("OptimisticOracle: proposer.js", function () {
       assert.equal(spy.getCall(-1).lastArg.payout, toBN(totalDefaultBond).add(toBN(finalFee).divn(2)));
       assert.ok(spy.getCall(-1).lastArg.settleResult.tx);
       assert.equal(spy.callCount, spyCountPreSettle + 1);
+    });
+
+    it("Can settle other account's proposals", async function () {
+      // Make one proposal for bot to settle.
+      let collateralCurrency = collateralCurrenciesForIdentifier[0];
+      await collateralCurrency.methods
+        .approve(optimisticOracle.options.address, totalDefaultBond)
+        .send({ from: randoProposer });
+      await optimisticOracle.methods
+        .proposePrice(
+          requester,
+          identifiersToTest[0],
+          requestTime,
+          ancillaryDataAddresses[0],
+          "1" // Arbitrary price that bot will dispute
+        )
+        .send({ from: randoProposer });
+
+      // Now, advance time so that the proposals expire and check that the bot can settle the proposals
+      await optimisticOracle.methods.setCurrentTime((Number(startTime) + liveness).toString()).send({ from: owner });
+
+      // Now make the bot settle the requests.
+      await proposer.update();
+      await proposer.settleRequests();
+
+      // Check that the requests are in the correct state.
+      await verifyState(OptimisticOracleRequestStatesEnum.SETTLED, identifiersToTest[0], ancillaryDataAddresses[0]);
     });
 
     it("Correctly caches created price feeds", async function () {


### PR DESCRIPTION
**Motivation**

The optimistic oracle bot should optionally do settlements for arbitrary accounts.

**Summary**

This adds a new variable in the bot's config to allow additional accounts to be considered during settlement.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
