### PR TITLE
fix: add v1 OO interface for backcompat for downstream users

### DIFF
--- a/packages/core/contracts/oracle/interfaces/V1OptimisticOracleInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/V1OptimisticOracleInterface.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title Financial contract facing Oracle interface.
+ * @dev Interface used by financial contracts to interact with the Oracle. Voters will use a different interface.
+ */
+abstract contract V1OptimisticOracleInterface {
+    event RequestPrice(
+        address indexed requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        address currency,
+        uint256 reward,
+        uint256 finalFee
+    );
+    event ProposePrice(
+        address indexed requester,
+        address indexed proposer,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        int256 proposedPrice,
+        uint256 expirationTimestamp,
+        address currency
+    );
+    event DisputePrice(
+        address indexed requester,
+        address indexed proposer,
+        address indexed disputer,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        int256 proposedPrice
+    );
+    event Settle(
+        address indexed requester,
+        address indexed proposer,
+        address indexed disputer,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes ancillaryData,
+        int256 price,
+        uint256 payout
+    );
+
+    // Struct representing the state of a price request.
+    enum State {
+        Invalid, // Never requested.
+        Requested, // Requested, no other actions taken.
+        Proposed, // Proposed, but not expired or disputed yet.
+        Expired, // Proposed, not disputed, past liveness.
+        Disputed, // Disputed, but no DVM price returned yet.
+        Resolved, // Disputed and DVM price is available.
+        Settled // Final price has been set in the contract (can get here from Expired or Resolved).
+    }
+
+    // Struct representing a price request.
+    struct Request {
+        address proposer; // Address of the proposer.
+        address disputer; // Address of the disputer.
+        IERC20 currency; // ERC20 token used to pay rewards and fees.
+        bool settled; // True if the request is settled.
+        bool refundOnDispute; // True if the requester should be refunded their reward on dispute.
+        int256 proposedPrice; // Price that the proposer submitted.
+        int256 resolvedPrice; // Price resolved once the request is settled.
+        uint256 expirationTime; // Time at which the request auto-settles without a dispute.
+        uint256 reward; // Amount of the currency to pay to the proposer on settlement.
+        uint256 finalFee; // Final fee to pay to the Store upon request to the DVM.
+        uint256 bond; // Bond that the proposer and disputer must pay on top of the final fee.
+        uint256 customLiveness; // Custom liveness value set by the requester.
+    }
+
+    // This value must be <= the Voting contract's `ancillaryBytesLimit` value otherwise it is possible
+    // that a price can be requested to this contract successfully, but cannot be disputed because the DVM refuses
+    // to accept a price request made with ancillary data length over a certain size.
+    uint256 public constant ancillaryBytesLimit = 8192;
+
+    function defaultLiveness() external view virtual returns (uint256);
+
+    function finder() external view virtual returns (address);
+
+    function getCurrentTime() external view virtual returns (uint256);
+
+    /**
+     * @notice Requests a new price.
+     * @param identifier price identifier being requested.
+     * @param timestamp timestamp of the price being requested.
+     * @param ancillaryData ancillary data representing additional args being passed with the price request.
+     * @param currency ERC20 token used for payment of rewards and fees. Must be approved for use with the DVM.
+     * @param reward reward offered to a successful proposer. Will be pulled from the caller. Note: this can be 0,
+     *               which could make sense if the contract requests and proposes the value in the same call or
+     *               provides its own reward system.
+     * @return totalBond default bond (final fee) + final fee that the proposer and disputer will be required to pay.
+     * This can be changed with a subsequent call to setBond().
+     */
+    function requestPrice(
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        IERC20 currency,
+        uint256 reward
+    ) external virtual returns (uint256 totalBond);
+
+    /**
+     * @notice Set the proposal bond associated with a price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param bond custom bond amount to set.
+     * @return totalBond new bond + final fee that the proposer and disputer will be required to pay. This can be
+     * changed again with a subsequent call to setBond().
+     */
+    function setBond(
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        uint256 bond
+    ) external virtual returns (uint256 totalBond);
+
+    /**
+     * @notice Sets the request to refund the reward if the proposal is disputed. This can help to "hedge" the caller
+     * in the event of a dispute-caused delay. Note: in the event of a dispute, the winner still receives the other's
+     * bond, so there is still profit to be made even if the reward is refunded.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     */
+    function setRefundOnDispute(
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) external virtual;
+
+    /**
+     * @notice Sets a custom liveness value for the request. Liveness is the amount of time a proposal must wait before
+     * being auto-resolved.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param customLiveness new custom liveness.
+     */
+    function setCustomLiveness(
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        uint256 customLiveness
+    ) external virtual;
+
+    /**
+     * @notice Proposes a price value on another address' behalf. Note: this address will receive any rewards that come
+     * from this proposal. However, any bonds are pulled from the caller.
+     * @param proposer address to set as the proposer.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param proposedPrice price being proposed.
+     * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
+     * the proposer once settled if the proposal is correct.
+     */
+    function proposePriceFor(
+        address proposer,
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        int256 proposedPrice
+    ) public virtual returns (uint256 totalBond);
+
+    /**
+     * @notice Proposes a price value for an existing price request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @param proposedPrice price being proposed.
+     * @return totalBond the amount that's pulled from the proposer's wallet as a bond. The bond will be returned to
+     * the proposer once settled if the proposal is correct.
+     */
+    function proposePrice(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData,
+        int256 proposedPrice
+    ) external virtual returns (uint256 totalBond);
+
+    /**
+     * @notice Disputes a price request with an active proposal on another address' behalf. Note: this address will
+     * receive any rewards that come from this dispute. However, any bonds are pulled from the caller.
+     * @param disputer address to set as the disputer.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return totalBond the amount that's pulled from the caller's wallet as a bond. The bond will be returned to
+     * the disputer once settled if the dispute was value (the proposal was incorrect).
+     */
+    function disputePriceFor(
+        address disputer,
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) public virtual returns (uint256 totalBond);
+
+    /**
+     * @notice Disputes a price value for an existing price request with an active proposal.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return totalBond the amount that's pulled from the disputer's wallet as a bond. The bond will be returned to
+     * the disputer once settled if the dispute was valid (the proposal was incorrect).
+     */
+    function disputePrice(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) external virtual returns (uint256 totalBond);
+
+    /**
+     * @notice Retrieves a price that was previously requested by a caller. Reverts if the request is not settled
+     * or settleable. Note: this method is not view so that this call may actually settle the price request if it
+     * hasn't been settled.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return resolved price.
+     */
+    function settleAndGetPrice(
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) external virtual returns (int256);
+
+    /**
+     * @notice Attempts to settle an outstanding price request. Will revert if it isn't settleable.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return payout the amount that the "winner" (proposer or disputer) receives on settlement. This amount includes
+     * the returned bonds as well as additional rewards.
+     */
+    function settle(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) external virtual returns (uint256 payout);
+
+    /**
+     * @notice Gets the current data structure containing all information about a price request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return the Request data structure.
+     */
+    function getRequest(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) public view virtual returns (Request memory);
+
+    /**
+     * @notice Returns the state of a price request.
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return the State enum value.
+     */
+    function getState(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) public view virtual returns (State);
+
+    /**
+     * @notice Checks if a given request has resolved or been settled (i.e the optimistic oracle has a price).
+     * @param requester sender of the initial price request.
+     * @param identifier price identifier to identify the existing request.
+     * @param timestamp timestamp to identify the existing request.
+     * @param ancillaryData ancillary data of the price being requested.
+     * @return true if price has resolved or settled, false otherwise.
+     */
+    function hasPrice(
+        address requester,
+        bytes32 identifier,
+        uint256 timestamp,
+        bytes memory ancillaryData
+    ) public view virtual returns (bool);
+
+    function stampAncillaryData(bytes memory ancillaryData, address requester)
+        public
+        view
+        virtual
+        returns (bytes memory);
+}

