### PR TITLE
fix(sdk): improve oracle data loading

### DIFF
--- a/packages/sdk/src/oracle/README.md
+++ b/packages/sdk/src/oracle/README.md
@@ -28,6 +28,8 @@ export const config = {
       checkTxIntervalSec: number; // how fast transactions are checked for confirmation, default 5
       multicall2Address?: string; // optional multicall address for more efficient calls
       optimisticOracleAddress: string; // override default oracle address, or provide one if we cannot look it up, ie with testing
+      earliestBlockNumber?: number;  // ignore blocks before this block number if specified
+      maxEventRangeQuery?: number;  // optimize how quickly the first batch of requests are fetched by restricting the max number of events queried.
     },
   },
 };

--- a/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
+++ b/packages/sdk/src/oracle/services/statemachines/fetchPastEvents.ts
@@ -15,6 +15,7 @@ export type Params = {
   chainId: number;
   startBlock?: number;
   endBlock?: number;
+  maxRange?: number;
 };
 
 export type Memory = { error?: Error; state?: RangeState; iterations: number };
@@ -28,13 +29,13 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
   return {
     async start(params: Params, memory: Memory, ctx: ContextClient) {
       const provider = store.read().provider(params.chainId);
-      const { chainId, startBlock = 0, endBlock = await provider.getBlockNumber() } = params;
+      const { chainId, startBlock = 0, endBlock = await provider.getBlockNumber(), maxRange } = params;
 
       memory.error = undefined;
       // we use this wierd range thing because in the case we cant query the entire block range due to provider error
       // we want to move start block closer to endblock to reduce the range until it stops erroring. These range functions
       // will do that for us.
-      const rangeState = memory.state || rangeStart({ startBlock, endBlock });
+      const rangeState = memory.state || rangeStart({ startBlock, endBlock, maxRange });
       const { currentStart, currentEnd } = rangeState;
 
       try {

--- a/packages/sdk/src/oracle/tests/utils.test.ts
+++ b/packages/sdk/src/oracle/tests/utils.test.ts
@@ -57,4 +57,21 @@ describe("Oracle Utils", function () {
     rangeState = utils.rangeSuccessDescending(rangeState);
     assert.ok(rangeState.done);
   });
+  test("rangeDescending.maxRange", function () {
+    const startBlock = 0;
+    const endBlock = 14083360;
+    const maxRange = 100;
+
+    let rangeState = utils.rangeStart({ startBlock, endBlock, maxRange });
+
+    assert.equal(rangeState.currentStart, endBlock - maxRange);
+    assert.equal(rangeState.currentEnd, endBlock);
+    assert.equal(rangeState.currentRange, maxRange);
+    assert.ok(!rangeState.done);
+
+    rangeState = utils.rangeSuccessDescending(rangeState);
+    assert.equal(rangeState.currentStart, endBlock - maxRange * 2);
+    assert.equal(rangeState.currentEnd, endBlock - maxRange);
+    assert.ok(!rangeState.done);
+  });
 });

--- a/packages/sdk/src/oracle/types/state.ts
+++ b/packages/sdk/src/oracle/types/state.ts
@@ -51,6 +51,7 @@ export type ChainConfig = ChainMetadata & {
   // specify a block number which we do not care about blocks before this. This effectively prevents listing
   // requests older than this. If not specified, we will lookback to block 0 when considering request history.
   earliestBlockNumber?: number;
+  maxEventRangeQuery?: number;
 };
 
 // partial config lets user omit some fields which we can infer internally using contracts-frontend

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -212,25 +212,45 @@ export type RangeState = {
  * @param {Pick} state
  * @returns {RangeState}
  */
-export function rangeStart(state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier">): RangeState {
+export function rangeStart(
+  state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier"> & { maxRange?: number }
+): RangeState {
   const { startBlock, endBlock, multiplier = 2 } = state;
-  // the largest range we can have, since this is the users query for start and end
-  const maxRange = endBlock - startBlock;
-  assert(maxRange > 0, "End block must be higher than start block");
-  const currentStart = startBlock;
-  const currentEnd = endBlock;
-  const currentRange = maxRange;
+  if (state.maxRange && state.maxRange > 0) {
+    const range = endBlock - startBlock;
+    assert(range > 0, "End block must be higher than start block");
+    const currentRange = Math.min(state.maxRange, range);
+    const currentStart = endBlock - currentRange;
+    const currentEnd = endBlock;
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange: state.maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier,
+    };
+  } else {
+    // the largest range we can have, since this is the users query for start and end
+    const maxRange = endBlock - startBlock;
+    assert(maxRange > 0, "End block must be higher than start block");
+    const currentStart = startBlock;
+    const currentEnd = endBlock;
+    const currentRange = maxRange;
 
-  return {
-    done: false,
-    startBlock,
-    endBlock,
-    maxRange,
-    currentRange,
-    currentStart,
-    currentEnd,
-    multiplier,
-  };
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier,
+    };
+  }
 }
 /**
  * rangeSuccessDescending. We have 2 ways of querying events, from oldest to newest, or newest to oldest. Typically we want them in order, from


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Loading polygon requests are slow, since there are so many. 


**Summary**

This adds some levers to pull to change the performance characteristics of loading requests. You can now restrict the max block range, as well as the earliest block to ignore.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

Tested this by playing with the OO UI locally and have seen a large speed up in performance with the right parameters. 
