### PR TITLE
fix: fix error printing bugs in #3852

### DIFF
--- a/packages/common/src/RetryProvider.ts
+++ b/packages/common/src/RetryProvider.ts
@@ -129,9 +129,9 @@ export class RetryProvider {
         throw new Error(
           `Multiple Errors: \n${errors
             .map(
-              (error, index) =>
+              (error: Error, index) =>
                 `Provider ${index} at ${this.providerCaches[index]?.url || "unknown"}: ${
-                  error.stack || error.toString()
+                  error.stack || error.message || JSON.stringify(error)
                 }`
             )
             .join("\n\n")}`
@@ -139,7 +139,7 @@ export class RetryProvider {
       if (!shouldMoveToNextProvider) await new Promise((resolve) => setTimeout(resolve, delay * 1000)); // Delay only if not moving to a new provider.
 
       // Run function again with a different provider or retry index.
-      return await this._runRetry(fn, nextProviderIndex, nextRetryIndex);
+      return await this._runRetry(fn, nextProviderIndex, nextRetryIndex, errors);
     }
   }
 }


### PR DESCRIPTION
**Motivation**

Only the last error is printed and the `.toString()` causes the log to print [Object object] instead of the actual error.

**Summary**

This fixes the aforementioned issues.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
