### PR TITLE
feat(monitors): split UI link from other log messages due to length 

### DIFF
--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -119,10 +119,11 @@ class OptimisticOracleContractMonitor {
           )
         )}. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
+      const logLevel =
+        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "error");
+
       // The default log level should be reduced to "debug" for funding rate identifiers:
-      this.logger[
-        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "error")
-      ]({
+      this.logger[logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Request Alert 👮🏻!`,
         mrkdwn,
@@ -130,9 +131,7 @@ class OptimisticOracleContractMonitor {
       });
 
       // UI link is sent separately because it can break slack message limits.
-      this.logger[
-        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
-      ]({
+      this.logger[logLevel === "error" ? "info" : logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Request Alert 👮🏻!`,
         mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
@@ -177,10 +176,11 @@ class OptimisticOracleContractMonitor {
         )}. ` +
         `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
+      const logLevel =
+        this.logOverrides.proposedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error");
+
       // The default log level should be reduced to "info" for funding rate identifiers:
-      this.logger[
-        this.logOverrides.proposedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error")
-      ]({
+      this.logger[logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
         mrkdwn,
@@ -188,9 +188,7 @@ class OptimisticOracleContractMonitor {
       });
 
       // UI link is sent separately because it can break slack message limits.
-      this.logger[
-        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
-      ]({
+      this.logger[logLevel === "error" ? "info" : logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
         mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
@@ -230,7 +228,9 @@ class OptimisticOracleContractMonitor {
         this._formatAncillaryData(event.ancillaryData) +
         `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
-      this.logger[this.logOverrides.disputedPrice || "error"]({
+      const logLevel = this.logOverrides.disputedPrice || "error";
+
+      this.logger[logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
         mrkdwn,
@@ -238,9 +238,7 @@ class OptimisticOracleContractMonitor {
       });
 
       // UI link is sent separately because it can break slack message limits.
-      this.logger[
-        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
-      ]({
+      this.logger[logLevel === "error" ? "info" : logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
         mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
@@ -301,10 +299,11 @@ class OptimisticOracleContractMonitor {
         this._formatAncillaryData(event.ancillaryData) +
         `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
+      const logLevel =
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info");
+
       // The default log level should be reduced to "debug" for funding rate identifiers:
-      this.logger[
-        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
-      ]({
+      this.logger[logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Settlement Alert 🏧!`,
         mrkdwn,
@@ -312,9 +311,7 @@ class OptimisticOracleContractMonitor {
       });
 
       // UI link is sent separately because it can break slack message limits.
-      this.logger[
-        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
-      ]({
+      this.logger[logLevel === "error" ? "info" : logLevel]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Settlement Alert 🏧!`,
         mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -117,8 +117,7 @@ class OptimisticOracleContractMonitor {
           convertCollateralDecimals(
             this.oracleType === OptimisticOracleType.OptimisticOracle ? event.finalFee : event.request.finalFee
           )
-        )}. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}\n` +
-        `${this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData)}`;
+        )}. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -127,6 +126,16 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Request Alert 👮🏻!`,
         mrkdwn,
+        notificationPath: "optimistic-oracle",
+      });
+
+      // UI link is sent separately because it can break slack message limits.
+      this.logger[
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
+      ]({
+        at: "OptimisticOracleContractMonitor",
+        message: `${this.oracleType}: Price Request Alert 👮🏻!`,
+        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
         notificationPath: "optimistic-oracle",
       });
     }
@@ -166,8 +175,7 @@ class OptimisticOracleContractMonitor {
         `.\n Collateral currency address is ${createEtherscanLinkMarkdown(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.currency : event.request.currency
         )}. ` +
-        `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}\n` +
-        `${this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData)}`;
+        `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       // The default log level should be reduced to "info" for funding rate identifiers:
       this.logger[
@@ -176,6 +184,16 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
         mrkdwn,
+        notificationPath: "optimistic-oracle",
+      });
+
+      // UI link is sent separately because it can break slack message limits.
+      this.logger[
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
+      ]({
+        at: "OptimisticOracleContractMonitor",
+        message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
+        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
         notificationPath: "optimistic-oracle",
       });
     }
@@ -210,13 +228,22 @@ class OptimisticOracleContractMonitor {
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposedPrice : event.request.proposedPrice
         )}.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}\n` +
-        `${this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData)}`;
+        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
         mrkdwn,
+        notificationPath: "optimistic-oracle",
+      });
+
+      // UI link is sent separately because it can break slack message limits.
+      this.logger[
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
+      ]({
+        at: "OptimisticOracleContractMonitor",
+        message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
+        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
         notificationPath: "optimistic-oracle",
       });
     }
@@ -272,8 +299,7 @@ class OptimisticOracleContractMonitor {
           isDispute ? "winner of the dispute" : "proposer"
         }.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}\n` +
-        `${this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData)}`;
+        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -282,6 +308,16 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Settlement Alert 🏧!`,
         mrkdwn,
+        notificationPath: "optimistic-oracle",
+      });
+
+      // UI link is sent separately because it can break slack message limits.
+      this.logger[
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
+      ]({
+        at: "OptimisticOracleContractMonitor",
+        message: `${this.oracleType}: Price Settlement Alert 🏧!`,
+        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
         notificationPath: "optimistic-oracle",
       });
     }

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -278,8 +278,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
     assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
