### PR TITLE
feat(sdk)!: add skinny oo client and separate factories

### DIFF
--- a/packages/sdk/src/clients/bridgeDepositBox/client.e2e.ts
+++ b/packages/sdk/src/clients/bridgeDepositBox/client.e2e.ts
@@ -1,3 +1,0 @@
-describe("BridgeDepositBox", function () {
-  // TODO: add e2e tests once contract is available
-});

--- a/packages/sdk/src/clients/bridgePool/client.e2e.ts
+++ b/packages/sdk/src/clients/bridgePool/client.e2e.ts
@@ -1,3 +1,0 @@
-describe("BridgePool", function () {
-  // TODO: add e2e tests once contract is available
-});

--- a/packages/sdk/src/clients/optimisticOracle/client.ts
+++ b/packages/sdk/src/clients/optimisticOracle/client.ts
@@ -47,7 +47,7 @@ export type Request = RequestKey &
     refundOnDispute: boolean;
     proposedPrice: BigNumber;
     resolvedPrice: BigNumber;
-    expirationTimestamp: BigNumber;
+    expirationTime: BigNumber;
     reward: BigNumber;
     finalFee: BigNumber;
     bond: BigNumber;
@@ -124,7 +124,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         currency,
         proposer,
         proposedPrice,
-        expirationTimestamp,
+        expirationTime: expirationTimestamp,
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,

--- a/packages/sdk/src/clients/rateModelStore/client.e2e.ts
+++ b/packages/sdk/src/clients/rateModelStore/client.e2e.ts
@@ -1,3 +1,0 @@
-describe("RateModelStore", function () {
-  // TODO:
-});

