### PR TITLE
feat(Across-Bots): Add additional notification path for across infra to split away from uma infra

### DIFF
--- a/packages/insured-bridge-relayer/src/MulticallBundler.ts
+++ b/packages/insured-bridge-relayer/src/MulticallBundler.ts
@@ -78,6 +78,7 @@ export class MulticallBundler {
         at: "MulticallBundler#send",
         message: "One or more errors sending transaction batches",
         error,
+        notificationPath: "across-infrastructure",
       });
     });
 
@@ -120,6 +121,7 @@ export class MulticallBundler {
       message: call.message || "No message",
       mrkdwn: call.mrkdwn ? `${call.mrkdwn} ${receiptMarkdown}` : receiptMarkdown,
       level: call.level || "info",
+      notificationPath: "across-infrastructure",
     });
 
     // Just append the execution result. No need to return.
@@ -155,6 +157,7 @@ export class MulticallBundler {
         at: "MulticallBundler#batchTransactions",
         message: "Sending batched transactions individually😷",
         error,
+        notificationPath: "across-infrastructure",
       });
 
       // Allow all transactions to finish before propagating any errors.


### PR DESCRIPTION
**Motivation**

The #infrastructure slack channel is becoming too busy. This PR adds a seperate excilation path for across to faciliate the creation of a #across-infrastructure.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
