### PR TITLE
fix(sdk): add tx hashes to dispute, settle, propose 

### DIFF
--- a/packages/sdk/src/across/test/rateModel.e2e.ts
+++ b/packages/sdk/src/across/test/rateModel.e2e.ts
@@ -46,7 +46,7 @@ describe("rateModel", function () {
           blockSearchConfig.fromBlock
         );
         assert.fail("Should throw error");
-      } catch (err: any) {
+      } catch (err) {
         assert.equal(err.message.includes("method called before updating"), true);
       }
       rateModelDictionary.updateWithEvents(filteredEvents);
@@ -58,7 +58,7 @@ describe("rateModel", function () {
           blockSearchConfig.fromBlock - 1
         );
         assert.fail("Should throw error");
-      } catch (err: any) {
+      } catch (err) {
         assert.equal(err.message.includes("before first UpdatedRateModel event"), true);
       }
 
@@ -66,7 +66,7 @@ describe("rateModel", function () {
       try {
         await rateModelDictionary.getRateModelForBlockNumber(rateModelStore.address, blockSearchConfig.fromBlock - 1);
         assert.fail("Should throw error");
-      } catch (err: any) {
+      } catch (err) {
         assert.equal(err.message.includes("No updated rate model events for L1 token"), true);
       }
 
@@ -113,7 +113,7 @@ describe("rateModel", function () {
       try {
         await rateModelDictionary.getL1TokensFromRateModel(blockSearchConfig.fromBlock);
         assert.fail("Should throw error");
-      } catch (err: any) {
+      } catch (err) {
         assert.equal(err.message.includes("method called before updating"), true);
       }
       rateModelDictionary.updateWithEvents(filteredEvents);
@@ -139,7 +139,7 @@ describe("rateModel", function () {
     try {
       rateModel.parseAndReturnRateModelFromString("not a JSON");
       assert.fail("Should throw error");
-    } catch (err: any) {
+    } catch (err) {
       assert.equal(err.message.includes("JSON"), true);
     }
 
@@ -154,7 +154,7 @@ describe("rateModel", function () {
     try {
       rateModel.parseAndReturnRateModelFromString(JSON.stringify(rateModelWithMissingKeys));
       assert.fail("Should throw error");
-    } catch (err: any) {
+    } catch (err) {
       assert.equal(err.message.includes("does not contain all expected keys"), true);
     }
 
@@ -165,7 +165,7 @@ describe("rateModel", function () {
     try {
       rateModel.parseAndReturnRateModelFromString(JSON.stringify(rateModelWithExtraKeys));
       assert.fail("Should throw error");
-    } catch (err: any) {
+    } catch (err) {
       assert.equal(err.message.includes("contains unexpected keys"), true);
     }
 

--- a/packages/sdk/src/oracle/README.md
+++ b/packages/sdk/src/oracle/README.md
@@ -170,7 +170,7 @@ Sets the currently logged in user. This allows partial updates. Returns a string
 
 Clears the current user.
 
-`client.clearUser(): string `
+`client.clearUser(): string`
 
 ### setActiveRequest
 

--- a/packages/sdk/src/oracle/services/statemachines/disputePrice.ts
+++ b/packages/sdk/src/oracle/services/statemachines/disputePrice.ts
@@ -42,10 +42,17 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       // wait x seconds before running this state again
       return context.sleep(checkTxIntervalSec * 1000);
     },
-    async update(params: Params) {
-      const { chainId, currency, account } = params;
+    async update(params: Params, memory: Memory) {
+      const { chainId, currency, account, requester, identifier, timestamp, ancillaryData } = params;
+      const { hash } = memory;
       await update.balance(chainId, currency, account);
       await update.request(params);
+      store.write((w) =>
+        w
+          .chains(chainId)
+          .optimisticOracle()
+          .request({ chainId, requester, identifier, timestamp, ancillaryData, disputeTx: hash })
+      );
       return "done";
     },
   };

--- a/packages/sdk/src/oracle/services/statemachines/proposePrice.ts
+++ b/packages/sdk/src/oracle/services/statemachines/proposePrice.ts
@@ -42,10 +42,17 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       // wait x seconds before running this state again
       return context.sleep(checkTxIntervalSec * 1000);
     },
-    async update(params: Params) {
-      const { chainId, currency, account } = params;
+    async update(params: Params, memory: Memory) {
+      const { chainId, currency, account, requester, identifier, timestamp, ancillaryData } = params;
+      const { hash } = memory;
       await update.balance(chainId, currency, account);
       await update.request(params);
+      store.write((w) =>
+        w
+          .chains(chainId)
+          .optimisticOracle()
+          .request({ chainId, requester, identifier, timestamp, ancillaryData, proposeTx: hash })
+      );
       return "done";
     },
   };

--- a/packages/sdk/src/oracle/services/statemachines/settle.ts
+++ b/packages/sdk/src/oracle/services/statemachines/settle.ts
@@ -42,10 +42,17 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       // wait x seconds before running this state again
       return context.sleep(checkTxIntervalSec * 1000);
     },
-    async update(params: Params) {
-      const { chainId, currency, account } = params;
+    async update(params: Params, memory: Memory) {
+      const { chainId, currency, account, requester, identifier, timestamp, ancillaryData } = params;
+      const { hash } = memory;
       await update.balance(chainId, currency, account);
       await update.request(params);
+      store.write((w) =>
+        w
+          .chains(chainId)
+          .optimisticOracle()
+          .request({ chainId, requester, identifier, timestamp, ancillaryData, settleTx: hash })
+      );
       return "done";
     },
   };

--- a/packages/sdk/src/tables/README.md
+++ b/packages/sdk/src/tables/README.md
@@ -27,8 +27,8 @@ Create a new folder named after the type of data you are storing in the tables d
 
 - README.md: Add some notes on what the table is for and any stores it can use
 - index.ts: Expose your tables based on the name type of store it uses, for example `export {default as JsMap} from './js-map'`
-- ${store-type}.ts: Create a table file named for the store its compatible with, for example `js-map.ts`
-- ${store-type}.test.ts: Any tests you want to run
+- \${store-type}.ts: Create a table file named for the store its compatible with, for example `js-map.ts`
+- \${store-type}.test.ts: Any tests you want to run
 
 See the [blocks table](./blocks/README.md) as an example.
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
Transaction hashes were not being added to the request state when submitting them

**Summary**
This adds transaction hashes to request state when you propose, dispute and settle. Just uses the hash returned from the transaction. Waits until tx is mined before adding it. 

There was a bunch of new linting issues found, so those can be ignored. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


