### PR TITLE
fix: Update the Monitor, proposer and disputer bots to work with OOv2 contracts

### DIFF
--- a/packages/financial-templates-lib/src/clients/OptimisticOracleClient.ts
+++ b/packages/financial-templates-lib/src/clients/OptimisticOracleClient.ts
@@ -52,6 +52,7 @@ export type OptimisticOracleContract = SkinnyOptimisticOracleWeb3 | OptimisticOr
 
 export enum OptimisticOracleType {
   OptimisticOracle = "OptimisticOracle",
+  OptimisticOracleV2 = "OptimisticOracleV2",
   SkinnyOptimisticOracle = "SkinnyOptimisticOracle",
 }
 export class OptimisticOracleClient {
@@ -208,7 +209,7 @@ export class OptimisticOracleClient {
       at: "OptimisticOracleClient",
       message: "Queried past event requests",
       eventRequestCount: eventResults.map((e) => e.web3RequestCount).reduce((x, y) => x + y),
-      earliestBlockToQuery,
+      earliestBlockToQuery: earliestBlockToQuery ?? 0,
       latestBlockToQuery: currentBlock.number,
       blocksPerEventSearch: this.blocksPerEventSearch,
     });

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
@@ -70,7 +70,6 @@ describe("OptimisticOracleEventClient.js", function () {
 
   const pushPrice = async (price) => {
     const [lastQuery] = (await mockOracle.methods.getPendingQueries().call()).slice(-1);
-    console.log("lastQuery", lastQuery);
     await mockOracle.methods
       .pushPrice(lastQuery.identifier, lastQuery.time, lastQuery.ancillaryData, price)
       .send({ from: accounts[0] });

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -338,7 +338,19 @@ class OptimisticOracleContractMonitor {
   }
 
   _generateUILink(transactionHash, chainId) {
-    return `<${this.optimisticOracleUIBaseUrl}/request?transactionHash=${transactionHash}&chainId=${chainId}|View in UI>`;
+    let oracleType;
+    switch (this.oracleType) {
+      case OptimisticOracleType.OptimisticOracle:
+        oracleType = "Optimistic";
+        break;
+      case OptimisticOracleType.OptimisticOracleV2:
+        oracleType = "OptimisticV2";
+        break;
+      case OptimisticOracleType.SkinnyOptimisticOracle:
+        oracleType = "Skinny";
+        break;
+    }
+    return `<${this.optimisticOracleUIBaseUrl}/request?transactionHash=${transactionHash}&chainId=${chainId}&oracleType=${oracleType}|View in UI>`;
   }
 }
 

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -18,6 +18,7 @@ const {
 } = require("@uma/financial-templates-lib");
 
 const OptimisticOracle = getContract("OptimisticOracle");
+const OptimisticOracleV2 = getContract("OptimisticOracleV2");
 const SkinnyOptimisticOracle = getContract("SkinnyOptimisticOracle");
 const OptimisticRequesterTest = getContract("OptimisticRequesterTest");
 const Finder = getContract("Finder");
@@ -37,11 +38,15 @@ describe("OptimisticOracleContractMonitor.js", function () {
   let disputer;
 
   let optimisticRequester;
+  let optimisticRequesterV2;
   let optimisticOracle;
+  let optimisticOracleV2;
   let skinnyOptimisticOracle;
   let eventClient;
+  let eventClientV2;
   let skinnyEventClient;
   let contractMonitor;
+  let contractMonitorV2;
   let skinnyContractMonitor;
   let spyLogger;
   let mockOracle;
@@ -105,6 +110,7 @@ describe("OptimisticOracleContractMonitor.js", function () {
   });
 
   let requestTxn, proposalTxn, disputeTxn, settlementTxn;
+  let requestV2Txn, proposalV2Txn, disputeV2Txn, settlementV2Txn;
   let skinnyRequestTxn, skinnyProposalTxn, skinnyDisputeTxn, skinnySettlementTxn;
   beforeEach(async function () {
     mockOracle = await MockOracle.new(finder.options.address, timer.options.address).send({ from: owner });
@@ -128,6 +134,9 @@ describe("OptimisticOracleContractMonitor.js", function () {
     optimisticOracle = await OptimisticOracle.new(liveness, finder.options.address, timer.options.address).send({
       from: owner,
     });
+    optimisticOracleV2 = await OptimisticOracleV2.new(liveness, finder.options.address, timer.options.address).send({
+      from: owner,
+    });
     skinnyOptimisticOracle = await SkinnyOptimisticOracle.new(
       liveness,
       finder.options.address,
@@ -136,7 +145,9 @@ describe("OptimisticOracleContractMonitor.js", function () {
 
     // Contract used to make price requests. Mint it some collateral to pay rewards with.
     optimisticRequester = await OptimisticRequesterTest.new(optimisticOracle.options.address).send({ from: owner });
+    optimisticRequesterV2 = await OptimisticRequesterTest.new(optimisticOracleV2.options.address).send({ from: owner });
     await collateral.methods.mint(optimisticRequester.options.address, initialUserBalance).send({ from: owner });
+    await collateral.methods.mint(optimisticRequesterV2.options.address, initialUserBalance).send({ from: owner });
 
     startTime = parseInt(await optimisticOracle.methods.getCurrentTime().call());
     requestTime = startTime - 10;
@@ -152,6 +163,15 @@ describe("OptimisticOracleContractMonitor.js", function () {
       web3,
       optimisticOracle.options.address,
       OptimisticOracleType.OptimisticOracle,
+      0, // startingBlockNumber
+      null // endingBlockNumber
+    );
+    eventClientV2 = new OptimisticOracleEventClient(
+      spyLogger,
+      OptimisticOracleV2.abi,
+      web3,
+      optimisticOracleV2.options.address,
+      OptimisticOracleType.OptimisticOracleV2,
       0, // startingBlockNumber
       null // endingBlockNumber
     );
@@ -174,6 +194,12 @@ describe("OptimisticOracleContractMonitor.js", function () {
       monitorConfig,
       contractProps,
     });
+    contractMonitorV2 = new OptimisticOracleContractMonitor({
+      logger: spyLogger,
+      optimisticOracleContractEventClient: eventClientV2,
+      monitorConfig,
+      contractProps,
+    });
     skinnyContractMonitor = new OptimisticOracleContractMonitor({
       logger: spyLogger,
       optimisticOracleContractEventClient: skinnyEventClient,
@@ -185,6 +211,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
     requestTxn = await optimisticRequester.methods
       .requestPrice(identifier, requestTime, defaultAncillaryData, collateral.options.address, reward)
       .send({ from: owner });
+
+    requestV2Txn = await optimisticRequesterV2.methods
+      .requestPrice(identifier, requestTime, defaultAncillaryData, collateral.options.address, reward)
+      .send({ from: owner });
+
     await collateral.methods.approve(skinnyOptimisticOracle.options.address, MAX_UINT_VAL).send({ from: requester });
     skinnyRequestTxn = await skinnyOptimisticOracle.methods
       .requestPrice(identifier, requestTime, defaultAncillaryData, collateral.options.address, reward, finalFee, 0)
@@ -192,6 +223,7 @@ describe("OptimisticOracleContractMonitor.js", function () {
 
     // Make proposals
     await collateral.methods.approve(optimisticOracle.options.address, MAX_UINT_VAL).send({ from: proposer });
+    await collateral.methods.approve(optimisticOracleV2.options.address, MAX_UINT_VAL).send({ from: proposer });
     await collateral.methods
       .approve(skinnyOptimisticOracle.options.address, MAX_UINT_VAL)
       .send({ from: skinnyProposer });
@@ -199,6 +231,11 @@ describe("OptimisticOracleContractMonitor.js", function () {
     proposalTxn = await optimisticOracle.methods
       .proposePrice(optimisticRequester.options.address, identifier, requestTime, defaultAncillaryData, correctPrice)
       .send({ from: proposer });
+
+    proposalV2Txn = await optimisticOracleV2.methods
+      .proposePrice(optimisticRequesterV2.options.address, identifier, requestTime, defaultAncillaryData, correctPrice)
+      .send({ from: proposer });
+
     const requestEvents = await skinnyOptimisticOracle.getPastEvents("RequestPrice", { fromBlock: 0 });
     skinnyProposalTxn = await skinnyOptimisticOracle.methods
       .proposePrice(
@@ -213,11 +250,18 @@ describe("OptimisticOracleContractMonitor.js", function () {
 
     // Make disputes and resolve them
     await collateral.methods.approve(optimisticOracle.options.address, MAX_UINT_VAL).send({ from: disputer });
+    await collateral.methods.approve(optimisticOracleV2.options.address, MAX_UINT_VAL).send({ from: disputer });
     await collateral.methods.approve(skinnyOptimisticOracle.options.address, MAX_UINT_VAL).send({ from: disputer });
     disputeTxn = await optimisticOracle.methods
       .disputePrice(optimisticRequester.options.address, identifier, requestTime, defaultAncillaryData)
       .send({ from: disputer });
     await pushPrice(correctPrice);
+
+    disputeV2Txn = await optimisticOracleV2.methods
+      .disputePrice(optimisticRequesterV2.options.address, identifier, requestTime, defaultAncillaryData)
+      .send({ from: disputer });
+    await pushPrice(correctPrice);
+
     const proposeEvents = await skinnyOptimisticOracle.getPastEvents("ProposePrice", { fromBlock: 0 });
     skinnyDisputeTxn = await skinnyOptimisticOracle.methods
       .disputePrice(requester, identifier, requestTime, defaultAncillaryData, proposeEvents[0].returnValues.request)
@@ -228,226 +272,232 @@ describe("OptimisticOracleContractMonitor.js", function () {
     settlementTxn = await optimisticOracle.methods
       .settle(optimisticRequester.options.address, identifier, requestTime, defaultAncillaryData)
       .send({ from: owner });
+
+    settlementV2Txn = await optimisticOracleV2.methods
+      .settle(optimisticRequesterV2.options.address, identifier, requestTime, defaultAncillaryData)
+      .send({ from: owner });
+
     const disputeEvents = await skinnyOptimisticOracle.getPastEvents("DisputePrice", { fromBlock: 0 });
     skinnySettlementTxn = await skinnyOptimisticOracle.methods
       .settle(requester, identifier, requestTime, defaultAncillaryData, disputeEvents[0].returnValues.request)
       .send({ from: owner });
   });
-
-  it("Winston correctly emits price request message", async function () {
-    await eventClient.update();
-    await contractMonitor.checkForRequests();
-
-    assert.equal(spyLogLevel(spy, -1), "error");
-
-    // Should contain etherscan addresses for the requester and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.options.address}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.transactionHash}`));
-
-    assert.isTrue(
-      lastSpyLogIncludes(
-        spy,
-        `${sampleBaseUIUrl}/request?transactionHash=${requestTxn.transactionHash}&chainId=${contractProps.chainId}`
-      )
-    );
-
-    // should contain the correct request information.
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
-    assert.isTrue(lastSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
-    assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Final Fee
-    let spyCount = spy.callCount;
-
-    // Make another request with different ancillary data.
-    const newTxn = await optimisticRequester.methods
-      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
-      .send({ from: owner });
-    await eventClient.update();
-    await contractMonitor.checkForRequests();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
-
-    // Check that only two extra events were emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
-  });
-  it("Winston correctly emits price proposal message", async function () {
-    await eventClient.update();
-    await contractMonitor.checkForProposals();
-
-    assert.equal(spyLogLevel(spy, -1), "error");
-
-    // Should contain etherscan addresses for the proposer and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${proposer}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalTxn.transactionHash}`));
-    assert.isTrue(
-      lastSpyLogIncludes(
-        spy,
-        `${sampleBaseUIUrl}/request?transactionHash=${proposalTxn.transactionHash}&chainId=${contractProps.chainId}`
-      )
-    );
-
-    // should contain the correct proposal information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
-    assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
-    assert.isTrue(lastSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
-    let spyCount = spy.callCount;
-
-    // Make another proposal with different ancillary data.
-    await optimisticRequester.methods
-      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
-      .send({ from: owner });
-    const newTxn = await optimisticOracle.methods
-      .proposePrice(
-        optimisticRequester.options.address,
-        identifier,
-        requestTime,
-        alternativeAncillaryData,
-        correctPrice
-      )
-      .send({ from: proposer });
-    await eventClient.update();
-    await contractMonitor.checkForProposals();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
-
-    // Check that only two extra events were emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
-  });
-  it("Winston correctly emits price dispute message", async function () {
-    await eventClient.update();
-    await contractMonitor.checkForDisputes();
-
-    assert.equal(spyLogLevel(spy, -1), "error");
-
-    // Should contain etherscan addresses for the disputer and transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeTxn.transactionHash}`));
-
-    assert.isTrue(
-      lastSpyLogIncludes(
-        spy,
-        `${sampleBaseUIUrl}/request?transactionHash=${disputeTxn.transactionHash}&chainId=${contractProps.chainId}`
-      )
-    );
-
-    // should contain the correct dispute information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
-    assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
-    let spyCount = spy.callCount;
-
-    // Make another dispute with different ancillary data.
-    await optimisticRequester.methods
-      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
-      .send({ from: owner });
-    await optimisticOracle.methods
-      .proposePrice(
-        optimisticRequester.options.address,
-        identifier,
-        requestTime,
-        alternativeAncillaryData,
-        correctPrice
-      )
-      .send({ from: proposer });
-    const newTxn = await optimisticOracle.methods
-      .disputePrice(optimisticRequester.options.address, identifier, requestTime, alternativeAncillaryData)
-      .send({ from: disputer });
-    await eventClient.update();
-    await contractMonitor.checkForDisputes();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
-
-    // Check that only two extra events were emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
-  });
-  it("Winston correctly emits price settlement message", async function () {
-    await eventClient.update();
-    await contractMonitor.checkForSettlements();
-
-    assert.equal(spyLogLevel(spy, -1), "info");
-
-    // Should contain etherscan addresses for the transaction
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementTxn.transactionHash}`));
-
-    assert.isTrue(
-      lastSpyLogIncludes(
-        spy,
-        `${sampleBaseUIUrl}/request?transactionHash=${settlementTxn.transactionHash}&chainId=${contractProps.chainId}`
-      )
-    );
-
-    // should contain the correct settlement information.
-    assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
-    assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
-    assert.isTrue(lastSpyLogIncludes(spy, disputer)); // Disputer
-    assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
-    assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
-    assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
-    assert.isTrue(lastSpyLogIncludes(spy, "17.00")); // Price
-    // Proposal was disputed, payout made to winner of disputer
-    // Dispute reward equals: default bond (2x final fee) + proposal reward + 1/2 of loser's final fee
-    // = (2 * 1) + 3 + (0.5 * 1) = 5.5
-    assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
-    let spyCount = spy.callCount;
-
-    // Make another settlement without a dispute, with different ancillary data.
-    await optimisticRequester.methods
-      .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
-      .send({ from: owner });
-    const newProposalTime = await optimisticOracle.methods.getCurrentTime().call();
-    await optimisticOracle.methods
-      .proposePrice(
-        optimisticRequester.options.address,
-        identifier,
-        requestTime,
-        alternativeAncillaryData,
-        correctPrice
-      )
-      .send({ from: proposer });
-    await optimisticOracle.methods
-      .setCurrentTime((Number(newProposalTime) + liveness).toString())
-      .send({ from: owner });
-    const newTxn = await optimisticOracle.methods
-      .settle(optimisticRequester.options.address, identifier, requestTime, alternativeAncillaryData)
-      .send({ from: owner });
-    await eventClient.update();
-    await contractMonitor.checkForSettlements();
-    assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
-    // Proposal this time was not disputed so payout to the proposer.
-    // Proposer reward equals: default bond (2x final fee) + proposal reward
-    // = (2 * 1) + 3 = 5
-    assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
-    // Check that only twp extra events were emitted since we already "checked" the original events.
-    assert.equal(spy.callCount, spyCount + 1);
-  });
-  it("Can correctly create contract monitor with no config provided", async function () {
-    let errorThrown;
-    try {
-      // Create an invalid config. A valid config expects two arrays of addresses.
-      contractMonitor = new OptimisticOracleContractMonitor({
-        logger: spyLogger,
-        optimisticOracleContractEventClient: eventClient,
-        monitorConfig: { optimisticOracleUIBaseUrl: "https://sampleurl.com/" },
-        contractProps,
-      });
+  describe("OptimisticOracle", function () {
+    it("Winston correctly emits price request message", async function () {
+      await eventClient.update();
       await contractMonitor.checkForRequests();
+
+      assert.equal(spyLogLevel(spy, -1), "error");
+
+      // Should contain etherscan addresses for the requester and transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequester.options.address}`));
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestTxn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${requestTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Optimistic`
+        )
+      );
+
+      // should contain the correct request information.
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
+      assert.isTrue(lastSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
+      assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Final Fee
+      let spyCount = spy.callCount;
+
+      // Make another request with different ancillary data.
+      const newTxn = await optimisticRequester.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: owner });
+      await eventClient.update();
+      await contractMonitor.checkForRequests();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Winston correctly emits price proposal message", async function () {
+      await eventClient.update();
       await contractMonitor.checkForProposals();
+
+      assert.equal(spyLogLevel(spy, -1), "error");
+
+      // Should contain etherscan addresses for the proposer and transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${proposer}`));
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalTxn.transactionHash}`));
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${proposalTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Optimistic`
+        )
+      );
+
+      // should contain the correct proposal information.
+      assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
+      assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
+      assert.isTrue(lastSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
+      let spyCount = spy.callCount;
+
+      // Make another proposal with different ancillary data.
+      await optimisticRequester.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: owner });
+      const newTxn = await optimisticOracle.methods
+        .proposePrice(
+          optimisticRequester.options.address,
+          identifier,
+          requestTime,
+          alternativeAncillaryData,
+          correctPrice
+        )
+        .send({ from: proposer });
+      await eventClient.update();
+      await contractMonitor.checkForProposals();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Winston correctly emits price dispute message", async function () {
+      await eventClient.update();
       await contractMonitor.checkForDisputes();
+
+      assert.equal(spyLogLevel(spy, -1), "error");
+
+      // Should contain etherscan addresses for the disputer and transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeTxn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${disputeTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Optimistic`
+        )
+      );
+
+      // should contain the correct dispute information.
+      assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
+      assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
+      let spyCount = spy.callCount;
+
+      // Make another dispute with different ancillary data.
+      await optimisticRequester.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: owner });
+      await optimisticOracle.methods
+        .proposePrice(
+          optimisticRequester.options.address,
+          identifier,
+          requestTime,
+          alternativeAncillaryData,
+          correctPrice
+        )
+        .send({ from: proposer });
+      const newTxn = await optimisticOracle.methods
+        .disputePrice(optimisticRequester.options.address, identifier, requestTime, alternativeAncillaryData)
+        .send({ from: disputer });
+      await eventClient.update();
+      await contractMonitor.checkForDisputes();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Winston correctly emits price settlement message", async function () {
+      await eventClient.update();
       await contractMonitor.checkForSettlements();
-      errorThrown = false;
-    } catch (err) {
-      errorThrown = true;
-    }
-    assert.isFalse(errorThrown);
+
+      assert.equal(spyLogLevel(spy, -1), "info");
+
+      // Should contain etherscan addresses for the transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementTxn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${settlementTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Optimistic`
+        )
+      );
+
+      // should contain the correct settlement information.
+      assert.isTrue(lastSpyLogIncludes(spy, optimisticRequester.options.address)); // Requester
+      assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
+      assert.isTrue(lastSpyLogIncludes(spy, disputer)); // Disputer
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, "17.00")); // Price
+      // Proposal was disputed, payout made to winner of disputer
+      // Dispute reward equals: default bond (2x final fee) + proposal reward + 1/2 of loser's final fee
+      // = (2 * 1) + 3 + (0.5 * 1) = 5.5
+      assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
+      let spyCount = spy.callCount;
+
+      // Make another settlement without a dispute, with different ancillary data.
+      await optimisticRequester.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: owner });
+      const newProposalTime = await optimisticOracle.methods.getCurrentTime().call();
+      await optimisticOracle.methods
+        .proposePrice(
+          optimisticRequester.options.address,
+          identifier,
+          requestTime,
+          alternativeAncillaryData,
+          correctPrice
+        )
+        .send({ from: proposer });
+      await optimisticOracle.methods
+        .setCurrentTime((Number(newProposalTime) + liveness).toString())
+        .send({ from: owner });
+      const newTxn = await optimisticOracle.methods
+        .settle(optimisticRequester.options.address, identifier, requestTime, alternativeAncillaryData)
+        .send({ from: owner });
+      await eventClient.update();
+      await contractMonitor.checkForSettlements();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      // Proposal this time was not disputed so payout to the proposer.
+      // Proposer reward equals: default bond (2x final fee) + proposal reward
+      // = (2 * 1) + 3 = 5
+      assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
+      // Check that only twp extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Can correctly create contract monitor with no config provided", async function () {
+      let errorThrown;
+      try {
+        // Create an invalid config. A valid config expects two arrays of addresses.
+        contractMonitor = new OptimisticOracleContractMonitor({
+          logger: spyLogger,
+          optimisticOracleContractEventClient: eventClient,
+          monitorConfig: { optimisticOracleUIBaseUrl: "https://sampleurl.com/" },
+          contractProps,
+        });
+        await contractMonitor.checkForRequests();
+        await contractMonitor.checkForProposals();
+        await contractMonitor.checkForDisputes();
+        await contractMonitor.checkForSettlements();
+        errorThrown = false;
+      } catch (err) {
+        errorThrown = true;
+      }
+      assert.isFalse(errorThrown);
+    });
   });
   describe("SkinnyOptimisticOracle", function () {
     it("Winston correctly emits price request message", async function () {
@@ -459,6 +509,13 @@ describe("OptimisticOracleContractMonitor.js", function () {
       // Should contain etherscan addresses for the requester and transaction
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${requester}`));
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyRequestTxn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${skinnyRequestTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Skinny`
+        )
+      );
 
       // should contain the correct request information.
       assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
@@ -498,6 +555,13 @@ describe("OptimisticOracleContractMonitor.js", function () {
       // Should contain etherscan addresses for the proposer and transaction
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${skinnyProposer}`));
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyProposalTxn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${skinnyProposalTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Skinny`
+        )
+      );
 
       // should contain the correct proposal information.
       assert.isTrue(lastSpyLogIncludes(spy, requester)); // Requester
@@ -551,6 +615,13 @@ describe("OptimisticOracleContractMonitor.js", function () {
       // Should contain etherscan addresses for the disputer and transaction
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnyDisputeTxn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${skinnyDisputeTxn.transactionHash}&chainId=${contractProps.chainId}&oracleType=Skinny`
+        )
+      );
 
       // should contain the correct dispute information.
       assert.isTrue(lastSpyLogIncludes(spy, requester)); // Requester
@@ -666,6 +737,201 @@ describe("OptimisticOracleContractMonitor.js", function () {
         .send({ from: owner });
       await skinnyEventClient.update();
       await skinnyContractMonitor.checkForSettlements();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      // Proposal this time was not disputed so payout to the proposer.
+      // Proposer reward equals: default bond (2x final fee) + proposal reward
+      // = (2 * 1) + 3 = 5
+      assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.00 made to the proposer"));
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+  });
+  describe("OptimisticOracleV2", function () {
+    it("Winston correctly emits price request message", async function () {
+      await eventClientV2.update();
+      await contractMonitorV2.checkForRequests();
+
+      assert.equal(spyLogLevel(spy, -1), "error");
+
+      // Should contain etherscan addresses for the requester and transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${optimisticRequesterV2.options.address}`));
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${requestV2Txn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${requestV2Txn.transactionHash}&chainId=${contractProps.chainId}&oracleType=OptimisticV2`
+        )
+      );
+
+      // should contain the correct request information.
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
+      assert.isTrue(lastSpyLogIncludes(spy, "3.00")); // Reward, formatted correctly
+      assert.isTrue(lastSpyLogIncludes(spy, "1.00")); // Final Fee
+      let spyCount = spy.callCount;
+
+      // Make another request with different ancillary data.
+      const newTxn = await optimisticRequesterV2.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: requester });
+      await eventClientV2.update();
+      await contractMonitorV2.checkForRequests();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Winston correctly emits price proposal message", async function () {
+      await eventClientV2.update();
+      await contractMonitorV2.checkForProposals();
+
+      assert.equal(spyLogLevel(spy, -1), "error");
+
+      // Should contain etherscan addresses for the proposer and transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${proposer}`));
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${proposalV2Txn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${proposalV2Txn.transactionHash}&chainId=${contractProps.chainId}&oracleType=OptimisticV2`
+        )
+      );
+
+      // should contain the correct proposal information.
+      assert.isTrue(lastSpyLogIncludes(spy, optimisticRequesterV2.options.address)); // Requester
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, collateral.options.address)); // Currency
+      assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
+      assert.isTrue(lastSpyLogIncludes(spy, (Number(proposalTime) + liveness).toString())); // Expiration time
+      let spyCount = spy.callCount;
+
+      // Make another proposal with different ancillary data.
+      await optimisticRequesterV2.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: requester });
+      const newTxn = await optimisticOracleV2.methods
+        .proposePrice(
+          optimisticRequesterV2.options.address,
+          identifier,
+          requestTime,
+          alternativeAncillaryData,
+          correctPrice
+        )
+        .send({ from: proposer });
+      await eventClientV2.update();
+      await contractMonitorV2.checkForProposals();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Winston correctly emits price dispute message", async function () {
+      await eventClientV2.update();
+      await contractMonitorV2.checkForDisputes();
+
+      assert.equal(spyLogLevel(spy, -1), "error");
+
+      // Should contain etherscan addresses for the disputer and transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/address/${disputer}`));
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${disputeV2Txn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/request?transactionHash=${disputeV2Txn.transactionHash}&chainId=${contractProps.chainId}&oracleType=OptimisticV2`
+        )
+      );
+
+      // should contain the correct dispute information.
+      assert.isTrue(lastSpyLogIncludes(spy, optimisticRequesterV2.options.address)); // Requester
+      assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, "-17.00")); // Proposed Price
+      let spyCount = spy.callCount;
+
+      // Make another dispute with different ancillary data.
+      await optimisticRequesterV2.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: requester });
+      await optimisticOracleV2.methods
+        .proposePrice(
+          optimisticRequesterV2.options.address,
+          identifier,
+          requestTime,
+          alternativeAncillaryData,
+
+          correctPrice
+        )
+        .send({ from: proposer });
+
+      const newTxn = await optimisticOracleV2.methods
+        .disputePrice(optimisticRequesterV2.options.address, identifier, requestTime, alternativeAncillaryData)
+        .send({ from: disputer });
+      await eventClientV2.update();
+      await contractMonitorV2.checkForDisputes();
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
+      assert.isTrue(lastSpyLogIncludes(spy, alternativeAncillaryRaw)); // Ancillary Data
+
+      // Check that only two extra events were emitted since we already "checked" the original events.
+      assert.equal(spy.callCount, spyCount + 1);
+    });
+    it("Winston correctly emits price settlement message", async function () {
+      await eventClientV2.update();
+      await contractMonitorV2.checkForSettlements();
+
+      assert.equal(spyLogLevel(spy, -1), "info");
+
+      // Should contain etherscan addresses for the transaction
+      assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementV2Txn.transactionHash}`));
+
+      // should contain the correct settlement information.
+      assert.isTrue(lastSpyLogIncludes(spy, optimisticRequesterV2.options.address)); // Requester
+      assert.isTrue(lastSpyLogIncludes(spy, proposer)); // Proposer
+      assert.isTrue(lastSpyLogIncludes(spy, disputer)); // Disputer
+      assert.isTrue(lastSpyLogIncludes(spy, hexToUtf8(identifier))); // Identifier
+      assert.isTrue(lastSpyLogIncludes(spy, requestTime)); // Timestamp
+      assert.isTrue(lastSpyLogIncludes(spy, defaultAncillaryData)); // Ancillary Data
+      assert.isTrue(lastSpyLogIncludes(spy, "17.00")); // Price
+      // Proposal was disputed, payout made to winner of disputer
+      // Dispute reward equals: default bond (2x final fee) + proposal reward + 1/2 of loser's final fee
+      // = (2 * 1) + 3 + (0.5 * 1) = 5.5
+      assert.isTrue(lastSpyLogIncludes(spy, "payout was 5.50 made to the winner of the dispute"));
+      let spyCount = spy.callCount;
+
+      // Make another settlement without a dispute, with different ancillary data.
+      await optimisticRequesterV2.methods
+        .requestPrice(identifier, requestTime, alternativeAncillaryData, collateral.options.address, reward)
+        .send({ from: requester });
+      const newProposalTime = await optimisticOracleV2.methods.getCurrentTime().call();
+      await optimisticOracleV2.methods
+        .proposePrice(
+          optimisticRequesterV2.options.address,
+          identifier,
+          requestTime,
+          alternativeAncillaryData,
+
+          correctPrice
+        )
+        .send({ from: proposer });
+      await optimisticOracleV2.methods
+        .setCurrentTime((Number(newProposalTime) + liveness).toString())
+        .send({ from: owner });
+
+      const newTxn = await optimisticOracleV2.methods
+        .settle(optimisticRequesterV2.options.address, identifier, requestTime, alternativeAncillaryData)
+        .send({ from: owner });
+      await eventClientV2.update();
+      await contractMonitorV2.checkForSettlements();
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${newTxn.transactionHash}`));
       // Proposal this time was not disputed so payout to the proposer.
       // Proposer reward equals: default bond (2x final fee) + proposal reward

--- a/packages/optimistic-oracle/test/index.js
+++ b/packages/optimistic-oracle/test/index.js
@@ -12,6 +12,7 @@ const { getContract, deployments } = hre;
 const { SpyTransport, spyLogLevel, spyLogIncludes, OptimisticOracleType } = require("@uma/financial-templates-lib");
 
 const OptimisticOracle = getContract("OptimisticOracle");
+const OptimisticOracleV2 = getContract("OptimisticOracleV2");
 const SkinnyOptimisticOracle = getContract("SkinnyOptimisticOracle");
 const MockOracle = getContract("MockOracleAncillary");
 const Finder = getContract("Finder");
@@ -26,6 +27,7 @@ describe("index.js", function () {
   let errorRetriesTimeout = 0.1; // 100 milliseconds between performing retries
 
   let optimisticOracle;
+  let optimisticOracleV2;
   let skinnyOptimisticOracle;
   let finder;
   let timer;
@@ -41,6 +43,11 @@ describe("index.js", function () {
     optimisticOracle = await OptimisticOracle.new("120", finder.options.address, timer.options.address).send({
       from: accounts[0],
     });
+
+    optimisticOracleV2 = await OptimisticOracleV2.new("120", finder.options.address, timer.options.address).send({
+      from: accounts[0],
+    });
+
     skinnyOptimisticOracle = await SkinnyOptimisticOracle.new(
       "120",
       finder.options.address,
@@ -49,6 +56,10 @@ describe("index.js", function () {
 
     // Add deployed addresses to hardhat deployments so they are available from `getAddress`.
     deployments.save("OptimisticOracle", { address: optimisticOracle.options.address, abi: OptimisticOracle.abi });
+    deployments.save("OptimisticOracleV2", {
+      address: optimisticOracleV2.options.address,
+      abi: OptimisticOracleV2.abi,
+    });
     deployments.save("SkinnyOptimisticOracle", {
       address: skinnyOptimisticOracle.options.address,
       abi: SkinnyOptimisticOracle.abi,
@@ -106,6 +117,35 @@ describe("index.js", function () {
     assert.isTrue(spyLogIncludes(spy, 0, "OptimisticOracle proposer started"));
     assert.isTrue(spyLogIncludes(spy, 0, skinnyOptimisticOracle.options.address));
     assert.equal(spy.getCall(0).lastArg.optimisticOracleType, "SkinnyOptimisticOracle");
+    assert.isTrue(spyLogIncludes(spy, spy.callCount - 1, "End of serverless execution loop - terminating process"));
+  });
+  it("Works with OptimisticOracleV2", async function () {
+    // We will create a new spy logger, listening for debug events because success logs are tagged with the
+    // debug level.
+    spy = sinon.spy();
+    spyLogger = winston.createLogger({
+      level: "debug",
+      transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
+    });
+
+    await Main.run({
+      logger: spyLogger,
+      web3,
+      pollingDelay,
+      errorRetries,
+      errorRetriesTimeout,
+      optimisticOracleType: OptimisticOracleType.OptimisticOracleV2,
+    });
+
+    for (let i = 0; i < spy.callCount; i++) {
+      assert.notStrictEqual(spyLogLevel(spy, i), "error");
+    }
+
+    // The first log should indicate that the OO-Proposer runner started successfully
+    // and auto detected the OO's deployed address.
+    assert.isTrue(spyLogIncludes(spy, 0, "OptimisticOracle proposer started"));
+    assert.isTrue(spyLogIncludes(spy, 0, optimisticOracleV2.options.address));
+    assert.equal(spy.getCall(0).lastArg.optimisticOracleType, "OptimisticOracleV2");
     assert.isTrue(spyLogIncludes(spy, spy.callCount - 1, "End of serverless execution loop - terminating process"));
   });
 });

--- a/packages/optimistic-oracle/test/proposerV2.js
+++ b/packages/optimistic-oracle/test/proposerV2.js
@@ -1,0 +1,776 @@
+const winston = require("winston");
+const sinon = require("sinon");
+const hre = require("hardhat");
+const { getContract } = hre;
+const { assert } = require("chai");
+
+const { toWei, hexToUtf8, utf8ToHex, padRight } = web3.utils;
+
+const {
+  OptimisticOracleClient,
+  OptimisticOracleType,
+  GasEstimator,
+  SpyTransport,
+  lastSpyLogLevel,
+  spyLogIncludes,
+  PriceFeedMockScaled,
+} = require("@uma/financial-templates-lib");
+const { OptimisticOracleProposer } = require("../src/proposer");
+const {
+  interfaceName,
+  getPrecisionForIdentifier,
+  OptimisticOracleRequestStatesEnum,
+  OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY,
+  OPTIMISTIC_ORACLE_IGNORE,
+} = require("@uma/common");
+
+const OptimisticOracleV2 = getContract("OptimisticOracleV2");
+const OptimisticRequesterTest = getContract("OptimisticRequesterTest");
+const Finder = getContract("Finder");
+const IdentifierWhitelist = getContract("IdentifierWhitelist");
+const Token = getContract("ExpandedERC20");
+const AddressWhitelist = getContract("AddressWhitelist");
+const Store = getContract("Store");
+const MockOracle = getContract("MockOracleAncillary");
+const Timer = getContract("Timer");
+
+const objectsInArrayInclude = (superset, subset) => {
+  assert.equal(superset.length, subset.length);
+  for (let i = 0; i < superset.length; i++) assert.deepInclude(superset[i], subset[i]);
+};
+
+describe("OptimisticOracleV2: proposer.js", function () {
+  let owner;
+  let requester;
+  let randoProposer;
+  let disputer;
+  let botRunner;
+
+  // Contracts
+  let optimisticRequester;
+  let optimisticOracle;
+  let finder;
+  let timer;
+  let identifierWhitelist;
+  let collateralWhitelist;
+  let store;
+  let mockOracle;
+
+  // Offchain infra
+  let client;
+  let gasEstimator;
+  let proposer;
+  let spyLogger;
+  let spy;
+
+  // Timestamps that we'll use throughout the test.
+  let requestTime;
+  let startTime;
+
+  // Default testing values.
+  const liveness = 7200; // 2 hours
+  const initialUserBalance = toWei("100");
+  const finalFee = toWei("1");
+  const totalDefaultBond = toWei("2"); // 2x final fee
+
+  // These identifiers are special test ones that are mapped to certain `priceFeedDecimal`
+  // configurations used to construct pricefeeds. For example, "TEST8DECIMALS" will construct
+  // a pricefeed that returns prices in 8 decimals. This is useful for testing that a bot is
+  // constructing the right type of pricefeed by default. This mapping is stored in @uma/common/PriceIdentifierUtils.js
+  const identifiersToTest = [
+    padRight(utf8ToHex("TEST8DECIMALS"), 64),
+    padRight(utf8ToHex("TEST6DECIMALS"), 64),
+    padRight(utf8ToHex("TEST18DECIMALS"), 64),
+    padRight(utf8ToHex("TEST18DECIMALS"), 64),
+  ];
+  let collateralCurrenciesForIdentifier;
+
+  const verifyState = async (state, identifier, ancillaryData = "0x", time = requestTime) => {
+    assert.equal(
+      (await optimisticOracle.methods.getState(requester, identifier, time, ancillaryData).call()).toString(),
+      state
+    );
+  };
+
+  const pushPrice = async (price) => {
+    const [lastQuery] = (await mockOracle.methods.getPendingQueries().call()).slice(-1);
+    await mockOracle.methods
+      .pushPrice(lastQuery.identifier, lastQuery.time, lastQuery.ancillaryData, price)
+      .send({ from: owner });
+  };
+
+  before(async function () {
+    [owner, requester, randoProposer, disputer, botRunner] = await web3.eth.getAccounts();
+
+    finder = await Finder.new().send({ from: owner });
+    timer = await Timer.new().send({ from: owner });
+    identifierWhitelist = await IdentifierWhitelist.new().send({ from: owner });
+    collateralWhitelist = await AddressWhitelist.new().send({ from: owner });
+    store = await Store.new({ rawValue: "0" }, { rawValue: "0" }, timer.options.address).send({ from: owner });
+    mockOracle = await MockOracle.new(finder.options.address, timer.options.address).send({ from: owner });
+
+    // Whitelist test identifiers we can use to make default price requests.
+    for (let i = 0; i < identifiersToTest.length; i++) {
+      await identifierWhitelist.methods.addSupportedIdentifier(identifiersToTest[i]).send({ from: owner });
+    }
+
+    // Add deployed contracts to finder.
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.Oracle), mockOracle.options.address)
+      .send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.IdentifierWhitelist), identifierWhitelist.options.address)
+      .send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.AddressWhitelist), collateralWhitelist.options.address)
+      .send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.Store), store.options.address)
+      .send({ from: owner });
+  });
+
+  beforeEach(async function () {
+    // Create and save a new collateral token for each request so we can test
+    // that proposer can use different currencies for each request to post bonds.
+    collateralCurrenciesForIdentifier = [];
+    for (let i = 0; i < identifiersToTest.length; i++) {
+      let collateral = await Token.new("Wrapped Ether", "WETH", getPrecisionForIdentifier(identifiersToTest[i])).send({
+        from: owner,
+      });
+      await collateral.methods.addMember(1, owner).send({ from: owner });
+      await collateral.methods.mint(botRunner, initialUserBalance).send({ from: owner });
+      await collateral.methods.mint(requester, initialUserBalance).send({ from: owner });
+      await collateral.methods.mint(disputer, initialUserBalance).send({ from: owner });
+      await collateral.methods.mint(randoProposer, initialUserBalance).send({ from: owner });
+      await collateralWhitelist.methods.addToWhitelist(collateral.options.address).send({ from: owner });
+      await store.methods.setFinalFee(collateral.options.address, { rawValue: finalFee }).send({ from: owner });
+      collateralCurrenciesForIdentifier[i] = collateral;
+    }
+
+    optimisticOracle = await OptimisticOracleV2.new(liveness, finder.options.address, timer.options.address).send({
+      from: owner,
+    });
+
+    // Contract used to make price requests
+    optimisticRequester = await OptimisticRequesterTest.new(optimisticOracle.options.address).send({ from: owner });
+
+    startTime = Number(await optimisticOracle.methods.getCurrentTime().call());
+    requestTime = startTime - 10;
+
+    spy = sinon.spy();
+    spyLogger = winston.createLogger({
+      level: "info",
+      transports: [new SpyTransport({ level: "info" }, { spy: spy })],
+    });
+
+    client = new OptimisticOracleClient(
+      spyLogger,
+      OptimisticOracleV2.abi,
+      MockOracle.abi,
+      web3,
+      optimisticOracle.options.address,
+      mockOracle.options.address,
+      604800, // lookback
+      OptimisticOracleType.OptimisticOracleV2
+    );
+
+    gasEstimator = new GasEstimator(spyLogger);
+  });
+
+  describe("Valid price identifiers", function () {
+    // Test using packed token address as ancillary data to better simulate what will
+    // happen with financial contracts
+    let ancillaryDataAddresses = [];
+
+    let commonPriceFeedConfig;
+
+    beforeEach(async function () {
+      // Make a new price request for each identifier, each of which should cause the keeper bot to
+      // construct a pricefeed with a new precision.
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        // To simulate a requested price from the EMP, the collateral currency should be in
+        // lower case since the EMP contract will convert from address to bytes.
+        let ancillaryData = collateralCurrenciesForIdentifier[i].options.address.toLowerCase();
+        ancillaryDataAddresses[i] = ancillaryData;
+
+        await optimisticOracle.methods
+          .requestPrice(
+            identifiersToTest[i],
+            requestTime,
+            ancillaryData,
+            collateralCurrenciesForIdentifier[i].options.address,
+            0
+          )
+          .send({ from: requester });
+      }
+
+      // Construct OO Proposer using a valid default price feed config containing any additional properties
+      // not set in DefaultPriceFeedConfig
+      commonPriceFeedConfig = {
+        currentPrice: "1.2", // Mocked current price. This will be scaled to the identifier's precision.
+        historicalPrice: "2.4", // Mocked historical price. This will be scaled to the identifier's precision.
+      };
+      // For this test, we'll dispute any proposals that are not equal to historical price up to a
+      // 10% margin of error
+      let optimisticOracleProposerConfig = { disputePriceErrorPercent: 0.1, otherAccountsToSettle: [randoProposer] };
+      proposer = new OptimisticOracleProposer({
+        logger: spyLogger,
+        optimisticOracleClient: client,
+        gasEstimator,
+        account: botRunner,
+        commonPriceFeedConfig,
+        optimisticOracleProposerConfig,
+      });
+
+      // Update the bot to read the new OO state.
+      await proposer.update();
+    });
+
+    it("_setAllowances", async function () {
+      // Calling it once should set allowances
+      await proposer._setAllowances();
+
+      // Check for the successful INFO log emitted by the proposer.
+      assert.equal(lastSpyLogLevel(spy), "info");
+      assert.isTrue(spyLogIncludes(spy, -1, "Approved OptimisticOracle to transfer unlimited collateral tokens"));
+      const totalCalls = spy.callCount;
+
+      // Should have sent one INFO log for each currency approved.
+      assert.equal(spy.callCount, collateralCurrenciesForIdentifier.length);
+
+      // Calling it again should skip setting allowances.
+      await proposer._setAllowances();
+      assert.equal(totalCalls, spy.callCount);
+    });
+
+    it("Can send proposals to new price requests", async function () {
+      // Should have one price request for each identifier.
+      let expectedResults = [];
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        expectedResults.push({
+          requester: requester,
+          identifier: hexToUtf8(identifiersToTest[i]),
+          ancillaryData: ancillaryDataAddresses[i],
+          timestamp: requestTime.toString(),
+          currency: collateralCurrenciesForIdentifier[i].options.address,
+          reward: "0",
+          finalFee,
+        });
+      }
+      let result = client.getUnproposedPriceRequests();
+      objectsInArrayInclude(result, expectedResults);
+
+      // Now: Execute `sendProposals()` and test that the bot correctly responds to these price proposals
+      await proposer.sendProposals();
+
+      // Check that the onchain requests have been proposed to.
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        await verifyState(OptimisticOracleRequestStatesEnum.PROPOSED, identifiersToTest[i], ancillaryDataAddresses[i]);
+      }
+
+      // Check for the successful INFO log emitted by the proposer.
+      assert.equal(lastSpyLogLevel(spy), "info");
+      assert.isTrue(spyLogIncludes(spy, -1, "Proposed price"));
+      assert.equal(spy.getCall(-1).lastArg.proposalBond, totalDefaultBond);
+      assert.ok(spy.getCall(-1).lastArg.proposalResult.tx);
+      let spyCallCount = spy.callCount;
+
+      // After one run, the pricefeed classes should all be cached in the proposer bot's state:
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        assert.isTrue(
+          proposer.priceFeedCache[web3.utils.hexToUtf8(identifiersToTest[i])] instanceof PriceFeedMockScaled
+        );
+      }
+
+      // Updating and calling `sendProposals` again does nothing.
+      await proposer.update();
+      await proposer.sendProposals();
+      assert.equal(spy.callCount, spyCallCount);
+    });
+
+    it("Can send disputes to proposals", async function () {
+      // Should have one price request for each identifier.
+      let expectedRequests = [];
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        expectedRequests.push({
+          requester: requester,
+          identifier: hexToUtf8(identifiersToTest[i]),
+          ancillaryData: ancillaryDataAddresses[i],
+          timestamp: requestTime.toString(),
+          currency: collateralCurrenciesForIdentifier[i].options.address,
+          reward: "0",
+          finalFee,
+        });
+      }
+      let result = client.getUnproposedPriceRequests();
+      objectsInArrayInclude(result, expectedRequests);
+
+      // Propose a price for each request:
+      // 1) "TEST8DECIMALS"
+      // 2) "TEST6DECIMALS"
+      // 3) "TEST18DECIMALS"
+      // 4) "TEST18DECIMALS"
+
+      // The historical price is 2.4.
+      // Dispute prices must be within 10% of 2.4, so the allowed range is [2.16, 2.64]
+      let disputablePrices = [
+        // 2.17e8
+        // - NOT DISPUTED.
+        "216000000",
+        // 2.15e6
+        // - DISPUTED
+        "2150000",
+        // 2.65e18
+        // - DISPUTED
+        "2650000000000000000",
+        // 2.63e18
+        // - NOT DISPUTED
+        "2640000000000000000",
+      ];
+      // Should have one proposal for each identifier
+      let expectedProposals = [];
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        let collateralCurrency = collateralCurrenciesForIdentifier[i];
+        await collateralCurrency.methods
+          .approve(optimisticOracle.options.address, totalDefaultBond)
+          .send({ from: randoProposer });
+        await optimisticOracle.methods
+          .proposePrice(requester, identifiersToTest[i], requestTime, ancillaryDataAddresses[i], disputablePrices[i])
+          .send({ from: randoProposer });
+        expectedProposals.push({
+          requester: requester,
+          identifier: hexToUtf8(identifiersToTest[i]),
+          ancillaryData: ancillaryDataAddresses[i],
+          timestamp: requestTime.toString(),
+          proposer: randoProposer,
+          proposedPrice: disputablePrices[i],
+          expirationTimestamp: (startTime + liveness).toString(),
+          currency: collateralCurrenciesForIdentifier[i].options.address,
+        });
+      }
+      await proposer.update();
+      result = client.getUndisputedProposals();
+      objectsInArrayInclude(result, expectedProposals);
+
+      // Now: Execute `sendDisputes()` and test that the bot correctly responds to these price proposals
+      await proposer.sendDisputes();
+
+      // Check that the onchain proposals have been disputed.
+      // Check also that the first and the last proposal are NOT disputed
+      for (let i = 1; i < identifiersToTest.length - 1; i++) {
+        await verifyState(OptimisticOracleRequestStatesEnum.DISPUTED, identifiersToTest[i], ancillaryDataAddresses[i]);
+      }
+      await verifyState(OptimisticOracleRequestStatesEnum.PROPOSED, identifiersToTest[0], ancillaryDataAddresses[0]);
+      await verifyState(
+        OptimisticOracleRequestStatesEnum.PROPOSED,
+        identifiersToTest[identifiersToTest.length - 1],
+        ancillaryDataAddresses[identifiersToTest.length - 1]
+      );
+
+      // Check for the successful INFO log emitted by the proposer.
+      assert.equal(lastSpyLogLevel(spy), "info");
+      assert.isTrue(spyLogIncludes(spy, -1, "Disputed proposal"));
+      assert.equal(spy.getCall(-1).lastArg.disputeBond, totalDefaultBond);
+      assert.ok(spy.getCall(-1).lastArg.disputeResult.tx);
+      let spyCallCount = spy.callCount;
+
+      // After one run, the pricefeed classes should all be cached in the proposer bot's state:
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        assert.isTrue(
+          proposer.priceFeedCache[web3.utils.hexToUtf8(identifiersToTest[i])] instanceof PriceFeedMockScaled
+        );
+      }
+
+      // Updating and calling `sendDisputes` again does nothing.
+      await proposer.update();
+      await proposer.sendDisputes();
+      assert.equal(spy.callCount, spyCallCount);
+    });
+
+    it("Can settle proposals and disputes", async function () {
+      // Should have one price request for each identifier.
+      let expectedRequests = [];
+      for (let i = 0; i < identifiersToTest.length; i++) {
+        expectedRequests.push({
+          requester: requester,
+          identifier: hexToUtf8(identifiersToTest[i]),
+          ancillaryData: ancillaryDataAddresses[i],
+          timestamp: requestTime.toString(),
+          currency: collateralCurrenciesForIdentifier[i].options.address,
+          reward: "0",
+          finalFee,
+        });
+      }
+      let result = client.getUnproposedPriceRequests();
+      objectsInArrayInclude(result, expectedRequests);
+
+      // Make one proposal for bot to dispute:
+      let collateralCurrency = collateralCurrenciesForIdentifier[0];
+      await collateralCurrency.methods
+        .approve(optimisticOracle.options.address, totalDefaultBond)
+        .send({ from: randoProposer });
+      await optimisticOracle.methods
+        .proposePrice(
+          requester,
+          identifiersToTest[0],
+          requestTime,
+          ancillaryDataAddresses[0],
+          toWei("1") // Arbitrary price that bot will dispute
+        )
+        .send({ from: randoProposer });
+
+      // Now make the bot propose to the remaining requests.
+      await proposer.update();
+      await proposer.sendProposals();
+
+      // Finally, execute `sendDisputes()` and dispute the first proposal we made.
+      await proposer.update();
+      await proposer.sendDisputes();
+
+      // Check that the requests are in the correct state.
+      await verifyState(OptimisticOracleRequestStatesEnum.DISPUTED, identifiersToTest[0], ancillaryDataAddresses[0]);
+      for (let i = 1; i < identifiersToTest.length; i++) {
+        await verifyState(OptimisticOracleRequestStatesEnum.PROPOSED, identifiersToTest[i], ancillaryDataAddresses[i]);
+      }
+
+      // Now, advance time so that the proposals expire and check that the bot can settle the proposals
+      await optimisticOracle.methods.setCurrentTime((Number(startTime) + liveness).toString()).send({ from: owner });
+      await proposer.update();
+      let spyCountPreSettle = spy.callCount;
+      await proposer.settleRequests();
+
+      // Check that all of the bot's proposals have been settled.
+      for (let i = 1; i < identifiersToTest.length; i++) {
+        await verifyState(OptimisticOracleRequestStatesEnum.SETTLED, identifiersToTest[i], ancillaryDataAddresses[i]);
+      }
+      assert.equal(lastSpyLogLevel(spy), "info");
+      assert.isTrue(spyLogIncludes(spy, -1, "Settled proposal"));
+      assert.isTrue(spyLogIncludes(spy, -1, "2.00")); // total default bond of 2e18, scaled by wei
+      assert.isTrue(spyLogIncludes(spy, -1, "tx")); // contains a tx hash
+      assert.equal(spy.callCount, spyCountPreSettle + (identifiersToTest.length - 1));
+
+      // Finally resolve the dispute and check that the bot settles the dispute.
+      // Push an arbitrary price, as it doesn't matter in this test who wins the dispute, just that it resolves.
+      await pushPrice("1");
+      await proposer.update();
+      spyCountPreSettle = spy.callCount;
+      await proposer.settleRequests();
+
+      // Check that the bot's dispute has been settled.
+      await verifyState(OptimisticOracleRequestStatesEnum.SETTLED, identifiersToTest[0], ancillaryDataAddresses[0]);
+      assert.equal(lastSpyLogLevel(spy), "info");
+      assert.isTrue(spyLogIncludes(spy, -1, "Settled dispute"));
+      // Note: payout is equal to original default bond + 1/2 of loser's dispute bond (not including loser's final fee)
+      assert.isTrue(spyLogIncludes(spy, -1, "2.50")); // total default bond of 2e18 + half looser bond of 0.5e18, scaled by wei
+      assert.isTrue(spyLogIncludes(spy, -1, "tx")); // contains a tx hash
+      assert.equal(spy.callCount, spyCountPreSettle + 1);
+    });
+
+    it("Can settle other account's proposals", async function () {
+      // Make one proposal for bot to settle.
+      let collateralCurrency = collateralCurrenciesForIdentifier[0];
+      await collateralCurrency.methods
+        .approve(optimisticOracle.options.address, totalDefaultBond)
+        .send({ from: randoProposer });
+      await optimisticOracle.methods
+        .proposePrice(
+          requester,
+          identifiersToTest[0],
+          requestTime,
+          ancillaryDataAddresses[0],
+          toWei("1") // Arbitrary price that bot will dispute
+        )
+        .send({ from: randoProposer });
+
+      // Now, advance time so that the proposals expire and check that the bot can settle the proposals
+      await optimisticOracle.methods.setCurrentTime((Number(startTime) + liveness).toString()).send({ from: owner });
+
+      // Now make the bot settle the requests.
+      await proposer.update();
+      await proposer.settleRequests();
+
+      // Check that the requests are in the correct state.
+      await verifyState(OptimisticOracleRequestStatesEnum.SETTLED, identifiersToTest[0], ancillaryDataAddresses[0]);
+    });
+
+    it("Can settle other anyone's proposals", async function () {
+      // Create new proposer to inject a custom config.
+      proposer = new OptimisticOracleProposer({
+        logger: spyLogger,
+        optimisticOracleClient: client,
+        gasEstimator,
+        account: botRunner,
+        commonPriceFeedConfig,
+        optimisticOracleProposerConfig: { disputePriceErrorPercent: 0.1, settleAllRequests: true },
+      });
+
+      // Make one proposal for bot to settle.
+      let collateralCurrency = collateralCurrenciesForIdentifier[0];
+      await collateralCurrency.methods
+        .approve(optimisticOracle.options.address, totalDefaultBond)
+        .send({ from: randoProposer });
+      await optimisticOracle.methods
+        .proposePrice(
+          requester,
+          identifiersToTest[0],
+          requestTime,
+          ancillaryDataAddresses[0],
+          toWei("1") // Arbitrary price that bot will dispute
+        )
+        .send({ from: randoProposer });
+
+      // Now, advance time so that the proposals expire and check that the bot can settle the proposals
+      await optimisticOracle.methods.setCurrentTime((Number(startTime) + liveness).toString()).send({ from: owner });
+
+      // Now make the bot settle the requests.
+      await proposer.update();
+      await proposer.settleRequests();
+
+      // Check that the requests are in the correct state.
+      await verifyState(OptimisticOracleRequestStatesEnum.SETTLED, identifiersToTest[0], ancillaryDataAddresses[0]);
+    });
+
+    it("Correctly caches created price feeds", async function () {
+      // Call `sendProposals` which should create a new pricefeed for each identifier.
+      await proposer.sendProposals();
+
+      // Check that only 1 price feed is cached for each unique identifier, which also tests that the re-requested
+      // identifier does not create 2 pricefeeds.
+      assert.equal(Object.keys(proposer.priceFeedCache).length, identifiersToTest.length - 1);
+
+      // Call `sendDisputes` which should just fetch pricefeeds from the cache instead of creating new ones.
+      await proposer.sendDisputes();
+      assert.equal(Object.keys(proposer.priceFeedCache).length, identifiersToTest.length - 1);
+    });
+  });
+
+  it("Skip price requests with identifiers that proposer cannot construct a price feed for", async function () {
+    // Request a valid identifier but set an invalid price feed config:
+    await optimisticOracle.methods
+      .requestPrice(identifiersToTest[0], requestTime, "0x", collateralCurrenciesForIdentifier[0].options.address, 0)
+      .send({ from: requester });
+
+    // This pricefeed config will cause the proposer to fail to construct a price feed because the
+    // PriceFeedMock type requires a `currentPrice` and a `historicalPrice` to be specified, which are missing
+    // here (and also not included in the DefaultPriceFeedConfig for the tested identifiers).
+    let invalidPriceFeedConfig = {};
+    proposer = new OptimisticOracleProposer({
+      logger: spyLogger,
+      optimisticOracleClient: client,
+      gasEstimator,
+      account: botRunner,
+      commonPriceFeedConfig: invalidPriceFeedConfig,
+    });
+    await proposer.update();
+
+    // `sendProposals`: Should throw an error
+    await proposer.sendProposals();
+    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.isTrue(spyLogIncludes(spy, -1, "Failed to construct a PriceFeed for price request"));
+    assert.isTrue(spyLogIncludes(spy, -1, "sendProposals"));
+
+    // Manually send proposal.
+    const collateralCurrency = collateralCurrenciesForIdentifier[0];
+    await collateralCurrency.methods
+      .approve(optimisticOracle.options.address, totalDefaultBond)
+      .send({ from: randoProposer });
+    await optimisticOracle.methods
+      .proposePrice(requester, identifiersToTest[0], requestTime, "0x", toWei("1"))
+      .send({ from: randoProposer });
+
+    // `sendDisputes`: Should throw another error
+    await proposer.update();
+    await proposer.sendDisputes();
+    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.isTrue(spyLogIncludes(spy, -1, "Failed to construct a PriceFeed for price request"));
+    assert.isTrue(spyLogIncludes(spy, -1, "sendDisputes"));
+  });
+
+  it("Skip price requests with historical prices that proposer fails to fetch", async function () {
+    // Request a valid identifier that is getting bad data from the data source.
+    // Note: "INVALID" maps specifically to the InvalidPriceFeedMock in the DefaultPriceFeedConfig.js file.
+    const invalidPriceFeedIdentifier = padRight(utf8ToHex("INVALID"), 64);
+    await identifierWhitelist.methods.addSupportedIdentifier(invalidPriceFeedIdentifier).send({ from: owner });
+    await optimisticOracle.methods
+      .requestPrice(
+        invalidPriceFeedIdentifier,
+        requestTime,
+        "0x",
+        collateralCurrenciesForIdentifier[0].options.address,
+        // collateral token doesn't matter as the error should log before its used
+        0
+      )
+      .send({ from: requester });
+    proposer = new OptimisticOracleProposer({
+      logger: spyLogger,
+      optimisticOracleClient: client,
+      gasEstimator,
+      account: botRunner,
+    });
+    await proposer.update();
+    await proposer.sendProposals();
+
+    // `sendProposals`: Should throw an error
+    await proposer.sendProposals();
+    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.isTrue(spyLogIncludes(spy, -1, "Failed to query historical price for price request"));
+    assert.isTrue(spyLogIncludes(spy, -1, "sendProposals"));
+
+    // Manually send proposal.
+    const collateralCurrency = collateralCurrenciesForIdentifier[0];
+    await collateralCurrency.methods
+      .approve(optimisticOracle.options.address, totalDefaultBond)
+      .send({ from: randoProposer });
+    await optimisticOracle.methods
+      .proposePrice(requester, invalidPriceFeedIdentifier, requestTime, "0x", toWei("1"))
+      .send({ from: randoProposer });
+
+    // `sendDisputes`: Should throw another error
+    await proposer.update();
+    await proposer.sendDisputes();
+    assert.equal(lastSpyLogLevel(spy), "error");
+    assert.isTrue(spyLogIncludes(spy, -1, "Failed to query historical price for price request"));
+    assert.isTrue(spyLogIncludes(spy, -1, "sendDisputes"));
+  });
+
+  it("Skips expiry price requests for expiry-blacklisted identifiers", async function () {
+    // Set requester's expiration timestamp to be equal to the price request timestamp to simulate expiry:
+    await optimisticRequester.methods.setExpirationTimestamp(requestTime).send({ from: owner });
+
+    const collateralCurrency = collateralCurrenciesForIdentifier[0];
+    const ancillaryData = collateralCurrency.options.address.toLowerCase();
+    const ancillaryDataAddress = ancillaryData;
+
+    // Use the test blacklisted identifier, which we assume to be at index 0 in `OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY`:
+    const identifierToIgnore = padRight(utf8ToHex(OPTIMISTIC_ORACLE_IGNORE_POST_EXPIRY[0]), 64);
+    await identifierWhitelist.methods.addSupportedIdentifier(identifierToIgnore).send({ from: owner });
+
+    await optimisticRequester.methods
+      .requestPrice(identifierToIgnore, requestTime, ancillaryData, collateralCurrency.options.address, 0)
+      .send({ from: owner });
+
+    // Use debug spy to catch "skip" log.
+    spyLogger = winston.createLogger({
+      level: "debug",
+      transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
+    });
+    proposer = new OptimisticOracleProposer({
+      logger: spyLogger,
+      optimisticOracleClient: client,
+      gasEstimator,
+      account: botRunner,
+      commonPriceFeedConfig: { currentPrice: "1", historicalPrice: "2" },
+    });
+
+    // Update the bot to read the new OO state.
+    await proposer.update();
+
+    // Client should still see the unproposed price request:
+    objectsInArrayInclude(client.getUnproposedPriceRequests(), [
+      {
+        requester: optimisticRequester.options.address,
+        identifier: hexToUtf8(identifierToIgnore),
+        ancillaryData: ancillaryDataAddress,
+        timestamp: requestTime.toString(),
+        currency: collateralCurrency.options.address,
+        reward: "0",
+        finalFee,
+      },
+    ]);
+
+    // Running the bot's sendProposals method should skip the price request which it sees as an expiry request:
+    await proposer.sendProposals();
+    assert.equal(lastSpyLogLevel(spy), "debug");
+    assert.isTrue(
+      spyLogIncludes(spy, -1, "EMP contract has expired and identifier's price resolution logic transforms post-expiry")
+    );
+    assert.equal(spy.getCall(-1).lastArg.expirationTimestamp, requestTime);
+
+    // Show that if the contract's expiration timestamp were 1 second later, then the bot would not interpret the price
+    // request as an expiry one and would propose
+    await optimisticRequester.methods.setExpirationTimestamp(Number(requestTime) + 1).send({ from: owner });
+    await proposer.update();
+    await proposer.sendProposals();
+
+    assert.equal(
+      (
+        await optimisticOracle.methods
+          .getState(optimisticRequester.options.address, identifierToIgnore, requestTime, ancillaryDataAddress)
+          .call()
+      ).toString(),
+      OptimisticOracleRequestStatesEnum.PROPOSED
+    );
+    assert.equal(lastSpyLogLevel(spy), "info");
+    assert.isTrue(spyLogIncludes(spy, -1, "Proposed price"));
+    assert.ok(spy.getCall(-1).lastArg.proposalResult.tx);
+
+    // Resetting the expiration timestamp should make sendDispute to skip the price request:
+    await optimisticRequester.methods.setExpirationTimestamp(requestTime).send({ from: owner });
+    await proposer.update();
+    await proposer.sendDisputes();
+    assert.equal(lastSpyLogLevel(spy), "debug");
+    assert.isTrue(
+      spyLogIncludes(spy, -1, "EMP contract has expired and identifier's price resolution logic transforms post-expiry")
+    );
+    assert.equal(spy.getCall(-1).lastArg.expirationTimestamp, requestTime);
+
+    // Finally, if the contract's expiration timestamp is set 1 second later, then the bot would not interpret the price
+    // request as an expiry one and could dispute (but won't dispute because the dispute price equals the proposed one).
+    await optimisticRequester.methods.setExpirationTimestamp(Number(requestTime) + 1).send({ from: owner });
+    await proposer.update();
+    await proposer.sendDisputes();
+    assert.isTrue(spyLogIncludes(spy, -1, "Skipping dispute because proposal price is within allowed margin of error"));
+  });
+
+  it("Skips all price requests for master-blacklisted identifiers", async function () {
+    const collateralCurrency = collateralCurrenciesForIdentifier[0];
+    const ancillaryData = collateralCurrency.options.address.toLowerCase();
+    const ancillaryDataAddress = ancillaryData;
+
+    const identifierToIgnore = padRight(utf8ToHex(OPTIMISTIC_ORACLE_IGNORE[0]), 64);
+    await identifierWhitelist.methods.addSupportedIdentifier(identifierToIgnore).send({ from: owner });
+
+    await optimisticOracle.methods
+      .requestPrice(identifierToIgnore, requestTime, ancillaryData, collateralCurrency.options.address, 0)
+      .send({ from: requester });
+
+    // Use debug spy to catch "skip" log.
+    spyLogger = winston.createLogger({
+      level: "debug",
+      transports: [new SpyTransport({ level: "debug" }, { spy: spy })],
+    });
+    proposer = new OptimisticOracleProposer({
+      logger: spyLogger,
+      optimisticOracleClient: client,
+      gasEstimator,
+      account: botRunner,
+      commonPriceFeedConfig: { currentPrice: "1", historicalPrice: "2" },
+    });
+
+    // Update the bot to read the new OO state.
+    await proposer.update();
+
+    // No allowances should be set for blacklisted identifier
+    assert.equal(lastSpyLogLevel(spy), "debug");
+    assert.isTrue(spyLogIncludes(spy, -1, "Identifier is blacklisted"));
+
+    // Client should still see the unproposed price request:
+    objectsInArrayInclude(client.getUnproposedPriceRequests(), [
+      {
+        requester: requester,
+        identifier: hexToUtf8(identifierToIgnore),
+        ancillaryData: ancillaryDataAddress,
+        timestamp: requestTime.toString(),
+        currency: collateralCurrency.options.address,
+        reward: "0",
+        finalFee,
+      },
+    ]);
+
+    // Running the bot's sendProposals method should skip the price request:
+    await proposer.sendProposals();
+    assert.equal(lastSpyLogLevel(spy), "debug");
+    assert.isTrue(spyLogIncludes(spy, -1, "Identifier is blacklisted"));
+    await verifyState(OptimisticOracleRequestStatesEnum.REQUESTED, identifierToIgnore, ancillaryDataAddress);
+  });
+});


### PR DESCRIPTION
**Motivation**

This PR updates the monitor, disputer and proposer bots to work with the OOv2.

**Summary**

Bot and test updated.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
