### PR TITLE
feat: add event based request path for OO

### DIFF
--- a/packages/core/contracts/common/implementation/Lockable.sol
+++ b/packages/core/contracts/common/implementation/Lockable.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.0;
  * and https://github.com/balancer-labs/balancer-core/blob/master/contracts/BPool.sol.
  */
 contract Lockable {
-    bool internal _notEntered;
+    bool private _notEntered;
 
     constructor() {
         // Storing an initial non-zero value makes deployment a bit more expensive, but in exchange the refund on every
@@ -57,5 +57,21 @@ contract Lockable {
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
         _notEntered = true;
+    }
+
+    // These functions are intended to be used by child contracts to temporarily disable and re-enable the guard.
+    // Intended use:
+    // _startReentrantGuardDisabled();
+    // ...
+    // _endReentrantGuardDisabled();
+    //
+    // IMPORTANT: these should NEVER be used in a method that isn't inside a nonReentrant block. Otherwise, it's
+    // possible to permanently lock your contract.
+    function _startReentrantGuardDisabled() internal {
+        _notEntered = true;
+    }
+
+    function _endReentrantGuardDisabled() internal {
+        _notEntered = false;
     }
 }

--- a/packages/core/contracts/common/implementation/Lockable.sol
+++ b/packages/core/contracts/common/implementation/Lockable.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.0;
  * and https://github.com/balancer-labs/balancer-core/blob/master/contracts/BPool.sol.
  */
 contract Lockable {
-    bool private _notEntered;
+    bool internal _notEntered;
 
     constructor() {
         // Storing an initial non-zero value makes deployment a bit more expensive, but in exchange the refund on every

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -19,6 +19,8 @@ import "../../common/implementation/FixedPoint.sol";
 import "../../common/implementation/AncillaryData.sol";
 import "../../common/implementation/AddressWhitelist.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title Optimistic Requester.
  * @notice Optional interface that requesters can implement to receive callbacks.
@@ -697,7 +699,11 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         }
 
         return
-            _getOracle().hasPrice(identifier, timestamp, _stampAncillaryData(ancillaryData, requester))
+            _getOracle().hasPrice(
+                identifier,
+                _getDvmTimestamp(request, timestamp),
+                _stampAncillaryData(ancillaryData, requester)
+            )
                 ? State.Resolved
                 : State.Disputed;
     }

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -264,9 +264,23 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
         _getRequest(msg.sender, identifier, timestamp, ancillaryData).customLiveness = customLiveness;
     }
 
