### PR TITLE
feat(OO-bot): Improve settlement logs

### DIFF
--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -192,9 +192,9 @@ class OptimisticOracleContractMonitor {
           this.contractProps.networkId
         ) +
         ` disputed a price for the request made by ${event.requester} at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
-        `The proposer ${
+        `The proposer ${createEtherscanLinkMarkdown(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposer : event.request.proposer
-        } proposed a price of ${this.formatDecimalString(
+        )} proposed a price of ${this.formatDecimalString(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposedPrice : event.request.proposedPrice
         )}. ` +
         this._formatAncillaryData(event.ancillaryData) +
@@ -245,12 +245,14 @@ class OptimisticOracleContractMonitor {
           .toString();
       }
       const mrkdwn =
-        `Detected a price request settlement for the request made by ${event.requester} at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
-        `The proposer was ${
+        `Detected a price request settlement for the request made by ${createEtherscanLinkMarkdown(
+          event.requester
+        )} at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
+        `The proposer was ${createEtherscanLinkMarkdown(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposer : event.request.proposer
-        } and the disputer was ${
+        )} and the disputer was ${createEtherscanLinkMarkdown(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.disputer : event.request.disputer
-        }. ` +
+        )}. ` +
         `The settlement price is ${this.formatDecimalString(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.price : event.request.resolvedPrice
         )}. ` +

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -141,7 +141,10 @@ class OptimisticOracleContractMonitor {
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposer : event.request.proposer,
           this.contractProps.networkId
         ) +
-        ` proposed a price for the request made by ${event.requester} at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
+        ` proposed a price for the request made by ${createEtherscanLinkMarkdown(
+          event.requester,
+          this.contractProps.networkId
+        )} at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
         `The proposal price of ${this.formatDecimalString(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposedPrice : event.request.proposedPrice
         )} will expire at ${

--- a/packages/optimistic-oracle/src/proposer.js
+++ b/packages/optimistic-oracle/src/proposer.js
@@ -448,17 +448,25 @@ class OptimisticOracleProposer {
         transaction: settle,
         transactionConfig: { ...this.gasEstimator.getCurrentFastPrice(), from: this.account },
       });
+      console.log("receipt", receipt.events.Settle.returnValues);
+      console.log("skinny", this.optimisticOracleClient.oracleType);
+      console.log(
+        "select",
+        this.optimisticOracleClient.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
+          ? receipt.events.Settle.returnValues.request.proposer
+          : receipt.events.Settle.returnValues.proposer
+      );
       const mrkdwn =
         createEtherscanLinkMarkdown(
-          this.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
+          this.optimisticOracleClient.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
             ? receipt.events.Settle.returnValues.request.proposer
             : receipt.events.Settle.returnValues.proposer,
           this.chainId
         ) +
         " proposed a price of " +
         this.formatDecimalString(
-          this.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
-            ? receipt.events.Settle.returnValues.request.price
+          this.optimisticOracleClient.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
+            ? receipt.events.Settle.returnValues.request.proposedPrice
             : receipt.events.Settle.returnValues.price
         ) +
         " proposal for " +
@@ -484,6 +492,7 @@ class OptimisticOracleProposer {
         notificationPath: "optimistic-oracle",
       });
     } catch (error) {
+      console.log("error", error);
       const message =
         error.type === "call" ? "Cannot settle for unknown reason☹️" : "Failed to settle proposal or dispute🚨";
       this.logger.error({ at: "OptimisticOracleProposer#settleRequests", message, priceRequest, error });

--- a/packages/optimistic-oracle/src/proposer.js
+++ b/packages/optimistic-oracle/src/proposer.js
@@ -6,10 +6,14 @@ const {
   OptimisticOracleType,
 } = require("@uma/financial-templates-lib");
 const {
+  createFormatFunction,
+  createEtherscanLinkMarkdown,
+  parseAncillaryData,
   createObjectFromDefaultProps,
   runTransaction,
   OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY,
   OPTIMISTIC_ORACLE_IGNORE,
+  ZERO_ADDRESS,
 } = require("@uma/common");
 const { getAbi } = require("@uma/contracts-node");
 
@@ -36,6 +40,7 @@ class OptimisticOracleProposer {
     this.optimisticOracleClient = optimisticOracleClient;
     this.web3 = this.optimisticOracleClient.web3;
     this.commonPriceFeedConfig = commonPriceFeedConfig;
+    this.chainId = optimisticOracleClient.chainId;
 
     // Gas Estimator to calculate the current Fast gas rate.
     this.gasEstimator = gasEstimator;
@@ -43,6 +48,9 @@ class OptimisticOracleProposer {
     this.createEmpContract = (empAddress) => {
       return new this.web3.eth.Contract(getAbi("ExpiringMultiParty"), empAddress);
     };
+
+    // Formats an 18 decimal point string with a define number of decimals and precision for use in message generation.
+    this.formatDecimalString = createFormatFunction(2, 4, false);
 
     this.optimisticOracleContract = this.optimisticOracleClient.oracle;
 
@@ -435,30 +443,45 @@ class OptimisticOracleProposer {
       priceRequest,
     });
     try {
-      const { receipt, returnValue, transactionConfig } = await runTransaction({
+      const { receipt, returnValue } = await runTransaction({
         web3: this.web3,
         transaction: settle,
         transactionConfig: { ...this.gasEstimator.getCurrentFastPrice(), from: this.account },
       });
-
-      const logResult = {
-        tx: receipt.transactionHash,
-        // This is undefined unless the oracle type is SkinnyOptimisticOracle.
-        ...receipt.events.Settle.returnValues.request,
-        ...receipt.events.Settle.returnValues,
-        identifier: this.hexToUtf8(receipt.events.Settle.returnValues.identifier),
-        ancillaryData: receipt.events.Settle.returnValues.ancillaryData || "0x",
-      };
-      this.logger.info({
-        at: "OptimisticOracleProposer#settleRequests",
-        message: "Settled proposal or dispute!⛑",
-        priceRequest,
-        payout:
+      const mrkdwn =
+        createEtherscanLinkMarkdown(
+          this.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
+            ? receipt.events.Settle.returnValues.request.proposer
+            : receipt.events.Settle.returnValues.proposer,
+          this.chainId
+        ) +
+        " proposed a price of " +
+        this.formatDecimalString(
+          this.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
+            ? receipt.events.Settle.returnValues.request.price
+            : receipt.events.Settle.returnValues.price
+        ) +
+        " proposal for " +
+        this.hexToUtf8(receipt.events.Settle.returnValues.identifier) +
+        " at timestamp " +
+        receipt.events.Settle.returnValues.timestamp +
+        " with " +
+        this._formatAncillaryData(receipt.events.Settle.returnValues.ancillaryData) +
+        " which has been settled! proposer payout is " +
+        this.formatDecimalString(
           this.optimisticOracleClient.oracleType === OptimisticOracleType.SkinnyOptimisticOracle
             ? returnValue.payout.toString()
-            : returnValue.toString(),
-        settleResult: logResult,
-        transactionConfig,
+            : returnValue.toString()
+        ) +
+        " tx: " +
+        createEtherscanLinkMarkdown(receipt.transactionHash, this.chainId);
+      this.logger.info({
+        at: "OptimisticOracleProposer#settleRequests",
+        message: `Settled ${
+          receipt.events.Settle.returnValues.disputer === ZERO_ADDRESS ? "proposal 💍!" : "dispute ⛑!"
+        }`,
+        mrkdwn,
+        notificationPath: "optimistic-oracle",
       });
     } catch (error) {
       const message =
@@ -530,6 +553,20 @@ class OptimisticOracleProposer {
     );
     if (newPriceFeed) this.priceFeedCache[identifier] = newPriceFeed;
     return newPriceFeed;
+  }
+
+  _formatAncillaryData(ancillaryData) {
+    try {
+      // Return the decoded ancillary data as a string. The `replace` syntax removes any escaped quotes from the string.
+      return "Ancillary data: " + JSON.stringify(parseAncillaryData(ancillaryData)).replace(/"/g, "");
+    } catch (_) {
+      try {
+        // If that fails, try to return the ancillary data UTF-8 decoded.
+        return "Ancillary data: " + this.web3.utils.hexToUtf8(ancillaryData);
+      } catch (_) {
+        return "Could not parse ancillary data nor UTF-8 decode: " + ancillaryData || "0x";
+      }
+    }
   }
 }
 

--- a/packages/optimistic-oracle/test/skinnyProposer.js
+++ b/packages/optimistic-oracle/test/skinnyProposer.js
@@ -4,7 +4,7 @@ const hre = require("hardhat");
 const { getContract } = hre;
 const { assert } = require("chai");
 
-const { toWei, hexToUtf8, utf8ToHex, toBN, padRight } = web3.utils;
+const { toWei, hexToUtf8, utf8ToHex, padRight } = web3.utils;
 
 const {
   OptimisticOracleClient,
@@ -487,9 +487,9 @@ describe("SkinnyOptimisticOracle: proposer.js", function () {
         );
       }
       assert.equal(lastSpyLogLevel(spy), "info");
-      assert.isTrue(spyLogIncludes(spy, -1, "Settled proposal or dispute"));
-      assert.equal(spy.getCall(-1).lastArg.payout, totalDefaultBond);
-      assert.ok(spy.getCall(-1).lastArg.settleResult.tx);
+      assert.isTrue(spyLogIncludes(spy, -1, "Settled dispute"));
+      assert.isTrue(spyLogIncludes(spy, -1, "2.00")); // total default bond of 2e18, scaled by wei
+      assert.isTrue(spyLogIncludes(spy, -1, "tx")); // contains a tx hash
       assert.equal(spy.callCount, spyCountPreSettle + (identifiersToTest.length - 1));
 
       // Finally resolve the dispute and check that the bot settles the dispute.
@@ -508,10 +508,10 @@ describe("SkinnyOptimisticOracle: proposer.js", function () {
         latestPriceSettlement.returnValues.request
       );
       assert.equal(lastSpyLogLevel(spy), "info");
-      assert.isTrue(spyLogIncludes(spy, -1, "Settled proposal or dispute"));
+      assert.isTrue(spyLogIncludes(spy, -1, "Settled dispute"));
       // Note: payout is equal to original default bond + 1/2 of loser's dispute bond (not including loser's final fee)
-      assert.equal(spy.getCall(-1).lastArg.payout, toBN(totalDefaultBond).add(toBN(finalFee).divn(2)));
-      assert.ok(spy.getCall(-1).lastArg.settleResult.tx);
+      assert.isTrue(spyLogIncludes(spy, -1, "2.50")); // total default bond of 2e18 + half looser bond of 0.5e18, scaled by wei
+      assert.isTrue(spyLogIncludes(spy, -1, "tx")); // contains a tx hash
       assert.equal(spy.callCount, spyCountPreSettle + 1);
     });
 


### PR DESCRIPTION
Settlement logs can be really messy. this was not an issue before as we were not settling a lot of request. now, however, we are settling requests on a number of chains. To improve quality of life, this PR refines how settlement logs are produced.

Sample message boy output mark-down:

[0x3C4...4293BC](https://etherscan.io/address/0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC) proposed a price of1.00 proposal for TEST8DECIMALS at timestamp 1643168842 with Ancillary data 0x which has been settled! proposer payout is 2.00 tx: [0xcad...cfc567](https://etherscan.io/tx/0xcad8a94db472de0aff860dd8db7b594f59cb0d522a0b8499051b2eaabfcfc567)

