### PR TITLE
fix(serverless-spoke): extend stdout buffer to avoid process being killed

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -21,6 +21,11 @@ let customLogger;
 
 const waitForLoggerDelay = process.env.WAIT_FOR_LOGGER_DELAY || 5;
 
+// To be used with exec to override the default input output buffer size.
+// 1024 * 1024 is the default.
+// This is 1024 * 1024 * 8.
+const maxBuffer = 8388608;
+
 spoke.post("/", async (req, res) => {
   // Use a custom logger if provided. Otherwise, initialize a local logger.
   // Note: no reason to put this into the try-catch since a logger is required to throw the error.
@@ -95,7 +100,7 @@ function _execShellCommand(cmd, inputEnv, strategyRunnerSpoke = false) {
   return new Promise((resolve) => {
     const { stdout, stderr } = exec(
       cmd,
-      { env: { ...process.env, ...inputEnv }, stdio: "inherit" },
+      { env: { ...process.env, ...inputEnv }, stdio: "inherit", maxBuffer },
       (error, stdout, stderr) => {
         // The output from the process execution contains punctuation marks and escape chars that should be stripped.
         stdout = _stripExecStdout(stdout, strategyRunnerSpoke);


### PR DESCRIPTION
**Motivation**

Max buffer is being _sometimes_ in the bots due to the extreme amount of logging coming from the arbitrum finalizer.

We're seeing logs like this:
```
"execResponse":{"error":{"code":"ERR_CHILD_PROCESS_STDIO_MAXBUFFER"
```

**Summary**

To stop the process from being terminated due to the buffer being maxed out, this PR extends the buffer by 8x to alleviate the issue. I'm unaware of how to completely get rid of this issue, but there doesn't seem to be an obvious reason why we can't extend the buffer to 8MB from a default of 1MB.

See [docs](https://nodejs.org/docs/latest-v16.x/api/child_process.html#child_processexeccommand-options-callback) for more info on this option.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
