### PR TITLE
fix(merkle-distributor): tracking remainingAmount in claimMulti

### DIFF
--- a/packages/core/contracts/merkle-distributor/implementation/MerkleDistributor.sol
+++ b/packages/core/contracts/merkle-distributor/implementation/MerkleDistributor.sol
@@ -156,7 +156,7 @@ contract MerkleDistributor is Ownable {
                 merkleWindows[claims[nextI].windowIndex].rewardToken != currentRewardToken
                 // Next claim reward token is different than current one.
             ) {
-                merkleWindows[_claim.windowIndex].remainingAmount -= _claim.amount;
+                merkleWindows[_claim.windowIndex].remainingAmount -= batchedAmount;
                 currentRewardToken.safeTransfer(_claim.account, batchedAmount);
                 batchedAmount = 0;
             }

--- a/packages/core/test/merkle-distributor/MerkleDistributor.js
+++ b/packages/core/test/merkle-distributor/MerkleDistributor.js
@@ -640,8 +640,18 @@ describe("MerkleDistributor.js", function () {
         const underfundedBatchedClaims = [];
         const underfundedWindowIndex = rewardLeafs.length;
 
-        // Underfunded reward set recipients and amounts are same as for the first set.
-        rewardRecipients.push(createRewardRecipientsFromSampleData(SamplePayouts));
+        // Underfunded rewards set has amounts the same as for the first set, but all recipients are the same one
+        // address in order to check if remainingAmount is being tracked correctly.
+        const underfundedRewards = Object.keys(SamplePayouts.exampleRecipients).map(
+          (recipientAddress, i, recipients) => {
+            return {
+              account: recipients[0],
+              amount: SamplePayouts.exampleRecipients[recipientAddress],
+              accountIndex: i,
+            };
+          }
+        );
+        rewardRecipients.push(underfundedRewards);
 
         // Generate leafs for each recipient for the underfunded reward set.
         rewardLeafs.push(rewardRecipients[underfundedWindowIndex].map((item) => ({ ...item, leaf: createLeaf(item) })));


### PR DESCRIPTION

Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Paid out claims were not tracked correctly for batched claims.


**Summary**

`remainingAmount` is now reduced by the sum of batched claim amounts.


**Details**

Tests have been also modified to include the same recipient address for underfunded rewards set.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


