### PR TITLE
feat: add script to register oo in side chains with admin child

### DIFF
--- a/packages/scripts/src/admin-proposals/adminChildRegistration.ts
+++ b/packages/scripts/src/admin-proposals/adminChildRegistration.ts
@@ -1,0 +1,112 @@
+// This script generates and submits an upgrade transaction to add/upgrade the optimistic oracle in the DVM in
+// the mainnet and layer 2 blockchains. It can be run on a local hardhat node fork of the mainnet or can be run
+// directly on the mainnet to execute the upgrade transactions.
+// To run this on the localhost first fork mainnet into a local hardhat node by running:
+// HARDHAT_CHAIN_ID=1 yarn hardhat node --fork https://mainnet.infura.io/v3/<YOUR-INFURA-KEY> --port 9545 --no-deploy
+// Then execute the script:
+// OPTIMISTIC_ORACLE_V2_10=<OPTIMISM-OOV2-ADDRESS> \
+// NODE_URL_10=<OPTIMISM-NODE-URL> \
+// \
+// OPTIMISTIC_ORACLE_V2_288=<BOBA-OOV2-ADDRESS> \
+// NODE_URL_288=<OPTIMISM-NODE-URL> \
+// \
+// OPTIMISTIC_ORACLE_V2_137=<POLYGON-OOV2-ADDRESS> \
+// NODE_URL_137=<OPTIMISM-NODE-URL> \
+// \
+// OPTIMISTIC_ORACLE_V2_42161=<ARBITRUM-OOV2-ADDRESS> \
+// NODE_URL_42161=<OPTIMISM-NODE-URL> \
+// \
+// OPTIMISTC_ORACLE_V2=<MAINNET-OOV2-ADDRESS> \
+// \
+// yarn hardhat run ./src/upgrade-tests/162/1_Propose.ts  --network localhost
+
+const hre = require("hardhat");
+
+import { BytesLike } from "@ethersproject/bytes";
+import { AdminChildMessenger, Finder, GovernorSpoke, Registry } from "@uma/contracts-node/typechain/core/ethers";
+import { getContractInstance } from "../utils/contracts";
+const { RegistryRolesEnum } = require("@uma/common");
+
+// PARAMETERS
+const deployed_optimistic_oracle_address = process.env.OPTIMISTIC_ORACLE_V2;
+
+const OPTIMISTIC_ORACLE_V2 = "OptimisticOracleV2"; // TODO use interfaceName.OptimisticOracle
+
+async function main() {
+  const finder = await getContractInstance<Finder>("Finder");
+  const registry = await getContractInstance<Registry>("Registry");
+  const governor = await getContractInstance<GovernorSpoke>("GovernorSpoke");
+  const adminChildMessenger = await getContractInstance<AdminChildMessenger>("Admin_ChildMessenger");
+
+  const adminProposalTransactions: {
+    to: string;
+    data: BytesLike;
+  }[] = [];
+
+  if (!deployed_optimistic_oracle_address) throw new Error("OPTIMISTIC_ORACLE_V2 not set");
+
+  if (!(await registry.isContractRegistered(deployed_optimistic_oracle_address))) {
+    console.log(`Registering ${deployed_optimistic_oracle_address} on mainnet`);
+
+    // 1. Temporarily add the Governor as a contract creator.
+    const addGovernorToRegistryTx = await registry.populateTransaction.addMember(
+      RegistryRolesEnum.CONTRACT_CREATOR,
+      governor.address
+    );
+    if (!addGovernorToRegistryTx.data) throw new Error("addGovernorToRegistryTx.data is empty");
+    adminProposalTransactions.push({ to: registry.address, data: addGovernorToRegistryTx.data });
+
+    // 2. Register the OptimisticOracle as a verified contract.
+    const registerOptimisticOracleTx = await registry.populateTransaction.registerContract(
+      [],
+      deployed_optimistic_oracle_address
+    );
+    if (!registerOptimisticOracleTx.data) throw new Error("registerOptimisticOracleTx.data is empty");
+    adminProposalTransactions.push({ to: registry.address, data: registerOptimisticOracleTx.data });
+
+    // 3. Remove the Governor from being a contract creator.
+    const removeGovernorFromRegistryTx = await registry.populateTransaction.removeMember(
+      RegistryRolesEnum.CONTRACT_CREATOR,
+      governor.address
+    );
+    if (!removeGovernorFromRegistryTx.data) throw new Error("removeGovernorFromRegistryTx.data is empty");
+    adminProposalTransactions.push({ to: registry.address, data: removeGovernorFromRegistryTx.data });
+
+    // 4. Add the OptimisticOracle to the Finder.
+    const addOptimisticOracleToFinderTx = await finder.populateTransaction.changeImplementationAddress(
+      hre.ethers.utils.formatBytes32String(OPTIMISTIC_ORACLE_V2),
+      deployed_optimistic_oracle_address
+    );
+    if (!addOptimisticOracleToFinderTx.data) throw new Error("addOptimisticOracleToFinderTx.data is empty");
+    adminProposalTransactions.push({ to: finder.address, data: addOptimisticOracleToFinderTx.data });
+  }
+
+  const calldata: string = hre.ethers.utils.defaultAbiCoder.encode(
+    [
+      {
+        type: "tuple[]",
+        components: [
+          { name: "to", type: "address" },
+          { name: "data", type: "bytes" },
+        ],
+      },
+    ],
+    [adminProposalTransactions]
+  );
+
+  await adminChildMessenger.processMessageFromCrossChainParent(calldata, governor.address, {
+    gasLimit: 10_000_000,
+  });
+
+  console.log("Proposal Done.");
+}
+
+main().then(
+  () => {
+    process.exit(0);
+  },
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/packages/scripts/src/admin-proposals/adminChildRegistration.ts
+++ b/packages/scripts/src/admin-proposals/adminChildRegistration.ts
@@ -1,24 +1,7 @@
-// This script generates and submits an upgrade transaction to add/upgrade the optimistic oracle in the DVM in
-// the mainnet and layer 2 blockchains. It can be run on a local hardhat node fork of the mainnet or can be run
-// directly on the mainnet to execute the upgrade transactions.
 // To run this on the localhost first fork mainnet into a local hardhat node by running:
-// HARDHAT_CHAIN_ID=1 yarn hardhat node --fork https://mainnet.infura.io/v3/<YOUR-INFURA-KEY> --port 9545 --no-deploy
-// Then execute the script:
-// OPTIMISTIC_ORACLE_V2_10=<OPTIMISM-OOV2-ADDRESS> \
-// NODE_URL_10=<OPTIMISM-NODE-URL> \
-// \
-// OPTIMISTIC_ORACLE_V2_288=<BOBA-OOV2-ADDRESS> \
-// NODE_URL_288=<OPTIMISM-NODE-URL> \
-// \
-// OPTIMISTIC_ORACLE_V2_137=<POLYGON-OOV2-ADDRESS> \
-// NODE_URL_137=<OPTIMISM-NODE-URL> \
-// \
-// OPTIMISTIC_ORACLE_V2_42161=<ARBITRUM-OOV2-ADDRESS> \
-// NODE_URL_42161=<OPTIMISM-NODE-URL> \
-// \
-// OPTIMISTC_ORACLE_V2=<MAINNET-OOV2-ADDRESS> \
-// \
-// yarn hardhat run ./src/upgrade-tests/162/1_Propose.ts  --network localhost
+// CONTRACT_ADDRESS=<CONTRACT_ADDRESS> \
+// CONTRACT_NAME=<CONTRACT_NAME> \
+// yarn hardhat run ./src/admin-proposals/adminChildRegistration.ts  --network <network>
 
 const hre = require("hardhat");
 
@@ -28,9 +11,8 @@ import { getContractInstance } from "../utils/contracts";
 const { RegistryRolesEnum } = require("@uma/common");
 
 // PARAMETERS
-const deployed_optimistic_oracle_address = process.env.OPTIMISTIC_ORACLE_V2;
-
-const OPTIMISTIC_ORACLE_V2 = "OptimisticOracleV2"; // TODO use interfaceName.OptimisticOracle
+const newContractAddress = process.env.CONTRACT_ADDRESS;
+const newContractInterfaceName = process.env.CONTRACT_NAME;
 
 async function main() {
   const finder = await getContractInstance<Finder>("Finder");
@@ -43,10 +25,11 @@ async function main() {
     data: BytesLike;
   }[] = [];
 
-  if (!deployed_optimistic_oracle_address) throw new Error("OPTIMISTIC_ORACLE_V2 not set");
+  if (!newContractAddress) throw new Error("CONTRACT_ADDRESS not set");
+  if (!newContractInterfaceName) throw new Error("CONTRACT_NAME not set");
 
-  if (!(await registry.isContractRegistered(deployed_optimistic_oracle_address))) {
-    console.log(`Registering ${deployed_optimistic_oracle_address} on mainnet`);
+  if (!(await registry.isContractRegistered(newContractAddress))) {
+    console.log(`Registering ${newContractAddress} as ${newContractInterfaceName} in ${hre.network.name}`);
 
     // 1. Temporarily add the Governor as a contract creator.
     const addGovernorToRegistryTx = await registry.populateTransaction.addMember(
@@ -56,13 +39,10 @@ async function main() {
     if (!addGovernorToRegistryTx.data) throw new Error("addGovernorToRegistryTx.data is empty");
     adminProposalTransactions.push({ to: registry.address, data: addGovernorToRegistryTx.data });
 
-    // 2. Register the OptimisticOracle as a verified contract.
-    const registerOptimisticOracleTx = await registry.populateTransaction.registerContract(
-      [],
-      deployed_optimistic_oracle_address
-    );
-    if (!registerOptimisticOracleTx.data) throw new Error("registerOptimisticOracleTx.data is empty");
-    adminProposalTransactions.push({ to: registry.address, data: registerOptimisticOracleTx.data });
+    // 2. Register the CONTRACT_NAME as a verified contract.
+    const registerNewContractTx = await registry.populateTransaction.registerContract([], newContractAddress);
+    if (!registerNewContractTx.data) throw new Error("registerNewContractTx.data is empty");
+    adminProposalTransactions.push({ to: registry.address, data: registerNewContractTx.data });
 
     // 3. Remove the Governor from being a contract creator.
     const removeGovernorFromRegistryTx = await registry.populateTransaction.removeMember(
@@ -72,13 +52,15 @@ async function main() {
     if (!removeGovernorFromRegistryTx.data) throw new Error("removeGovernorFromRegistryTx.data is empty");
     adminProposalTransactions.push({ to: registry.address, data: removeGovernorFromRegistryTx.data });
 
-    // 4. Add the OptimisticOracle to the Finder.
-    const addOptimisticOracleToFinderTx = await finder.populateTransaction.changeImplementationAddress(
-      hre.ethers.utils.formatBytes32String(OPTIMISTIC_ORACLE_V2),
-      deployed_optimistic_oracle_address
+    // 4. Add the CONTRACT_NAME to the Finder.
+    const addNewContractToFinderTx = await finder.populateTransaction.changeImplementationAddress(
+      hre.ethers.utils.formatBytes32String(newContractInterfaceName),
+      newContractAddress
     );
-    if (!addOptimisticOracleToFinderTx.data) throw new Error("addOptimisticOracleToFinderTx.data is empty");
-    adminProposalTransactions.push({ to: finder.address, data: addOptimisticOracleToFinderTx.data });
+    if (!addNewContractToFinderTx.data) throw new Error("addNewContractToFinderTx.data is empty");
+    adminProposalTransactions.push({ to: finder.address, data: addNewContractToFinderTx.data });
+  } else {
+    throw new Error("Contract already registered");
   }
 
   const calldata: string = hre.ethers.utils.defaultAbiCoder.encode(
@@ -95,10 +77,10 @@ async function main() {
   );
 
   await adminChildMessenger.processMessageFromCrossChainParent(calldata, governor.address, {
-    gasLimit: 10_000_000,
+    gasLimit: 1_000_000,
   });
 
-  console.log("Proposal Done.");
+  console.log("Contract added to Registry and Finder successfully.");
 }
 
 main().then(

--- a/packages/scripts/src/admin-proposals/adminChildRegistration.ts
+++ b/packages/scripts/src/admin-proposals/adminChildRegistration.ts
@@ -81,9 +81,7 @@ async function main() {
     [adminProposalTransactions]
   );
 
-  const tx = await adminChildMessenger.processMessageFromCrossChainParent(calldata, governor.address, {
-    gasLimit: 1_000_000,
-  });
+  const tx = await adminChildMessenger.processMessageFromCrossChainParent(calldata, governor.address);
 
   await tx.wait();
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Add a script to register arbitrary contracts in Registry and Finder in non-rollup chains from the `AdminChild_Messenger`


**Summary**

Created a new script that runs the required transactions and receives as arguments the contract name and contract address to register

Example of transaction run in avalanche: https://dashboard.tenderly.co/tx/ava/0x8acd9cd97c17322a5dc552d9bbc2ee9af159a7111eb2f6b7b16d6f2c9323a06c


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