-    // Check that only one extra event was emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
+    // Check that only two extra events were emitted since we already "checked" the original events.
+    assert.equal(spy.callCount, spyCount + 2);
   });
   it("Winston correctly emits price proposal message", async function () {
     await eventClient.update();
@@ -331,8 +331,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
     assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
-    // Check that only one extra event was emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
+    // Check that only two extra events were emitted since we already "checked" the original events.
+    assert.equal(spy.callCount, spyCount + 2);
   });
   it("Winston correctly emits price dispute message", async function () {
     await eventClient.update();
@@ -386,8 +386,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
     assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
-    // Check that only one extra event was emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
+    // Check that only two extra events were emitted since we already "checked" the original events.
+    assert.equal(spy.callCount, spyCount + 2);
   });
   it("Winston correctly emits price settlement message", async function () {
     await eventClient.update();
@@ -451,8 +451,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
     // Proposer reward equals: default bond (2x final fee) + proposal reward
     // = (2 * 1) + 3 = 5
     assert.isTrue(secondSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
-    // Check that only one extra event was emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
+    // Check that only twp extra events were emitted since we already "checked" the original events.
+    assert.equal(spy.callCount, spyCount + 2);
   });
   it("Can correctly create contract monitor with no config provided", async function () {
     let errorThrown;
@@ -511,8 +511,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
       assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
-      // Check that only one extra event was emitted since we already "checked" the original events.
-      assert.equal(spy.callCount, spyCount + 1);
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 2);
     });
     it("Winston correctly emits price proposal message", async function () {
       await skinnyEventClient.update();
@@ -564,8 +564,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
       assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
-      // Check that only one extra event was emitted since we already "checked" the original events.
-      assert.equal(spy.callCount, spyCount + 1);
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 2);
     });
     it("Winston correctly emits price dispute message", async function () {
       await skinnyEventClient.update();
@@ -628,8 +628,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
       assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
-      // Check that only one extra event was emitted since we already "checked" the original events.
-      assert.equal(spy.callCount, spyCount + 1);
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 2);
     });
     it("Winston correctly emits price settlement message", async function () {
       await skinnyEventClient.update();
@@ -696,8 +696,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       // Proposer reward equals: default bond (2x final fee) + proposal reward
       // = (2 * 1) + 3 = 5
       assert.isTrue(secondSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
-      // Check that only one extra event was emitted since we already "checked" the original events.
-      assert.equal(spy.callCount, spyCount + 1);
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 2);
     });
   });
 });

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -13,7 +13,8 @@ const {
   OptimisticOracleEventClient,
   SpyTransport,
   lastSpyLogIncludes,
-  lastSpyLogLevel,
+  spyLogIncludes,
+  spyLogLevel,
   OptimisticOracleType,
 } = require("@uma/financial-templates-lib");
 
