### PR TITLE
feat: Round realized LP fee % to match UMIP

### DIFF
--- a/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
+++ b/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js
@@ -1032,10 +1032,7 @@ describe("InsuredBridgeL1Client", function () {
       // jupiter notebook, this should be a rate of 0.000117987509354032.
 
       await client.update();
-      assert.equal(
-        (await client.calculateRealizedLpFeePctForDeposit(depositData)).toString(),
-        toWei("0.000117987509354032")
-      );
+      assert.equal((await client.calculateRealizedLpFeePctForDeposit(depositData)).toString(), toWei("0.000117"));
 
       // Next, relay a large deposit of 60 units. this takes the pool utilization from 0% to 60% (note we did not
       // actually relay the relay in `depositData` so utilization is still 0 before this action).
@@ -1048,10 +1045,7 @@ describe("InsuredBridgeL1Client", function () {
       // However, the quote at the time of the depositData should NOT increase relay was done after that quote
       // timestamp. Check that this has not moved.
       await client.update();
-      assert.equal(
-        (await client.calculateRealizedLpFeePctForDeposit(depositData)).toString(),
-        toWei("0.000117987509354032")
-      );
+      assert.equal((await client.calculateRealizedLpFeePctForDeposit(depositData)).toString(), toWei("0.000117"));
 
       // If we set the quoteTimestamp to the current block time then the realizedLPFee should increase.
       assert.equal(
@@ -1061,7 +1055,7 @@ describe("InsuredBridgeL1Client", function () {
             quoteTimestamp: (await web3.eth.getBlock("latest")).timestamp,
           })
         ).toString(),
-        toWei("0.002081296752280018")
+        toWei("0.002081")
       );
     });
   });

--- a/packages/sdk/src/across/feeCalculator.test.ts
+++ b/packages/sdk/src/across/feeCalculator.test.ts
@@ -18,17 +18,17 @@ describe("Realized liquidity provision calculation", function () {
     // utilization at pointB (after the deposit), expected APY rate and the expected weekly rate. The numbers are
     // generated from the juypter notebook defined in the comments above.
     const testedIntervals = [
-      { utilA: toBNWei("0"), utilB: toBNWei("0.01"), apy: "615384615384600", wpy: "11830749673498" },
-      { utilA: toBNWei("0"), utilB: toBNWei("0.50"), apy: "30769230769230768", wpy: "582965040710805" },
-      { utilA: toBNWei("0.5"), utilB: toBNWei("0.51"), apy: "62153846153846200", wpy: "1160264449662626" },
-      { utilA: toBNWei("0.5"), utilB: toBNWei("0.56"), apy: "65230769230769233", wpy: "1215959072035989" },
-      { utilA: toBNWei("0.5"), utilB: toBNWei("0.5").add(100), apy: "60000000000000000", wpy: "1121183982821340" },
-      { utilA: toBNWei("0.6"), utilB: toBNWei("0.7"), apy: "114175824175824180", wpy: "2081296752280018" },
-      { utilA: toBNWei("0.7"), utilB: toBNWei("0.75"), apy: "294285714285714280", wpy: "4973074331615530" },
-      { utilA: toBNWei("0.7"), utilB: toBNWei("0.7").add(100), apy: "220000000000000000", wpy: "3831376003126766" },
-      { utilA: toBNWei("0.95"), utilB: toBNWei("1.00"), apy: "1008571428571428580", wpy: "13502339199904125" },
-      { utilA: toBNWei("0"), utilB: toBNWei("0.99"), apy: "220548340548340547", wpy: "3840050658887291" },
-      { utilA: toBNWei("0"), utilB: toBNWei("1.00"), apy: "229000000000000000", wpy: "3973273191633388" },
+      { utilA: toBNWei("0"), utilB: toBNWei("0.01"), apy: "615384615384600", wpy: "11000000000000" },
+      { utilA: toBNWei("0"), utilB: toBNWei("0.50"), apy: "30769230769230768", wpy: "582000000000000" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.51"), apy: "62153846153846200", wpy: "1160000000000000" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.56"), apy: "65230769230769233", wpy: "1215000000000000" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.5").add(100), apy: "60000000000000000", wpy: "1121000000000000" },
+      { utilA: toBNWei("0.6"), utilB: toBNWei("0.7"), apy: "114175824175824180", wpy: "2081000000000000" },
+      { utilA: toBNWei("0.7"), utilB: toBNWei("0.75"), apy: "294285714285714280", wpy: "4973000000000000" },
+      { utilA: toBNWei("0.7"), utilB: toBNWei("0.7").add(100), apy: "220000000000000000", wpy: "3831000000000000" },
+      { utilA: toBNWei("0.95"), utilB: toBNWei("1.00"), apy: "1008571428571428580", wpy: "13502000000000000" },
+      { utilA: toBNWei("0"), utilB: toBNWei("0.99"), apy: "220548340548340547", wpy: "3840000000000000" },
+      { utilA: toBNWei("0"), utilB: toBNWei("1.00"), apy: "229000000000000000", wpy: "3973000000000000" },
     ];
 
     testedIntervals.forEach((interval) => {

--- a/packages/sdk/src/across/feeCalculator.ts
+++ b/packages/sdk/src/across/feeCalculator.ts
@@ -3,7 +3,7 @@
 // and ethers BNs in the main entry point function calculateRealizedLpFeePct.
 
 import Decimal from "decimal.js";
-import { BigNumberish, BN, toBN, toBNWei, fromWei, min, max, fixedPointAdjustment } from "./utils";
+import { BigNumberish, BN, toBN, toBNWei, toWei, fromWei, min, max, fixedPointAdjustment } from "./utils";
 
 // note a similar type exists in the constants file, but are strings only. This is a bit more permissive to allow
 // backward compatibility for callers with a rate model defined with bignumbers and not strings.
@@ -82,5 +82,9 @@ export function calculateRealizedLpFeePct(
   utilizationAfterDeposit: BigNumberish
 ) {
   const apy = calculateApyFromUtilization(rateModel, toBN(utilizationBeforeDeposit), toBN(utilizationAfterDeposit));
-  return convertApyToWeeklyFee(apy);
+  const weeklyFee = convertApyToWeeklyFee(apy);
+
+  // IS_RELAY_VALID UMIP requires that the realized fee percent is floor rounded as decimal to 6 decimals.
+  const [predec, postdec] = fromWei(weeklyFee.toString()).split(".");
+  return toBN(toWei(postdec ? [predec, postdec.slice(0, 6)].join(".") : predec));
 }

--- a/packages/sdk/src/across/feeCalculator.ts
+++ b/packages/sdk/src/across/feeCalculator.ts
@@ -3,6 +3,7 @@
 // and ethers BNs in the main entry point function calculateRealizedLpFeePct.
 
 import Decimal from "decimal.js";
+import { BigNumber } from "ethers";
 import { BigNumberish, BN, toBN, toBNWei, fromWei, min, max, fixedPointAdjustment } from "./utils";
 
 // note a similar type exists in the constants file, but are strings only. This is a bit more permissive to allow


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

[A change to UMIP-136](https://github.com/UMAprotocol/UMIPs/pull/515) will require that realized LP fee %'s are accurate to 6 decimals. This PR changes the fee calculator to always return realized LP fees to this precision.

**Summary**
Reviewers, there are two questions I have:
- Currently I am changing the precision of the realized LP fee % in the `sdk`, but I wonder if this should be lower at the client level?
- Does there exist a common function we can use to implement the precision change? I don't like manipulating the string as I am doing as it seems error prone.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
