### PR TITLE
fix(sdk): syncronize oo client index and details page

### DIFF
--- a/packages/sdk/src/oracle/services/optimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracle.ts
@@ -1,5 +1,5 @@
 import { optimisticOracle } from "../../clients";
-import { BigNumberish, BigNumber, Provider, Signer, TransactionResponse } from "../types/ethers";
+import { BigNumberish, BigNumber, Provider, Signer, TransactionResponse, Log } from "../types/ethers";
 import type { RequestState } from "../types/state";
 
 type Props = {
@@ -54,4 +54,13 @@ export class OptimisticOracle {
   ): Promise<RequestState> {
     return this.contract.callStatic.getState(requester, identifier, timestamp, ancillaryData);
   }
+  makeEventFromLog = (log: Log) => {
+    const description = this.contract.interface.parseLog(log);
+    return {
+      ...log,
+      ...description,
+      event: description.name,
+      eventSignature: description.signature,
+    };
+  };
 }

--- a/packages/sdk/src/oracle/services/statemachines/pollNewEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/pollNewEvents.ts
@@ -46,6 +46,9 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
           memory.lastBlock = latestBlock;
           // just count how many successful iterations we do as a kind of sanity check
           memory.iterations++;
+        } else {
+          // if we dont have a lastblock set, set it to our current block
+          memory.lastBlock = memory.lastBlock || currentBlock;
         }
       } catch (err) {
         // store an error for an iteration if we need to debug. we want to keep polling though.

--- a/packages/sdk/src/oracle/services/statemachines/proposePrice.ts
+++ b/packages/sdk/src/oracle/services/statemachines/proposePrice.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
 import { Update } from "../update";
 import Store from "../../store";
-import { Signer } from "../../types/ethers";
+import { Signer, TransactionReceipt } from "../../types/ethers";
 import { Handlers as GenericHandlers } from "../../types/statemachine";
-import { InputRequest } from "../../types/state";
+import { InputRequest, OptimisticOracleEvent } from "../../types/state";
 import { ContextClient } from "./utils";
 
 export type Params = InputRequest & {
@@ -15,7 +15,7 @@ export type Params = InputRequest & {
   checkTxIntervalSec: number;
 };
 
-export type Memory = { hash?: string };
+export type Memory = { hash?: string; receipt?: TransactionReceipt };
 
 export function initMemory(): Memory {
   return {};
@@ -36,7 +36,9 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       const { chainId, confirmations, checkTxIntervalSec } = params;
       const { hash } = memory;
       assert(hash, "requires hash");
-      if (await update.isConfirmed(chainId, hash, confirmations)) {
+      const receipt = await update.isConfirmed(chainId, hash, confirmations);
+      if (receipt) {
+        memory.receipt = receipt as TransactionReceipt;
         return "update";
       }
       // wait x seconds before running this state again
@@ -44,15 +46,25 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
     },
     async update(params: Params, memory: Memory) {
       const { chainId, currency, account, requester, identifier, timestamp, ancillaryData } = params;
-      const { hash } = memory;
+      const { hash, receipt } = memory;
+      const oracle = store.read().oracleService(chainId);
       await update.balance(chainId, currency, account);
       await update.request(params);
-      store.write((w) =>
-        w
-          .chains(chainId)
+      store.write((w) => {
+        w.chains(chainId)
           .optimisticOracle()
-          .request({ chainId, requester, identifier, timestamp, ancillaryData, proposeTx: hash })
-      );
+          .request({ chainId, requester, identifier, timestamp, ancillaryData, proposeTx: hash });
+
+        if (receipt) {
+          const events = receipt.logs.map(oracle.makeEventFromLog);
+          events.forEach((event) => {
+            w.chains(chainId)
+              .optimisticOracle()
+              .event((event as unknown) as OptimisticOracleEvent);
+          });
+        }
+      });
+      await update.sortedRequests(chainId);
       return "done";
     },
   };

--- a/packages/sdk/src/oracle/store/write.ts
+++ b/packages/sdk/src/oracle/store/write.ts
@@ -3,7 +3,7 @@ import type * as ethersTypes from "../types/ethers";
 import * as state from "../types/state";
 import * as statemachine from "../types/statemachine";
 
-import { requestId, insertOrderedAscending, eventKey } from "../utils";
+import { requestId, insertOrderedAscending, eventKey, isUnique } from "../utils";
 import { factory as Erc20Factory } from "../services/erc20";
 import { OptimisticOracle as OptimisticOracleService } from "../services/optimisticOracle";
 import Multicall2 from "../../multicall2";
@@ -81,7 +81,10 @@ export class OptimisticOracle {
   }
   event(event: state.OptimisticOracleEvent): void {
     if (!this.state.events) this.state.events = [];
-    insertOrderedAscending(this.state.events, event, eventKey);
+    // avoid duplicates
+    if (isUnique(this.state.events, event, eventKey)) {
+      insertOrderedAscending(this.state.events, event, eventKey);
+    }
   }
 }
 export class Chain {

--- a/packages/sdk/src/oracle/types/ethers.ts
+++ b/packages/sdk/src/oracle/types/ethers.ts
@@ -5,7 +5,12 @@ export type { Signer, BigNumber, BigNumberish, Contract } from "ethers";
 export type { Overrides } from "@ethersproject/contracts";
 export { Provider, JsonRpcSigner, JsonRpcProvider, Web3Provider, FallbackProvider } from "@ethersproject/providers";
 export { TransactionRequest, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
-export type { Event };
+export type { Event, Interface };
+
+export type SerializableEvent = Omit<
+  Event,
+  "decode" | "removeListener" | "getBlock" | "getTransaction" | "getTransactionReceipt"
+>;
 
 // taken from ethers code https://github.com/ethers-io/ethers.js/blob/master/packages/abi/src.ts/interface.ts#L654
 export type Log = Parameters<Interface["parseLog"]>[0];

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -177,7 +177,7 @@ export class TransactionConfirmer {
   async getReceipt(hash: string): Promise<TransactionReceipt> {
     return this.provider.getTransactionReceipt(hash);
   }
-  async isConfirmed(hash: string, confirmations = 1): Promise<boolean | TransactionReceipt> {
+  async isConfirmed(hash: string, confirmations = 1): Promise<false | TransactionReceipt> {
     try {
       const receipt = await this.getReceipt(hash);
       if (receipt.confirmations >= confirmations) return receipt;
@@ -315,4 +315,11 @@ export function insertOrderedAscending<T>(array: T[], element: T, orderBy: (elem
   const index = sortedLastIndexBy(array, element, orderBy);
   array.splice(index, 0, element);
   return array;
+}
+export function isUnique<T>(array: T[], element: T, id: (element: T) => string | number): boolean {
+  const elementId = id(element);
+  const found = array.find((next: T) => {
+    return id(next) === elementId;
+  });
+  return found === undefined;
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
https://app.shortcut.com/uma-project/story/4883/have-the-app-refresh-more-frequently-so-the-state-of-proposals-is-more-accurately-reflected-without-the-user-needing-to-refresh

The index page was not updating correctly when sending proposal/deposits in detail page.

**Summary**

This strips events of transaction receipt when proposign/disputing and adds them to the internal event list and updates the index state.  also fixes potential bug where polling for new events was not working.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


Tested this on kovan using already pending requests. tested proposal and dispute and both worked to update index page accordingly