--- a/packages/sdk/src/oracle/README.md
+++ b/packages/sdk/src/oracle/README.md
@@ -40,8 +40,8 @@ const config:PartialConfig = {
 // this starts both a skinny and optimistic oracle, you have to make sure to omit the oracle address
 // in the config to let them auto populate, or make sure you set the addresses differently for each type
 const configTable = {
-  [oracle.types.state.OracleType.Optimistic]:config,
-  [oracle.types.state.OracleType.Skinny]:config,
+  [oracle.types.state.OracleType.Optimistic]: config,
+  [oracle.types.state.OracleType.Skinny]: config,
 }
 
 const state = {

--- a/packages/sdk/src/oracle/factory.ts
+++ b/packages/sdk/src/oracle/factory.ts
@@ -1,0 +1,28 @@
+import assert from "assert";
+import { SortedRequests } from "./services/sortedRequests";
+import { ClientTable } from "./types/interfaces";
+import { State, OracleType, PartialConfigTable } from "./types/state";
+import { Emit } from "./store";
+import SkinnyFactory from "./skinnyFactory";
+import OptimisticFactory from "./optimisticFactory";
+
+export type PublicEmit = (oracleType: OracleType, state: State, prev: State) => void;
+const EventHandler = (oracleType: OracleType, publicEmit: PublicEmit): Emit => (state: State, prev: State) =>
+  publicEmit(oracleType, state, prev);
+
+export default (configTable: PartialConfigTable, emit: PublicEmit): ClientTable => {
+  const sortedRequests = new SortedRequests();
+  return Object.fromEntries(
+    Object.entries(configTable).map(([oracleType, config]) => {
+      assert(config, "requires config for type: " + oracleType);
+      switch (oracleType) {
+        case OracleType.Optimistic:
+          return [oracleType, OptimisticFactory(config, EventHandler(oracleType, emit), sortedRequests)];
+        case OracleType.Skinny:
+          return [oracleType, SkinnyFactory(config, EventHandler(oracleType, emit), sortedRequests)];
+        default:
+          throw new Error("Unknown oracle type: " + oracleType);
+      }
+    })
+  );
+};

--- a/packages/sdk/src/oracle/index.ts
+++ b/packages/sdk/src/oracle/index.ts
@@ -4,3 +4,6 @@ export * as types from "./types";
 export * as store from "./store";
 export * as utils from "./utils";
 export * as errors from "./errors";
+export { default as skinnyFactory } from "./skinnyFactory";
+export { default as optimisticFactory } from "./optimisticFactory";
+export { default as factory } from "./factory";

--- a/packages/sdk/src/oracle/optimisticFactory.ts
+++ b/packages/sdk/src/oracle/optimisticFactory.ts
@@ -1,0 +1,18 @@
+import { Client, factory } from "./client";
+import { OptimisticOracle, getOptimisticOracleAddress } from "./services/optimisticOracle";
+import { SortedRequests } from "./services/sortedRequests";
+import { DefaultConfig, getMulticall2Address } from "./utils";
+import { state } from "./types";
+import { Emit } from "./store";
+
+export default (
+  config: state.PartialConfig,
+  emit: Emit,
+  sortedRequests: SortedRequests = new SortedRequests()
+): Client => {
+  const fullConfig = DefaultConfig({
+    getMulticall2Address,
+    getOptimisticOracleAddress,
+  })({ ...config }, state.OracleType.Optimistic);
+  return factory(fullConfig, emit, OptimisticOracle, sortedRequests);
+};

--- a/packages/sdk/src/oracle/services/index.ts
+++ b/packages/sdk/src/oracle/services/index.ts
@@ -2,3 +2,4 @@ export * as erc20 from "./erc20";
 export * as optimisticOracle from "./optimisticOracle";
 export * as statemachines from "./statemachines";
 export * as sortedRequests from "./sortedRequests";
+export * as skinnyOptimisticOracle from "./skinnyOptimisticOracle";

--- a/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
@@ -58,7 +58,7 @@ function validateSolidityRequest(request: Request): SolidityRequest {
   };
 }
 
-export class OptimisticOracle implements OracleInterface {
+export class SkinnyOptimisticOracle implements OracleInterface {
   private readonly contract: optimisticOracle.Instance;
   private readonly events: OptimisticOracleEvent[] = [];
   private requests: Record<string, Request> = {};

--- a/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
@@ -1,40 +1,61 @@
-import { optimisticOracle } from "../../clients";
+import assert from "assert";
+import { skinnyOptimisticOracle as optimisticOracle } from "../../clients";
 import { BigNumberish, Provider, Signer, TransactionResponse, Log, TransactionReceipt } from "../types/ethers";
 import type { OracleInterface, RequestKey, OracleProps, Request } from "../types/interfaces";
 import { requestId, insertOrderedAscending, eventKey, isUnique, getAddress } from "../utils";
 
-import { RequestPrice, ProposePrice, DisputePrice, Settle } from "../../clients/optimisticOracle";
+import {
+  RequestPrice,
+  ProposePrice,
+  DisputePrice,
+  Settle,
+  SolidityRequest,
+} from "../../clients/skinnyOptimisticOracle";
 
 export type OptimisticOracleEvent = RequestPrice | ProposePrice | DisputePrice | Settle;
 
 export type { RequestPrice, ProposePrice, DisputePrice, Settle };
 
-// this had to be copied in because interfaces in contracts-frontend and contracts-node are different
-// The frontend cant use contracts-node because async calls are required for addresses, when testing in node
-// we arent able to import contracts-frontend.
 export function getOptimisticOracleAddress(chainId: number): string {
   switch (chainId.toString()) {
     case "1":
-      return getAddress("0xc43767f4592df265b4a9f1a398b97ff24f38c6a6");
+      return getAddress("0xeE3Afe347D5C74317041E2618C49534dAf887c24");
     case "4":
-      return getAddress("0x3746badD4d6002666dacd5d7bEE19f60019A8433");
-    case "10":
-      return getAddress("0x56e2d1b8C7dE8D11B282E1b4C924C32D91f9102B");
+      return getAddress("0xAbE04Ace666294aefD65F991d78CE9F9218aFC67");
     case "42":
       return getAddress("0xB1d3A89333BBC3F5e98A991d6d4C1910802986BC");
     case "100":
-      return getAddress("0xd2ecb3afe598b746F8123CaE365a598DA831A449");
-    case "137":
-      return getAddress("0xBb1A8db2D4350976a11cdfA60A1d43f97710Da49");
-    case "288":
-      return getAddress("0x7da554228555C8Bf3748403573d48a2138C6b848");
-    case "42161":
-      return getAddress("0x031A7882cE3e8b4462b057EBb0c3F23Cd731D234");
-    case "80001":
-      return getAddress("0xAB75727d4e89A7f7F04f57C00234a35950527115");
+      return getAddress("0xAa04b5D40574Fb8C001249B24d1c6B35a207F0bD");
     default:
-      throw new Error(`No address found for deployment OptimisticOracle on chainId ${chainId}`);
+      throw new Error(`No address found for deployment Skinny Optimistic Oracle on chainId ${chainId}`);
   }
+}
+
+function validateSolidityRequest(request: Request): SolidityRequest {
+  assert(request.proposer, "Missing proposer");
+  assert(request.disputer, "Missing disputer");
+  assert(request.currency, "Missing currency");
+  assert(request.settled, "Missing settled");
+  assert(request.proposedPrice, "Missing proposedPrice");
+  assert(request.resolvedPrice, "Missing resolvedPrice");
+  assert(request.expirationTime, "Missing expirationTime");
+  assert(request.reward, "Missing reward");
+  assert(request.finalFee, "Missing finalFee");
+  assert(request.bond, "Missing bond");
+  assert(request.customLiveness, "Missing customLiveness");
+  return {
+    proposer: request.proposer,
+    disputer: request.disputer,
+    currency: request.currency,
+    settled: request.settled,
+    proposedPrice: request.proposedPrice,
+    resolvedPrice: request.resolvedPrice,
+    expirationTime: request.expirationTime,
+    reward: request.reward,
+    finalFee: request.finalFee,
+    bond: request.bond,
+    customLiveness: request.customLiveness,
+  };
 }
 
 export class OptimisticOracle implements OracleInterface {
@@ -78,10 +99,9 @@ export class OptimisticOracle implements OracleInterface {
     const { requests = {} } = optimisticOracle.getEventState(this.events);
     Object.values(requests).map((request) => this.upsertRequest(request));
   };
-  async fetchRequest({ requester, identifier, timestamp, ancillaryData }: RequestKey): Promise<Request> {
-    const request = await this.contract.callStatic.getRequest(requester, identifier, timestamp, ancillaryData);
-    const state = await this.contract.callStatic.getState(requester, identifier, timestamp, ancillaryData);
-    return this.upsertRequest({ ...request, state, requester, identifier, timestamp, ancillaryData });
+  async fetchRequest(key: RequestKey): Promise<Request> {
+    // skinny oo does not have a way to query request data from contract, can only find this though events.
+    return this.getRequest(key);
   }
 
   getRequest(key: RequestKey): Request {
@@ -93,8 +113,9 @@ export class OptimisticOracle implements OracleInterface {
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey
   ): Promise<TransactionResponse> {
+    const request = validateSolidityRequest(this.getRequest({ requester, identifier, timestamp, ancillaryData }));
     const contract = optimisticOracle.connect(this.address, signer);
-    const tx = await contract.disputePrice(requester, identifier, timestamp, ancillaryData);
+    const tx = await contract.disputePrice(requester, identifier, timestamp, ancillaryData, request);
     this.setDisputeHash({ requester, identifier, timestamp, ancillaryData }, tx.hash);
     return tx;
   }
@@ -103,8 +124,9 @@ export class OptimisticOracle implements OracleInterface {
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
     price: BigNumberish
   ): Promise<TransactionResponse> {
+    const request = validateSolidityRequest(this.getRequest({ requester, identifier, timestamp, ancillaryData }));
     const contract = optimisticOracle.connect(this.address, signer);
-    const tx = await contract.proposePrice(requester, identifier, timestamp, ancillaryData, price);
+    const tx = await contract.proposePrice(requester, identifier, timestamp, ancillaryData, request, price);
     this.setProposeHash({ requester, identifier, timestamp, ancillaryData }, tx.hash);
     return tx;
   }
@@ -112,8 +134,9 @@ export class OptimisticOracle implements OracleInterface {
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey
   ): Promise<TransactionResponse> {
+    const request = validateSolidityRequest(this.getRequest({ requester, identifier, timestamp, ancillaryData }));
     const contract = optimisticOracle.connect(this.address, signer);
-    const tx = await contract.settle(requester, identifier, timestamp, ancillaryData);
+    const tx = await contract.settle(requester, identifier, timestamp, ancillaryData, request);
     this.setSettleHash({ requester, identifier, timestamp, ancillaryData }, tx.hash);
     return tx;
   }

--- a/packages/sdk/src/oracle/services/sortedRequests.ts
+++ b/packages/sdk/src/oracle/services/sortedRequests.ts
@@ -1,11 +1,12 @@
+// this is a special service that works across all oracles type, chains, etc, to give a combined
+// view of all requests across running instances.
 import sortedIndex from "lodash/sortedIndex";
 import sortedLastIndex from "lodash/sortedLastIndex";
 
 import { exists } from "../../utils";
 import { requestId } from "../utils";
 
-import { Request, Requests } from "../types/interfaces";
-import { InputRequest } from "../types/state";
+import { InputRequestWithOracleType, RequestWithOracleType, RequestsWithOracleType } from "../types/state";
 
 // this was copied out of store and made to be 1. a class, and 2. sync.  Could not modify old implementation since
 // other services rely on this currently and it causes cascading refactors. This has been copied without modification to logic.
@@ -83,22 +84,22 @@ export class SortedStore<Id, Data> {
 }
 
 // this sorts requests across all chains and oracles
-export class SortedRequests extends SortedStore<string, Request> {
-  setByRequest(value: InputRequest): void {
+export class SortedRequests extends SortedStore<string, RequestWithOracleType> {
+  setByRequest(value: InputRequestWithOracleType): void {
     return this.set(this.id(value), value);
   }
-  descending(): Requests {
+  descending(): RequestsWithOracleType {
     // sadly you cannot control lodash sorting descending, so reverse is necessary
     return this.values().reverse();
   }
-  ascending(): Requests {
+  ascending(): RequestsWithOracleType {
     return this.values();
   }
-  getByRequest(request: InputRequest): Request {
+  getByRequest(request: InputRequestWithOracleType): RequestWithOracleType {
     // always return at least the original query data
     return this.get(this.id(request)) || request;
   }
-  id(request: InputRequest): string {
-    return requestId(request) + "!" + request.chainId;
+  id(request: InputRequestWithOracleType): string {
+    return requestId(request) + "!" + request.chainId + "!" + request.oracleType;
   }
 }

--- a/packages/sdk/src/oracle/services/tests/skinnyOracle.e2e.ts
+++ b/packages/sdk/src/oracle/services/tests/skinnyOracle.e2e.ts
@@ -1,0 +1,38 @@
+import dotenv from "dotenv";
+import assert from "assert";
+import { ethers } from "ethers";
+import { Provider } from "@ethersproject/providers";
+import { OptimisticOracle, getOptimisticOracleAddress } from "../skinnyOptimisticOracle";
+
+dotenv.config();
+
+// mainnet test only
+const ooAddress = getOptimisticOracleAddress(1);
+const request = {
+  requester: "0x7355Efc63Ae731f584380a9838292c7046c1e433",
+  identifier: "0x49535f52454c41595f56414c4944000000000000000000000000000000000000",
+  timestamp: 1654874916,
+  ancillaryData:
+    "0x72656c6179486173683a30313634323935643530393533613431323231363131343761623233303231343166306438636132613730373461303733373537626631626365656165663739",
+};
+
+describe("Skinny Oracle Service", function () {
+  let provider: Provider;
+  let oo: OptimisticOracle;
+  beforeAll(async () => {
+    provider = ethers.getDefaultProvider(process.env.CUSTOM_NODE_URL, 1);
+    oo = new OptimisticOracle(provider, ooAddress, 1);
+  });
+  test("update", async function () {
+    await oo.update();
+  });
+  test("getProps", async function () {
+    const result = await oo.getProps();
+    assert.ok(result.defaultLiveness);
+  });
+  test("getRequest", async function () {
+    const result = await oo.getRequest(request);
+    assert.ok(result);
+    assert.equal(result.state, 6);
+  });
+});

--- a/packages/sdk/src/oracle/skinnyFactory.ts
+++ b/packages/sdk/src/oracle/skinnyFactory.ts
@@ -1,5 +1,5 @@
 import { Client, factory } from "./client";
-import { OptimisticOracle, getOptimisticOracleAddress } from "./services/skinnyOptimisticOracle";
+import { SkinnyOptimisticOracle, getOptimisticOracleAddress } from "./services/skinnyOptimisticOracle";
 import { SortedRequests } from "./services/sortedRequests";
 import { DefaultConfig, getMulticall2Address } from "./utils";
 import { state } from "./types";
@@ -14,5 +14,5 @@ export default (
     getMulticall2Address,
     getOptimisticOracleAddress,
   })({ ...config }, state.OracleType.Skinny);
-  return factory(fullConfig, emit, OptimisticOracle, sortedRequests);
+  return factory(fullConfig, emit, SkinnyOptimisticOracle, sortedRequests);
 };

--- a/packages/sdk/src/oracle/skinnyFactory.ts
+++ b/packages/sdk/src/oracle/skinnyFactory.ts
@@ -1,0 +1,18 @@
+import { Client, factory } from "./client";
+import { OptimisticOracle, getOptimisticOracleAddress } from "./services/skinnyOptimisticOracle";
+import { SortedRequests } from "./services/sortedRequests";
+import { DefaultConfig, getMulticall2Address } from "./utils";
+import { state } from "./types";
+import { Emit } from "./store";
+
+export default (
+  config: state.PartialConfig,
+  emit: Emit,
+  sortedRequests: SortedRequests = new SortedRequests()
+): Client => {
+  const fullConfig = DefaultConfig({
+    getMulticall2Address,
+    getOptimisticOracleAddress,
+  })({ ...config }, state.OracleType.Skinny);
+  return factory(fullConfig, emit, OptimisticOracle, sortedRequests);
+};

--- a/packages/sdk/src/oracle/store/read.ts
+++ b/packages/sdk/src/oracle/store/read.ts
@@ -1,6 +1,16 @@
 import filter from "lodash/filter";
 
-import type { State, Chain, InputRequest, Erc20Props, ChainConfig, Context, Memory, User } from "../types/state";
+import type {
+  State,
+  Chain,
+  InputRequest,
+  Erc20Props,
+  ChainConfig,
+  Context,
+  Memory,
+  User,
+  OracleType,
+} from "../types/state";
 import type { JsonRpcSigner, BigNumber, Provider } from "../types/ethers";
 import { TransactionConfirmer, requestId } from "../utils";
 import { OracleInterface, Request, Requests } from "../types/interfaces";
@@ -19,6 +29,11 @@ export default class Read {
     const config = this.state?.config?.chains?.[chainId];
     assertExists(config, "No config set for chain: " + chainId);
     return config;
+  };
+  oracleType = (): OracleType => {
+    const source = this.state?.config?.oracleType;
+    assertExists(source, "No oracle name set on config");
+    return source;
   };
   requestChainId = (): number => {
     const chainId = this.state?.inputs?.request?.chainId;
@@ -165,10 +180,6 @@ export default class Read {
   };
   descendingRequests = (): Requests => {
     return this.state.descendingRequests || [];
-  };
-  findRequest = (query: InputRequest): Request | undefined => {
-    const sortedRequestService = this.sortedRequestsService();
-    return sortedRequestService.getByRequest(query);
   };
   filterRequests = (query: Partial<Request>): Requests => {
     return filter(this.descendingRequests(), query);

--- a/packages/sdk/src/oracle/store/write.ts
+++ b/packages/sdk/src/oracle/store/write.ts
@@ -160,10 +160,10 @@ export default class Write {
     if (!this.state.commands) this.state.commands = {};
     this.state.commands[context.id] = context;
   }
-  sortedRequestsService(): void {
+  sortedRequestsService(sortedRequests: SortedRequests): void {
     if (this.state?.services?.sortedRequests) return;
     // only want to add this once
-    this.state.services = { sortedRequests: new SortedRequests() };
+    this.state.services = { sortedRequests };
   }
   descendingRequests(sortedRequests: Requests): void {
     this.state.descendingRequests = sortedRequests;

--- a/packages/sdk/src/oracle/types/interfaces.ts
+++ b/packages/sdk/src/oracle/types/interfaces.ts
@@ -1,5 +1,7 @@
-import { BigNumberish, BigNumber, Signer, TransactionResponse, TransactionReceipt } from "../types/ethers";
+import { BigNumberish, BigNumber, Signer, TransactionResponse, TransactionReceipt, Provider } from "../types/ethers";
 import { RequestState, RequestKey, Request as RequestFromEvent } from "../../clients/optimisticOracle";
+import { Client } from "../client";
+import { OracleType } from "../types/state";
 
 export { RequestState, RequestKey };
 
@@ -9,6 +11,10 @@ export interface OracleProps {
 
 export type Request = RequestFromEvent & { chainId: number };
 export type Requests = Request[];
+
+export interface NewOracle {
+  new (provider: Provider, address: string, chainId: number): OracleInterface;
+}
 
 export interface OracleInterface {
   // u se this to query on chain for request data given the key.
@@ -23,3 +29,7 @@ export interface OracleInterface {
   getProps: () => Promise<OracleProps>;
   listRequests: () => Requests;
 }
+
+export type ClientTable = {
+  [key in OracleType]?: Client;
+};

--- a/packages/sdk/src/oracle/types/state.ts
+++ b/packages/sdk/src/oracle/types/state.ts
@@ -47,21 +47,32 @@ export type ChainConfig = ChainMetadata & {
   maxEventRangeQuery?: number;
 };
 
+export type InputRequestWithOracleType = InputRequest & { oracleType: OracleType };
+export type RequestWithOracleType = Request & { oracleType: OracleType };
+export type RequestsWithOracleType = RequestWithOracleType[];
 // partial config lets user omit some fields which we can infer internally using contracts-frontend
 export type PartialChainConfig = PartialBy<
   ChainConfig,
   "optimisticOracleAddress" | "chainId" | "checkTxIntervalSec" | "earliestBlockNumber"
 >;
 
+export enum OracleType {
+  Optimistic = "Optimistic",
+  Skinny = "Skinny",
+}
 // config definition
 export type Config = {
   chains: Record<number, ChainConfig>;
+  oracleType: OracleType;
 };
 
 export type PartialConfig = {
   chains: Record<number, PartialChainConfig>;
 };
 
+export type PartialConfigTable = {
+  [key in OracleType]?: PartialConfig;
+};
 export type Balances = Record<string, BigNumber>;
 
 export type User = {

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -15,6 +15,7 @@ import {
   PartialConfig,
   ChainMetadata,
   Config,
+  OracleType,
 } from "./types/state";
 import type { Provider, TransactionReceipt, BigNumberish } from "./types/ethers";
 import { ContextType } from "./types/statemachine";
@@ -98,34 +99,6 @@ export function getFlags(state: State): Record<Flag, boolean> {
   return flags;
 }
 
-// this had to be copied in because interfaces in contracts-frontend and contracts-node are different
-// The frontend cant use contracts-node because async calls are required for addresses, when testing in node
-// we arent able to import contracts-frontend.
-export function getOptimisticOracleAddress(chainId: number): string {
-  switch (chainId.toString()) {
-    case "1":
-      return getAddress("0xc43767f4592df265b4a9f1a398b97ff24f38c6a6");
-    case "4":
-      return getAddress("0x3746badD4d6002666dacd5d7bEE19f60019A8433");
-    case "10":
-      return getAddress("0x56e2d1b8C7dE8D11B282E1b4C924C32D91f9102B");
-    case "42":
-      return getAddress("0xB1d3A89333BBC3F5e98A991d6d4C1910802986BC");
-    case "100":
-      return getAddress("0xd2ecb3afe598b746F8123CaE365a598DA831A449");
-    case "137":
-      return getAddress("0xBb1A8db2D4350976a11cdfA60A1d43f97710Da49");
-    case "288":
-      return getAddress("0x7da554228555C8Bf3748403573d48a2138C6b848");
-    case "42161":
-      return getAddress("0x031A7882cE3e8b4462b057EBb0c3F23Cd731D234");
-    case "80001":
-      return getAddress("0xAB75727d4e89A7f7F04f57C00234a35950527115");
-    default:
-      throw new Error(`No address found for deployment OptimisticOracle on chainId ${chainId}`);
-  }
-}
-
 export function getMulticall2Address(chainId: number): string {
   switch (chainId.toString()) {
     case "1":
@@ -140,8 +113,16 @@ export function getMulticall2Address(chainId: number): string {
       throw new Error(`No address found for deployment Multicall2 on chainId ${chainId}`);
   }
 }
+type AddressGetter = (chainId: number) => string;
+interface AddressGetters {
+  getMulticall2Address: AddressGetter;
+  getOptimisticOracleAddress: AddressGetter;
+}
 
-export function defaultChainConfig(chainId: number, chainConfig: PartialChainConfig): ChainConfig {
+export const DefaultChainConfig = ({ getMulticall2Address, getOptimisticOracleAddress }: AddressGetters) => (
+  chainId: number,
+  chainConfig: PartialChainConfig
+): ChainConfig => {
   let multicall2Address = chainConfig.multicall2Address;
   try {
     multicall2Address = multicall2Address || getMulticall2Address(chainId);
@@ -160,17 +141,17 @@ export function defaultChainConfig(chainId: number, chainConfig: PartialChainCon
     optimisticOracleAddress,
     checkTxIntervalSec,
   };
-}
+};
 
-export function defaultConfig(config: PartialConfig): Config {
+export const DefaultConfig = (getters: AddressGetters) => (config: PartialConfig, oracleType: OracleType): Config => {
   return Object.entries(config.chains).reduce(
     (config: Config, [chainId, chainConfig]) => {
-      config.chains[Number(chainId)] = defaultChainConfig(Number(chainId), chainConfig);
+      config.chains[Number(chainId)] = DefaultChainConfig(getters)(Number(chainId), chainConfig);
       return config;
     },
-    { chains: {} }
+    { ...config, chains: {}, oracleType }
   );
-}
+};
 
 export class TransactionConfirmer {
   constructor(private provider: Provider) {}
@@ -342,4 +323,8 @@ export function isUnique<T>(array: T[], element: T, id: (element: T) => string |
     return id(next) === elementId;
   });
   return found === undefined;
+}
+
+export function isSupportedOracleType(oracleType: string): oracleType is OracleType {
+  return oracleType in OracleType;
 }


### PR DESCRIPTION
BREAKING CHANGE: instantiating oracle client now requires passing configs keyed by optimistic or skinny oracle types

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We want to add skinny oo to the oracle client


**Summary**

This makes the required changes to support the skinny oo, mainly this is adding the skinny stateful client and adding a new factory function to allow user to create clients of multiple types. docs are also updated.  THis is a breaking change, and changes are tested on the OO UI frontend, there will need to be a new PR on the FE to integrate these changes.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested



