### PR TITLE
fix(sdk): take into account lp transfers into fee calc

### DIFF
--- a/packages/sdk/src/across/clients/bridgePool.e2e.ts
+++ b/packages/sdk/src/across/clients/bridgePool.e2e.ts
@@ -13,10 +13,12 @@ const multicall2Address = "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696";
 const wethAddress = "0x7355Efc63Ae731f584380a9838292c7046c1e433";
 const badgerAddress = "0x43298F9f91a4545dF64748e78a2c777c580573d6";
 const wbtcAddress = "0x02fbb64517E1c6ED69a6FAa3ABf37Db0482f1152";
+const usdcAddress = "0x256C8919CE1AB0e33974CF6AA9c71561Ef3017b6";
 const users = [
   "0x06d8aeb52f99f8542429df3009ed26535c22d5aa",
   "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
   "0x718648C8c531F91b528A7757dD2bE813c3940608",
+  "0x67eb87fA6f2a81F864575B3930292A322B5Cf9FA",
 ];
 const txReceipt = {
   to: "0x7355Efc63Ae731f584380a9838292c7046c1e433",
@@ -122,9 +124,9 @@ describe("Client", function () {
   });
   test("read users", async function () {
     for (const userAddress of users) {
-      await client.updateUser(userAddress, wethAddress);
-      const user = get(state, ["users", userAddress, wethAddress]);
-      const pool = get(state, ["pools", wethAddress]);
+      await client.updateUser(userAddress, usdcAddress);
+      const user = get(state, ["users", userAddress, usdcAddress]);
+      const pool = get(state, ["pools", usdcAddress]);
       assert.ok(pool);
       assert.ok(user);
     }
@@ -142,6 +144,11 @@ describe("Client", function () {
   test("read wbtc pool", async function () {
     await client.updatePool(wbtcAddress);
     const result = get(state, ["pools", wbtcAddress]);
+    assert.ok(result);
+  });
+  test("read usdc pool", async function () {
+    await client.updatePool(usdcAddress);
+    const result = get(state, ["pools", usdcAddress]);
     assert.ok(result);
   });
 });


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

An issues was found with the fee calculation, an account shows a huge fee earned that was not possible.


**Summary**

This bug happens because we previously did not take into account LP token transfers, only withdraws or deposits. This is more of a proposal as to how we can take this into account.

ultimately the fee calculation is updated to this:
`const feesEarned = positionValue.sub(totalDeposited.add(totalTransferredValue));`
Where position value is your current position value from contract - (( sum of deposit events - sum of withdraw events) + (total transferred events to you - total transferred events from you)) 

previously the total transferred was not added into equation.  I'm not totally sure if this captures fees correctly but the results do look in the right ballpark, and it does not change calculations for accounts which have had no transfers.

Bear in mind also, this error is only currently seen on 3 accounts, 2 of which transferred lp tokens to the same account, all of them are related to UMA. this issue does not currently affect third parties, though it could in the future.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


