### PR TITLE
feat(transports): Add discord logger transport

### DIFF
--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -54,14 +54,15 @@ export class DiscordTransport extends Transport {
     }
 
     // For each markdown link, build the new link with the discord format. Replace the original link with the new one.
+    let modifiedMessage = msg;
     for (let i = 0; i < startIndexes.length; i++) {
       const originalUrl = msg.substring(startIndexes[i], endIndexes[i] + 1);
       const pipeIndex = originalUrl.indexOf("|");
       const markdownUrl =
         `[${originalUrl.substring(pipeIndex + 1, originalUrl.length - 1)}]` + // hyperlink
         `(${originalUrl.substring(1, pipeIndex)})`; // url
-      msg = msg.replace(originalUrl, markdownUrl);
+      modifiedMessage = modifiedMessage.replace(originalUrl, markdownUrl);
     }
-    return msg;
+    return modifiedMessage;
   }
 }

--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -1,0 +1,67 @@
+import Transport from "winston-transport";
+
+import axios from "axios";
+
+type TransportOptions = ConstructorParameters<typeof Transport>[0];
+
+export class DiscordTransport extends Transport {
+  private readonly defaultWebHookUrl: string;
+  private readonly escalationPathWebhookUrls: { [key: string]: string };
+  constructor(
+    winstonOpts: TransportOptions,
+    ops: { defaultWebHookUrl: string; escalationPathWebhookUrls: { [key: string]: string } }
+  ) {
+    super(winstonOpts);
+    this.defaultWebHookUrl = ops.defaultWebHookUrl;
+    this.escalationPathWebhookUrls = ops.escalationPathWebhookUrls || {};
+  }
+
+  // Note: info must be any because that's what the base class uses.
+  async log(info: any, callback: () => void): Promise<void> {
+    try {
+      const body = {
+        username: "UMA Infrastructure",
+        avatar_url: "https://i.imgur.com/RCcxxEZ.png",
+        embeds: [{ title: `${info.at}: ${info.message}`, description: this.formatLinks(info.mrkdwn), color: 9696729 }],
+      };
+
+      // Select webhook url based on escalation path. if escalation path is not found, use default webhook url.
+      const webHook = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
+
+      // Send webhook request. This posts the message on discord.
+      await axios.post(webHook, body);
+    } catch (error) {
+      console.error("Discord error", error);
+    }
+
+    callback();
+  }
+
+  // Discord URLS are formatted differently to markdown links produced upstream in the bots. For example, slack links
+  // will look like this <https://google.com|google.com> but links for discord should look like this
+  // [google.com](https://google.com).This function takes in the one format and converts it to the other such that
+  // links sent to discord are nicely formatted and clickable.
+  formatLinks(msg: any): any {
+    // Find the start and end indexes of all the markdown links.
+    const startIndexes: any = [];
+    const endIndexes: any = [];
+    for (let i = 0; i < msg.length; i++) {
+      const startIndex = msg.indexOf("<http", i);
+      if (!startIndexes.includes(startIndex) && startIndex != -1) startIndexes.push(startIndex);
+
+      const endIndex = msg.indexOf(">", i);
+      if (!endIndexes.includes(endIndex) && endIndex != -1) endIndexes.push(endIndex);
+    }
+
+    // For each markdown link, build the new link with the discord format. Replace the original link with the new one.
+    for (let i = 0; i < startIndexes.length; i++) {
+      const originalUrl = msg.substring(startIndexes[i], endIndexes[i] + 1);
+      const pipeIndex = originalUrl.indexOf("|");
+      const markdownUrl =
+        `[${originalUrl.substring(pipeIndex + 1, originalUrl.length - 1)}]` + // hyperlink
+        `(${originalUrl.substring(1, pipeIndex)})`; // url
+      msg = msg.replace(originalUrl, markdownUrl);
+    }
+    return msg;
+  }
+}

