### PR TITLE
feat(sdk): use events to populate transaction/block numbers for state

### DIFF
--- a/packages/sdk/src/oracle/client.ts
+++ b/packages/sdk/src/oracle/client.ts
@@ -21,7 +21,12 @@ export class Client {
   }
   setActiveRequest(params: InputRequest): string {
     const requester = ethers.utils.getAddress(params.requester);
-    return this.sm.types.setActiveRequest.create({ ...params, requester });
+    // these are case and number senstive
+    const ancillaryData = params.ancillaryData.toLowerCase();
+    const identifier = params.identifier.toLowerCase();
+    const chainId = Number(params.chainId);
+    const timestamp = Number(params.timestamp);
+    return this.sm.types.setActiveRequest.create({ requester, ancillaryData, identifier, chainId, timestamp });
   }
   setActiveRequestByTransaction(params: setActiveRequestByTransaction.Params): string {
     return this.sm.types.setActiveRequestByTransaction.create(params);
@@ -35,6 +40,7 @@ export class Client {
     assert(user.address, "requires a user account address");
     assert(user.signer, "requires a user signer");
     assert(user.chainId === inputRequest.chainId, "On wrong chain");
+    assert(request.currency, "Request currency is unknown");
     return this.sm.types.approve.create(
       {
         currency: request.currency,
@@ -58,6 +64,7 @@ export class Client {
     assert(user.address, "requires a user account address");
     assert(user.signer, "requires a user signer");
     assert(user.chainId === inputRequest.chainId, "On wrong chain");
+    assert(request.currency, "Request currency is unknown");
     return this.sm.types.proposePrice.create(
       {
         ...inputRequest,
@@ -79,6 +86,7 @@ export class Client {
     assert(user.address, "requires a user account address");
     assert(user.signer, "requires a user signer");
     assert(user.chainId === inputRequest.chainId, "On wrong chain");
+    assert(request.currency, "Request currency is unknown");
     return this.sm.types.disputePrice.create(
       {
         ...inputRequest,

--- a/packages/sdk/src/oracle/errors.ts
+++ b/packages/sdk/src/oracle/errors.ts
@@ -1,0 +1,26 @@
+import { exists } from "../utils";
+
+// This error should be thrown if an expected value does not exist
+export class ExistenceError extends Error {
+  constructor(message = "") {
+    super(message);
+    this.name = "ExistenceError";
+    // if this isnt included, we cannot use instanceof to check the type
+    Object.setPrototypeOf(this, ExistenceError.prototype);
+  }
+}
+
+// Special assert which checks for existence and throw existence error
+export function assertExists<T>(condition: T, message = ""): asserts condition is NonNullable<T> {
+  if (!exists(condition)) throw new ExistenceError(message);
+}
+
+// Ignore only existence errors. If thrown properly this can be used to convert a non existent value to undefined.
+export function ignoreExistenceError<X extends () => any>(call: X): ReturnType<X> | undefined {
+  try {
+    return call();
+  } catch (err) {
+    if (err instanceof ExistenceError) return undefined;
+    throw err;
+  }
+}

--- a/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
@@ -42,11 +42,10 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
         // reprocess all known events and create a table of requests from it
         await update.sortedRequests(chainId);
 
-        try {
-          // we can just try to update the current active request, we dont care if it fails, active request might not be set
+        // check if the user is viewing a request
+        if (store.has().inputRequest() && store.has().sortedRequestsService()) {
+          // try to update the active request by event data
           await update.activeRequestFromEvents();
-        } catch (err) {
-          // do nothing
         }
 
         // we signal that the current range was a success, now move currentStart, currentEnd accordingly

--- a/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
@@ -41,6 +41,14 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
         await update.oracleEvents(chainId, currentStart, currentEnd);
         // reprocess all known events and create a table of requests from it
         await update.sortedRequests(chainId);
+
+        try {
+          // we can just try to update the current active request, we dont care if it fails, active request might not be set
+          await update.activeRequestFromEvents();
+        } catch (err) {
+          // do nothing
+        }
+
         // we signal that the current range was a success, now move currentStart, currentEnd accordingly
         // we set multiplier to 1 so we dont grow the range on success, this tends to create more errors and slow down querying
         memory.state = rangeSuccessDescending({ ...rangeState, multiplier: 1 });

--- a/packages/sdk/src/oracle/services/statemachines/pollNewEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/pollNewEvents.ts
@@ -30,21 +30,30 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       const currentBlock = memory.lastBlock || startBlock || latestBlock;
       memory.error = undefined;
       try {
-        // dont worry about querying if latest and current are the same
+        // dont worry about querying if latest and current are the same. This optimization causes wierd effects
+        // during testing, as block number rarely changes unless user moves it manually, giving the impression that events are missed.
         if (latestBlock !== currentBlock) {
           // this pulls all events from current to latest block
           await update.oracleEvents(chainId, currentBlock, latestBlock);
           // update our request table list with all known events
           await update.sortedRequests(chainId);
+
+          try {
+            // we can just try to update the current active request, we dont care if it fails, active request might not be set
+            await update.activeRequestFromEvents();
+          } catch (err) {
+            // do nothing
+          }
+
           // reset our last block seen to the latest (end) block
           memory.lastBlock = latestBlock;
+          // just count how many successful iterations we do as a kind of sanity check
+          memory.iterations++;
         }
       } catch (err) {
         // store an error for an iteration if we need to debug
         memory.error = (err as unknown) as Error;
       }
-      // just count how many iterations we do as a kind of sanity check
-      memory.iterations++;
 
       // we dont need to poll these events very fast, so just set to once a min
       return ctx.sleep(pollRateSec * 1000);

--- a/packages/sdk/src/oracle/store/has.ts
+++ b/packages/sdk/src/oracle/store/has.ts
@@ -1,5 +1,6 @@
 import Read from "./read";
-import { ignoreError } from "../utils";
+// we only ignore this specific error type explicitly emitted from reader class, meaning value is undefined
+import { ignoreExistenceError as ignoreError } from "../errors";
 import type { State } from "../types/state";
 
 // This class checks for existence for values you could potentially read. It mirrors the read interface but returns bools from functions.

--- a/packages/sdk/src/oracle/store/has.ts
+++ b/packages/sdk/src/oracle/store/has.ts
@@ -1,7 +1,11 @@
-import Read from "./read";
+// return true only if value is not null or undefined
+import { exists } from "../../utils";
+
 // we only ignore this specific error type explicitly emitted from reader class, meaning value is undefined
 import { ignoreExistenceError } from "../errors";
 import type { State } from "../types/state";
+
+import Read from "./read";
 
 // This class checks for existence for values you could potentially read. It mirrors the read interface but returns bools from functions.
 export default class Has {
@@ -14,9 +18,9 @@ export default class Has {
     // the rule about reads is they will only throw errors if it cant return the value you request.
     // If no errors are thrown the read was successful.
     // Reads will never not return a value without throwing an error, enforced by TS.
-    return !!ignoreExistenceError(this.read.inputRequest);
+    return exists(ignoreExistenceError(this.read.inputRequest));
   };
   sortedRequestsService = (): boolean => {
-    return !!ignoreExistenceError(this.read.sortedRequestsService);
+    return exists(ignoreExistenceError(this.read.sortedRequestsService));
   };
 }

--- a/packages/sdk/src/oracle/store/has.ts
+++ b/packages/sdk/src/oracle/store/has.ts
@@ -1,6 +1,6 @@
 import Read from "./read";
 // we only ignore this specific error type explicitly emitted from reader class, meaning value is undefined
-import { ignoreExistenceError as ignoreError } from "../errors";
+import { ignoreExistenceError } from "../errors";
 import type { State } from "../types/state";
 
 // This class checks for existence for values you could potentially read. It mirrors the read interface but returns bools from functions.
@@ -14,9 +14,9 @@ export default class Has {
     // the rule about reads is they will only throw errors if it cant return the value you request.
     // If no errors are thrown the read was successful.
     // Reads will never not return a value without throwing an error, enforced by TS.
-    return !!ignoreError(this.read.inputRequest);
+    return !!ignoreExistenceError(this.read.inputRequest);
   };
   sortedRequestsService = (): boolean => {
-    return !!ignoreError(this.read.sortedRequestsService);
+    return !!ignoreExistenceError(this.read.sortedRequestsService);
   };
 }

--- a/packages/sdk/src/oracle/store/has.ts
+++ b/packages/sdk/src/oracle/store/has.ts
@@ -1,0 +1,21 @@
+import Read from "./read";
+import { ignoreError } from "../utils";
+import type { State } from "../types/state";
+
+// This class checks for existence for values you could potentially read. It mirrors the read interface but returns bools from functions.
+export default class Has {
+  private read: Read;
+  constructor(private state: State) {
+    // by design, reads do not mutate or cause side effects
+    this.read = new Read(state);
+  }
+  inputRequest = (): boolean => {
+    // the rule about reads is they will only throw errors if it cant return the value you request.
+    // If no errors are thrown the read was successful.
+    // Reads will never not return a value without throwing an error, enforced by TS.
+    return !!ignoreError(this.read.inputRequest);
+  };
+  sortedRequestsService = (): boolean => {
+    return !!ignoreError(this.read.sortedRequestsService);
+  };
+}

--- a/packages/sdk/src/oracle/store/index.ts
+++ b/packages/sdk/src/oracle/store/index.ts
@@ -1,5 +1,6 @@
 import Write from "./write";
 import Read from "./read";
+import Has from "./has";
 
 import Store, { Emit as GenericEmit } from "./store";
 import { State } from "../types/state";
@@ -7,7 +8,7 @@ import { State } from "../types/state";
 type WriteCallback = (write: Write, state: State) => void;
 type Emit = GenericEmit<State>;
 
-export { Write, Store, Read, Emit, WriteCallback };
+export { Write, Store, Read, Emit, WriteCallback, Has };
 
 /**
  * OracleStore. Wraps the store with a specific state shape and passes the Write client through to end user.
@@ -41,5 +42,13 @@ export default class OracleStore {
    */
   get = (): State => {
     return this.store.read();
+  };
+  /**
+   * has. Checks for existence. Mirrors the read interface, but instead of reading values returns true or false.
+   *
+   * @returns {Has}
+   */
+  has = (): Has => {
+    return new Has(this.store.read());
   };
 }

--- a/packages/sdk/src/oracle/store/read.ts
+++ b/packages/sdk/src/oracle/store/read.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import filter from "lodash/filter";
 
 import type {
@@ -20,6 +19,7 @@ import { TransactionConfirmer, requestId } from "../utils";
 import { OptimisticOracle } from "../services/optimisticOracle";
 import { Erc20 } from "../services/erc20";
 import { SortedRequests } from "../services/sortedRequests";
+import { assertExists as assert } from "../errors";
 
 // This is a typescript compatible way of pulling out values from the global state object, essentially
 // forming a basic API. Most calls are parameterless, requiring first setting state which determines, the

--- a/packages/sdk/src/oracle/store/read.ts
+++ b/packages/sdk/src/oracle/store/read.ts
@@ -19,7 +19,7 @@ import { TransactionConfirmer, requestId } from "../utils";
 import { OptimisticOracle } from "../services/optimisticOracle";
 import { Erc20 } from "../services/erc20";
 import { SortedRequests } from "../services/sortedRequests";
-import { assertExists as assert } from "../errors";
+import { assertExists } from "../errors";
 
 // This is a typescript compatible way of pulling out values from the global state object, essentially
 // forming a basic API. Most calls are parameterless, requiring first setting state which determines, the
@@ -30,55 +30,55 @@ export default class Read {
   chainConfig = (optionalChainId?: number): ChainConfig => {
     const chainId = optionalChainId || this.requestChainId();
     const config = this.state?.config?.chains?.[chainId];
-    assert(config, "No config set for chain: " + chainId);
+    assertExists(config, "No config set for chain: " + chainId);
     return config;
   };
   requestChainId = (): number => {
     const chainId = this.state?.inputs?.request?.chainId;
-    assert(chainId, "ChainId is not set on request");
+    assertExists(chainId, "ChainId is not set on request");
     return chainId;
   };
   user = (): Partial<User> => {
     const result = this.state?.inputs?.user;
-    assert(result, "user not set");
+    assertExists(result, "user not set");
     return result;
   };
   userChainId = (): number => {
     const chainId = this.state?.inputs?.user?.chainId;
-    assert(chainId, "ChainId is not set");
+    assertExists(chainId, "ChainId is not set");
     return chainId;
   };
   requestChain = (optionalChainId?: number): Partial<Chain> => {
     const chainId = optionalChainId || this.requestChainId();
     const chain = this.state?.chains?.[chainId];
-    assert(chain, "Chain not set");
+    assertExists(chain, "Chain not set");
     return chain;
   };
   userAddress = (): string => {
     const address = this.state?.inputs?.user?.address;
-    assert(address, "User address is not set");
+    assertExists(address, "User address is not set");
     return address;
   };
   oracleAddress = (optionalChainId?: number): string => {
     const chain = this.requestChain(optionalChainId);
     const address = chain?.optimisticOracle?.address;
-    assert(address, "Optimistic oracle address not set");
+    assertExists(address, "Optimistic oracle address not set");
     return address;
   };
   signer = (): JsonRpcSigner => {
     const signer = this.state?.inputs?.user?.signer;
-    assert(signer, "Signer is not set");
+    assertExists(signer, "Signer is not set");
     return signer;
   };
   inputRequest = (): InputRequest => {
     const input = this.state?.inputs?.request;
-    assert(input, "Input request is not set");
+    assertExists(input, "Input request is not set");
     return input;
   };
   defaultLiveness = (): BigNumber => {
     const chain = this.requestChain();
     const liveness = chain?.optimisticOracle?.defaultLiveness;
-    assert(liveness, "Optimistic oracle defaultLiveness set");
+    assertExists(liveness, "Optimistic oracle defaultLiveness set");
     return liveness;
   };
   request = (): FullRequest => {
@@ -86,63 +86,63 @@ export default class Read {
     const input = this.inputRequest();
     const id = requestId(input);
     const request = chain?.optimisticOracle?.requests?.[id];
-    assert(request, "Request has not been fetched");
+    assertExists(request, "Request has not been fetched");
     return request;
   };
   collateralProps = (): Partial<Erc20Props> => {
     const request = this.request();
-    assert(request.currency, "Request currency not set");
+    assertExists(request.currency, "Request currency not set");
     const chain = this.requestChain();
     const props = chain.erc20s?.[request.currency]?.props;
-    assert(props, "Props not set on collateral token");
+    assertExists(props, "Props not set on collateral token");
     return props;
   };
   userCollateralBalance = (): BigNumber => {
     const request = this.request();
-    assert(request.currency, "Request currency not set");
+    assertExists(request.currency, "Request currency not set");
     const chain = this.requestChain();
     const user = this.userAddress();
     const balance = chain?.erc20s?.[request.currency]?.balances?.[user];
-    assert(balance, "Balance not set on collateral token for user");
+    assertExists(balance, "Balance not set on collateral token for user");
     return balance;
   };
   userCollateralAllowance = (): BigNumber => {
     const request = this.request();
-    assert(request.currency, "Request currency not set");
+    assertExists(request.currency, "Request currency not set");
     const chain = this.requestChain();
     const user = this.userAddress();
     const oracle = this.oracleAddress();
     const allowance = chain?.erc20s?.[request.currency]?.allowances?.[oracle]?.[user];
-    assert(allowance, "Allowance not set on user on collateral token for oracle");
+    assertExists(allowance, "Allowance not set on user on collateral token for oracle");
     return allowance;
   };
   oracleService = (optionalChainId?: number): OptimisticOracle => {
     const chainId = optionalChainId || this.requestChainId();
     const result = this.state?.services?.chains?.[chainId]?.optimisticOracle;
-    assert(result, "Optimistic Oracle Not found on chain " + chainId);
+    assertExists(result, "Optimistic Oracle Not found on chain " + chainId);
     return result;
   };
   collateralService = (): Erc20 => {
     const chainId = this.requestChainId();
     const request = this.request();
-    assert(request.currency, "Request currency not set");
+    assertExists(request.currency, "Request currency not set");
     const result = this.state?.services?.chains?.[chainId]?.erc20s?.[request.currency];
-    assert(result, "Token not supported on chain " + chainId);
+    assertExists(result, "Token not supported on chain " + chainId);
     return result;
   };
   command = (id: string): Context<unknown, unknown & Memory> => {
     const result = this.state?.commands?.[id];
-    assert(result, "Unable to find command " + id);
+    assertExists(result, "Unable to find command " + id);
     return result;
   };
   tokenService = (chainId: number, address: string): Erc20 => {
     const result = this.state?.services?.chains?.[chainId]?.erc20s?.[address];
-    assert(result, "Token service not found: " + [chainId, address].join("."));
+    assertExists(result, "Token service not found: " + [chainId, address].join("."));
     return result;
   };
   provider = (chainId: number): Provider => {
     const result = this.state?.services?.chains?.[chainId]?.provider;
-    assert(result, "Provider not found on chainid: " + chainId);
+    assertExists(result, "Provider not found on chainid: " + chainId);
     return result;
   };
   transactionService = (chainId: number): TransactionConfirmer => {
@@ -158,19 +158,19 @@ export default class Read {
   chain = (optionalChainId?: number): Partial<Chain> => {
     const chainId = optionalChainId || this.requestChainId();
     const chain = this.state?.chains?.[chainId];
-    assert(chain, "No chain for chainId: " + chainId);
+    assertExists(chain, "No chain for chainId: " + chainId);
     return chain;
   };
   currentTime = (optionalChainId?: number): BigNumber => {
     const chainId = optionalChainId || this.requestChainId();
     const chain = this.chain(chainId);
     const time = chain?.currentTime;
-    assert(time, "Current time not available on chain: " + chainId);
+    assertExists(time, "Current time not available on chain: " + chainId);
     return time;
   };
   sortedRequestsService = (): SortedRequests => {
     const result = this.state?.services?.sortedRequests;
-    assert(result, "Sorted request service not set");
+    assertExists(result, "Sorted request service not set");
     return result;
   };
   oracleEvents = (chainId: number): OptimisticOracleEvent[] => {

--- a/packages/sdk/src/oracle/store/write.ts
+++ b/packages/sdk/src/oracle/store/write.ts
@@ -70,10 +70,11 @@ export class OptimisticOracle {
   address(address: string): void {
     this.state.address = address;
   }
-  request(inputRequest: state.InputRequest, request: state.Request): void {
-    const id = requestId(inputRequest);
+  request(request: state.FullRequest): void {
+    const id = requestId(request);
     if (!this.state.requests) this.state.requests = {};
-    this.state.requests[id] = request;
+    // merge data in rather than replace
+    this.state.requests[id] = { ...this.state.requests[id], ...request };
   }
   defaultLiveness(defaultLiveness: ethersTypes.BigNumber): void {
     this.state.defaultLiveness = defaultLiveness;

--- a/packages/sdk/src/oracle/tests/errors.test.ts
+++ b/packages/sdk/src/oracle/tests/errors.test.ts
@@ -1,0 +1,42 @@
+import assert from "assert";
+import * as errors from "../errors";
+describe("Oracle Errors", function () {
+  test("assertExists", function () {
+    const message = "Value does not exist";
+    let plan = 0;
+    try {
+      errors.assertExists(null, message);
+    } catch (err) {
+      assert.ok(err instanceof errors.ExistenceError);
+      assert.equal(err.message, message);
+      assert.equal(err.name, "ExistenceError");
+      plan++;
+    }
+    try {
+      throw new Error(message);
+    } catch (err) {
+      assert.ok(!(err instanceof errors.ExistenceError));
+      plan++;
+    }
+    assert.equal(plan, 2);
+  });
+  test("ignoreExistenceError", function () {
+    const a = errors.ignoreExistenceError(() => {
+      throw new errors.ExistenceError();
+    });
+    assert.equal(a, undefined);
+    const b = errors.ignoreExistenceError(() => 1);
+    assert.equal(b, 1);
+
+    let plan = 0;
+    try {
+      errors.ignoreExistenceError(() => {
+        throw new Error("dont ignore me");
+      });
+    } catch (err) {
+      assert.ok(err);
+      plan++;
+    }
+    assert.equal(plan, 1);
+  });
+});

--- a/packages/sdk/src/oracle/types/state.ts
+++ b/packages/sdk/src/oracle/types/state.ts
@@ -140,10 +140,20 @@ export type RequestIndex = RequestByEvent & { chainId: number };
 export type RequestIndexes = RequestIndex[];
 export type { RequestPrice, ProposePrice, DisputePrice, Settle };
 
+// combine all request data into a mega request object
+export type FullRequest = InputRequest &
+  // we cant assume any of these props will exist if we get event before query contract
+  Partial<Request> &
+  // take the more specific types from the Request type by omitting overlapping properties
+  Omit<
+    RequestIndex,
+    "proposedPrice" | "resolvedPrice" | "expirationTime" | "reward" | "finalFee" | "bond" | "customLiveness"
+  >;
+
 export type OptimisticOracle = {
   address: string;
   defaultLiveness: BigNumber;
-  requests: Record<string, Request>;
+  requests: Record<string, FullRequest>;
   events: OptimisticOracleEvent[];
 };
 

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -1,4 +1,9 @@
 import assert from "assert";
+import { ethers } from "ethers";
+import sortedLastIndexBy from "lodash/sortedLastIndexBy";
+// this request id does not include chain id
+export { requestId } from "../clients/optimisticOracle";
+
 import {
   State,
   RequestState,
@@ -13,9 +18,6 @@ import {
 import type { Provider, TransactionReceipt, BigNumberish } from "./types/ethers";
 import { ContextType } from "./types/statemachine";
 import { Read } from "./store";
-import { ethers } from "ethers";
-export { requestId } from "../clients/optimisticOracle";
-import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 
 export const getAddress = ethers.utils.getAddress;
 export const hexValue = ethers.utils.hexValue;

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -7,7 +7,7 @@ export type BigNumberish = number | string | BigNumber;
 // check if a value is not null or undefined, useful for numbers which could be 0.
 // "is" syntax: https://stackoverflow.com/questions/40081332/what-does-the-is-keyword-do-in-typescript
 /* eslint-disable-next-line @typescript-eslint/ban-types */
-export function exists<T>(value: T | null | undefined): value is T {
+export function exists<T>(value: T | null | undefined): value is NonNullable<T> {
   return value !== null && value !== undefined;
 }
 


### PR DESCRIPTION
BREAKING CHANGE!: request type properties can now be undefined

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
We want to be able to link to the transactions that requested/proposed/disputed requests.

**Summary**
Updates event decoding to also attach transaction hash data to the active request on an interval. Uses exisitng polling commands to update the request. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
