### PR TITLE
feat(across-bots): Send funds more aggressivly over bridge when util is high

### DIFF
--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -67,8 +67,8 @@ export class CrossDomainFinalizer {
     for (const l2Token of bridgeableL2Tokens) {
       // For each bridgeable L2Token, check the balance in the deposit box. If it is greater than
       // crossDomainFinalizationThreshold, as a percentage, then we can bridge it. If the liquidity utilization is
-      // greater than 75% then half the crossDomainFinalizationThreshold to send funds more aggressively over the
-      // bridge at high utilizations.
+      // greater than 75% then set the crossDomainFinalizationThreshold to half its set value to send funds more
+      // aggressively over the bridge at high utilizations.
 
       try {
         const { symbol, decimals, l2PoolBalance } = await this._getL2TokenInfo(l2Token);

--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -66,7 +66,7 @@ export class CrossDomainFinalizer {
     let nonce = await this.l2Client.l2Web3.eth.getTransactionCount(this.account);
     for (const l2Token of bridgeableL2Tokens) {
       // For each bridgeable L2Token, check the balance in the deposit box. If it is greater than
-      // crossDomainFinalizationThreshold, as a percentage, then we can bridge it. if the liquidity utilization is
+      // crossDomainFinalizationThreshold, as a percentage, then we can bridge it. If the liquidity utilization is
       // greater than 75% then half the crossDomainFinalizationThreshold to send funds more aggressively over the
       // bridge at high utilizations.
 


### PR DESCRIPTION
If pool utilization is high we should more aggresivly send funds over the bridge. This PR adds a 75% cutoff at which the `crossDomainFinalizationThreshold` is halfed to make bridging more aggressive as we run out of funds.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