--- a/packages/sdk/src/clients/optimisticOracle/client.ts
+++ b/packages/sdk/src/clients/optimisticOracle/client.ts
@@ -1,15 +1,19 @@
-import { OptimisticOracleEthers, OptimisticOracleEthers__factory, getOptimisticOracleAbi } from "@uma/contracts-node";
+import {
+  V1OptimisticOracleInterfaceEthers,
+  V1OptimisticOracleInterfaceEthers__factory,
+  getV1OptimisticOracleInterfaceAbi,
+} from "@uma/contracts-node";
 import type { SignerOrProvider, GetEventType } from "../..";
 import { Event, BigNumberish, utils } from "ethers";
 
-export type Instance = OptimisticOracleEthers;
-const Factory = OptimisticOracleEthers__factory;
+export type Instance = V1OptimisticOracleInterfaceEthers;
+const Factory = V1OptimisticOracleInterfaceEthers__factory;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
   return Factory.connect(address, provider);
 }
 
-export const contractInterface = new utils.Interface(getOptimisticOracleAbi());
+export const contractInterface = new utils.Interface(getV1OptimisticOracleInterfaceAbi());
 
 export type RequestPrice = GetEventType<Instance, "RequestPrice">;
 export type ProposePrice = GetEventType<Instance, "ProposePrice">;


### PR DESCRIPTION
**Motivation**

We need to preserve the old interface to continue interacting with the deployed OO.


**Summary**

This adds a "V1" interface that should be used when interacting with the existing deployed OO. The SDK client was also updated.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
