### PR TITLE
feat: add better provider logging and retries to redundant event calls

### DIFF
--- a/packages/common/src/ProviderUtils.ts
+++ b/packages/common/src/ProviderUtils.ts
@@ -164,9 +164,14 @@ export function getWeb3ByChainId(chainId: number): Web3 {
 export function getRetryWeb3sByChainId(chainId: number): Web3[] {
   const retryConfigJson = process.env[`RETRY_CONFIG_${chainId}`] || "[]";
   const retryConfig: RetryConfig[] = JSON.parse(retryConfigJson);
-  const nodeUrl = process.env[`NODE_URL_${chainId}`];
-  // Construct a new web3 object for each URL that isn't a duplicate of NODE_URL_{chainId}.
-  return retryConfig.filter((config) => config.url !== nodeUrl).map((config) => new Web3(config.url));
+
+  if (retryConfig.length === 0) {
+    const providerUrl = process.env[`NODE_URL_${chainId}`];
+    if (!providerUrl) throw new Error(`No providers found for chain id ${chainId}`);
+    return [new Web3(providerUrl)];
+  }
+
+  return retryConfig.map((config) => new Web3(createBasicProvider([config])));
 }
 
 /**

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -36,7 +36,7 @@ export class InsuredBridgeL2Client {
     readonly chainId: number = 0,
     readonly startingBlockNumber: number = 0,
     readonly endingBlockNumber: number | null = null,
-    readonly redundantL2Web3s: Web3[] = []
+    readonly redundantL2Web3s: Web3[] = [l2Web3]
   ) {
     this.bridgeDepositBox = (new l2Web3.eth.Contract(
       getAbi("BridgeDepositBox"),
@@ -106,6 +106,8 @@ export class InsuredBridgeL2Client {
   }
 
   async getBridgeDepositBoxEvents(eventSearchOptions: EventSearchOptions, eventName: string): Promise<EventData[]> {
+    // Note: the primary l2Web3 is not used here because the main l2Web3 usually uses a combination of the list of
+    // redundant providers. Including both would mean calling the same provider(s) twice.
     const eventsData = await getEventsForMultipleProviders(
       this.redundantL2Web3s,
       getAbi("BridgeDepositBox"),

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -36,7 +36,7 @@ export class InsuredBridgeL2Client {
     readonly chainId: number = 0,
     readonly startingBlockNumber: number = 0,
     readonly endingBlockNumber: number | null = null,
-    readonly fallbackL2Web3s: Web3[] = []
+    readonly redundantL2Web3s: Web3[] = []
   ) {
     this.bridgeDepositBox = (new l2Web3.eth.Contract(
       getAbi("BridgeDepositBox"),
@@ -107,7 +107,7 @@ export class InsuredBridgeL2Client {
 
   async getBridgeDepositBoxEvents(eventSearchOptions: EventSearchOptions, eventName: string): Promise<EventData[]> {
     const eventsData = await getEventsForMultipleProviders(
-      [this.l2Web3].concat(this.fallbackL2Web3s),
+      this.redundantL2Web3s,
       getAbi("BridgeDepositBox"),
       this.bridgeDepositAddress,
       eventName,

--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL2Client.js
@@ -175,7 +175,7 @@ describe("InsuredBridgeL2Client", () => {
       chainId,
       0,
       null,
-      [new Web3(ganache.provider())] // Ganache provider will be different from hardhat provider that is already
+      [web3, new Web3(ganache.provider())] // Ganache provider will be different from hardhat provider that is already
       // connected to the BridgeDepositBox.
     );
 


### PR DESCRIPTION
**Motivation**

We'd like the redundant provider calls to have at least the same number of retries that they normally do.


**Summary**

This updates the way that the redundant providers are created in a few ways:
1. It no longer concatenates the primary RetryProvider with the split "fallback" or redundant ones, since the primary RetryProvider is contains all of the other providers (so it amounts to calling the same provider twice).
2. If there is no Retry config, this just constructs a single provider with no retries using the NODE_URL_<chain id> env variable. This is done because if the user didn't include a retry config, they did not intend to have any retries.
3. It adds some additional logging to the retry provider. Now, when it errors, it will print out an error for each URL in the config. This means that a user can see why each provider errored and which provider urls were generating each error. This also means that any provider error that is layered on top of the retry provider will see the url that was called to create that error. Note: this does mean that provider urls are exposed in logs. I don't think that's a huge issue though.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
