### PR TITLE
feat(voting-v2): add method to withdraw and restake

### DIFF
--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -206,6 +206,18 @@ contract Staker is StakerInterface, Ownable, Testable {
         return (tokensToMint);
     }
 
+    /**
+     * @notice Stake accumulated rewards. This is just a convenience method that combines withdraw with stake in the
+     * same transaction.
+     * @dev this method requires that the user has approved this contract.
+     * @return uint256 the amount of tokens that the user is staking.
+     */
+    function withdrawAndRestake() public returns (uint256) {
+        uint256 rewards = withdrawRewards();
+        stake(rewards);
+        return rewards;
+    }
+
     /****************************************
      *        OWNER ADMIN FUNCTIONS         *
      ****************************************/

--- a/packages/core/test/oracle/Staker.ts
+++ b/packages/core/test/oracle/Staker.ts
@@ -97,6 +97,17 @@ describe("Staker", function () {
       assert.equal(await staker.methods.outstandingRewards(account2).call(), toWei("960"));
       assert.equal(await staker.methods.outstandingRewards(account3).call(), toWei("320"));
     });
+    it("Withdraw and restake", async function () {
+      await staker.methods.stake(amountToStake).send({ from: account1 });
+
+      // Advance time forward 1000 seconds. At an emission rate of 0.64 per second we should see the accumulation of
+      // all rewards equal to the amount staked * 1000 * 0.64 = 640.
+      await advanceTime(1000);
+
+      await staker.methods.withdrawAndRestake().send({ from: account1 });
+      const stakingBalance = await staker.methods.voterStakes(account1).call();
+      assert.equal(stakingBalance.activeStake, amountToStake.add(toWei("640")));
+    });
     it("Blocks bad unstake attempt", async function () {
       await staker.methods.stake(amountToStake).send({ from: account1 });
 


### PR DESCRIPTION
**Motivation**

We would like for users to be able to stake their rewards in a single transaction.


**Summary**

This adds a method to withdraw and stake rewards.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
