### PR TITLE
feat(Discord-transport): Only send discord logs if the message contains mrkdwn

### DIFF
--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -25,6 +25,7 @@ export class DiscordTransport extends Transport {
   // Note: info must be any because that's what the base class uses.
   async log(info: any, callback: () => void): Promise<void> {
     try {
+      if (!info.mrkdwn) return; // We only ever want to send messages to Discord that have Markdown in them.
       const body = {
         username: "UMA Infrastructure",
         avatar_url: "https://i.imgur.com/RCcxxEZ.png",


### PR DESCRIPTION

**Motivation**

We only want to send messages to Discord if and only if the message contains markdown.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

