### PR TITLE
fix: [N12] Unused "using for" directive

### DIFF
--- a/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
+++ b/packages/core/contracts/oracle/implementation/OptimisticOracle.sol
@@ -76,7 +76,6 @@ contract OptimisticOracle is OptimisticOracleInterface, Testable, Lockable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
     using Address for address;
-    using AncillaryData for bytes;
 
     event RequestPrice(
         address indexed requester,


### PR DESCRIPTION
**Motivation**

The OptimisticOracle contract includes the directive using AncillaryData for bytes ,
even though none of the library methods are ever used directly on a bytes value.

Consider removing the directive if it will remain unused.


**Summary**

Removed the directive.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A