### PR TITLE
feat: add logger formatter to FPL release

### DIFF
--- a/packages/financial-templates-lib/src/index.ts
+++ b/packages/financial-templates-lib/src/index.ts
@@ -23,3 +23,4 @@ export * from "./price-feed/PriceFeedMockScaled";
 export * from "./price-feed/InvalidPriceFeedMock";
 export * from "./price-feed/utils";
 export * from "./proxy-transaction-handler/DSProxyManager";
+export * from "./logger/Formatters";


### PR DESCRIPTION
**Motivation**

Other repos that directly depend on the FPL package (such as the across relayer) need, in some contexts, to access the Winston formatters exported from the FPL. This PR adds the correct export structure to enable this.
