### PR TITLE
feat: add console slog to production config

### DIFF
--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -45,7 +45,7 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
     const { LoggingWinston } = require("@google-cloud/logging-winston");
     transports.push(new LoggingWinston());
     if (!require("@google-cloud/trace-agent").get().enabled) require("@google-cloud/trace-agent").start();
-  } else if (transportsConfig.createConsoleTransport || process.env.LOG_TO_CONSOLE == "true") {
+  } else if (transportsConfig?.createConsoleTransport || process.env.LOG_TO_CONSOLE == "true") {
     // Add a console transport to log to the console.
     transports.push(createConsoleTransport());
   }

--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -45,7 +45,11 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
     const { LoggingWinston } = require("@google-cloud/logging-winston");
     transports.push(new LoggingWinston());
     if (!require("@google-cloud/trace-agent").get().enabled) require("@google-cloud/trace-agent").start();
-  } else if (transportsConfig.createConsoleTransport != undefined ? transportsConfig.createConsoleTransport : true) {
+  } else if (
+    transportsConfig.createConsoleTransport != undefined
+      ? transportsConfig.createConsoleTransport
+      : true || process.env.LOG_TO_CONSOLE == "true"
+  ) {
     // Add a console transport to log to the console.
     transports.push(createConsoleTransport());
   }

--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -45,11 +45,7 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
     const { LoggingWinston } = require("@google-cloud/logging-winston");
     transports.push(new LoggingWinston());
     if (!require("@google-cloud/trace-agent").get().enabled) require("@google-cloud/trace-agent").start();
-  } else if (
-    transportsConfig.createConsoleTransport != undefined
-      ? transportsConfig.createConsoleTransport
-      : true || process.env.LOG_TO_CONSOLE == "true"
-  ) {
+  } else if (transportsConfig.createConsoleTransport || process.env.LOG_TO_CONSOLE == "true") {
     // Add a console transport to log to the console.
     transports.push(createConsoleTransport());
   }


### PR DESCRIPTION
**Motivation**

We should be able to produce a logger that can: 1) log to GCP stack drive via the `ENVIRONMENT=production` and 2) be able to create a console tranport.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
