### PR TITLE
feat: fix dai on Arbitrum L2->L1 Cross Domain Finalizer

### DIFF
--- a/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
+++ b/packages/insured-bridge-relayer/src/CrossDomainFinalizer.ts
@@ -52,7 +52,9 @@ export class CrossDomainFinalizer {
     // we don't want to finalize DAI actions due to this not working over the canonical Optimism bridge.
     const whitelistedL2Tokens = this.l1Client
       .getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString())
-      .filter((address) => address !== "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"); // Remove DAI on Optimism address.
+      .filter((address) =>
+        this.l2Client.chainId != 10 ? true : address !== "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+      ); // Remove DAI on Optimism address. If chainId is not 10 then do no filtering.
 
     // Check if any of the whitelisted l2Tokens are bridgeable. Do this in one parallel call. Returns an array of bool
     // for each l2Token, describing if it can be bridged from L2->L1.
@@ -129,7 +131,9 @@ export class CrossDomainFinalizer {
     const whitelistedL2Tokens = [
       ...this.l1Client.getWhitelistedL2TokensForChainId(this.l2Client.chainId.toString()),
       "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", // Append L2ETH on Optimism address.
-    ].filter((address) => address !== "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"); // Remove DAI on Optimism address.
+    ].filter((address) =>
+      this.l2Client.chainId != 10 ? true : address !== "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
+    ); // Remove DAI on Optimism address. If chainId is not 10 then do no filtering.
 
     // Fetch TokensBridged events.
     await this.fetchTokensBridgedEvents();


### PR DESCRIPTION
**Motivation**

Dai Has the same address on Optimism and Arbitrum. This means the previous PR to remove Dai from the L2->L1 Cross domain finalizer from optimism also resulted in it being removed from the Arbitrum finalizer.

This PR adds a further step in the filtration process on L2Addresses to include Dai on arbitrum, thereby re-enabling this token for finalization.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