@@ -27,6 +28,9 @@ const AddressWhitelist = getContract("AddressWhitelist");
 const Timer = getContract("Timer");
 const Store = getContract("Store");
 const MockOracle = getContract("MockOracleAncillary");
+
+const secondSpyLogIncludes = (spy, value) => spyLogIncludes(spy, -2, value);
+const secondSpyLogLevel = (spy) => spyLogLevel(spy, -2);
 
 describe("OptimisticOracleContractMonitor.js", function () {
   let accounts;
@@ -238,11 +242,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
     await eventClient.update();
     await contractMonitor.checkForRequests();
 
-    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.equal(secondSpyLogLevel(spy), "error");
 
     // Should contain etherscan addresses for the requester and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.options.address}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.options.address}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.transactionHash}`));
 
     assert.isTrue(
       lastSpyLogIncludes(
@@ -257,12 +261,12 @@ describe("OptimisticOracleContractMonitor.js", function () {
     );
 
     // should contain the correct request information.
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
-    assert.isTrue(lastSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
-    assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Final Fee
+    assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+    assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+    assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, collateral.options.address)); // Currency
+    assert.isTrue(secondSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
+    assert.isTrue(secondSpyLogIncludes(spy, "1.00")); // Final Fee
     let spyCount = spy.callCount;
 
     // Make another request with different ancillary data.
@@ -271,8 +275,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       .send({ from: owner });
     await eventClient.update();
     await contractMonitor.checkForRequests();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
     // Check that only one extra event was emitted since we already "checked" the original events.
     assert.equal(spy.callCount, spyCount + 1);
@@ -281,11 +285,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
     await eventClient.update();
     await contractMonitor.checkForProposals();
 
-    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.equal(secondSpyLogLevel(spy), "error");
 
     // Should contain etherscan addresses for the proposer and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${proposer}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/address/${proposer}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalTxn.transactionHash}`));
 
     assert.isTrue(
       lastSpyLogIncludes(
@@ -300,13 +304,13 @@ describe("OptimisticOracleContractMonitor.js", function () {
     );
 
     // should contain the correct proposal information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
-    assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
-    assert.isTrue(lastSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
+    assert.isTrue(secondSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
+    assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+    assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+    assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, collateral.options.address)); // Currency
+    assert.isTrue(secondSpyLogIncludes(spy, "-17.00")); // Proposed Price
+    assert.isTrue(secondSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
     let spyCount = spy.callCount;
 
     // Make another proposal with different ancillary data.
@@ -324,8 +328,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       .send({ from: proposer });
     await eventClient.update();
     await contractMonitor.checkForProposals();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
     // Check that only one extra event was emitted since we already "checked" the original events.
     assert.equal(spy.callCount, spyCount + 1);
@@ -334,11 +338,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
     await eventClient.update();
     await contractMonitor.checkForDisputes();
 
-    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.equal(secondSpyLogLevel(spy), "error");
 
     // Should contain etherscan addresses for the disputer and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeTxn.transactionHash}`));
 
     assert.isTrue(
       lastSpyLogIncludes(
@@ -353,12 +357,12 @@ describe("OptimisticOracleContractMonitor.js", function () {
     );
 
     // should contain the correct dispute information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
-    assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
+    assert.isTrue(secondSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
+    assert.isTrue(secondSpyLogIncludes(spy, proposer)); // Proposer
+    assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+    assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+    assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, "-17.00")); // Proposed Price
     let spyCount = spy.callCount;
 
     // Make another dispute with different ancillary data.
@@ -379,8 +383,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
       .send({ from: disputer });
     await eventClient.update();
     await contractMonitor.checkForDisputes();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
     // Check that only one extra event was emitted since we already "checked" the original events.
     assert.equal(spy.callCount, spyCount + 1);
@@ -389,10 +393,10 @@ describe("OptimisticOracleContractMonitor.js", function () {
     await eventClient.update();
     await contractMonitor.checkForSettlements();
 
-    assert.equal(lastSpyLogLevel(spy), "info");
+    assert.equal(secondSpyLogLevel(spy), "info");
 
     // Should contain etherscan addresses for the transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementTxn.transactionHash}`));
 
     assert.isTrue(
       lastSpyLogIncludes(
@@ -407,17 +411,17 @@ describe("OptimisticOracleContractMonitor.js", function () {
     );
 
     // should contain the correct settlement information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
-    assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
-    assert.isTrue(lastSpyLogIncludes(spy, disputer)); // Disputer
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, "17.00")); // Price
+    assert.isTrue(secondSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
+    assert.isTrue(secondSpyLogIncludes(spy, proposer)); // Proposer
+    assert.isTrue(secondSpyLogIncludes(spy, disputer)); // Disputer
+    assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+    assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+    assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+    assert.isTrue(secondSpyLogIncludes(spy, "17.00")); // Price
     // Proposal was disputed, payout made to winner of disputer
     // Dispute reward equals: default bond (2x final fee) + proposal reward + 1/2 of loser's final fee
     // = (2 * 1) + 3 + (0.5 * 1) = 5.5
-    assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
+    assert.isTrue(secondSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
     let spyCount = spy.callCount;
 
     // Make another settlement without a dispute, with different ancillary data.
@@ -442,11 +446,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
       .send({ from: owner });
     await eventClient.update();
     await contractMonitor.checkForSettlements();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+    assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
     // Proposal this time was not disputed so payout to the proposer.
     // Proposer reward equals: default bond (2x final fee) + proposal reward
     // = (2 * 1) + 3 = 5
-    assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
+    assert.isTrue(secondSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
     // Check that only one extra event was emitted since we already "checked" the original events.
     assert.equal(spy.callCount, spyCount + 1);
   });
@@ -475,19 +479,19 @@ describe("OptimisticOracleContractMonitor.js", function () {
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForRequests();
 
-      assert.equal(lastSpyLogLevel(spy), "error");
+      assert.equal(secondSpyLogLevel(spy), "error");
 
       // Should contain etherscan addresses for the requester and transaction
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${requester}`));
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyRequestTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/address/${requester}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyRequestTxn.transactionHash}`));
 
       // should contain the correct request information.
-      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-      assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
-      assert.isTrue(lastSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
-      assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Final Fee
+      assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, collateral.options.address)); // Currency
+      assert.isTrue(secondSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
+      assert.isTrue(secondSpyLogIncludes(spy, "1.00")); // Final Fee
       let spyCount = spy.callCount;
 
       // Make another request with different ancillary data.
@@ -504,8 +508,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
         .send({ from: requester });
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForRequests();
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
       // Check that only one extra event was emitted since we already "checked" the original events.
       assert.equal(spy.callCount, spyCount + 1);
@@ -514,20 +518,20 @@ describe("OptimisticOracleContractMonitor.js", function () {
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForProposals();
 
-      assert.equal(lastSpyLogLevel(spy), "error");
+      assert.equal(secondSpyLogLevel(spy), "error");
 
       // Should contain etherscan addresses for the proposer and transaction
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${skinnyProposer}`));
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyProposalTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/address/${skinnyProposer}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyProposalTxn.transactionHash}`));
 
       // should contain the correct proposal information.
-      assert.isTrue(lastSpyLogIncludes(spy, requester)); // Requester
-      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-      assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
-      assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
-      assert.isTrue(lastSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
+      assert.isTrue(secondSpyLogIncludes(spy, requester)); // Requester
+      assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, collateral.options.address)); // Currency
+      assert.isTrue(secondSpyLogIncludes(spy, "-17.00")); // Proposed Price
+      assert.isTrue(secondSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
       let spyCount = spy.callCount;
 
       // Make another proposal with different ancillary data.
@@ -557,8 +561,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
         .send({ from: skinnyProposer });
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForProposals();
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
       // Check that only one extra event was emitted since we already "checked" the original events.
       assert.equal(spy.callCount, spyCount + 1);
@@ -567,19 +571,19 @@ describe("OptimisticOracleContractMonitor.js", function () {
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForDisputes();
 
-      assert.equal(lastSpyLogLevel(spy), "error");
+      assert.equal(secondSpyLogLevel(spy), "error");
 
       // Should contain etherscan addresses for the disputer and transaction
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyDisputeTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyDisputeTxn.transactionHash}`));
 
       // should contain the correct dispute information.
-      assert.isTrue(lastSpyLogIncludes(spy, requester)); // Requester
-      assert.isTrue(lastSpyLogIncludes(spy, skinnyProposer)); // Proposer
-      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-      assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
+      assert.isTrue(secondSpyLogIncludes(spy, requester)); // Requester
+      assert.isTrue(secondSpyLogIncludes(spy, skinnyProposer)); // Proposer
+      assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, "-17.00")); // Proposed Price
       let spyCount = spy.callCount;
 
       // Make another dispute with different ancillary data.
@@ -621,8 +625,8 @@ describe("OptimisticOracleContractMonitor.js", function () {
         .send({ from: disputer });
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForDisputes();
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
 
       // Check that only one extra event was emitted since we already "checked" the original events.
       assert.equal(spy.callCount, spyCount + 1);
@@ -631,23 +635,23 @@ describe("OptimisticOracleContractMonitor.js", function () {
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForSettlements();
 
-      assert.equal(lastSpyLogLevel(spy), "info");
+      assert.equal(secondSpyLogLevel(spy), "info");
 
       // Should contain etherscan addresses for the transaction
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnySettlementTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnySettlementTxn.transactionHash}`));
 
       // should contain the correct settlement information.
-      assert.isTrue(lastSpyLogIncludes(spy, requester)); // Requester
-      assert.isTrue(lastSpyLogIncludes(spy, skinnyProposer)); // Proposer
-      assert.isTrue(lastSpyLogIncludes(spy, disputer)); // Disputer
-      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-      assert.isTrue(lastSpyLogIncludes(spy, "17.00")); // Price
+      assert.isTrue(secondSpyLogIncludes(spy, requester)); // Requester
+      assert.isTrue(secondSpyLogIncludes(spy, skinnyProposer)); // Proposer
+      assert.isTrue(secondSpyLogIncludes(spy, disputer)); // Disputer
+      assert.isTrue(secondSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(secondSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(secondSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(secondSpyLogIncludes(spy, "17.00")); // Price
       // Proposal was disputed, payout made to winner of disputer
       // Dispute reward equals: default bond (2x final fee) + proposal reward + 1/2 of loser's final fee
       // = (2 * 1) + 3 + (0.5 * 1) = 5.5
-      assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
+      assert.isTrue(secondSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
       let spyCount = spy.callCount;
 
       // Make another settlement without a dispute, with different ancillary data.
@@ -687,11 +691,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
         .send({ from: owner });
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForSettlements();
-      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(secondSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
       // Proposal this time was not disputed so payout to the proposer.
       // Proposer reward equals: default bond (2x final fee) + proposal reward
       // = (2 * 1) + 3 = 5
-      assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
+      assert.isTrue(secondSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
       // Check that only one extra event was emitted since we already "checked" the original events.
       assert.equal(spy.callCount, spyCount + 1);
     });


### PR DESCRIPTION
**Motivation**

UI links overflow slack messages.


**Summary**

This just splits the UI link into its own message.

Note: these UI links are never sent as errors. If the regular message is sent as error, this UI link is downgraded to info, so it won't send alerts.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
