### PR TITLE
feat: update dockerfile to contain Across relayer bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,7 @@
-# This docker container can be pulled from umaprotocol/protocol on dockerhub.
-# To get the latest image, run: docker pull umaprotocol/protocol
-# This docker container is used to access all components of the UMA ecosystem
-# including liquidator, disputors and monitor bots. Settings for these bots are
-# defined via enviroment variables. For example to run a liquidator bot run:
-# docker run --env MNEMONIC="<mnemonic>" \
-#     --env PAGERDUTY_API_KEY="<pagerduty api key>" \
-#     --env PAGERDUTY_SERVICE_ID="<pagerduty service id>" \
-#     --env PAGERDUTY_FROM_EMAIL="<from email>" \
-#     --env SLACK_WEBHOOK="<slack webhook>" \
-#     --env EMP_ADDRESS="<emp address>" \
-#     --env POLLING_DELAY="<update delay in ms>" \
-#     --env COMMAND="npx truffle exec ../liquidator/index.js --network mainnet_mnemonic" \
-#     umaprotocol/protocol:latest
-#
-# To build the docker image locally, run the following command from the `protocol` directory:
-#   docker build -t <username>/<imagename> .
-#
-# To `docker run` with your locally built image, replace `umaprotocol/protocol` with <username>/<imagename>.
+# This docker container can be pulled from umaprotocol/protocol on dockerhub. This docker container is used to access 
+# all components of the UMA ecosystem. The entry point into the bot is defined using a COMMAND enviroment variable
+# that defines what is executed in the root of the protocol package. This container also contains other UMA packages
+# that are not in the protocol repo, such as the Across v2 relayer. To access these set a command 
 
 # Fix node version due to high potential for incompatibilities.
 FROM node:14
@@ -35,6 +20,18 @@ RUN yarn
 # Clean and run all package build steps, but exclude dapps (to save time).
 RUN yarn clean
 RUN yarn qbuild
+
+# Set up additional UMA packages installed in this docker container.
+WORKDIR /across-relayer
+RUN git https://github.com/across-protocol/relayer-v2.git
+WORKDIR /across-relayer/relayer-v2
+RUN mv * ..
+WORKDIR /across-relayer
+RUN rm -rf relayer-v2
+RUN yarn && yarn build
+
+# Set back the working directory to the protocol directory to default to that package.
+WORKDIR / protocol
 
 # Command to run any command provided by the COMMAND env variable.
 ENTRYPOINT ["/bin/bash", "scripts/runCommand.sh"]

--- a/scripts/runCommand.sh
+++ b/scripts/runCommand.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Simple script that simply runs a command input as an environment variable. Should be run from the core/ directory.
-# Note: this is used to allow the docker image to run arbitrary commands by specifying them in the environment rather
-# than the `docker run` command.
-$COMMAND
+# Simple script that simply runs a command input as an environment variable. This is used to allow the docker image to
+# run arbitrary commands by specifying them in the environment rather than the docker run command. Optionally, specify
+#  UMA_PACKAGE as an ENV which lets you navigate to additional base packages installed within the container.
+if [ -z ${UMA_PACKAGE+x} ]; then $COMMAND; else cd ../${UMA_PACKAGE} && $COMMAND; fi


### PR DESCRIPTION
**Motivation**

We require the ability to run additional packages within our production infrastructure, such as the across v2 bots. This PR enables this by defining a new pattern in the docker container: sub packages. This works by installing an additional package within the container (the full across-relayer-v2 package that can be found [here](https://github.com/across-protocol/relayer-v2)) and defining some logic around which package is run under which situation.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested