### PR TITLE
feat: extend serverless to contain more configs for multi-chain

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -95,17 +95,39 @@ hub.post("/", async (req, res) => {
       // Check if bot is running on a non-default chain, and fetch last block number seen on this or the default chain.
       const [botWeb3, spokeCustomNodeUrl] = _getWeb3AndUrlForBot(configObject[botName]);
       const chainId = await _getChainId(botWeb3);
-      nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
-
-      // If we've seen this chain ID already we can skip it:
+      // If we've seen this chain ID already we can skip it.
       if (blockNumbersForChain[chainId]) continue;
 
-      // Fetch last seen block for this chain:
-      let lastQueriedBlockNumber = await _getLastQueriedBlockNumber(req.body.configFile, chainId, logger);
+      nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
 
-      // Next, get the head block for the chosen chain, which we'll use to override the last queried block number
+      // If STORE_MULTI_CHAIN_BLOCK_NUMBERS is set then this bot requires to know a number of last seen blocks across
+      // a set of chainIds. Construct a batch promise to evaluate the latest block number for each chainId.
+      if (configObject[botName]?.environmentVariables?.STORE_MULTI_CHAIN_BLOCK_NUMBERS) {
+        const multiChainIds = configObject[botName]?.environmentVariables?.STORE_MULTI_CHAIN_BLOCK_NUMBERS;
+        let promises = [];
+        for (const chainId of multiChainIds) {
+          promises.push(
+            _getLastQueriedBlockNumber(req.body.configFile, chainId, logger),
+            _getBlockNumberOnChainIdMultiChain(configObject[botName], chainId)
+          );
+        }
+        let results = await Promise.all(promises);
+        results.forEach((_, index) => {
+          if (index % 2 !== 0) return;
+          const chainId = multiChainIds[Math.floor(index / 2)];
+          blockNumbersForChain[chainId] = {
+            lastQueriedBlockNumber: results[index],
+            latestBlockNumber: results[index + 1],
+          };
+        });
+      }
+
+      // Fetch last seen block for this chain and get the head block for the chosen chain, which we'll use to override the last queried block number
       // stored in GCP at the end of this hub execution.
-      let latestBlockNumber = await _getLatestBlockNumber(botWeb3);
+      let [lastQueriedBlockNumber, latestBlockNumber] = await Promise.all([
+        _getLastQueriedBlockNumber(req.body.configFile, chainId, logger),
+        _getLatestBlockNumber(botWeb3),
+      ]);
 
       // If the last queried block number stored on GCP Data Store is undefined, then its possible that this is
       // the first time that the hub is being run for this chain. Therefore, try setting it to the head block number
@@ -145,11 +167,15 @@ hub.post("/", async (req, res) => {
     for (const botName in configObject) {
       const [, spokeCustomNodeUrl] = _getWeb3AndUrlForBot(configObject[botName]);
       const chainId = nodeUrlToChainIdCache[spokeCustomNodeUrl];
-      const lastQueriedBlockNumber = blockNumbersForChain[chainId].lastQueriedBlockNumber;
-      const latestBlockNumber = blockNumbersForChain[chainId].latestBlockNumber;
 
       // Execute the spoke's command:
-      const botConfig = _appendEnvVars(configObject[botName], botName, lastQueriedBlockNumber, latestBlockNumber);
+      const botConfig = _appendEnvVars(
+        configObject[botName],
+        botName,
+        chainId,
+        blockNumbersForChain,
+        configObject[botName]?.environmentVariables?.STORE_MULTI_CHAIN_BLOCK_NUMBERS
+      );
       botConfigs[botName] = botConfig;
       promiseArray.push(
         Promise.race([
@@ -257,10 +283,13 @@ hub.post("/", async (req, res) => {
     }
 
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res.status(500).send({
-      message: errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
-      output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
-    });
+    res
+      .status(500)
+      .send({
+        message:
+          errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
+        output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
+      });
   }
 });
 
@@ -408,6 +437,10 @@ function _getWeb3AndUrlForBot(botConfig) {
   }
 }
 
+async function _getBlockNumberOnChainIdMultiChain(botConfig, chainId) {
+  return await new Web3(botConfig?.environmentVariables[`NODE_URL_${chainId}`]).eth.getBlockNumber();
+}
+
 // Get the latest block number from either `overrideNodeUrl` or `CUSTOM_NODE_URL`. Used to update the `
 // lastSeenBlockNumber` after each run.
 async function _getLatestBlockNumber(web3) {
@@ -419,11 +452,18 @@ async function _getChainId(web3) {
 }
 
 // Add additional environment variables for a given config file. Used to attach starting and ending block numbers.
-function _appendEnvVars(config, botName, lastQueriedBlockNumber, latestBlockNumber) {
+function _appendEnvVars(config, botName, chainId, blockNumbersForChain, multiChainBlocks) {
   // The starting block number should be one block after the last queried block number to not double report that block.
-  config.environmentVariables["STARTING_BLOCK_NUMBER"] = Number(lastQueriedBlockNumber) + 1;
-  config.environmentVariables["ENDING_BLOCK_NUMBER"] = latestBlockNumber;
+  config.environmentVariables["STARTING_BLOCK_NUMBER"] =
+    Number(blockNumbersForChain[chainId].lastQueriedBlockNumber) + 1;
+  config.environmentVariables["ENDING_BLOCK_NUMBER"] = blockNumbersForChain[chainId].latestBlockNumber;
   config.environmentVariables["BOT_IDENTIFIER"] = botName;
+  if (multiChainBlocks)
+    multiChainBlocks.forEach((chainId) => {
+      config.environmentVariables[`STARTING_BLOCK_NUMBER_${chainId}`] =
+        Number(blockNumbersForChain[chainId].lastQueriedBlockNumber) + 1;
+      config.environmentVariables[`ENDING_BLOCK_NUMBER_${chainId}`] = blockNumbersForChain[chainId].latestBlockNumber;
+    });
   return config;
 }
 

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -283,13 +283,10 @@ hub.post("/", async (req, res) => {
     }
 
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
-    res
-      .status(500)
-      .send({
-        message:
-          errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
-        output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
-      });
+    res.status(500).send({
+      message: errorOutput instanceof Error ? "A fatal error occurred in the hub" : "Some spoke calls returned errors",
+      output: errorOutput instanceof Error ? errorOutput.message : errorOutput,
+    });
   }
 });
 


### PR DESCRIPTION
**Motivation**

Across v2 monitor requires to know information about a number of chains latest blocks and last blocks seen. This PR updates the hub to add addtional storage slots to enable this.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
