### PR TITLE
fix(sdk): disable provider polling and correctly check done for past …

### DIFF
--- a/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
@@ -35,7 +35,7 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       // we want to move start block closer to endblock to reduce the range until it stops erroring. These range functions
       // will do that for us.
       const rangeState = memory.state || rangeStart({ startBlock, endBlock });
-      const { currentStart, currentEnd, done } = rangeState;
+      const { currentStart, currentEnd } = rangeState;
 
       try {
         // this just queries events between start and end
@@ -54,11 +54,11 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
         // the provider threw an error so we will reduce our range by moving startblock closer to endblock next iteration
         memory.state = rangeFailureDescending(rangeState);
       }
-      // the range functions will tell us when we have successfully queried the entire range of blocks.
-      if (done) return "done";
       memory.iterations++;
+      // the range functions will tell us when we have successfully queried the entire range of blocks.
+      if (memory?.state?.done) return "done";
       // sleep to let other contexts run, but just resume right after.
-      return ctx.sleep(10);
+      return ctx.sleep(100);
     },
   };
 }

--- a/packages/sdk/src/oracle/store/write.ts
+++ b/packages/sdk/src/oracle/store/write.ts
@@ -114,8 +114,15 @@ export class Services {
   constructor(private state: Partial<state.ChainServices>) {}
   provider(rpcUrls: string[]): void {
     if (this.state?.provider) return;
-    const providers = rpcUrls.map((url) => ethers.getDefaultProvider(url));
+    const providers = rpcUrls.map((url) => {
+      const provider = ethers.getDefaultProvider(url);
+      // turn off all polling, we will poll manually
+      provider.polling = false;
+      return provider;
+    });
     this.state.provider = new ethers.providers.FallbackProvider(providers, 1);
+    // turn off all polling, we will poll manually
+    this.state.provider.polling = false;
   }
   erc20s(address: string): void {
     if (!this.state?.provider) return;


### PR DESCRIPTION
…events

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
During testing with hardhat forks we are seeing an extraordinary amount of calls to `eth_getBlockByNumber` when inspecting alchemy logs.

**Summary**

It was determined through some experimentation that disabling polling in the ethers provider silenced all network traffic ( unless specifically needed). This is OK to do within this client because all calls get manually polled.  Also found a slight bug causing past events to get called more than once. 

**Details**
This sounds really unbelievable, but when not disabling polling for a single provider, we end up seeing tons of logs.  Polling will also need to be disabled within the OO UI app from onboard.  I ran this test while having all app logic disabled and a single ethers provider. The provider was wrapping onboards provider with polling enabled (this is default behavior) caused thousands of `eth_getBlockByNumber` within minutes. This is only visible through alchemy logs

We can see here the latest logs showing 4 min ago:
![image](https://user-images.githubusercontent.com/4429761/154517612-0b0565e9-722f-4b28-a0d8-5b382bd1345c.png)

And the last page, log 100, showing 5 min ago:
![image](https://user-images.githubusercontent.com/4429761/154517685-29969c16-5d15-4360-a4e0-2bf2aba149a9.png)

Within 1 minute 100 at least requests are generated. I think there are many more, but only this many could be serviced, as it seems like theres a huge backlog of calls coming in after the app closes.  This seems like a problem with ethers, onboard 
 or metamask polling, as the app logic is completely disabled during this test. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


