### PR TITLE
fix(logger): Update slack transport logic to not skip one line when breaking a multi-line message into multiple messages

### DIFF
--- a/packages/financial-templates-lib/src/logger/SlackTransport.ts
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.ts
@@ -252,7 +252,7 @@ export function splitByNewLine(block: Block): Block[] {
     line += "\n";
     const newBlock = createSectionBlock(smallerBlocks[smallerBlocks.length - 1].text.text + line);
     if (JSON.stringify(newBlock).length + line.length > SLACK_MAX_CHAR_LIMIT) {
-      smallerBlocks.push(createSectionBlock(""));
+      smallerBlocks.push(createSectionBlock(line));
     } else {
       smallerBlocks[smallerBlocks.length - 1].text.text += line;
     }

--- a/packages/financial-templates-lib/test/logger/SlackTransport.splitByNewLine.js
+++ b/packages/financial-templates-lib/test/logger/SlackTransport.splitByNewLine.js
@@ -10,13 +10,16 @@ describe("SlackTransport: split message to fit character limit", async function 
 
   it("Split by new lines", async function () {
     const line = "0123456789\n";
-    const text = cloneLines(line, 1000);
-    const block = createBlock(text);
+    const expectedContent = cloneLines(line, 1000);
+    const block = createBlock(expectedContent);
     const splitBlocks = splitByNewLine(block);
 
+    let content = "";
     for (const block of splitBlocks) {
+      content += block.text.text;
       assert.isTrue(block.text.text.length < SLACK_MAX_CHAR_LIMIT);
     }
+    assert.equal(content, expectedContent);
   });
 });
 


### PR DESCRIPTION
**Motivation**

When a multi-line message is broken into multiple messages to fit Slack's length limit, currently, the Slack transport logic would skip the first line of a new message. This issue is fixed in this PR.

Live test result: https://risklabs.slack.com/archives/C03GT3LE78E/p1656264890397689

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

