### PR TITLE
fix(discord-transport): Remove extra log messages for links and refine discord config to be more granular on where messages are sent

### DIFF
--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -34,16 +34,15 @@ export class DiscordTransport extends Transport {
         embeds: [{ title: `${info.message}`, description: this.formatLinks(info.mrkdwn), color: 9696729 }],
       };
 
-      // A log message can conditionally contain additional Discord specific settings. Validate these first.
-
+      // A log message can conditionally contain additional Discord specific paths. Validate these first.
       let webHooks: string[] = [];
-      if (info.discordSettings) {
+      if (info.discordPaths) {
         // If it contains "noPost" then this is a noop message for Discord and the log should be skipped.
-        if (info.discordSettings == ["noPost"]) return;
+        if (info.discordPaths == ["noPost"]) return;
 
-        // Else, Assign a webhook for each escalationPathWebHook defined for the provided discordSettings. This lets
+        // Else, Assign a webhook for each escalationPathWebHook defined for the provided discordPaths. This lets
         // the logger define exactly which logs should go to which discord channel.
-        webHooks = info.discordSettings.map((discordSetting: string) => this.escalationPathWebhookUrls[discordSetting]);
+        webHooks = info.discordPaths.map((discordPath: string) => this.escalationPathWebhookUrls[discordPath]);
       }
 
       // Else, There are no discord specific settings. In this case, we treat this like a normal log. Either the

--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -37,8 +37,8 @@ export class DiscordTransport extends Transport {
       // A log message can conditionally contain additional Discord specific paths. Validate these first.
       let webHooks: string[] = [];
       if (info.discordPaths) {
-        // If it contains "noPost" then this is a noop message for Discord and the log should be skipped.
-        if (info.discordPaths == ["noPost"]) return;
+        // If it is null then this is a noop message for Discord and the log should be skipped.
+        if (info.discordPaths === null) return;
 
         // Else, Assign a webhook for each escalationPathWebHook defined for the provided discordPaths. This lets
         // the logger define exactly which logs should go to which discord channel.

--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -34,10 +34,22 @@ export class DiscordTransport extends Transport {
         embeds: [{ title: `${info.message}`, description: this.formatLinks(info.mrkdwn), color: 9696729 }],
       };
 
-      // Either the transport is configured to send on undefined escalation paths (will use default path if path does
-      // not exist) or the transport has a defined escalation path for the given message's notification path.
+      // A log message can conditionally contain additional Discord specific settings. Validate these first.
+
       let webHooks: string[] = [];
-      if (this.postOnNonEscalationPaths || this.escalationPathWebhookUrls[info.notificationPath]) {
+      if (info.discordSettings) {
+        // If it contains "noPost" then this is a noop message for Discord and the log should be skipped.
+        if (info.discordSettings == ["noPost"]) return;
+
+        // Else, Assign a webhook for each escalationPathWebHook defined for the provided discordSettings. This lets
+        // the logger define exactly which logs should go to which discord channel.
+        webHooks = info.discordSettings.map((discordSetting: string) => this.escalationPathWebhookUrls[discordSetting]);
+      }
+
+      // Else, There are no discord specific settings. In this case, we treat this like a normal log. Either the
+      // transport is configured to send on undefined escalation paths (will use default path if path does
+      // not exist) or the transport has a defined escalation path for the given message's notification path.
+      else if (this.postOnNonEscalationPaths || this.escalationPathWebhookUrls[info.notificationPath]) {
         // The webhook is preferentially set to the defined escalation path, or the default webhook.
         const webHook = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
 

--- a/packages/financial-templates-lib/src/logger/SlackTransport.ts
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.ts
@@ -68,7 +68,14 @@ function slackFormatter(info: any): SlackFormatterResponse {
     // sub points. This is also expanded as a sub indented section.
     for (const key in info) {
       // these keys have been printed in the previous block or should not be included in slack messages.
-      if (key == "at" || key == "level" || key == "message" || key == "bot-identifier" || key == "notificationPath")
+      if (
+        key == "at" ||
+        key == "level" ||
+        key == "message" ||
+        key == "bot-identifier" ||
+        key == "notificationPath" ||
+        key == "discordPaths"
+      )
         continue;
 
       // If the key is `mrkdwn` then simply return only the markdown as the txt object. This assumes all formatting has

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -54,7 +54,7 @@ class OptimisticOracleContractMonitor {
       },
       optimisticOracleUIBaseUrl: {
         // Base URL for the Optimistic Oracle UI.
-        value: "https://placeholder.umaproject.org/",
+        value: "https://oracle.umaproject.org",
         isValid: (x) => typeof x === "string",
       },
     };
@@ -117,24 +117,19 @@ class OptimisticOracleContractMonitor {
           convertCollateralDecimals(
             this.oracleType === OptimisticOracleType.OptimisticOracle ? event.finalFee : event.request.finalFee
           )
-        )}. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
-
-      const logLevel =
-        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "error");
+        )}. tx: ${createEtherscanLinkMarkdown(
+          event.transactionHash,
+          this.contractProps.networkId
+        )}. ${this._generateUILink(event.transactionHash, this.contractProps.networkId)}.`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
-      this.logger[logLevel]({
+      this.logger[
+        this.logOverrides.requestedPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "error")
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Request Alert 👮🏻!`,
         mrkdwn,
-        notificationPath: "optimistic-oracle",
-      });
-
-      // UI link is sent separately because it can break slack message limits.
-      this.logger[logLevel === "error" ? "info" : logLevel]({
-        at: "OptimisticOracleContractMonitor",
-        message: `${this.oracleType}: Price Request Alert 👮🏻!`,
-        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
+        discordSettings: ["oo-events"],
         notificationPath: "optimistic-oracle",
       });
     }
