### PR TITLE
fix: [N09] Unexplained and unused constants

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -127,7 +127,8 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
 
     // This is effectively the extra ancillary data to add ",ooRequester:0000000000000000000000000000000000000000".
     uint256 private constant MAX_ADDED_ANCILLARY_DATA = 53;
-    uint256 public constant OO_ANCILLARY_DATA_LIMIT = ancillaryBytesLimit - 53;
+    uint256 public constant OO_ANCILLARY_DATA_LIMIT = ancillaryBytesLimit - MAX_ADDED_ANCILLARY_DATA;
+    int256 public constant TOO_EARLY_RESPONSE = type(int256).min;
 
     /**
      * @notice Constructor.
@@ -273,7 +274,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
      * 1. The timestamp at which the request is evaluated is the time of the proposal, not the timestamp associated
      *    with the request.
      *
-     * 2. The proposer cannot propose the "too early" value (type(int256).min). This is to ensure that a proposer who
+     * 2. The proposer cannot propose the "too early" value (TOO_EARLY_RESPONSE). This is to ensure that a proposer who
      *    prematurely proposes a response loses their bond.
      *
      * 3. RefundoOnDispute is automatically set, meaning disputes trigger the reward to be automatically refunded to
@@ -323,7 +324,7 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
             "proposePriceFor: Requested"
         );
         Request storage request = _getRequest(requester, identifier, timestamp, ancillaryData);
-        if (request.eventBased) require(proposedPrice != type(int256).min, "Cannot propose 'too early'");
+        if (request.eventBased) require(proposedPrice != TOO_EARLY_RESPONSE, "Cannot propose 'too early'");
         request.proposer = proposer;
         request.proposedPrice = proposedPrice;
 

--- a/packages/core/contracts/zodiac/OptimisticGovernor.sol
+++ b/packages/core/contracts/zodiac/OptimisticGovernor.sol
@@ -45,6 +45,8 @@ contract OptimisticGovernor is Module, Lockable {
     // This will usually be "ZODIAC" but a deployer may want to create a more specific identifier.
     bytes32 public identifier;
     OptimisticOracleInterface public optimisticOracle;
+    
+    int256 public constant PROPOSAL_VALID_RESPONSE = int256(1e18);
 
     struct Transaction {
         address to;
@@ -214,7 +216,7 @@ contract OptimisticGovernor is Module, Lockable {
         collateral.safeTransferFrom(msg.sender, address(this), totalBond);
         collateral.safeIncreaseAllowance(address(optimisticOracle), totalBond);
 
-        optimisticOracle.proposePriceFor(msg.sender, address(this), identifier, time, ancillaryData, int256(1e18));
+        optimisticOracle.proposePriceFor(msg.sender, address(this), identifier, time, ancillaryData, PROPOSAL_VALID_RESPONSE);
 
         emit TransactionsProposed(id, proposer, time, proposal, _explanation);
     }
@@ -245,7 +247,7 @@ contract OptimisticGovernor is Module, Lockable {
 
         // This will revert if the price has not settled.
         int256 price = optimisticOracle.settleAndGetPrice(identifier, _originalTime, ancillaryData);
-        require(price == int256(1e18), "Proposal was rejected");
+        require(price == PROPOSAL_VALID_RESPONSE, "Proposal was rejected");
 
         for (uint256 i = 0; i < _transactions.length; i++) {
             Transaction memory transaction = _transactions[i];
@@ -280,7 +282,7 @@ contract OptimisticGovernor is Module, Lockable {
         int256 price = optimisticOracle.settleAndGetPrice(identifier, _originalTime, ancillaryData);
 
         // Check that proposal was rejected.
-        require(price != int256(1e18), "Proposal was not rejected");
+        require(price != PROPOSAL_VALID_RESPONSE, "Proposal was not rejected");
 
         // Delete the proposal.
         delete proposalHashes[_proposalId];

--- a/packages/core/contracts/zodiac/OptimisticGovernor.sol
+++ b/packages/core/contracts/zodiac/OptimisticGovernor.sol
@@ -45,7 +45,7 @@ contract OptimisticGovernor is Module, Lockable {
     // This will usually be "ZODIAC" but a deployer may want to create a more specific identifier.
     bytes32 public identifier;
     OptimisticOracleInterface public optimisticOracle;
-    
+
     int256 public constant PROPOSAL_VALID_RESPONSE = int256(1e18);
 
     struct Transaction {
@@ -216,7 +216,14 @@ contract OptimisticGovernor is Module, Lockable {
         collateral.safeTransferFrom(msg.sender, address(this), totalBond);
         collateral.safeIncreaseAllowance(address(optimisticOracle), totalBond);
 
-        optimisticOracle.proposePriceFor(msg.sender, address(this), identifier, time, ancillaryData, PROPOSAL_VALID_RESPONSE);
+        optimisticOracle.proposePriceFor(
+            msg.sender,
+            address(this),
+            identifier,
+            time,
+            ancillaryData,
+            PROPOSAL_VALID_RESPONSE
+        );
 
         emit TransactionsProposed(id, proposer, time, proposal, _explanation);
     }


### PR DESCRIPTION
**Motivation**

Throughout the OptimisticGovernor contract, to check if a proposal has been approved
by the Optimistic Oracle the literal value int256 1e18 is used, where 1e18 signifies that a
proposal was not rejected by the Optimistic Oracle.

Similarly, in the update to the OptimisticOracle contract the function proposedPrice
uses a magic value type(int256).min to indicate that an event-based proposal cannot be
resolved, because the event has not yet taken place.

Lastly, in the OptimisticOracle contract the MAX_ADDED_ANCILLARY_DATA constant is
declared on line 129. On the next line the constant should be used, but instead the value of the
constant is used directly to derive another constant.


To improve the overall readability of the codebase and to facilitate refactoring, consider
defining a constant for every literal or magic value used, giving it a clear and self-explanatory
name, and then using it in place of literal values. Also consider adding an inline comment
explaining how literal values were calculated or why they were chosen.


**Summary**

Fixed these issues.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A