### PR TITLE
feat(transports): Modify discord transport config

### DIFF
--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -34,7 +34,7 @@ export class DiscordTransport extends Transport {
       // Select webhook from escalation path. If no escalation, use default webhook url, if postOnNonEscalationPaths is
       // true.Else, if postOnNonEscalationPaths is false and there is no escalation path, do not post. This enables the
       // transport to be configured to only send messages that have a specific escalation path.
-      if (this.postOnNonEscalationPaths && this.escalationPathWebhookUrls[info.notificationPath] != undefined) {
+      if (this.postOnNonEscalationPaths && this.escalationPathWebhookUrls[info.notificationPath]) {
         const webHook = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
 
         // Send webhook request. This posts the message on discord.


### PR DESCRIPTION
**Motivation**

We dont always want to post all messages to the discord transport, like we do with other transports. For example, you might only want to post messages that include the specific escalation path. eg you send OO messages to slack but not risk/infrastructure messages.

this PR adds another setting`postOnNonEscalationPaths` that lets the user toggle this behavour.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

