### PR TITLE
fix: [H01] fixes duplicate request rewards

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -842,7 +842,11 @@ contract VotingV2 is
             requestIndex < indexTo;
             requestIndex = unsafe_inc_64(requestIndex)
         ) {
-            if (deletedRequests[requestIndex] != 0) requestIndex = deletedRequests[requestIndex] + 1;
+            if (deletedRequests[requestIndex] != 0) {
+                requestIndex = deletedRequests[requestIndex];
+                continue;
+            }
+
             if (requestIndex > indexTo - 1) break; // This happens if the last element was a rolled vote.
             PriceRequest storage priceRequest = priceRequests[priceRequestIds[requestIndex]];
             VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -3040,13 +3040,12 @@ describe("VotingV2", function () {
     const identifier4 = padRight(utf8ToHex("request-retrieval4"), 64);
     const time4 = "4000";
 
-    // Make the Oracle support these two identifiers.
+    // Make the Oracle support these identifiers.
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier1).send({ from: accounts[0] });
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier2).send({ from: accounts[0] });
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier3).send({ from: accounts[0] });
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier4).send({ from: accounts[0] });
 
-    // Requests should not be added to the current voting round.
     await voting.methods.requestPrice(identifier1, time1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier2, time2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier3, time3).send({ from: registeredContract });
@@ -3105,6 +3104,7 @@ describe("VotingV2", function () {
     await voting.methods.updateTrackers(account1).send({ from: account1 });
     await voting.methods.updateTrackers(account2).send({ from: account1 });
 
+    // Both users should have the same lastRequestIndexConsidered.
     assert.equal((await voting.methods.voterStakes(account1).call()).lastRequestIndexConsidered, 4);
     assert.equal((await voting.methods.voterStakes(account2).call()).lastRequestIndexConsidered, 4);
   });

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -3024,4 +3024,88 @@ describe("VotingV2", function () {
       toWei("30000000").add(toWei("6400"))
     );
   });
+
+  it("Duplicate Request Rewards", async function () {
+    // We want to test that the slashing mechanism works properly when two consecutive price requests are rolled.
+    // To accomplish this, we generate four price requests, the first and fourth of which are voted on and resolved,
+    // while p2 and p3 do not receive votes and are thus rolled. Given that all users calling updateTrackers, regardless of order,
+    // process the same price requests, the lastRequestIndexConsidered must be the same for all.
+
+    const identifier1 = padRight(utf8ToHex("request-retrieval1"), 64);
+    const time1 = "1000";
+    const identifier2 = padRight(utf8ToHex("request-retrieval2"), 64);
+    const time2 = "2000";
+    const identifier3 = padRight(utf8ToHex("request-retrieval3"), 64);
+    const time3 = "3000";
+    const identifier4 = padRight(utf8ToHex("request-retrieval4"), 64);
+    const time4 = "4000";
+
+    // Make the Oracle support these two identifiers.
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier1).send({ from: accounts[0] });
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier2).send({ from: accounts[0] });
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier3).send({ from: accounts[0] });
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier4).send({ from: accounts[0] });
+
+    // Requests should not be added to the current voting round.
+    await voting.methods.requestPrice(identifier1, time1).send({ from: registeredContract });
+    await voting.methods.requestPrice(identifier2, time2).send({ from: registeredContract });
+    await voting.methods.requestPrice(identifier3, time3).send({ from: registeredContract });
+    await voting.methods.requestPrice(identifier4, time4).send({ from: registeredContract });
+
+    // Move to the voting round.
+    await moveToNextRound(voting, accounts[0]);
+    const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
+
+    // Commit vote 1 and 4.
+    const price = getRandomSignedInt();
+    const salt = getRandomSignedInt();
+    const hash4 = computeVoteHash({
+      price: price,
+      salt: salt,
+      account: account1,
+      time: time4,
+      roundId,
+      identifier: identifier4,
+    });
+    const hash1 = computeVoteHash({
+      price: price,
+      salt: salt,
+      account: account1,
+      time: time1,
+      roundId,
+      identifier: identifier1,
+    });
+
+    await voting.methods.commitVote(identifier4, time4, hash4).send({ from: account1 });
+    await voting.methods.commitVote(identifier1, time1, hash1).send({ from: account1 });
+
+    // Move to the reveal phase of the voting period.
+    await moveToNextPhase(voting, account1);
+
+    // Reveal vote.
+    await voting.methods.revealVote(identifier4, time4, price, salt).send({ from: account1 });
+    await voting.methods.revealVote(identifier1, time1, price, salt).send({ from: account1 });
+
+    await moveToNextRound(voting, account1);
+
+    assert.isTrue(await voting.methods.hasPrice(identifier4, time4).call({ from: registeredContract }));
+    assert.isTrue(await voting.methods.hasPrice(identifier1, time1).call({ from: registeredContract }));
+    assert.isFalse(await voting.methods.hasPrice(identifier2, time2).call({ from: registeredContract }));
+    assert.isFalse(await voting.methods.hasPrice(identifier3, time3).call({ from: registeredContract }));
+
+    assert.equal(
+      (await voting.methods.getPrice(identifier4, time4).call({ from: registeredContract })).toString(),
+      price.toString()
+    );
+    assert.equal(
+      (await voting.methods.getPrice(identifier1, time1).call({ from: registeredContract })).toString(),
+      price.toString()
+    );
+
+    await voting.methods.updateTrackers(account1).send({ from: account1 });
+    await voting.methods.updateTrackers(account2).send({ from: account1 });
+
+    assert.equal((await voting.methods.voterStakes(account1).call()).lastRequestIndexConsidered, 4);
+    assert.equal((await voting.methods.voterStakes(account2).call()).lastRequestIndexConsidered, 4);
+  });
 });


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

```
The request processing logic within _updateAccountSlashingTrackers is not
able to correctly handle multiple rolled votes that appear sequentually in the request array.
```


**Summary**

To avoid adding more complexity to this logic, I implemented the simple change suggested by the audit.

```
A straightforward fix that sets requestIndex =
deletedRequests[requestIndex] on line 845 (remove the + 1 ) and then inserts a
continue statement. This would return execution back to line 843 where
requestIndex would be incremented as before, but ensures that the
deletedRequests[requestIndex] != 0 test on line 845 is applied to this new
index.
```


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
