### PR TITLE
feat(discordTransport): Add in a delay between sequential restful calls to discord API to work around rate limits

### DIFF
--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -1,3 +1,5 @@
+import { delay } from "../helpers/delay";
+
 import Transport from "winston-transport";
 
 import axios from "axios";
@@ -44,8 +46,12 @@ export class DiscordTransport extends Transport {
         else webHooks = [webHook];
       }
 
-      // Send webhook request to each of the configured webhooks upstream. This posts the messages on Discord.
-      if (webHooks.length) await Promise.all(webHooks.map((webHook: string) => axios.post(webHook, body)));
+      // Send webhook request to each of the configured webhooks upstream. This posts the messages on Discord. Execute
+      // these sequentially with a soft delay of 2 seconds between calls to avoid hitting the discord rate limit.
+      for (const webHook of webHooks) {
+        await axios.post(webHook, body);
+        await delay(2);
+      }
     } catch (error) {
       console.error("Discord error", error);
     }

--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -48,10 +48,11 @@ export class DiscordTransport extends Transport {
 
       // Send webhook request to each of the configured webhooks upstream. This posts the messages on Discord. Execute
       // these sequentially with a soft delay of 2 seconds between calls to avoid hitting the discord rate limit.
-      for (const webHook of webHooks) {
-        await axios.post(webHook, body);
-        await delay(2);
-      }
+      if (webHooks.length)
+        for (const webHook of webHooks) {
+          await axios.post(webHook, body);
+          await delay(2);
+        }
     } catch (error) {
       console.error("Discord error", error);
     }


### PR DESCRIPTION
**Motivation**

Discord API sometimes hits rate limit issues. This PR adds a dirty fix to this by slowing down how quickly we hit the API.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