--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -46,7 +46,7 @@ export class DiscordTransport extends Transport {
     const startIndexes: any = [];
     const endIndexes: any = [];
     for (let i = 0; i < msg.length; i++) {
-      const startIndex = msg.indexOf("<http", i);
+      const startIndex = msg.indexOf("<", i);
       if (!startIndexes.includes(startIndex) && startIndex != -1) startIndexes.push(startIndex);
 
       const endIndex = msg.indexOf(">", i);

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -93,10 +93,9 @@ class OptimisticOracleContractMonitor {
       );
       const mrkdwn =
         createEtherscanLinkMarkdown(event.requester, this.contractProps.networkId) +
-        ` requested a price at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
+        ` requested a price at the timestamp ${event.timestamp} for the identifier: ${event.identifier}.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        ". " +
-        `Collateral currency address is ${
+        `. \nCollateral currency address is ${
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.currency : event.request.currency
         }. Reward amount is ${this.formatDecimalString(
           convertCollateralDecimals(
@@ -106,8 +105,7 @@ class OptimisticOracleContractMonitor {
           convertCollateralDecimals(
             this.oracleType === OptimisticOracleType.OptimisticOracle ? event.finalFee : event.request.finalFee
           )
-        )}. ` +
-        `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
+        )}. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -142,16 +140,15 @@ class OptimisticOracleContractMonitor {
           this.contractProps.networkId
         ) +
         ` proposed a price for the request made by ${event.requester} at the timestamp ${event.timestamp} for the identifier: ${event.identifier}. ` +
-        `The proposal price of ${this.formatDecimalString(
+        `\nThe proposal price of ${this.formatDecimalString(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposedPrice : event.request.proposedPrice
         )} will expire at ${
           this.oracleType === OptimisticOracleType.OptimisticOracle
             ? event.expirationTimestamp
             : event.request.expirationTime
-        }. ` +
+        }.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        ". " +
-        `Collateral currency address is ${
+        +`.\n Collateral currency address is ${
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.currency : event.request.currency
         }. ` +
         `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
@@ -193,10 +190,9 @@ class OptimisticOracleContractMonitor {
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposer : event.request.proposer
         } proposed a price of ${this.formatDecimalString(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposedPrice : event.request.proposedPrice
-        )}. ` +
+        )}.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        ". " +
-        `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
+        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
@@ -253,10 +249,9 @@ class OptimisticOracleContractMonitor {
         )}. ` +
         `The payout was ${this.formatDecimalString(convertCollateralDecimals(payout))} made to the ${
           isDispute ? "winner of the dispute" : "proposer"
-        }. ` +
+        }.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        ". " +
-        `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
+        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -298,7 +293,7 @@ class OptimisticOracleContractMonitor {
     } catch (_) {
       try {
         // If that fails, try to return the ancillary data UTF-8 decoded.
-        return "Ancillary could not be parsed. UTF-8 decoded data: " + this.web3.utils.hexToUtf8(ancillaryData);
+        return "Ancillary data: " + this.web3.utils.hexToUtf8(ancillaryData);
       } catch (_) {
         return "Could not parse ancillary data nor UTF-8 decode: " + ancillaryData || "0x";
       }

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -148,10 +148,10 @@ class OptimisticOracleContractMonitor {
             : event.request.expirationTime
         }.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        +`.\n Collateral currency address is ${
+        `.\n Collateral currency address is ${
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.currency : event.request.currency
         }. ` +
-        `tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
+        `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       // The default log level should be reduced to "info" for funding rate identifiers:
       this.logger[


### PR DESCRIPTION
**Motivation**

We want to be able to send messages from our bots to discord. This PR adds a discord transport to facilitate this.

The configs are set to be the same as slack: a `defaultWebHookUrl` that is used for all messages unless a `escalationPathWebhookUrls` is provided for the associated message `notificationPath`.

Sample message

![image](https://user-images.githubusercontent.com/12886084/151230623-588ab583-1f42-40af-918e-5bf5e58a36f0.png)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested