### PR TITLE
feat(contract-notifier): add multichain support

### DIFF
--- a/packages/contract-notifier/README.md
+++ b/packages/contract-notifier/README.md
@@ -12,7 +12,8 @@ The expiring contracts notifier uses following environment variables:
 
 - `NOTIFIER_CONFIG` is a JSON object containing application specific parameters:
   - `maxTimeTillExpiration` is maximum time in seconds till expiration for the contract to be included in the notification, defaulting to 1 week.
-  - `apiEndpoint` sets API to fetch contract information, defaulting to https://prod.api.umaproject.org
+  - `chainId` indicates on which chain the monitored contracts are deployed, defaulting to 1 (Ethereum Mainnet).
+  - `apiEndpoint` sets API to fetch contract information, defaulting to https://prod.api.umaproject.org. As each API endpoint serves its own network this parameter should be consistent with `chainId` above.
 - `POLLING_DELAY` is value in seconds for delay between consecutive runs, defaults to 1h. If set to 0 then running in serverless mode will exit after the loop.
 - `BOT_IDENTIFIER` identifies the application name in the logs.
 - `ERROR_RETRIES` is number of times to retry failed operation (e.g. due to API not responding). It defaults to 3 re-tries on error within the execution loop.

--- a/packages/contract-notifier/index.js
+++ b/packages/contract-notifier/index.js
@@ -33,11 +33,19 @@ async function run({ logger, pollingDelay, errorRetries, errorRetriesTimeout, no
 
     const getTime = () => Math.round(new Date().getTime() / 1000);
 
+    const chainId = notifierConfig.chainId;
     const apiEndpoint = notifierConfig.apiEndpoint;
     const maxTimeTillExpiration = notifierConfig.maxTimeTillExpiration;
     const networker = new Networker(logger);
 
-    const contractNotifier = new ContractNotifier({ logger, networker, getTime, apiEndpoint, maxTimeTillExpiration });
+    const contractNotifier = new ContractNotifier({
+      logger,
+      networker,
+      getTime,
+      chainId,
+      apiEndpoint,
+      maxTimeTillExpiration,
+    });
 
     // Create a execution loop that will run indefinitely (or yield early if in serverless mode)
     for (;;) {
@@ -95,6 +103,7 @@ async function Poll(callback) {
       // Notifier config contains all configuration settings for the notifier. This includes the following:
       // NOTIFIER_CONFIG={
       //  "maxTimeTillExpiration": 604800,                   // If time till expiration (in seconds) is below this fire the alert.
+      //  "chainId": 1,                                      // Contracts deployment chain.
       //  "apiEndpoint": "https://prod.api.umaproject.org"   // API endpoint to check for contract information.
       // }
       notifierConfig: process.env.NOTIFIER_CONFIG ? JSON.parse(process.env.NOTIFIER_CONFIG) : {},
@@ -102,6 +111,7 @@ async function Poll(callback) {
     // Fill in notifierConfig defaults:
     executionParameters.notifierConfig = {
       maxTimeTillExpiration: 604800,
+      chainId: 1,
       apiEndpoint: "https://prod.api.umaproject.org",
       ...executionParameters.notifierConfig,
     };

--- a/packages/contract-notifier/src/ContractNotifier.js
+++ b/packages/contract-notifier/src/ContractNotifier.js
@@ -9,13 +9,15 @@ class ContractNotifier {
    * @param {Object} logger Winston module used to send logs.
    * @param {Object} networker Used to send the API requests.
    * @param {Function} getTime Returns the current time.
+   * @param {Integer} chainId Contracts deployment chain.
    * @param {String} apiEndpoint API endpoint to monitor.
    * @param {Integer} maxTimeTillExpiration Period in seconds to look for upcoming contract expirations.
    */
-  constructor({ logger, networker, getTime, apiEndpoint, maxTimeTillExpiration }) {
+  constructor({ logger, networker, getTime, chainId, apiEndpoint, maxTimeTillExpiration }) {
     this.logger = logger;
     this.networker = networker;
     this.getTime = getTime;
+    this.chainId = chainId;
     this.apiEndpoint = apiEndpoint;
     this.maxTimeTillExpiration = maxTimeTillExpiration;
   }
@@ -58,8 +60,7 @@ class ContractNotifier {
         }
         const expirationUtcString = new Date(contract.expirationTimestamp * 1000).toUTCString();
         return {
-          // UMA API currently supports only Ethereum mainnet, thus chainId of 1 is hardcoded here:
-          chainId: 1,
+          chainId: this.chainId,
           address: contract.address,
           expirationTimestamp: contract.expirationTimestamp,
           tokenName: tokenName,


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

There are increasing number of LSP contract deployments on other chains than Ethereum mainnet that should be monitored for upcoming expirations.


**Summary**

Allows running `contract-notifier` against selected API endpoints for supported chains.


**Details**

Each instance of `contract-notifier` is expected to run against its configured `chainId` and corresponding `apiEndpoint`. Google Datastore already had `chainId` parameter, so no changes needed there.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested



