### PR TITLE
fix(across-relayer): more accurately determine a safe last block number to query

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL2Client.ts
@@ -65,7 +65,7 @@ export class InsuredBridgeL2Client {
     // Define a config to bound the queries by.
     const blockSearchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.endingBlockNumber || (await this.l2Web3.eth.getBlockNumber()),
+      toBlock: this.endingBlockNumber || (await this.getLatestBlockNumber()),
     };
     if (blockSearchConfig.fromBlock > blockSearchConfig.toBlock) {
       this.logger.debug({
@@ -103,6 +103,10 @@ export class InsuredBridgeL2Client {
       message: "Insured bridge l2 client updated",
       chainId: this.chainId,
     });
+  }
+
+  async getLatestBlockNumber(): Promise<number> {
+    return Math.min(...(await Promise.all(this.redundantL2Web3s.map((web3) => web3.eth.getBlockNumber()))));
   }
 
   async getBridgeDepositBoxEvents(eventSearchOptions: EventSearchOptions, eventName: string): Promise<EventData[]> {


### PR DESCRIPTION
**Motivation**

We're often seeing errors like this:
```
One of the blocks specified in filter (fromBlock, toBlock or blockHash) cannot be found.
```

**Summary**

I'm assuming this is happening because of block propagation delays between providers. To more accurately determine the latest block to query for each provider, this change queries all redundant providers and takes the min to ensure all providers have seen that block.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
