### PR TITLE
feat(sdk): request list checker using events

### DIFF
--- a/packages/sdk/src/oracle/services/optimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracle.ts
@@ -1,16 +1,16 @@
-import { OptimisticOracleEthers, OptimisticOracleEthers__factory } from "@uma/contracts-node";
+import { optimisticOracle } from "../../clients";
 import { BigNumberish, BigNumber, Provider, Signer, TransactionResponse } from "../types/ethers";
 import type { RequestState } from "../types/state";
 
 type Props = {
   defaultLiveness: BigNumber;
 };
-type Request = ReturnType<OptimisticOracleEthers["getRequest"]>;
+type Request = ReturnType<optimisticOracle.Instance["getRequest"]>;
 
 export class OptimisticOracle {
-  public readonly contract: OptimisticOracleEthers;
+  public readonly contract: optimisticOracle.Instance;
   constructor(protected provider: Provider, protected address: string) {
-    this.contract = OptimisticOracleEthers__factory.connect(address, provider);
+    this.contract = optimisticOracle.connect(address, provider);
   }
   async getRequest(
     requester: string,
@@ -22,16 +22,16 @@ export class OptimisticOracle {
   }
   async disputePrice(
     signer: Signer,
-    ...args: Parameters<OptimisticOracleEthers["disputePrice"]>
+    ...args: Parameters<optimisticOracle.Instance["disputePrice"]>
   ): Promise<TransactionResponse> {
-    const contract = OptimisticOracleEthers__factory.connect(this.address, signer);
+    const contract = optimisticOracle.connect(this.address, signer);
     return contract.disputePrice(...args);
   }
   async proposePrice(
     signer: Signer,
-    ...args: Parameters<OptimisticOracleEthers["proposePrice"]>
+    ...args: Parameters<optimisticOracle.Instance["proposePrice"]>
   ): Promise<TransactionResponse> {
-    const contract = OptimisticOracleEthers__factory.connect(this.address, signer);
+    const contract = optimisticOracle.connect(this.address, signer);
     return contract.proposePrice(...args);
   }
   async getProps(): Promise<Props> {

--- a/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
@@ -1,0 +1,57 @@
+// this will attempt to fetch all events down to startBlock in descending order. It will try to reduce the
+// range of blocks queried to prevent errors with the provider. This can sometimes lead to really long query times
+// for providers on chains which are very restrictive about block range.
+// Normally you want to query events in order, ie oldest to newest, but in this case we want to prioritize the
+// newest requests first in the case we cant fetch the whole range. Also we will store all events in order and
+// process them on each iteration, so we should always have a consistent view of request with our currently known events.
+import Store from "../../store";
+import { Handlers as GenericHandlers } from "../../types/statemachine";
+import { ContextClient } from "./utils";
+import { Update } from "../update";
+import { rangeStart, rangeSuccessDescending, rangeFailureDescending, RangeState } from "../../utils";
+
+export type Params = {
+  chainId: number;
+  startBlock?: number;
+  endBlock?: number;
+};
+
+export type Memory = { error?: Error; state?: RangeState; iterations: number };
+
+export function initMemory(): Memory {
+  return { iterations: 0 };
+}
+
+export function Handlers(store: Store): GenericHandlers<Params, Memory> {
+  const update = new Update(store);
+  return {
+    async start(params: Params, memory: Memory, ctx: ContextClient) {
+      const provider = store.read().provider(params.chainId);
+      const { chainId, startBlock = 0, endBlock = await provider.getBlockNumber() } = params;
+
+      memory.error = undefined;
+      // we use this wierd range thing because in the case we cant query the entire block range due to provider error
+      // we want to move start block closer to endblock to reduce the range until it stops erroring. These range functions
+      // will do that for us.
+      const rangeState = memory.state || rangeStart({ startBlock, endBlock });
+      const { currentStart, currentEnd, done } = rangeState;
+
+      try {
+        // this just queries events between start and end
+        await update.oracleEvents(chainId, currentStart, currentEnd);
+        // we signal that the current range was a success, now move currentStart, currentEnd accordingly
+        // we set multiplier to 1 so we dont grow the range on success, this tends to create more errors and slow down querying
+        memory.state = rangeSuccessDescending({ ...rangeState, multiplier: 1 });
+      } catch (err) {
+        memory.error = err;
+        // the provider threw an error so we will reduce our range by moving startblock closer to endblock next iteration
+        memory.state = rangeFailureDescending(rangeState);
+      }
+      // the range functions will tell us when we have successfully queried the entire range of blocks.
+      if (done) return "done";
+      memory.iterations++;
+      // sleep to let other contexts run, but just resume right after.
+      return ctx.sleep(10);
+    },
+  };
+}

--- a/packages/sdk/src/oracle/services/statemachines/index.ts
+++ b/packages/sdk/src/oracle/services/statemachines/index.ts
@@ -6,6 +6,8 @@ export * as disputePrice from "./disputePrice";
 export * as proposePrice from "./proposePrice";
 export * as switchOrAddChain from "./switchOrAddChain";
 export * as pollActiveRequest from "./pollActiveRequest";
+export * as fetchPastEvents from "./fetchPastEvents";
+export * as pollNewEvents from "./pollNewEvents";
 
 export * from "./statemachine";
 export * from "./utils";

--- a/packages/sdk/src/oracle/services/statemachines/pollNewEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/pollNewEvents.ts
@@ -1,0 +1,51 @@
+// this statemachine will continue to poll for new events from startBlock ( or latest block if not defined).
+// It will maintain memory of the last block it polled for events up to, and use that as the start block for next
+// iteration, while always querying up to the latest block.
+import Store from "../../store";
+import { Handlers as GenericHandlers } from "../../types/statemachine";
+import { ContextClient } from "./utils";
+import { Update } from "../update";
+
+export type Params = {
+  chainId: number;
+  startBlock?: number;
+  pollRateSec?: number;
+};
+
+export type Memory = { error?: Error; lastBlock?: number; iterations: number };
+
+export function initMemory(): Memory {
+  return { iterations: 0 };
+}
+
+export function Handlers(store: Store): GenericHandlers<Params, Memory> {
+  const update = new Update(store);
+  return {
+    async start(params: Params, memory: Memory, ctx: ContextClient) {
+      // start at the latest block, we have other command to get historical events
+      const { chainId, startBlock, pollRateSec = 50 } = params;
+      const provider = store.read().provider(chainId);
+      const latestBlock = await provider.getBlockNumber();
+      // our current block is the start block, or last known block we have queried up to
+      const currentBlock = memory.lastBlock || startBlock || latestBlock;
+      memory.error = undefined;
+      try {
+        // dont worry about querying if latest and current are the same
+        if (latestBlock !== currentBlock) {
+          // this pulls all events from current to latest block
+          await update.oracleEvents(chainId, currentBlock, latestBlock);
+          // reset our last block seen to the latest (end) block
+          memory.lastBlock = latestBlock;
+        }
+      } catch (err) {
+        // store an error for an iteration if we need to debug
+        memory.error = err;
+      }
+      // just count how many iterations we do as a kind of sanity check
+      memory.iterations++;
+
+      // we dont need to poll these events very fast, so just set to once a min
+      return ctx.sleep(pollRateSec * 1000);
+    },
+  };
+}

--- a/packages/sdk/src/oracle/services/statemachines/statemachine.ts
+++ b/packages/sdk/src/oracle/services/statemachines/statemachine.ts
@@ -12,6 +12,8 @@ import * as proposePrice from "./proposePrice";
 import * as switchOrAddChain from "./switchOrAddChain";
 import * as pollActiveRequest from "./pollActiveRequest";
 import * as pollActiveUser from "./pollActiveUser";
+import * as fetchPastEvents from "./fetchPastEvents";
+import * as pollNewEvents from "./pollNewEvents";
 
 /**
  * StateMachine. This class will be used to handle all change requests by the user, including setting state which
@@ -42,6 +44,8 @@ export class StateMachine {
     [ContextType.switchOrAddChain]: ContextManager<switchOrAddChain.Params, switchOrAddChain.Memory>;
     [ContextType.pollActiveRequest]: ContextManager<pollActiveRequest.Params, pollActiveRequest.Memory>;
     [ContextType.pollActiveUser]: ContextManager<pollActiveUser.Params, pollActiveUser.Memory>;
+    [ContextType.fetchPastEvents]: ContextManager<fetchPastEvents.Params, fetchPastEvents.Memory>;
+    [ContextType.pollNewEvents]: ContextManager<pollNewEvents.Params, pollNewEvents.Memory>;
   };
   constructor(private store: Store) {
     // need to initizlie state types here manually for each new context type
@@ -98,6 +102,18 @@ export class StateMachine {
         ContextType.pollActiveUser,
         pollActiveUser.Handlers(store),
         pollActiveUser.initMemory,
+        this.handleCreate
+      ),
+      [ContextType.fetchPastEvents]: new ContextManager<fetchPastEvents.Params, fetchPastEvents.Memory>(
+        ContextType.fetchPastEvents,
+        fetchPastEvents.Handlers(store),
+        fetchPastEvents.initMemory,
+        this.handleCreate
+      ),
+      [ContextType.pollNewEvents]: new ContextManager<pollNewEvents.Params, pollNewEvents.Memory>(
+        ContextType.pollNewEvents,
+        pollNewEvents.Handlers(store),
+        pollNewEvents.initMemory,
         this.handleCreate
       ),
     };
@@ -199,6 +215,20 @@ export class StateMachine {
         case ContextType.pollActiveUser: {
           next = await this.types[context.type].step(
             (context as unknown) as Context<pollActiveUser.Params, pollActiveUser.Memory>,
+            now
+          );
+          break;
+        }
+        case ContextType.fetchPastEvents: {
+          next = await this.types[context.type].step(
+            (context as unknown) as Context<fetchPastEvents.Params, fetchPastEvents.Memory>,
+            now
+          );
+          break;
+        }
+        case ContextType.pollNewEvents: {
+          next = await this.types[context.type].step(
+            (context as unknown) as Context<pollNewEvents.Params, pollNewEvents.Memory>,
             now
           );
           break;

--- a/packages/sdk/src/oracle/services/statemachines/utils.ts
+++ b/packages/sdk/src/oracle/services/statemachines/utils.ts
@@ -80,11 +80,11 @@ export class ContextManager<P, M extends Memory> {
   constructor(
     private type: ContextType,
     private handlers: Handlers<P, M>,
-    private initMemory: () => M,
+    private initMemory: (params: P) => M,
     private emit: (ctx: Context<P, M>) => void
   ) {}
   create = (params: P, user?: string): string => {
-    const context = create<P, M>(this.type, params, this.initMemory(), { user });
+    const context = create<P, M>(this.type, params, this.initMemory(params), { user });
     this.emit(context);
     return context.id;
   };

--- a/packages/sdk/src/oracle/store/read.ts
+++ b/packages/sdk/src/oracle/store/read.ts
@@ -1,9 +1,20 @@
 import assert from "assert";
 import filter from "lodash/filter";
 
-import type { State, Chain, Inputs, Request, Erc20Props, ChainConfig, Context, Memory, User } from "../types/state";
+import type {
+  State,
+  Chain,
+  Inputs,
+  Request,
+  Erc20Props,
+  ChainConfig,
+  Context,
+  Memory,
+  User,
+  OptimisticOracleEvent,
+} from "../types/state";
 import type { JsonRpcSigner, BigNumber, Provider } from "../types/ethers";
-import { TransactionConfirmer } from "../utils";
+import { TransactionConfirmer, requestId } from "../utils";
 import { OptimisticOracle } from "../services/optimisticOracle";
 import { Erc20 } from "../services/erc20";
 
@@ -70,7 +81,7 @@ export default class Read {
   request = (): Request => {
     const chain = this.requestChain();
     const input = this.inputRequest();
-    const id = [input.requester, input.identifier, input.timestamp, input.ancillaryData].join("!");
+    const id = requestId(input);
     const request = chain?.optimisticOracle?.requests?.[id];
     assert(request, "Request has not been fetched");
     return request;
@@ -147,5 +158,9 @@ export default class Read {
     const time = chain?.currentTime;
     assert(time, "Current time not available on chain: " + chainId);
     return time;
+  };
+  oracleEvents = (chainId: number): OptimisticOracleEvent[] => {
+    const chain = this.state?.chains?.[chainId];
+    return chain?.optimisticOracle?.events || [];
   };
 }

--- a/packages/sdk/src/oracle/store/write.ts
+++ b/packages/sdk/src/oracle/store/write.ts
@@ -3,6 +3,7 @@ import type * as ethersTypes from "../types/ethers";
 import * as state from "../types/state";
 import * as statemachine from "../types/statemachine";
 
+import { requestId, insertOrderedAscending, eventKey } from "../utils";
 import { factory as Erc20Factory } from "../services/erc20";
 import { OptimisticOracle as OptimisticOracleService } from "../services/optimisticOracle";
 import Multicall2 from "../../multicall2";
@@ -68,18 +69,17 @@ export class OptimisticOracle {
   address(address: string): void {
     this.state.address = address;
   }
-  request(inputRequest: state.Inputs["request"], request: state.Request): void {
-    const id = [
-      inputRequest.requester,
-      inputRequest.identifier,
-      inputRequest.timestamp,
-      inputRequest.ancillaryData,
-    ].join("!");
+  request(inputRequest: state.InputRequest, request: state.Request): void {
+    const id = requestId(inputRequest);
     if (!this.state.requests) this.state.requests = {};
     this.state.requests[id] = request;
   }
   defaultLiveness(defaultLiveness: ethersTypes.BigNumber): void {
     this.state.defaultLiveness = defaultLiveness;
+  }
+  event(event: state.OptimisticOracleEvent): void {
+    if (!this.state.events) this.state.events = [];
+    insertOrderedAscending(this.state.events, event, eventKey);
   }
 }
 export class Chain {

--- a/packages/sdk/src/oracle/tests/utils.test.ts
+++ b/packages/sdk/src/oracle/tests/utils.test.ts
@@ -1,0 +1,60 @@
+import assert from "assert";
+import * as utils from "../utils";
+
+describe("Oracle Utils", function () {
+  test("rangeDescending", function () {
+    const startBlock = 0;
+    const endBlock = 14083360;
+    const range = endBlock - startBlock;
+    let expectedRange = range;
+
+    let rangeState = utils.rangeStart({ startBlock, endBlock });
+
+    assert.equal(rangeState.currentStart, startBlock);
+    assert.equal(rangeState.currentEnd, endBlock);
+    assert.equal(rangeState.currentRange, expectedRange);
+    assert.ok(!rangeState.done);
+
+    // halve range
+    expectedRange = Math.floor(expectedRange / (rangeState.multiplier || 2));
+    rangeState = utils.rangeFailureDescending(rangeState);
+    assert.equal(rangeState.currentRange, expectedRange);
+    assert.equal(rangeState.currentEnd, endBlock);
+    assert.equal(rangeState.currentStart, endBlock - expectedRange);
+    assert.ok(!rangeState.done);
+
+    expectedRange = Math.floor(expectedRange / (rangeState.multiplier || 2));
+    rangeState = utils.rangeFailureDescending(rangeState);
+    assert.equal(rangeState.currentRange, expectedRange);
+    assert.equal(rangeState.currentEnd, endBlock);
+    assert.equal(rangeState.currentStart, endBlock - expectedRange);
+    assert.ok(!rangeState.done);
+
+    expectedRange = Math.floor(expectedRange / (rangeState.multiplier || 2));
+    rangeState = utils.rangeFailureDescending(rangeState);
+    assert.equal(rangeState.currentRange, expectedRange);
+    assert.equal(rangeState.currentEnd, endBlock);
+    assert.equal(rangeState.currentStart, endBlock - expectedRange);
+    assert.ok(!rangeState.done);
+
+    expectedRange = Math.floor(expectedRange * (rangeState.multiplier || 2));
+    rangeState = utils.rangeSuccessDescending(rangeState);
+    assert.equal(rangeState.currentRange, expectedRange);
+    assert.equal(rangeState.currentEnd, endBlock - Math.floor(expectedRange / 2));
+    assert.equal(rangeState.currentStart, endBlock - (Math.floor(expectedRange / 2) + expectedRange));
+    assert.ok(!rangeState.done);
+
+    expectedRange = Math.floor(expectedRange * (rangeState.multiplier || 2));
+    rangeState = utils.rangeSuccessDescending(rangeState);
+    assert.equal(rangeState.currentRange, expectedRange);
+
+    expectedRange = Math.floor(expectedRange * (rangeState.multiplier || 2));
+    rangeState = utils.rangeSuccessDescending(rangeState);
+    assert.equal(rangeState.currentRange, expectedRange);
+    assert.equal(rangeState.currentStart, startBlock);
+    assert.ok(!rangeState.done);
+
+    rangeState = utils.rangeSuccessDescending(rangeState);
+    assert.ok(rangeState.done);
+  });
+});

--- a/packages/sdk/src/oracle/types/ethers.ts
+++ b/packages/sdk/src/oracle/types/ethers.ts
@@ -1,4 +1,6 @@
+import type { Event } from "ethers";
 export type { Signer, BigNumber, BigNumberish, Contract } from "ethers";
 export type { Overrides } from "@ethersproject/contracts";
 export { Provider, JsonRpcSigner, JsonRpcProvider, Web3Provider, FallbackProvider } from "@ethersproject/providers";
 export { TransactionRequest, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+export type { Event };

--- a/packages/sdk/src/oracle/types/statemachine.ts
+++ b/packages/sdk/src/oracle/types/statemachine.ts
@@ -14,6 +14,8 @@ export enum ContextType {
   switchOrAddChain = "switchOrAddChain",
   pollActiveRequest = "pollActiveRequest",
   pollActiveUser = "pollActiveUser",
+  fetchPastEvents = "fetchPastEvents",
+  pollNewEvents = "pollNewEvents",
 }
 
 export type ContextProps = {

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import {
   State,
   RequestState,
@@ -9,10 +10,12 @@ import {
   ChainMetadata,
   Config,
 } from "./types/state";
-import type { Provider, TransactionReceipt } from "./types/ethers";
+import type { Provider, TransactionReceipt, BigNumberish } from "./types/ethers";
 import { ContextType } from "./types/statemachine";
 import { Read } from "./store";
 import { ethers } from "ethers";
+export { requestId } from "../clients/optimisticOracle";
+import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 
 export const getAddress = ethers.utils.getAddress;
 export const hexValue = ethers.utils.hexValue;
@@ -193,4 +196,128 @@ export class TransactionConfirmer {
 export function chainConfigToChainMetadata(config: ChainConfig): ChainMetadata {
   const { checkTxIntervalSec, multicall2Address, optimisticOracleAddress, ...chainMetadata } = config;
   return chainMetadata;
+}
+
+// This state is meant for adjusting a start/end block when querying events. Some apis will fail if the range
+// is too big, so the following functions will adjust range dynamically.
+export type RangeState = {
+  startBlock: number;
+  endBlock: number;
+  maxRange: number;
+  currentRange: number;
+  currentStart: number; // This is the start value you want for your query.
+  currentEnd: number; // this is the end value you want for your query.
+  done: boolean; // Signals we successfully queried the entire range.
+  multiplier?: number; // Multiplier increases or decreases range by this value, depending on success or failure
+};
+
+/**
+ * rangeStart. This starts a new range query and sets defaults for state.  Use this as the first call before starting your queries
+ *
+ * @param {Pick} state
+ * @returns {RangeState}
+ */
+export function rangeStart(state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier">): RangeState {
+  const { startBlock, endBlock, multiplier = 2 } = state;
+  // the largest range we can have, since this is the users query for start and end
+  const maxRange = endBlock - startBlock;
+  assert(maxRange > 0, "End block must be higher than start block");
+  const currentStart = startBlock;
+  const currentEnd = endBlock;
+  const currentRange = maxRange;
+
+  return {
+    done: false,
+    startBlock,
+    endBlock,
+    maxRange,
+    currentRange,
+    currentStart,
+    currentEnd,
+    multiplier,
+  };
+}
+/**
+ * rangeSuccessDescending. We have 2 ways of querying events, from oldest to newest, or newest to oldest. Typically we want them in order, from
+ * oldest to newest, but for this particular case we want them newest to oldest, ie descending ( larger timestamp to smaller timestamp).
+ * This function will increase the range between start/end block and return a new start/end to use since by calling this you are signalling
+ * that the last range ended in a successful query.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeSuccessDescending(state: RangeState): RangeState {
+  const { startBlock, currentStart, maxRange, currentRange, multiplier = 2 } = state;
+  // we are done if we succeeded querying where the currentStart matches are initial start block
+  const done = currentStart <= startBlock;
+  // increase range up to max range for every successful query
+  const nextRange = Math.min(Math.ceil(currentRange * multiplier), maxRange);
+  // move our end point to the previously successful start, ie moving from newest to oldest
+  const nextEnd = currentStart;
+  // move our start block to the next range down
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+    done,
+  };
+}
+/**
+ * rangeFailureDescending. Like the previous function, this will decrease the range between start/end for your query, because you are signalling
+ * that the last query failed. It will also keep the end of your range the same, while moving the start range up. This is why
+ * its considered descending, it will attempt to move from end to start, rather than start to end.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeFailureDescending(state: RangeState): RangeState {
+  const { startBlock, currentEnd, currentRange, multiplier = 2 } = state;
+  const nextRange = Math.floor(currentRange / multiplier);
+  // this will eventually throw an error if you keep calling this function, which protects us against re-querying a broken api in a loop
+  assert(nextRange > 0, "Range must be above 0");
+  // we stay at the same end block
+  const nextEnd = currentEnd;
+  // move our start block closer to the end block, shrinking the range
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+  };
+}
+
+/**
+ * eventKey. Make a unique and sortable identifier string for an event
+ *
+ * @param {Event} event
+ * @returns {string} - the unique id
+ */
+export function eventKey(event: {
+  blockNumber: BigNumberish;
+  transactionIndex: BigNumberish;
+  logIndex: BigNumberish;
+}): string {
+  return [
+    // we pad these because numbers of varying lengths will not sort correctly, ie "10" will incorrectly sort before "9", but "09" will be correct.
+    event.blockNumber.toString().padStart(16, "0"),
+    event.transactionIndex.toString().padStart(16, "0"),
+    event.logIndex?.toString().padStart(16, "0"),
+    // ~ is the last printable ascii char, so it does not interfere with sorting
+  ].join("~");
+}
+/**
+ * insertOrdered. Inserts items in an array maintaining sorted order, in this case lowest to highest. Does not check duplicates.
+ * Mainly used for caching all known events, in order of oldest to newest.
+ *
+ * @param {T[]} array
+ * @param {T} element
+ * @param {Function} orderBy
+ */
+export function insertOrderedAscending<T>(array: T[], element: T, orderBy: (element: T) => string | number): T[] {
+  const index = sortedLastIndexBy(array, element, orderBy);
+  array.splice(index, 0, element);
+  return array;
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
We need a way to fetch oracle events to build up a table of requests we can lookup from. 

**Summary**
This adds 2 new commands which run at the start of the app. One is responsible for fetching historical events in a robust way, the other fetches all new events.  Historical events are tricky because of chains other than mainnet restricting the range of blocks you can query. This adds logic to dynamically adjust the range to prevent errors, and also allows a configurable "start block" on each chain to prevent history from going back to block 0.  Eventually these events will be used to populate a request index page. 

**Details**
Event requests spanning too large a block range cause errors on polygon-infura. To be really resilient to this, we reduce the block range requested with 3 static utility functions. These functions start a range at the newest events, and halve the range each time an error occurs, until no more errors occur for the range. it will then query each range from newest to oldest until it reaches block 0.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


