### PR TITLE
fix: fallback to mainnet prices for L2 ERC20 tokens

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -143,3 +143,9 @@ export type OrchestratorServices = {
   contracts: services.Contracts;
   prices: services.Prices;
 };
+
+export type ChainId = number;
+export const CHAIN_IDs = {
+  mainnet: 1,
+  polygon_matic: 137,
+};

--- a/packages/sdk/src/coingecko/coingecko.ts
+++ b/packages/sdk/src/coingecko/coingecko.ts
@@ -13,6 +13,12 @@ type CoinGeckoAssetPlatform = {
   shortname: string;
 };
 
+type CoinGeckoPrice = {
+  address: string;
+  timestamp: number;
+  price: number;
+};
+
 class Coingecko {
   private host: string;
   constructor(host = "https://api.coingecko.com/api/v3") {
@@ -45,7 +51,11 @@ class Coingecko {
   }
   // Return an array of spot prices for an array of collateral addresses in one async call. Note we might in future
   // This was adapted from packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
-  async getContractPrices(addresses: Array<string>, currency = "usd", platform_id = "ethereum") {
+  async getContractPrices(
+    addresses: Array<string>,
+    currency = "usd",
+    platform_id = "ethereum"
+  ): Promise<CoinGeckoPrice[]> {
     // Generate a unique set with no repeated. join the set with the required coingecko delimiter.
     const contract_addresses = Array.from(new Set(addresses.filter((n) => n).values()));
     assert(contract_addresses.length > 0, "Must supply at least 1 contract address");


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/5168/the-suint-kpi-option-is-showing-0-for-tvl-but-has-45k-uma-in-the-contract-https-polygonscan-com

**Summary**

Basically what I did was to identify the L2 ERC20 addresses for which CoinGecko didn't return a price and use the price of the corresponding mainnet address as fallback.

I also added an extra log to identify easily this issue

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

