### PR TITLE
fix(pf): use close price for matching cryptowatch close timestamps

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -190,7 +190,7 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     // its close price. We prefer prices that occurred before the target time.
     else {
       // Use period close price when request time matches close time. In all other cases use open price instead.
-      const matchedPrice = time == match.closeTime ? match.closePrice : match.openPrice;
+      const matchedPrice = time === match.closeTime ? match.closePrice : match.openPrice;
       returnPrice = this.invertPrice ? this._invertPriceSafely(matchedPrice) : matchedPrice;
       if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
       if (verbose) await this._printVerbose(match, returnPrice);

--- a/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.ts
@@ -189,7 +189,9 @@ export class CryptoWatchPriceFeed extends PriceFeedInterface {
     // why we prefer `before` periods to `after` ones. Similar reasoning is why we default to a period's open price to
     // its close price. We prefer prices that occurred before the target time.
     else {
-      returnPrice = this.invertPrice ? this._invertPriceSafely(match.openPrice) : match.openPrice;
+      // Use period close price when request time matches close time. In all other cases use open price instead.
+      const matchedPrice = time == match.closeTime ? match.closePrice : match.openPrice;
+      returnPrice = this.invertPrice ? this._invertPriceSafely(matchedPrice) : matchedPrice;
       if (!returnPrice) throw new Error(`${this.uuid} -- invalid price returned`);
       if (verbose) await this._printVerbose(match, returnPrice);
     }

--- a/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CryptoWatchPriceFeed.js
@@ -166,8 +166,8 @@ describe("CryptoWatchPriceFeed.js", function () {
     // During period 2.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376405)).toString(), toWei("1.2"));
 
-    // Matches both period 2's close price and period 3's open price, should pick earlier period by default.
-    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376460)).toString(), toWei("1.2"));
+    // Matches exactly period 2's close time, should pick its close price.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376460)).toString(), toWei("1.3"));
 
     // During period 3.
     assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376515)).toString(), toWei("1.3"));
@@ -460,11 +460,11 @@ describe("CryptoWatchPriceFeed.js", function () {
     );
 
     // When passing in ancillary data that doesn't specify TWAP length, pricefeed default twapLength is used. In this
-    // case, the default TWAP length is 0 so it should return the current price for the timestamp.
-    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376460, "")).toString(), web3.utils.toWei("1.2"));
+    // case, the default TWAP length is 0 so it should return the closing price as it matches close timestamp.
+    assert.equal((await cryptoWatchPriceFeed.getHistoricalPrice(1588376460, "")).toString(), web3.utils.toWei("1.3"));
     assert.equal(
       (await cryptoWatchPriceFeed.getHistoricalPrice(1588376460, utf8ToHex("key:value"))).toString(),
-      web3.utils.toWei("1.2")
+      web3.utils.toWei("1.3")
     );
 
     // If ancillary data can't be parsed to UTF8, then it should throw.

--- a/packages/scripts/src/local/getHistoricalPrice.js
+++ b/packages/scripts/src/local/getHistoricalPrice.js
@@ -69,7 +69,7 @@ async function main() {
       `Optional '--time' flag not specified, defaulting to the current Unix timestamp (in seconds): ${queryTime}`
     );
   } else {
-    queryTime = argv.time;
+    queryTime = Number(argv.time);
   }
   console.log(`⏰ Fetching nearest prices for the timestamp: ${new Date(queryTime * 1000).toUTCString()}`);
   const lookback = Math.round(Math.max(getTime() - queryTime, 1800));


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Normally price feed should pick the last available price at or before request timestamp.


**Summary**

When price request timestamp matches close timestamp for Cryptowatch it now resolves to matching close price (previously it returned open price for the same period).


**Details**

Added check on whether price request timestamp matches end of OHLC period.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

