### PR TITLE
fix(sdk): replace rmSync for better compatibility

### DIFF
--- a/packages/sdk/build.js
+++ b/packages/sdk/build.js
@@ -16,6 +16,23 @@ const moveFile = (from, to, filename) => {
   fs.renameSync(path.resolve(...from), path.resolve(...to));
 };
 
+// A deep deletion function for node like `rm -rf` which works for versions older than v14.14
+const rimraf = function (directoryPath) {
+  if (fs.existsSync(directoryPath)) {
+    fs.readdirSync(directoryPath).forEach((file) => {
+      const curPath = path.join(directoryPath, file);
+      if (fs.lstatSync(curPath).isDirectory()) {
+        // recurse
+        rimraf(curPath);
+      } else {
+        // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(directoryPath);
+  }
+};
+
 console.log("Building web version...");
 
 // running web build
@@ -54,7 +71,7 @@ moveFile("dist", "dist-node", "index.cjs.production.min.js.map");
 moveFile("dist", "dist-node", "index.js");
 
 // finally we delete the folder with all node-typings
-fs.rmSync(path.resolve("dist"), { recursive: true });
+rimraf(path.resolve("dist"));
 // now we can move 'dist-node' to 'dist/node' again
 fs.mkdirSync(path.resolve("dist"));
 moveFile("dist-node", "dist/node");


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

https://app.shortcut.com/uma-project/story/5250/adjust-the-sdk-build-script-to-not-use-fs-rmsync

**Summary**

I replaced the `rmSync` function call with functions that were added in older versions of NodeJS. The build script works now with NodeJS versions < v14.14


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
