### PR TITLE
feat(CrossDomainFinalizer): Fix issue finalizing OP L2->L1 transfers

### DIFF
--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -115,7 +115,7 @@ export class CrossDomainFinalizer {
     // Fetch all whitelisted L2 tokens.
     let whitelistedL2Tokens = this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString());
 
-    // If the l2Client ChainId is set to 10 then this is connected to optimism. Optimism is a special case where we are
+    // If the l2Client ChainId is set to 10 then this is connected to Optimism. Optimism is a special case where we are
     // bridging ETH over the canonical bridge, not WETH. As a result, we must consider ETH transfers as bridgeable and
     // search for them, if they are finalizable over the canonical bridge.
     if (this.l2Client.chainId === 10)

--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -113,7 +113,9 @@ export class CrossDomainFinalizer {
 
   async checkForConfirmedL2ToL1RelaysAndFinalize() {
     // Fetch all whitelisted L2 tokens.
-    const whitelistedL2Tokens = this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString());
+    let whitelistedL2Tokens = this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString());
+    if (this.l2Client.chainId == 10)
+      whitelistedL2Tokens = [...whitelistedL2Tokens, "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"];
 
     // Fetch TokensBridged events.
     await this.fetchTokensBridgedEvents();

--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -114,7 +114,11 @@ export class CrossDomainFinalizer {
   async checkForConfirmedL2ToL1RelaysAndFinalize() {
     // Fetch all whitelisted L2 tokens.
     let whitelistedL2Tokens = this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString());
-    if (this.l2Client.chainId == 10)
+
+    // If the l2Client ChainId is set to 10 then this is connected to optimism. Optimism is a special case where we are
+    // bridging ETH over the canonical bridge, not WETH. As a result, we must consider ETH transfers as bridgeable and
+    // search for them, if they are finalizable over the canonical bridge.
+    if (this.l2Client.chainId === 10)
       whitelistedL2Tokens = [...whitelistedL2Tokens, "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"];
 
     // Fetch TokensBridged events.

--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -112,14 +112,12 @@ export class CrossDomainFinalizer {
   }
 
   async checkForConfirmedL2ToL1RelaysAndFinalize() {
-    // Fetch all whitelisted L2 tokens.
-    let whitelistedL2Tokens = this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString());
-
-    // If the l2Client ChainId is set to 10 then this is connected to Optimism. Optimism is a special case where we are
-    // bridging ETH over the canonical bridge, not WETH. As a result, we must consider ETH transfers as bridgeable and
-    // search for them, if they are finalizable over the canonical bridge.
-    if (this.l2Client.chainId === 10)
-      whitelistedL2Tokens = [...whitelistedL2Tokens, "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"];
+    // Fetch all whitelisted L2 tokens. Append the ETH address on Optimism to the whitelist to enable finalization of
+    // Optimism -> Ethereum bridging actions. This is needed as we send ETH over the Optimism bridge, not WETH.
+    const whitelistedL2Tokens = [
+      ...this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString()),
+      "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+    ];
 
     // Fetch TokensBridged events.
     await this.fetchTokensBridgedEvents();

--- a/packages/insured-bridge-relayer/test/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/test/CrossDomainFinalizer.ts
@@ -80,7 +80,7 @@ let bridgePool2: any;
 let l2DeployData: any;
 
 // Hard-coded test params:
-const chainId = 10;
+const chainId = 1337;
 const defaultGasLimit = 1_000_000;
 const defaultGasPrice = toWei("1", "gwei");
 const defaultIdentifier = utf8ToHex("IS_CROSS_CHAIN_RELAY_VALID");
@@ -712,7 +712,7 @@ describe("CrossDomainFinalizer.ts", function () {
       assert.isTrue(spyLogIncludes(spy, -3, "Found L2->L1 relays to finalize"));
       assert.isTrue(spyLogIncludes(spy, -3, `confirmedL2TransactionsToExecute":["${bridgeTx.transactionHash}"]`));
       assert.isTrue(spyLogIncludes(spy, -2, "Gas estimator updated"));
-      assert.isTrue(spyLogIncludes(spy, -1, "Canonical L2->L1 transfer over the optimism bridge"));
+      assert.isTrue(spyLogIncludes(spy, -1, "Canonical L2->L1 transfer over"));
       assert.isTrue(spyLogIncludes(spy, -1, "A total of 4.00 L2ERC20 was bridged")); // depositAmount.muln(4) is 4.
     });
   });

--- a/packages/insured-bridge-relayer/test/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/test/CrossDomainFinalizer.ts
@@ -668,7 +668,7 @@ describe("CrossDomainFinalizer.ts", function () {
       await Promise.all([l1Client.update(), l2Client.update()]);
       await crossDomainFinalizer.checkForConfirmedL2ToL1RelaysAndFinalize();
       assert.isTrue(spyLogIncludes(spy, -2, "Checking for confirmed L2->L1 canonical bridge actions"));
-      assert.isTrue(spyLogIncludes(spy, -2, `whitelistedL2Tokens":["${l2Token.options.address}"]`));
+      assert.isTrue(spyLogIncludes(spy, -2, `whitelistedL2Tokens":["${l2Token.options.address}`));
       assert.isTrue(spyLogIncludes(spy, -2, "Checking for confirmed L2->L1 canonical bridge actions"));
       assert.isTrue(spyLogIncludes(spy, -2, `l2TokensBridgedTransactions":[]`));
       assert.isTrue(spyLogIncludes(spy, -1, `No L2->L1 relays to finalize`));


### PR DESCRIPTION

**Motivation**

There is an issue finalizing L2->L1 canonical transfers. This PR addresses this by including the L2 ETH address on optimism in the whitelist so the bot correctly atempts to finalize these.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
