### PR TITLE
feat(OO-proposer): make chainId a public varible to enable the proposer to correctly pull the value

### DIFF
--- a/packages/financial-templates-lib/src/clients/OptimisticOracleClient.ts
+++ b/packages/financial-templates-lib/src/clients/OptimisticOracleClient.ts
@@ -61,7 +61,7 @@ export class OptimisticOracleClient {
   // Store the last on-chain time the clients were updated to inform price request information.
   private lastUpdateTimestamp = 0;
   private hexToUtf8 = Web3.utils.hexToUtf8;
-  private chainId = -1;
+  public chainId = -1;
 
   // Oracle Data structures & values to enable synchronous returns of the state seen by the client.
   private unproposedPriceRequests: RequestPriceReturnValues[] = [];


### PR DESCRIPTION
**Motivation**

OO proposer logs was producing wrong etherscan links.

The OO proposer was pulling the chainId from the OO client [here](https://github.com/UMAprotocol/protocol/blob/f169c8f1442e0e2ebb8b7efadf505eea9bfed7da/packages/optimistic-oracle/src/proposer.js?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L43). 

This was not functioning correctly due to this state variable being private on OO client. this make this call default to undefined, and thus the `createEtherscanLinkMarkdown` was producing links for mainnet, which is wrong.

**Summary**

This PR fixes this by exposing the OO clients chainId variable so the proposer can correctly pull this.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
