### PR TITLE
feat(pf): implement rounded price methods

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,5 +5,6 @@ export * from "./MetaMaskTruffleProvider";
 export * from "./ProviderUtils";
 export * from "./HardhatConfig";
 export * from "./RetryProvider";
+export * from "./RoundingUtils";
 export * from "./UniswapV3Helpers";
 export * from "./types";


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Price feeds need to comply with rounding rules defined in price identifier UMIPs


**Summary**

Adds `getCurrentRoundedPrice` and `getHistoricalRoundedPrice` methods to price feeds.


**Details**

This is still WIP where rounded price methods have been added only to CryptoWatch price feed.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

