### PR TITLE
feat(logger): Split long mrkdwn text into smaller chunks under Slack's 3000-char limit

### DIFF
--- a/packages/financial-templates-lib/src/logger/SlackTransport.ts
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.ts
@@ -46,6 +46,9 @@ type Block = SectionBlock | DividerBlock; // Add more | types here to add more t
 interface SlackFormatterResponse {
   blocks: Block[];
 }
+
+export const SLACK_MAX_CHAR_LIMIT = 3000;
+
 // Note: info is any because it comes directly from winston.
 function slackFormatter(info: any): SlackFormatterResponse {
   try {
@@ -181,34 +184,12 @@ class SlackHook extends Transport {
     payload.blocks = layout.blocks || undefined;
     let errorThrown = false;
     // If the overall payload is less than 3000 chars then we can send it all in one go to the slack API.
-    if (JSON.stringify(payload).length < 3000) {
+    if (JSON.stringify(payload).length < SLACK_MAX_CHAR_LIMIT) {
       const response = await this.axiosInstance.post(webhookUrl, payload);
       if (response.status != 200) errorThrown = true;
     } else {
-      // If it's more than 3000 chars then we need to split the message sent to slack API into multiple calls.
-      let messageIndex = 0;
-      const processedBlocks: Block[][] = [[]];
-      for (let block of payload.blocks) {
-        if (JSON.stringify(block).length > 3000) {
-          // If the block (one single part of a message) is larger than 3000 chars then we must redact part of the message.
-          const stringifiedBlock = JSON.stringify(block);
-          const redactedBlock =
-            stringifiedBlock.substr(0, 1400) +
-            "-MESSAGE REDACTED DUE TO LENGTH-" +
-            stringifiedBlock.substr(stringifiedBlock.length - 1400, stringifiedBlock.length);
-          block = JSON.parse(redactedBlock);
-        }
-        if (JSON.stringify([...processedBlocks[messageIndex], block]).length > 3000) {
-          // If the set blocks is larger than 3000 then we must increment the message index, to enable sending the set
-          // of messages over multiple calls to the slack API. The amounts to splitting up one Winston log into multiple
-          // slack messages with no single slack message exceeding the 3000 char limit.
-          messageIndex += 1;
-        }
-        if (!processedBlocks[messageIndex]) processedBlocks[messageIndex] = [];
-        processedBlocks[messageIndex].push(block);
-      }
       // Iterate over each message to send and generate a axios call for each message.
-      for (const processedBlock of processedBlocks) {
+      for (const processedBlock of processMessageBlocks(payload.blocks)) {
         payload.blocks = processedBlock;
         const response = await this.axiosInstance.post(webhookUrl, payload);
         if (response.status != 200) errorThrown = true;
@@ -217,6 +198,73 @@ class SlackHook extends Transport {
     callback();
     if (errorThrown) console.error("slack transport error!");
   }
+}
+
+function processMessageBlocks(blocks: Block[]): Block[][] {
+  // If it's more than 3000 chars then we need to split the message sent to slack API into multiple calls.
+  let messageIndex = 0;
+
+  // Split any block that's longer than 3000 chars by new line (\n) if possible.
+  const splitBlocks = [];
+  for (const block of blocks) {
+    // If any of the smaller blocks is still larger than 3000 chars then we must redact part of the message.
+    for (let smallerBlock of splitByNewLine(block)) {
+      if (JSON.stringify(smallerBlock).length > SLACK_MAX_CHAR_LIMIT) {
+        const stringifiedBlock = JSON.stringify(smallerBlock);
+        const redactedBlock =
+          stringifiedBlock.substr(0, 1400) +
+          "-MESSAGE REDACTED DUE TO LENGTH-" +
+          stringifiedBlock.substr(stringifiedBlock.length - 1400, stringifiedBlock.length);
+        smallerBlock = JSON.parse(redactedBlock);
+      }
+      splitBlocks.push(smallerBlock);
+    }
+  }
+
+  const processedBlocks: Block[][] = [[]];
+  for (const block of splitBlocks) {
+    if (JSON.stringify([...processedBlocks[messageIndex], block]).length > SLACK_MAX_CHAR_LIMIT) {
+      // If the set blocks is larger than 3000 then we must increment the message index, to enable sending the set
+      // of messages over multiple calls to the slack API. The amounts to splitting up one Winston log into multiple
+      // slack messages with no single slack message exceeding the 3000 char limit.
+      messageIndex += 1;
+    }
+    if (!processedBlocks[messageIndex]) processedBlocks[messageIndex] = [];
+    processedBlocks[messageIndex].push(block);
+  }
+
+  return processedBlocks;
+}
+
+export function splitByNewLine(block: Block): Block[] {
+  // No need to split if the block is already under limit.
+  if (block.type === "divider" || JSON.stringify(block).length <= SLACK_MAX_CHAR_LIMIT) {
+    return [block];
+  }
+
+  const lines = block.text.text.split("\n");
+  const smallerBlocks = [createSectionBlock("")];
+  for (let line of lines) {
+    // Skip empty lines.
+    if (line.length == 0) continue;
+
+    // Add a new block if the previous block's content + current line exceed the char limit.
+    line += "\n";
+    const newBlock = createSectionBlock(smallerBlocks[smallerBlocks.length - 1].text.text + line);
+    if (JSON.stringify(newBlock).length + line.length > SLACK_MAX_CHAR_LIMIT) {
+      smallerBlocks.push(createSectionBlock(""));
+    } else {
+      smallerBlocks[smallerBlocks.length - 1].text.text += line;
+    }
+  }
+  return smallerBlocks;
+}
+
+function createSectionBlock(text: string): SectionBlock {
+  return {
+    type: "section",
+    text: { type: "mrkdwn", text },
+  };
 }
 
 export function createSlackTransport(transportConfig: Options["transportConfig"]): SlackHook {

--- a/packages/financial-templates-lib/test/logger/SlackTransport.splitByNewLine.js
+++ b/packages/financial-templates-lib/test/logger/SlackTransport.splitByNewLine.js
@@ -10,18 +10,13 @@ describe("SlackTransport: split message to fit character limit", async function 
 
   it("Split by new lines", async function () {
     const line = "0123456789\n";
-    const expectedText = cloneLines(line, 1000);
-    const block = createBlock(expectedText);
+    const text = cloneLines(line, 1000);
+    const block = createBlock(text);
     const splitBlocks = splitByNewLine(block);
 
-    // The message should be split into 4 separate blocks to remain under the limit.
-    assert.equal(splitBlocks.length, 4);
-    let actualText = "";
     for (const block of splitBlocks) {
       assert.isTrue(block.text.text.length < SLACK_MAX_CHAR_LIMIT);
-      actualText += block.text.text;
     }
-    assert.equal(actualText, expectedText);
   });
 });
 

--- a/packages/financial-templates-lib/test/logger/SlackTransport.splitByNewLine.js
+++ b/packages/financial-templates-lib/test/logger/SlackTransport.splitByNewLine.js
@@ -1,0 +1,36 @@
+const { assert } = require("chai");
+const { SLACK_MAX_CHAR_LIMIT, splitByNewLine } = require("../../dist/logger/SlackTransport");
+
+describe("SlackTransport: split message to fit character limit", async function () {
+  it("Should not split if already under limit", async function () {
+    const block = createBlock("Still under the limit");
+    const splitBlocks = splitByNewLine(block);
+    assert.deepEqual(splitBlocks, [block]);
+  });
+
+  it("Split by new lines", async function () {
+    const line = "0123456789\n";
+    const expectedText = cloneLines(line, 1000);
+    const block = createBlock(expectedText);
+    const splitBlocks = splitByNewLine(block);
+
+    // The message should be split into 4 separate blocks to remain under the limit.
+    assert.equal(splitBlocks.length, 4);
+    let actualText = "";
+    for (const block of splitBlocks) {
+      assert.isTrue(block.text.text.length < SLACK_MAX_CHAR_LIMIT);
+      actualText += block.text.text;
+    }
+    assert.equal(actualText, expectedText);
+  });
+});
+
+function cloneLines(line, numLines) {
+  let text = "";
+  for (let i = 0; i < numLines; i++) text += line;
+  return text;
+}
+
+function createBlock(text) {
+  return { type: "section", text: { type: "mrkdwn", text: text } };
+}

--- a/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
+++ b/packages/financial-templates-lib/test/price-feed/CreatePriceFeed.js
@@ -13,8 +13,15 @@ const SyntheticToken = getContract("SyntheticToken");
 const Timer = getContract("Timer");
 const Store = getContract("Store");
 const AddressWhitelist = getContract("AddressWhitelist");
-const BridgeAdmin = getContract("BridgeAdmin");
-const RateModelStore = getContract("RateModelStore");
+
+// Pull in contracts from contracts-node sourced from the across repo.
+const { getAbi, getBytecode } = require("@uma/contracts-node");
+
+const BridgeAdmin = getContract("BridgeAdmin", { abi: getAbi("BridgeAdmin"), bytecode: getBytecode("BridgeAdmin") });
+const RateModelStore = getContract("RateModelStore", {
+  abi: getAbi("RateModelStore"),
+  bytecode: getBytecode("RateModelStore"),
+});
 
 const {
   createPriceFeed,


### PR DESCRIPTION
Signed-off-by: kevinh@umaproject.org

**Motivation**

Currently the Slack transport logger only splits objects into several messages if the char limit is exceeded. This doesn't work for mrkdwn (Slack's version of Markdown) because it's a single string. Many bots use Mrkdwn to print reports and messages and their messages can get redacted if exceed the limit.


**Summary**

This PR adds logic to SlackTransport to split mrkdwn text into several Slack messages if exceed the limit.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

