### PR TITLE
feat(dvm-response-publisher): add dvm response publisher bot

### DIFF
--- a/packages/dvm-response-publisher/README.md
+++ b/packages/dvm-response-publisher/README.md
@@ -1,0 +1,8 @@
+listen for `PriceRequestAdded` events from the `Voting` contract https://github.com/UMAprotocol/protocol/blob/9fabd6cd7d2f1d0508199f779f64957f950c5f42/packages/core/contracts/oracle/implementation/Voting.sol#L287
+
+determine if the price has been added with the `hasPrice` method in the `Voting` contract https://github.com/UMAprotocol/protocol/blob/9fabd6cd7d2f1d0508199f779f64957f950c5f42/packages/core/contracts/oracle/implementation/Voting.sol#L304
+
+call `publishPrice` in the `OracleHub` contract https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/cross-chain-oracle/OracleHub.sol#L72
+
+call `stampAncillaryData` in the `OracleSpoke` contract https://github.com/UMAprotocol/protocol/blob/e703fead223c1b5a43bba6d976bc66f8c469d314/packages/core/contracts/cross-chain-oracle/OracleSpoke.sol#L160
+

--- a/packages/dvm-response-publisher/index.ts
+++ b/packages/dvm-response-publisher/index.ts
@@ -1,0 +1,40 @@
+import Web3 from "web3";
+import type { EventData } from "web3-eth-contract";
+// import type { VotingWeb3, OracleHubWeb3, OracleSpokeWeb3 } from "@uma/contracts-node";
+import { getAbi, getAddress } from "@uma/contracts-node";
+import "dotenv/config";
+// import Logger from "@uma/financial-templates-lib";
+
+run();
+
+async function run() {
+  const NETWORK = "mainnet";
+  const CHAIN_ID = 1;
+  const web3 = new Web3(`https://${NETWORK}.infura.io/v3/${process.env.INFURA_ID}`);
+  // voting
+  const VOTING_ABI = getAbi("Voting");
+  const VOTING_ADDRESS = await getAddress("Voting", CHAIN_ID);
+  const voting = new web3.eth.Contract(VOTING_ABI, VOTING_ADDRESS);
+
+  // const ORACLE_HUB_ABI = getAbi("OracleHub");
+  // const ORACLE_HUB_ADDRESS = await getAddress("OracleHub", CHAIN_ID);
+  // const oracleHub = new web3.eth.Contract(ORACLE_HUB_ABI, ORACLE_HUB_ADDRESS);
+
+  // const ORACLE_SPOKE_ABI = getAbi("OracleSpoke");
+  // const ORACLE_SPOKE_ADDRESS = await getAddress("OracleSpoke", 10);
+  // const oracleSpoke = new web3.eth.Contract(ORACLE_SPOKE_ABI, ORACLE_SPOKE_ADDRESS);
+
+  const priceRequestEvents = await voting.getPastEvents("PriceRequestAdded", {
+    fromBlock: 0,
+    toBlock: "latest",
+  });
+
+  console.log(priceRequestEvents.map(getReturnValues));
+}
+
+function getReturnValues(event: EventData) {
+  console.log(event.returnValues);
+  const { identifier, time } = event.returnValues;
+
+  return { identifier, time };
+}

--- a/packages/dvm-response-publisher/package.json
+++ b/packages/dvm-response-publisher/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@uma/dvm-response-publisher-bot",
+  "version": "0.0.0",
+  "description": "A bot for pushing DVM responses back to spoke (L1) chains",
+  "dependencies": {
+    "@uma/common": "^2.20.0",
+    "@uma/contracts-node": "^0.3.7",
+    "@uma/financial-templates-lib": "^2.27.4",
+    "dotenv": "^8.2.0"
+  },
+  "devDependencies": {
+    "@tsconfig/node14": "^1.0.0",
+    "@types/node": "^14.14.25",
+    "ts-node": "^10.1.0"
+  },
+  "homepage": "https://umaproject.org",
+  "license": "AGPL-3.0-or-later",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UMAprotocol/protocol.git"
+  },
+  "files": [
+    "/dist/**/*.js"
+  ],
+  "bin": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "build": "tsc -b",
+    "start": "ts-node index.ts"
+  },
+  "bugs": {
+    "url": "https://github.com/UMAprotocol/protocol/issues"
+  }
+}


### PR DESCRIPTION
**Motivation**

We need a bot which ensures that added price requests have published prices. This bot queries past `PriceRequestAdded` events in the `Voting` contract and checks for ones that do not have a price by calling the `hasPrice` method of the `Voting` contract. When a request with a missing price is discovered, the bot calls the `publishPrice` method on the `OracleHub` contract with that price request's identifier.


**Summary**

* Add a new package with an implementation of the bot described above.


**Details**

**NB:** after discussion with @chrismaree, we have decided to pause this task until the contract interfaces for DVM v2 are available. Our reasoning is that the `hasPrice` and `publishPrice` methods require `ancillaryData` as an argument (along with `identifier` and `timestamp`) and unfortunately, the existing contract does not pass along this ancillary data when emitting the `PriceRequestAdded` event. While we could have devised a complicated solution to get this data, we concluded that this would be a waste of time, because the DVM v2 contracts have been updated to pass along the ancillary data when firing the event. We would therefore have to go back and change the solution to take this into account.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

