### PR TITLE
improve(polymarket-notifier): Remove undefined Polymarket alerts

### DIFF
--- a/packages/polymarket-notifier/src/polymarketNotifier.js
+++ b/packages/polymarket-notifier/src/polymarketNotifier.js
@@ -76,7 +76,7 @@ class PolymarketNotifier {
       .map((contract) => {
         // excluding proposals without a proposed price and the requester is not Polymarket
         // the threshold for accepting a proposal is valid is currently set to 0.95 but can be adjusted
-        if (!contract.timestamp || !contract.proposedPrice || contract.requester != polymarketContract) {
+        if (!contract.timestamp || !contract.proposedPrice || !contract.outcome1Price || !contract.outcome2Price || contract.requester != polymarketContract) {
           return null;
         }
         // ensures the API price is greater than 0.95 when a 1 is proposed

--- a/packages/polymarket-notifier/src/polymarketNotifier.js
+++ b/packages/polymarket-notifier/src/polymarketNotifier.js
@@ -79,8 +79,8 @@ class PolymarketNotifier {
         if (
           !contract.timestamp ||
           !contract.proposedPrice ||
-          !contract.outcome1Price ||
-          !contract.outcome2Price ||
+          contract.outcome1Price === undefined ||
+          contract.outcome2Price === undefined ||
           contract.requester != polymarketContract
         ) {
           return null;

--- a/packages/polymarket-notifier/src/polymarketNotifier.js
+++ b/packages/polymarket-notifier/src/polymarketNotifier.js
@@ -76,7 +76,13 @@ class PolymarketNotifier {
       .map((contract) => {
         // excluding proposals without a proposed price and the requester is not Polymarket
         // the threshold for accepting a proposal is valid is currently set to 0.95 but can be adjusted
-        if (!contract.timestamp || !contract.proposedPrice || !contract.outcome1Price || !contract.outcome2Price || contract.requester != polymarketContract) {
+        if (
+          !contract.timestamp ||
+          !contract.proposedPrice ||
+          !contract.outcome1Price ||
+          !contract.outcome2Price ||
+          contract.requester != polymarketContract
+        ) {
           return null;
         }
         // ensures the API price is greater than 0.95 when a 1 is proposed


### PR DESCRIPTION
**Motivation**

Alerts are being sent daily for test markets that are not included in the Polymarket API. This PR prevents alerts for proposals that do not have pricing in the Polymarket API. The original logic was decided upon due to wanting alerts sent if the API is down, however, in that situation we have existing infrastructure alerts.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