-    // Allows the requester to set the request to be an "event based" request.
-    // This means that "too early" values are disallowed in proposals and the
-    // proposal timestamp is appended to the ancillary data.
+    /**
+     * @notice Sets the request to be an "event-based" request.
+     * @dev Calling this method has a few impacts on the request:
+     *
+     * 1. The timestamp at which the request is evaludated is the time of the proposal, not the timestamp associated
+     *    with the request.
+     *
+     * 2. The proposer cannot propose the "too early" value (type(int256).min). This is to ensure that a proposer who
+     *    prematurely proposes a response loses their bond.
+     *
+     * 3. RefundoOnDispute is automatically set, meaning disputes trigger the reward to be automatically refunded to
+     *    the requesting contract.
+     *
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     */
     function setEventBased(
         bytes32 identifier,
         uint256 timestamp,

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -19,8 +19,6 @@ import "../../common/implementation/FixedPoint.sol";
 import "../../common/implementation/AncillaryData.sol";
 import "../../common/implementation/AddressWhitelist.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title Optimistic Requester.
  * @notice Optional interface that requesters can implement to receive callbacks.

--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -270,7 +270,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * @notice Sets the request to be an "event-based" request.
      * @dev Calling this method has a few impacts on the request:
      *
-     * 1. The timestamp at which the request is evaludated is the time of the proposal, not the timestamp associated
+     * 1. The timestamp at which the request is evaluated is the time of the proposal, not the timestamp associated
      *    with the request.
      *
      * 2. The proposer cannot propose the "too early" value (type(int256).min). This is to ensure that a proposer who

--- a/packages/core/contracts/oracle/implementation/test/OptimisticRequesterTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/OptimisticRequesterTest.sol
@@ -76,6 +76,14 @@ contract OptimisticRequesterTest is OptimisticRequester {
         optimisticOracle.setCustomLiveness(_identifier, _timestamp, _ancillaryData, customLiveness);
     }
 
+    function setEventBased(
+        bytes32 _identifier,
+        uint256 _timestamp,
+        bytes memory _ancillaryData
+    ) external {
+        optimisticOracle.setEventBased(_identifier, _timestamp, _ancillaryData);
+    }
+
     function setRevert(bool _shouldRevert) external {
         shouldRevert = _shouldRevert;
     }

--- a/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
@@ -26,7 +26,7 @@ abstract contract OptimisticOracleInterface {
         IERC20 currency; // ERC20 token used to pay rewards and fees.
         bool settled; // True if the request is settled.
         bool refundOnDispute; // True if the requester should be refunded their reward on dispute.
-        bool eventBased;
+        bool eventBased; // True if the request is set to be event-based.
         int256 proposedPrice; // Price that the proposer submitted.
         int256 resolvedPrice; // Price resolved once the request is settled.
         uint256 expirationTime; // Time at which the request auto-settles without a dispute.

--- a/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
@@ -26,6 +26,7 @@ abstract contract OptimisticOracleInterface {
         IERC20 currency; // ERC20 token used to pay rewards and fees.
         bool settled; // True if the request is settled.
         bool refundOnDispute; // True if the requester should be refunded their reward on dispute.
+        bool eventBased;
         int256 proposedPrice; // Price that the proposer submitted.
         int256 resolvedPrice; // Price resolved once the request is settled.
         uint256 expirationTime; // Time at which the request auto-settles without a dispute.
@@ -33,7 +34,6 @@ abstract contract OptimisticOracleInterface {
         uint256 finalFee; // Final fee to pay to the Store upon request to the DVM.
         uint256 bond; // Bond that the proposer and disputer must pay on top of the final fee.
         uint256 customLiveness; // Custom liveness value set by the requester.
-        bool eventBased;
     }
 
     // This value must be <= the Voting contract's `ancillaryBytesLimit` value otherwise it is possible

--- a/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
@@ -33,6 +33,7 @@ abstract contract OptimisticOracleInterface {
         uint256 finalFee; // Final fee to pay to the Store upon request to the DVM.
         uint256 bond; // Bond that the proposer and disputer must pay on top of the final fee.
         uint256 customLiveness; // Custom liveness value set by the requester.
+        bool eventBased;
     }
 
     // This value must be <= the Voting contract's `ancillaryBytesLimit` value otherwise it is possible


### PR DESCRIPTION
**Motivation**

We would like the OO to handle event-based requests.

Note: test changes are not included yet, as I wanted to nail down the contracts first.

**Summary**

Rather than create a new flavor of the OO, it seemed somewhat simple to add this feature to the existing OO using an additional boolean in the Request struct.

For non event-based requests, this should add a few branches, but cost no real additional gas. We could potentially make an optimization to how we measure the length of the stamped ancillary data to decrease gas costs for those requests.

Event-based queries will be more expensive. They will involve an additional call to the OO, and they will require a more costly ancillary data stamping/construction when calling into the DVM.

This is how the event-based process works:
1. A contract that wants its resolution to happen after some event occurs can request a price immediately upon its construction.
2. The bool is set by calling setEventBased.
3. Now that the request is an "event based" request, it's now semantically considered a pre-request. Its timestamp no longer dictates what information can be considered. These types of proposals also disallow the "too early" value, INT_MIN. This prevents users from receiving a reward for proposing a correct "too early" value before the event has happened.
4. When disputers consider requests, they need to consider the proposal timestamp rather than the request timestamp to determine whether the request is too early.
5. When a request is sent to the DVM, an extra piece of data "proposalTimestamp" is included to indicate when the proposal happened so the voters can determine if the proposal was premature.
6. Once a request settles, if the "too early" result is returned, the contract can re-request knowing that the proposer that initiated the resolution was penalized.

Open questions: 
1. Generally the DVM works by only considering information before the _request timestamp_. This process implicitly invalidates that rule. Should we, instead, use the proposal timestamp as the request timestamp that is sent to the DVM instead of including it in ancillary data?
2. Is this simpler than having an entirely separate OO flavor? In my opinion, it seems simpler, as the additional complexity is pretty minimal and it is almost 100% backwards compatible (only exception is the getRequest return value that has an additional boolean in it).

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
