### PR TITLE
fix: Address Discord transport rate limiting issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-var-requires": 0,
         "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
+        "@typescript-eslint/ban-ts-comment": 0,
       },
     },
   ],

--- a/packages/financial-templates-lib/src/logger/DiscordTransport.ts
+++ b/packages/financial-templates-lib/src/logger/DiscordTransport.ts
@@ -22,7 +22,6 @@ export class DiscordTransport extends Transport {
   private readonly postOnNonEscalationPaths: boolean;
 
   private logQueue: QueueElement[];
-  private backOffDuration = 0;
   private isQueueBeingExecuted = false;
 
   constructor(

--- a/packages/financial-templates-lib/src/logger/Logger.ts
+++ b/packages/financial-templates-lib/src/logger/Logger.ts
@@ -75,7 +75,7 @@ export function createNewLogger(
   transportsConfig = {},
   botIdentifier = process.env.BOT_IDENTIFIER || "NO_BOT_ID"
 ): AugmentedLogger {
-  const _logger = winston.createLogger({
+  const logger = winston.createLogger({
     level: "debug",
     format: winston.format.combine(
       winston.format(botIdentifyFormatter(botIdentifier))(),
@@ -85,8 +85,7 @@ export function createNewLogger(
     ),
     transports: [...createTransports(transportsConfig), ...injectedTransports],
     exitOnError: !!process.env.EXIT_ON_ERROR,
-  });
-  const logger = _logger as AugmentedLogger;
+  }) as AugmentedLogger;
   logger.isFlushed = true; // The logger should start off in a flushed state of "true". i.e it is ready to be close.
   return logger;
 }

--- a/packages/financial-templates-lib/src/logger/Logger.ts
+++ b/packages/financial-templates-lib/src/logger/Logger.ts
@@ -31,15 +31,14 @@ import winston from "winston";
 import type { Logger as _Logger, LogEntry } from "winston";
 import type * as Transport from "winston-transport";
 import { createTransports } from "./Transports";
+import { delay } from "../helpers/delay";
 
 // This async function can be called by a bot if the log message is generated right before the process terminates.
-// By calling `await waitForLogger(Logger)`, with the local Logger instance, the process will wait for all upstream
-// transports to clear. This enables slower transports like slack to still send their messages before the process yields.
-// Note: typescript infers the return type to be unknown. This is fine, as the return type should be void and unused.
-export async function waitForLogger(logger: _Logger): Promise<unknown> {
-  const loggerDone = new Promise((resolve) => logger.on("finish", resolve));
-  logger.end();
-  return await loggerDone;
+// This method will check if the AugmentedLogger's isFlushed is set to true. If not, it will block until such time
+// that it has been set to true. Note that each blocking transport should implement this isFlushed bool to prevent
+// the logger from closing before all logs have been propagated.
+export async function waitForLogger(logger: AugmentedLogger) {
+  while (!logger.isFlushed) await delay(0.5); // While the logger is not flushed, wait for it to be flushed.
 }
 
 // If the log entry contains an error then extract the stack trace as the error message.
@@ -67,12 +66,16 @@ function botIdentifyFormatter(botIdentifier: string) {
   };
 }
 
+export interface AugmentedLogger extends _Logger {
+  isFlushed: boolean;
+}
+
 export function createNewLogger(
   injectedTransports: Transport[] = [],
   transportsConfig = {},
   botIdentifier = process.env.BOT_IDENTIFIER || "NO_BOT_ID"
-): _Logger {
-  return winston.createLogger({
+): AugmentedLogger {
+  const _logger = winston.createLogger({
     level: "debug",
     format: winston.format.combine(
       winston.format(botIdentifyFormatter(botIdentifier))(),
@@ -83,6 +86,9 @@ export function createNewLogger(
     transports: [...createTransports(transportsConfig), ...injectedTransports],
     exitOnError: !!process.env.EXIT_ON_ERROR,
   });
+  const logger = _logger as AugmentedLogger;
+  logger.isFlushed = true; // The logger should start off in a flushed state of "true". i.e it is ready to be close.
+  return logger;
 }
 
-export const Logger = createNewLogger();
+export const Logger: AugmentedLogger = createNewLogger();

--- a/packages/monitors/index.js
+++ b/packages/monitors/index.js
@@ -16,6 +16,7 @@ const {
   delay,
   multicallAddressMap,
   OptimisticOracleType,
+  waitForLogger,
 } = require("@uma/financial-templates-lib");
 
 // Monitor modules to report on client state changes.
@@ -395,6 +396,7 @@ async function run({
       if (pollingDelay === 0) {
         logger.debug({ at: "Monitor#index", message: "End of serverless execution loop - terminating process" });
         await delay(5); // Set a delay to let the transports flush fully.
+        await waitForLogger(logger); // Blocks exiting until the Discord transport is fully flushed.
         break;
       }
       logger.debug({ at: "Monitor#index", message: "End of execution loop - waiting polling delay" });

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -244,10 +244,6 @@ describe("OptimisticOracleContractMonitor.js", function () {
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.options.address}`));
     assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.transactionHash}`));
 
-    console.log(
-      "TARGET",
-      `${sampleBaseUIUrl}/request?transactionHash=${requestTxn.transactionHash}&chainId=${contractProps.chainId}`
-    );
     assert.isTrue(
       lastSpyLogIncludes(
         spy,

--- a/packages/monitors/test/index.js
+++ b/packages/monitors/test/index.js
@@ -284,6 +284,7 @@ describe("index.js", function () {
           level: "debug",
           transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
         });
+        spyLogger.isFlushed = true; // exit instantly when requested to do so.
 
         collateralToken = await Token.new("USDC", "USDC", 6).send({ from: contractCreator });
         syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 6).send({ from: contractCreator });
@@ -325,6 +326,7 @@ describe("index.js", function () {
           level: "debug",
           transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
         });
+        spyLogger.isFlushed = true; // exit instantly when requested to do so.
 
         await Poll.run({
           logger: spyLogger,
@@ -355,6 +357,7 @@ describe("index.js", function () {
           level: "debug",
           transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
         });
+        spyLogger.isFlushed = true; // exit instantly when requested to do so.
 
         let didThrowError = false;
         let errorString;
@@ -410,6 +413,7 @@ describe("index.js", function () {
           level: "debug",
           transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
         });
+        spyLogger.isFlushed = true; // exit instantly when requested to do so.
 
         errorRetries = 3; // set execution retries to 3 to validate.
         // Note both the token and medanizer price feeds are the same config. This is done so that createReferencePriceFeedForFinancialContract

--- a/packages/monitors/test/index.js
+++ b/packages/monitors/test/index.js
@@ -128,6 +128,7 @@ describe("index.js", function () {
           level: "debug",
           transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
         });
+        spyLogger.isFlushed = true; // exit instantly when requested to do so.
 
         // Create a new synthetic token
         syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18).send({ from: contractCreator });


### PR DESCRIPTION
**Motivation**

The discord transport was having rate limiting issues when we try and send too many requests at once. This PR implements a log queue that preseves dropped logs and backs off when the discord API informs us that we are hitting it too hard.

Note: The implementation done here will work well for other transports that struggle to flush! we could re-work this same technique into the slack, pagerduty and GCP transports in the future and bring back the much loved `waitForLogger` method that was deprecated due to its issues.


**Summary**

Fixes Discord transport and introduces a new paridime of log-blocking-flushing for the UMA ecosystem 🧘‍♂️.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