@@ -174,24 +169,19 @@ class OptimisticOracleContractMonitor {
         `.\n Collateral currency address is ${createEtherscanLinkMarkdown(
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.currency : event.request.currency
         )}. ` +
-        `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
-
-      const logLevel =
-        this.logOverrides.proposedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error");
+        `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}. ${this._generateUILink(
+          event.transactionHash,
+          this.contractProps.networkId
+        )}.`;
 
       // The default log level should be reduced to "info" for funding rate identifiers:
-      this.logger[logLevel]({
+      this.logger[
+        this.logOverrides.proposedPrice || (this._isFundingRateIdentifier(event.identifier) ? "info" : "error")
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
         mrkdwn,
-        notificationPath: "optimistic-oracle",
-      });
-
-      // UI link is sent separately because it can break slack message limits.
-      this.logger[logLevel === "error" ? "info" : logLevel]({
-        at: "OptimisticOracleContractMonitor",
-        message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
-        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
+        discordSettings: ["oo-fact-checking", "oo-events"],
         notificationPath: "optimistic-oracle",
       });
     }
@@ -226,22 +216,15 @@ class OptimisticOracleContractMonitor {
           this.oracleType === OptimisticOracleType.OptimisticOracle ? event.proposedPrice : event.request.proposedPrice
         )}.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
+        `. tx: ${createEtherscanLinkMarkdown(
+          event.transactionHash,
+          this.contractProps.networkId
+        )}. ${this._generateUILink(event.transactionHash, this.contractProps.networkId)}.`;
 
-      const logLevel = this.logOverrides.disputedPrice || "error";
-
-      this.logger[logLevel]({
+      this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
         mrkdwn,
-        notificationPath: "optimistic-oracle",
-      });
-
-      // UI link is sent separately because it can break slack message limits.
-      this.logger[logLevel === "error" ? "info" : logLevel]({
-        at: "OptimisticOracleContractMonitor",
-        message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
-        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
         notificationPath: "optimistic-oracle",
       });
     }
@@ -297,25 +280,20 @@ class OptimisticOracleContractMonitor {
           isDispute ? "winner of the dispute" : "proposer"
         }.\n` +
         this._formatAncillaryData(event.ancillaryData) +
