### PR TITLE
fix: Upgrade all dependent contracts to use the OOv2 and show they work in unit tests

### DIFF
--- a/packages/common/src/Constants.ts
+++ b/packages/common/src/Constants.ts
@@ -8,6 +8,7 @@ export const interfaceName = {
   CollateralWhitelist: "CollateralWhitelist",
   AddressWhitelist: "CollateralWhitelist",
   OptimisticOracle: "OptimisticOracle",
+  OptimisticOracleV2: "OptimisticOracleV2",
   Bridge: "Bridge",
   GenericHandler: "GenericHandler",
   MockOracleAncillary: "Oracle",

--- a/packages/common/src/hardhat/fixtures/default.ts
+++ b/packages/common/src/hardhat/fixtures/default.ts
@@ -54,6 +54,7 @@ export async function runDefaultFixture(
     await addToFinder("IdentifierWhitelist", interfaceName.IdentifierWhitelist);
     await addToFinder("AddressWhitelist", interfaceName.CollateralWhitelist);
     await addToFinder("OptimisticOracle", interfaceName.OptimisticOracle);
+    await addToFinder("OptimisticOracleV2", interfaceName.OptimisticOracleV2);
     await addToFinder("SkinnyOptimisticOracle", interfaceName.SkinnyOptimisticOracle);
     await addToFinder("Bridge", interfaceName.Bridge);
     await addToFinder("GenericHandler", interfaceName.GenericHandler);
@@ -81,9 +82,11 @@ export async function runDefaultFixture(
     // Add pre-registered contracts.
     const { address: governorAddress } = await deployments.get("Governor");
     const { address: optimisticOracleAddress } = await deployments.get("OptimisticOracle");
+    const { address: optimisticOracleV2Address } = await deployments.get("OptimisticOracleV2");
     await registry.methods.addMember(RegistryRolesEnum.CONTRACT_CREATOR, deployer).send({ from: deployer });
     await registry.methods.registerContract([], governorAddress).send({ from: deployer });
     await registry.methods.registerContract([], optimisticOracleAddress).send({ from: deployer });
+    await registry.methods.registerContract([], optimisticOracleV2Address).send({ from: deployer });
     await registry.methods.removeMember(RegistryRolesEnum.CONTRACT_CREATOR, deployer).send({ from: deployer });
   });
   await setup();

--- a/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
+++ b/packages/core/contracts/financial-templates/long-short-pair/LongShortPair.sol
@@ -17,7 +17,7 @@ import "../../common/interfaces/ExpandedIERC20.sol";
 import "../../oracle/interfaces/OracleInterface.sol";
 import "../../common/interfaces/AddressWhitelistInterface.sol";
 import "../../oracle/interfaces/FinderInterface.sol";
-import "../../oracle/interfaces/OptimisticOracleInterface.sol";
+import "../../oracle/interfaces/OptimisticOracleV2Interface.sol";
 import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
 
 import "../../oracle/implementation/Constants.sol";
@@ -152,7 +152,7 @@ contract LongShortPair is Testable, Lockable {
         collateralToken = params.collateralToken;
 
         financialProductLibrary = params.financialProductLibrary;
-        OptimisticOracleInterface optimisticOracle = _getOptimisticOracle();
+        OptimisticOracleV2Interface optimisticOracle = _getOptimisticOracle();
 
         // Ancillary data + additional stamped information should be less than ancillary data limit. Consider early
         // expiration ancillary data, if enableEarlyExpiration is set.
@@ -373,7 +373,7 @@ contract LongShortPair is Testable, Lockable {
     // Request a price in the optimistic oracle for a given request timestamp and ancillary data combo. Set the bonds
     // accordingly to the deployer's parameters. Will revert if re-requesting for a previously requested combo.
     function _requestOraclePrice(uint64 requestTimestamp, bytes memory requestAncillaryData) internal {
-        OptimisticOracleInterface optimisticOracle = _getOptimisticOracle();
+        OptimisticOracleV2Interface optimisticOracle = _getOptimisticOracle();
 
         // If the proposer reward was set then pull it from the caller of the function.
         if (proposerReward > 0) {
@@ -434,7 +434,7 @@ contract LongShortPair is Testable, Lockable {
         return AddressWhitelistInterface(finder.getImplementationAddress(OracleInterfaces.CollateralWhitelist));
     }
 
-    function _getOptimisticOracle() internal view returns (OptimisticOracleInterface) {
-        return OptimisticOracleInterface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracle));
+    function _getOptimisticOracle() internal view returns (OptimisticOracleV2Interface) {
+        return OptimisticOracleV2Interface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracleV2));
     }
 }

--- a/packages/core/contracts/financial-templates/optimistic-distributor/OptimisticDistributor.sol
+++ b/packages/core/contracts/financial-templates/optimistic-distributor/OptimisticDistributor.sol
@@ -10,7 +10,7 @@ import "../../merkle-distributor/implementation/MerkleDistributor.sol";
 import "../../oracle/implementation/Constants.sol";
 import "../../oracle/interfaces/FinderInterface.sol";
 import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
-import "../../oracle/interfaces/OptimisticOracleInterface.sol";
+import "../../oracle/interfaces/OptimisticOracleV2Interface.sol";
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -81,7 +81,7 @@ contract OptimisticDistributor is Lockable, MultiCaller, Testable {
     MerkleDistributor public immutable merkleDistributor;
 
     // Interface parameters that can be synced and stored in the contract.
-    OptimisticOracleInterface public optimisticOracle;
+    OptimisticOracleV2Interface public optimisticOracle;
 
     /********************************************
      *                  EVENTS                  *
@@ -381,8 +381,8 @@ contract OptimisticDistributor is Lockable, MultiCaller, Testable {
      *            INTERNAL FUNCTIONS            *
      ********************************************/
 
-    function _getOptimisticOracle() internal view returns (OptimisticOracleInterface) {
-        return OptimisticOracleInterface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracle));
+    function _getOptimisticOracle() internal view returns (OptimisticOracleV2Interface) {
+        return OptimisticOracleV2Interface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracleV2));
     }
 
     function _getIdentifierWhitelist() internal view returns (IdentifierWhitelistInterface) {
@@ -423,7 +423,7 @@ contract OptimisticDistributor is Lockable, MultiCaller, Testable {
         if (reward.previousProposalTimestamp == 0) return true;
 
         bytes memory ancillaryData = _appendRewardIndex(rewardIndex, reward.customAncillaryData);
-        OptimisticOracleInterface.Request memory blockingRequest =
+        OptimisticOracleV2Interface.Request memory blockingRequest =
             optimisticOracle.getRequest(
                 address(this),
                 reward.priceIdentifier,

--- a/packages/core/contracts/oracle/implementation/Constants.sol
+++ b/packages/core/contracts/oracle/implementation/Constants.sol
@@ -12,6 +12,7 @@ library OracleInterfaces {
     bytes32 public constant Registry = "Registry";
     bytes32 public constant CollateralWhitelist = "CollateralWhitelist";
     bytes32 public constant OptimisticOracle = "OptimisticOracle";
+    bytes32 public constant OptimisticOracleV2 = "OptimisticOracleV2";
     bytes32 public constant Bridge = "Bridge";
     bytes32 public constant GenericHandler = "GenericHandler";
     bytes32 public constant SkinnyOptimisticOracle = "SkinnyOptimisticOracle";

--- a/packages/core/contracts/zodiac/OptimisticGovernor.sol
+++ b/packages/core/contracts/zodiac/OptimisticGovernor.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../oracle/implementation/Constants.sol";
 import "../oracle/interfaces/FinderInterface.sol";
-import "../oracle/interfaces/OptimisticOracleInterface.sol";
+import "../oracle/interfaces/OptimisticOracleV2Interface.sol";
 import "../common/implementation/Lockable.sol";
 import "../common/interfaces/AddressWhitelistInterface.sol";
 import "../oracle/interfaces/IdentifierWhitelistInterface.sol";
@@ -54,7 +54,7 @@ contract OptimisticGovernor is Module, Lockable {
     string public rules;
     // This will usually be "ZODIAC" but a deployer may want to create a more specific identifier.
     bytes32 public identifier;
-    OptimisticOracleInterface public optimisticOracle;
+    OptimisticOracleV2Interface public optimisticOracle;
 
     int256 public constant PROPOSAL_VALID_RESPONSE = int256(1e18);
 
@@ -222,7 +222,7 @@ contract OptimisticGovernor is Module, Lockable {
         proposalHashes[proposalHash] = time;
 
         // Propose a set of transactions to the OO. If not disputed, they can be executed with executeProposal().
-        // docs: https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/oracle/interfaces/OptimisticOracleInterface.sol
+        // docs: https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/oracle/interfaces/OptimisticOracleV2Interface.sol
         optimisticOracle.requestPrice(identifier, time, ancillaryData, collateral, 0);
         uint256 totalBond = optimisticOracle.setBond(identifier, time, ancillaryData, bondAmount);
         optimisticOracle.setCustomLiveness(identifier, time, ancillaryData, liveness);
@@ -340,7 +340,7 @@ contract OptimisticGovernor is Module, Lockable {
         uint256 _originalTime = proposalHashes[_proposalHash];
 
         // Get the state of the proposal.
-        OptimisticOracleInterface.Request memory request =
+        OptimisticOracleV2Interface.Request memory request =
             optimisticOracle.getRequest(address(this), identifier, _originalTime, ancillaryData);
 
         // Check that proposal was disputed.
@@ -375,8 +375,8 @@ contract OptimisticGovernor is Module, Lockable {
         optimisticOracle = _getOptimisticOracle();
     }
 
-    function _getOptimisticOracle() private view returns (OptimisticOracleInterface) {
-        return OptimisticOracleInterface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracle));
+    function _getOptimisticOracle() private view returns (OptimisticOracleV2Interface) {
+        return OptimisticOracleV2Interface(finder.getImplementationAddress(OracleInterfaces.OptimisticOracleV2));
     }
 
     function _isContract(address addr) private view returns (bool) {

--- a/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
+++ b/packages/core/test/financial-templates/long-short-pair/LongShortPair.js
@@ -24,7 +24,7 @@ const IdentifierWhitelist = getContract("IdentifierWhitelist");
 const Finder = getContract("Finder");
 const Store = getContract("Store");
 const Timer = getContract("Timer");
-const OptimisticOracle = getContract("OptimisticOracle");
+const OptimisticOracleV2 = getContract("OptimisticOracleV2");
 const Token = getContract("ExpandedERC20");
 
 // Contracts
@@ -113,13 +113,13 @@ describe("LongShortPair", function () {
     longToken = await Token.new("Long Token", "lTKN", 18).send({ from: deployer });
     shortToken = await Token.new("Short Token", "sTKN", 18).send({ from: deployer });
 
-    optimisticOracle = await OptimisticOracle.new(
+    optimisticOracle = await OptimisticOracleV2.new(
       optimisticOracleLivenessTime,
       finder.options.address,
       timer.options.address
     ).send({ from: deployer });
     await finder.methods
-      .changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracle), optimisticOracle.options.address)
+      .changeImplementationAddress(utf8ToHex(interfaceName.OptimisticOracleV2), optimisticOracle.options.address)
       .send({ from: deployer });
 
     // Create LSP library and LSP contract.
@@ -646,8 +646,8 @@ describe("LongShortPair", function () {
       assert.equal(request.proposedPrice, "0");
       assert.equal(request.resolvedPrice, "0");
       assert.equal(request.reward, proposerReward);
-      assert.equal(request.bond, optimisticOracleProposerBond);
-      assert.equal(request.customLiveness, optimisticOracleLivenessTime);
+      assert.equal(request.requestSettings.bond, optimisticOracleProposerBond);
+      assert.equal(request.requestSettings.customLiveness, optimisticOracleLivenessTime);
 
       // Proposing a price without approving the proposal bond should revert.
       assert(

--- a/packages/core/test/zodiac/OptimisticGovernor.js
+++ b/packages/core/test/zodiac/OptimisticGovernor.js
@@ -12,7 +12,7 @@ const OptimisticGovernor = getContract("OptimisticGovernorTest");
 const Finder = getContract("Finder");
 const IdentifierWhitelist = getContract("IdentifierWhitelist");
 const AddressWhitelist = getContract("AddressWhitelist");
-const OptimisticOracle = getContract("OptimisticOracle");
+const OptimisticOracleV2 = getContract("OptimisticOracleV2");
 const MockOracle = getContract("MockOracleAncillary");
 const Timer = getContract("Timer");
 const Store = getContract("Store");
@@ -69,7 +69,7 @@ describe("OptimisticGovernor", () => {
     collateralWhitelist = await AddressWhitelist.deployed();
     store = await Store.deployed();
     identifierWhitelist = await IdentifierWhitelist.deployed();
-    optimisticOracle = await OptimisticOracle.deployed();
+    optimisticOracle = await OptimisticOracleV2.deployed();
     testToken = await TestnetERC20.new("Test", "TEST", 18).send({ from: accounts[0] });
     testToken2 = await TestnetERC20.new("Test2", "TEST2", 18).send({ from: accounts[0] });
 


### PR DESCRIPTION
**Motivation**

This PR shows how the OO v2 can be used with `LongShortPair`, `OptimisticDistributor` and `OptimisticGovernor` with minimal changes.

**Summary**

Only modification make to contracts is changing the import paths and type definition.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
