### PR TITLE
fix: fix BlockFinder concurrency issue

### DIFF
--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -58,9 +58,12 @@ export default class BlockFinder<T extends { number: number; timestamp: number |
 
   // Grabs the block for a particular number and caches it.
   private async getBlock(number: number) {
-    const index = sortedIndexBy(this.blocks, { number } as T, "number");
+    let index = sortedIndexBy(this.blocks, { number } as T, "number");
     if (this.blocks[index]?.number === number) return this.blocks[index]; // Return early if block already exists.
     const block = await this.requestBlock(number);
+    
+    // Recompute the index after the async call since the state of this.blocks could have changed!
+    index = sortedIndexBy(this.blocks, { number } as T, "number");
     this.blocks.splice(index, 0, block); // A simple insert at index.
     return block;
   }

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -64,6 +64,9 @@ export default class BlockFinder<T extends { number: number; timestamp: number |
     
     // Recompute the index after the async call since the state of this.blocks could have changed!
     index = sortedIndexBy(this.blocks, { number } as T, "number");
+    
+    // Rerun this check to avoid duplicate insertion.
+    if (this.blocks[index]?.number === number) return this.blocks[index];
     this.blocks.splice(index, 0, block); // A simple insert at index.
     return block;
   }

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -61,10 +61,10 @@ export default class BlockFinder<T extends { number: number; timestamp: number |
     let index = sortedIndexBy(this.blocks, { number } as T, "number");
     if (this.blocks[index]?.number === number) return this.blocks[index]; // Return early if block already exists.
     const block = await this.requestBlock(number);
-    
+
     // Recompute the index after the async call since the state of this.blocks could have changed!
     index = sortedIndexBy(this.blocks, { number } as T, "number");
-    
+
     // Rerun this check to avoid duplicate insertion.
     if (this.blocks[index]?.number === number) return this.blocks[index];
     this.blocks.splice(index, 0, block); // A simple insert at index.


### PR DESCRIPTION
**Motivation**

We're seeing bots break because of "undefined" blocks.

**Summary**

After running the debugger to get the state of the `this.blocks` array, I found that the this.blocks array was not sorted. This should be impossible since the elements are always inserted sorted and never removed.

After looking through the insertion points, I found this one, which computes the index, makes an async call, and then uses that index to insert the queried element. When this class is used concurrently, the state of this.blocks could have changed between the initiation of the async call and when it returns.

To avoid this, we need to recompute the index after the async call.

Note: it's hard to definitively say when this is fixed because the async scheduling is inherently chaotic. However, I will run local tests many times to attempt to tease out whether the error is still there.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