-        `. tx: ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}`;
-
-      const logLevel =
-        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info");
+        `. tx: ${createEtherscanLinkMarkdown(
+          event.transactionHash,
+          this.contractProps.networkId
+        )}. ${this._generateUILink(event.transactionHash, this.contractProps.networkId)}.`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
-      this.logger[logLevel]({
+      this.logger[
+        this.logOverrides.settledPrice || (this._isFundingRateIdentifier(event.identifier) ? "debug" : "info")
+      ]({
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Settlement Alert 🏧!`,
         mrkdwn,
         notificationPath: "optimistic-oracle",
-      });
-
-      // UI link is sent separately because it can break slack message limits.
-      this.logger[logLevel === "error" ? "info" : logLevel]({
-        at: "OptimisticOracleContractMonitor",
-        message: `${this.oracleType}: Price Settlement Alert 🏧!`,
-        mrkdwn: this._generateUILink(event.requester, event.identifier, event.timestamp, event.ancillaryData),
-        notificationPath: "optimistic-oracle",
+        discordSettings: ["noPost"],
       });
     }
     this.lastSettlementBlockNumber = this._getLastSeenBlockNumber(latestEvents);
@@ -355,11 +333,8 @@ class OptimisticOracleContractMonitor {
     }
   }
 
-  _generateUILink(requester, identifier, timestamp, ancillaryData) {
-    const hexIdentifier = this.padRight(this.utf8ToHex(identifier), 64);
-    return `<${this.optimisticOracleUIBaseUrl}?chainId=${this.contractProps.chainId}&requester=${this.toChecksumAddress(
-      requester
-    )}&identifier=${hexIdentifier}&timestamp=${timestamp}&ancillaryData=${ancillaryData}|View this request in the UI.>`;
+  _generateUILink(transactionHash, chainId) {
+    return `<${this.optimisticOracleUIBaseUrl}/request?transactionHash=${transactionHash}&chainId=${chainId}|View in UI>`;
   }
 }
 

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -293,7 +293,7 @@ class OptimisticOracleContractMonitor {
         message: `${this.oracleType}: Price Settlement Alert 🏧!`,
         mrkdwn,
         notificationPath: "optimistic-oracle",
-        discordPaths: ["noPost"],
+        discordPaths: null,
       });
     }
     this.lastSettlementBlockNumber = this._getLastSeenBlockNumber(latestEvents);

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -129,7 +129,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Request Alert 👮🏻!`,
         mrkdwn,
-        discordSettings: ["oo-events"],
+        discordPaths: ["oo-events"],
         notificationPath: "optimistic-oracle",
       });
     }
@@ -181,7 +181,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Proposal Alert 🧞‍♂️!`,
         mrkdwn,
-        discordSettings: ["oo-fact-checking", "oo-events"],
+        discordPaths: ["oo-fact-checking", "oo-events"],
         notificationPath: "optimistic-oracle",
       });
     }
@@ -293,7 +293,7 @@ class OptimisticOracleContractMonitor {
         message: `${this.oracleType}: Price Settlement Alert 🏧!`,
         mrkdwn,
         notificationPath: "optimistic-oracle",
-        discordSettings: ["noPost"],
+        discordPaths: ["noPost"],
       });
     }
     this.lastSettlementBlockNumber = this._getLastSeenBlockNumber(latestEvents);


### PR DESCRIPTION
**Motivation**

There are a number of features we'd like to add to the Discord transport:
- Use short link format on UI links to reduce log bloat. This should also remove the extra log produced for each of these.
- removing settlement logs from all discord channels
- Only having proposal logs in oo-fact-checking channel
- request and proposal logs in oo-events channel

This PR implements the above goals.

**Summary**

Short links are done by removing the duplicate logic and refining the `_generateUILink` function in the OO monitor.

The discord transport is refined to accomidate a new prop: `discordSettings` which can be used to spesific sub sets of transports.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
