### PR TITLE
fix: Across V1 event clients need to use paginated event search query now that DepositRelayed has over 10,000 events

### DIFF
--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -103,7 +103,7 @@ export class InsuredBridgeL1Client {
     readonly rateModelStoreAddress: string | null,
     readonly startingBlockNumber = 0,
     readonly endingBlockNumber: number | null = null,
-    readonly blocksPerEventSearch: number | null = 20000
+    readonly blocksPerEventSearch: number | null = null
   ) {
     // Cast the following contracts to web3-specific type
     this.bridgeAdmin = (new l1Web3.eth.Contract(

--- a/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
+++ b/packages/financial-templates-lib/src/clients/InsuredBridgeL1Client.ts
@@ -103,7 +103,7 @@ export class InsuredBridgeL1Client {
     readonly rateModelStoreAddress: string | null,
     readonly startingBlockNumber = 0,
     readonly endingBlockNumber: number | null = null,
-    readonly blocksPerEventSearch: number | null = null
+    readonly blocksPerEventSearch: number | null = 20000
   ) {
     // Cast the following contracts to web3-specific type
     this.bridgeAdmin = (new l1Web3.eth.Contract(

--- a/packages/financial-templates-lib/src/price-feed/InsuredBridgePriceFeed.ts
+++ b/packages/financial-templates-lib/src/price-feed/InsuredBridgePriceFeed.ts
@@ -1,7 +1,7 @@
 import { PriceFeedInterface } from "./PriceFeedInterface";
 import Web3 from "web3";
 import { getAbi } from "@uma/contracts-node";
-import { getEventsWithPaginatedBlockSearch, parseAncillaryData, Web3Contract } from "@uma/common";
+import { getEventsWithPaginatedBlockSearch, parseAncillaryData } from "@uma/common";
 import { BN } from "../types";
 import type { Logger } from "winston";
 import { InsuredBridgeL1Client, Relay } from "../clients/InsuredBridgeL1Client";
@@ -69,7 +69,7 @@ export class InsuredBridgePriceFeed extends PriceFeedInterface {
       depositHash: string;
     }
     let matchedRelay: MatchedRelay | undefined;
-    const latestL1Block = await this.l1Client.l1Web3.eth.getBlockNumber()
+    const latestL1Block = await this.l1Client.l1Web3.eth.getBlockNumber();
     for (const bridgePoolAddress of this.l1Client.getBridgePoolsAddresses()) {
       const bridgePool = new this.l1Client.l1Web3.eth.Contract(getAbi("BridgePool"), bridgePoolAddress);
       const relays = await getEventsWithPaginatedBlockSearch(bridgePool, "DepositRelayed", 0, latestL1Block, 20000);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Some nodes like Infura cannot return more than 10,000 events, and the default search for these clients is set to look up events for ALL of history

**Summary**

Sets a default page size for event queries. Note that `InsuredBridgePriceFeed.getHistoricalPrice` is not used in `insured-bridge-relayer` and its only used in the validation script `getHistoricalPrice`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
