### PR TITLE
fix: changed log lvl of unprofitable relays from error to info

### DIFF
--- a/packages/insured-bridge-relayer/src/Relayer.ts
+++ b/packages/insured-bridge-relayer/src/Relayer.ts
@@ -628,7 +628,7 @@ export class Relayer {
       case RelaySubmitType.Ignore:
         // Only send warning of unprofitable log once. Check if the bot has previously sent the warning for a given
         // depositHash. If it has, then set the log level to debug, else send a warning.
-        this.logger[(await previouslySentUnprofitableLog(relayableDeposit.deposit.depositHash)) ? "debug" : "error"]({
+        this.logger[(await previouslySentUnprofitableLog(relayableDeposit.deposit.depositHash)) ? "debug" : "info"]({
           at: "AcrossRelayer#Relayer",
           message: "Not relaying unprofitable deposit 😖",
           mrkdwn: this._generateMarkdownForNonProfitableRelay(relayableDeposit.deposit, profitabilityInformation),

--- a/packages/insured-bridge-relayer/test/Relayer.ts
+++ b/packages/insured-bridge-relayer/test/Relayer.ts
@@ -503,7 +503,7 @@ describe("Relayer.ts", function () {
       // As the relayer does not have enough token balance to do the relay (0 minted) should do nothing.
       await relayer.checkForPendingDepositsAndRelay();
       assert.isTrue(lastSpyLogIncludes(spy, "Not relaying"));
-      assert.equal(lastSpyLogLevel(spy), "error");
+      assert.equal(lastSpyLogLevel(spy), "info");
 
       // Running a second time should decrease the log level to "debug" as logs should not be produced multiple times.
       await relayer.checkForPendingDepositsAndRelay();


### PR DESCRIPTION
**Motivation**

Bot should not send error logs when a relay is unprofitable as it's irritating.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

