### PR TITLE
fix(optimistic-distributor): handle optimistic oracle upgrades

### DIFF
--- a/packages/core/contracts/financial-templates/optimistic-distributor/OptimisticDistributor.sol
+++ b/packages/core/contracts/financial-templates/optimistic-distributor/OptimisticDistributor.sol
@@ -433,7 +433,7 @@ contract OptimisticDistributor is Lockable, MultiCaller, Testable {
 
         // Previous proposal is blocking till disputed that can be detected by non-zero disputer address.
         // In case Optimistic Oracle was upgraded since the previous proposal it needs to be unblocked for new proposal.
-        // This can be detected by uninitialized bonding currency for the previus proposal.
+        // This can be detected by uninitialized bonding currency for the previous proposal.
         return blockingRequest.disputer != address(0) || address(blockingRequest.currency) == address(0);
     }
 }

--- a/packages/core/contracts/financial-templates/optimistic-distributor/OptimisticDistributor.sol
+++ b/packages/core/contracts/financial-templates/optimistic-distributor/OptimisticDistributor.sol
@@ -432,6 +432,8 @@ contract OptimisticDistributor is Lockable, MultiCaller, Testable {
             );
 
         // Previous proposal is blocking till disputed that can be detected by non-zero disputer address.
-        return blockingRequest.disputer != address(0);
+        // In case Optimistic Oracle was upgraded since the previous proposal it needs to be unblocked for new proposal.
+        // This can be detected by uninitialized bonding currency for the previus proposal.
+        return blockingRequest.disputer != address(0) || address(blockingRequest.currency) == address(0);
     }
 }


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Reward distribution could have been blocked if Optimistic Oracle upgrade is performed between proposal and execution.


**Summary**

This fix unblocks creating new proposals id Optimistic Oracle upgrade is detected.


**Details**

In case of Optimistic Oracle upgrade the proposal should be repeated and previous request should be settled manually through old Optimistic Oracle.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

