### PR TITLE
fix: lock node version to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # To `docker run` with your locally built image, replace `umaprotocol/protocol` with <username>/<imagename>.
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:lts
+FROM node:14
 
 # All source code and execution happens from the protocol directory.
 WORKDIR /protocol


### PR DESCRIPTION
**Motivation**

We have seen some issues when running infra on node 16. this PR locks the container to 14, the version with known compatibility.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
