### PR TITLE
feat(pf-configs): Add default price feed configs for ETHDOM and USDTDOM

### DIFF
--- a/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
+++ b/packages/financial-templates-lib/src/price-feed/DefaultPriceFeedConfigs.ts
@@ -337,6 +337,8 @@ export const defaultConfigs: { [name: string]: { type: string; [key: string]: an
   },
   BTCDOM: { type: "domfi", pair: "BTCDOM", minTimeBetweenUpdates: 60, lookback: 7200 },
   ALTDOM: { type: "domfi", pair: "ALTDOM", minTimeBetweenUpdates: 60, lookback: 7200 },
+  ETHDOM: { type: "domfi", pair: "ETHDOM", minTimeBetweenUpdates: 60, lookback: 7200 },
+  USDTDOM: { type: "domfi", pair: "USDTDOM", minTimeBetweenUpdates: 60, lookback: 7200 },
   AMPLUSD: {
     type: "medianizer",
     lookback: 7200,


### PR DESCRIPTION
**Motivation**

ETHDOM and USDTDOM need default price feed configs as they are used by LSP contracts.

**Summary**

Adds ETHDOM and USDTDOM pf configs to default price feed config file.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
