### PR TITLE
fix(sdk): fix properly unqueuing commands from statemachine queue

### DIFF
--- a/packages/sdk/src/oracle/services/statemachines/index.ts
+++ b/packages/sdk/src/oracle/services/statemachines/index.ts
@@ -1,5 +1,11 @@
 export * as setUser from "./setUser";
+export * as clearUser from "./clearUser";
 export * as setActiveRequest from "./setActiveRequest";
+export * as approve from "./approve";
+export * as disputePrice from "./disputePrice";
+export * as proposePrice from "./proposePrice";
+export * as switchOrAddChain from "./switchOrAddChain";
+export * as pollActiveRequest from "./pollActiveRequest";
 
 export * from "./statemachine";
 export * from "./utils";

--- a/packages/sdk/src/oracle/services/statemachines/statemachine.ts
+++ b/packages/sdk/src/oracle/services/statemachines/statemachine.ts
@@ -102,6 +102,11 @@ export class StateMachine {
     this.saveContext(context);
   };
 
+  // remove element from front of queue
+  private shift(): Context<unknown, unknown & Memory> | undefined {
+    return this.pending.shift();
+  }
+  // remove element from back of queue
   private pop(): Context<unknown, unknown & Memory> | undefined {
     return this.pending.pop();
   }
@@ -118,7 +123,7 @@ export class StateMachine {
    * @returns {Promise<boolean>} - Returns if there are still any pending contexts to run.
    */
   tick = async (now = Date.now()): Promise<boolean> => {
-    const context = this.pop();
+    const context = this.shift();
     // if this cant step, then push it to back of queue
     if (!shouldStep(context, now)) {
       context && !context.done && this.push(context);

--- a/packages/sdk/src/oracle/tests/client.e2e.ts
+++ b/packages/sdk/src/oracle/tests/client.e2e.ts
@@ -56,12 +56,14 @@ describe("Oracle Client", function () {
   test("setRequest", async function () {
     const id = client.setActiveRequest(request);
     await client.sm.tick();
+    await client.sm.tick();
     const input = store.read().inputRequest();
     assert.ok(input);
     assert.ok(store.read().command(id));
   });
   test("setUser", async function () {
     const id = client.setUser({ address, chainId, signer, provider });
+    await client.sm.tick();
     await client.sm.tick();
     const state = store.get();
     assert.ok(state?.inputs?.user);


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
State machine queue was acting like a stack and not a queue, which could cause commands to starve.

**Summary**

Use shift instead of pop when dequeuing

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


