### PR TITLE
improve: fx-tunnel-relayer should use paginated event search to increase lookback range

### DIFF
--- a/packages/financial-templates-lib/src/helpers/GasEstimator.ts
+++ b/packages/financial-templates-lib/src/helpers/GasEstimator.ts
@@ -183,8 +183,6 @@ export class GasEstimator {
     if (this.type == NetworkType.London) {
       this.latestMaxFeePerGasGwei = (gasInfo as LondonGasData).maxFeePerGas;
       this.latestMaxPriorityFeePerGasGwei = (gasInfo as LondonGasData).maxPriorityFeePerGas;
-      if (this.latestMaxPriorityFeePerGasGwei > this.latestMaxFeePerGasGwei)
-        this.latestMaxFeePerGasGwei = this.latestMaxPriorityFeePerGasGwei / 1.5;
 
       // Extract the base fee from the most recent block. If the block is not available or errored then is set to the
       // latest max fee per gas so we still have some value in the right ballpark to return to the client implementer.

--- a/packages/financial-templates-lib/src/helpers/GasEstimator.ts
+++ b/packages/financial-templates-lib/src/helpers/GasEstimator.ts
@@ -183,6 +183,9 @@ export class GasEstimator {
     if (this.type == NetworkType.London) {
       this.latestMaxFeePerGasGwei = (gasInfo as LondonGasData).maxFeePerGas;
       this.latestMaxPriorityFeePerGasGwei = (gasInfo as LondonGasData).maxPriorityFeePerGas;
+      if (this.latestMaxPriorityFeePerGasGwei > this.latestMaxFeePerGasGwei)
+        this.latestMaxFeePerGasGwei = this.latestMaxPriorityFeePerGasGwei / 1.5;
+
       // Extract the base fee from the most recent block. If the block is not available or errored then is set to the
       // latest max fee per gas so we still have some value in the right ballpark to return to the client implementer.
       // Base fee is represented in Wei so we convert to Gwei to be consistent with other variables in this class.

--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -34,13 +34,16 @@ export class Relayer {
     // First, query OracleChildTunnel on Polygon for any MessageSent events.
     // For some reason, the fromBlock filter doesn't work on local hardhat tests so I added this filter to explicitly
     // remove events with block numbers older than the window.
-    const { eventData: messageSentEvents, web3RequestCount } = await getEventsWithPaginatedBlockSearch(
+    const { eventData, web3RequestCount } = await getEventsWithPaginatedBlockSearch(
       this.oracleChildTunnel,
       "MessageSent",
       this.polygonEarliestBlockToQuery,
       this.polygonLatestBlockToQuery,
       3490 // Polygon Infura RPC limits you to 3500 blocks
     );
+    // This .filter shouldn't be neccessary and it isn't in prod (empirically) but for some reason without this it
+    // fails the test "ignores events older than earliest polygon block to query"
+    const messageSentEvents = eventData.filter((e: EventData) => e.blockNumber >= this.polygonEarliestBlockToQuery);
     this.logger.debug({
       at: "Relayer#relayMessage",
       message: "Found MessageSent events",

--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -46,7 +46,7 @@ export class Relayer {
       message: "Found MessageSent events",
       polygonEarliestBlockToQuery: this.polygonEarliestBlockToQuery,
       eventCount: messageSentEvents.length,
-      web3RequestCount
+      web3RequestCount,
     });
     // For any found events, grab its block number and check whether it has been checkpointed yet to the
     // CheckpointManager on Ethereum.

--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -39,7 +39,7 @@ export class Relayer {
       "MessageSent",
       this.polygonEarliestBlockToQuery,
       this.polygonLatestBlockToQuery,
-      3490
+      3490 // Polygon Infura RPC limits you to 3500 blocks
     );
     this.logger.debug({
       at: "Relayer#relayMessage",

--- a/packages/fx-tunnel-relayer/src/RelayerConfig.ts
+++ b/packages/fx-tunnel-relayer/src/RelayerConfig.ts
@@ -18,8 +18,6 @@ export class RelayerConfig {
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
     this.errorRetries = ERROR_RETRIES ? Number(ERROR_RETRIES) : 3;
     this.errorRetriesTimeout = ERROR_RETRIES_TIMEOUT ? Number(ERROR_RETRIES_TIMEOUT) : 1;
-    this.lookback = LOOKBACK ? Number(LOOKBACK) : 8400; // Polygon Infura node cannot look back more than
-    // 3500 blocks and 7200 seconds divided by an average block time of 2.4 seconds = 3000 blocks, safely under
-    // the limit.
+    this.lookback = LOOKBACK ? Number(LOOKBACK) : 172800; // ~2 days
   }
 }

--- a/packages/fx-tunnel-relayer/src/index.ts
+++ b/packages/fx-tunnel-relayer/src/index.ts
@@ -71,6 +71,7 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
       oracleChildTunnel: oracleChildTunnel.options.address,
       oracleRootTunnel: oracleRootTunnel.options.address,
       polygonEarliestBlockToQuery: polygonEarliestBlockToQuery,
+      polygonLatestBlockToQuery: polygonCurrentBlock.number,
     });
 
     const relayer = new Relayer(
@@ -81,7 +82,8 @@ export async function run(logger: winston.Logger, web3: Web3): Promise<void> {
       oracleChildTunnel,
       oracleRootTunnel,
       web3,
-      polygonEarliestBlockToQuery
+      polygonEarliestBlockToQuery,
+      polygonCurrentBlock.number
     );
 
     for (;;) {

--- a/packages/fx-tunnel-relayer/test/Relayer.ts
+++ b/packages/fx-tunnel-relayer/test/Relayer.ts
@@ -118,7 +118,7 @@ describe("Relayer unit tests", function () {
     deployments.save("OracleRootTunnel", { address: oracleChild.options.address, abi: getAbi("OracleRootTunnel") });
 
     // Construct Relayer that should relay messages without fail.
-    relayer = new Relayer(spyLogger, owner, gasEstimator, maticPosClient, oracleChild, oracleRoot, web3, 0);
+    relayer = new Relayer(spyLogger, owner, gasEstimator, maticPosClient, oracleChild, oracleRoot, web3, 0, 100);
   });
 
   it("exits without error if no MessageSent events emitted", async function () {
@@ -143,10 +143,7 @@ describe("Relayer unit tests", function () {
     assert.isTrue(lastSpyLogIncludes(spy, "Submitted relay proof"));
   });
   it("ignores events older than earliest polygon block to query", async function () {
-    // Save block number for event so that we can configure Relayer to ignore it.
-    const txn = await oracleChild.methods
-      .requestPrice(testIdentifier, testTimestamp, testAncillaryData)
-      .send({ from: owner });
+    await oracleChild.methods.requestPrice(testIdentifier, testTimestamp, testAncillaryData).send({ from: owner });
     const messageBytes = web3.eth.abi.encodeParameters(
       ["bytes32", "uint256", "bytes"],
       [testIdentifier, testTimestamp, expectedStampedAncillaryData]
@@ -164,7 +161,8 @@ describe("Relayer unit tests", function () {
       oracleChild,
       oracleRoot,
       web3,
-      Number(txn.blockNumber + 1)
+      100,
+      101
     );
     // Relay message and check that it ignores events as expected.
     await _relayer.fetchAndRelayMessages();
@@ -191,7 +189,8 @@ describe("Relayer unit tests", function () {
       oracleChild,
       oracleRoot,
       web3,
-      0
+      0,
+      100
     );
 
     await oracleChild.methods.requestPrice(testIdentifier, testTimestamp, testAncillaryData).send({ from: owner });
@@ -220,7 +219,8 @@ describe("Relayer unit tests", function () {
       oracleChild,
       oracleRoot,
       web3,
-      0
+      0,
+      100
     );
 
     await oracleChild.methods.requestPrice(testIdentifier, testTimestamp, testAncillaryData).send({ from: owner });

--- a/packages/fx-tunnel-relayer/test/index.ts
+++ b/packages/fx-tunnel-relayer/test/index.ts
@@ -89,6 +89,7 @@ describe("index.ts", function () {
 
   it("Runs with no errors", async function () {
     process.env.POLLING_DELAY = "0";
+    process.env.CHAIN_ID = ""; // Leave empty so Relayer uses hardhat network web3
 
     // Must not throw.
     await run(spyLogger, web3);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently the lookback is constrained to be > 1-2 hours which isn't sufficient for the average Polygon-->L1 message time which is ~3 hours on average.

This PR also fixes a bug with the GasEstimator where maxPriorityFeePerGas > maxFeePerGas which is prevalent in legacy gas markets like Polygon where we just set `fastest` gas equal to max priority fee.

I used this code to finalize an L2 to L1 message thats about 20 hours old: https://etherscan.io/tx/0xc2109a95dedb085a4b85dc6e9a55e10a38231f3df07fb6630baccb3f90c2a9d5

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [X]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
