### PR TITLE
fix: [M01] Incorrect refund of spamDeletionProposalBond

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -156,6 +156,7 @@ contract VotingV2 is
         uint256 requestTime;
         bool executed;
         address proposer;
+        uint256 bond;
     }
 
     // Maps round numbers to the spam deletion request.
@@ -972,7 +973,8 @@ contract VotingV2 is
                 spamRequestIndices: spamRequestIndices,
                 requestTime: currentTime,
                 executed: false,
-                proposer: msg.sender
+                proposer: msg.sender,
+                bond: spamDeletionProposalBond
             })
         );
 
@@ -1025,7 +1027,7 @@ contract VotingV2 is
             }
 
             // Return the spamDeletionProposalBond.
-            votingToken.transfer(spamDeletionProposals[proposalId].proposer, spamDeletionProposalBond);
+            votingToken.transfer(spamDeletionProposals[proposalId].proposer, spamDeletionProposals[proposalId].bond);
             emit ExecutedSpamDeletion(proposalId, true);
         }
         // Else, the spam deletion request was voted down. In this case we send the spamDeletionProposalBond to the store.

--- a/packages/core/test/oracle/SpamGuard.js
+++ b/packages/core/test/oracle/SpamGuard.js
@@ -467,6 +467,7 @@ describe("SpamGuard", function () {
 
     // Even if the bond changed in the meantime the user get's the original bond paid back.
     assert.equal(await votingToken.methods.balanceOf(account1).call(), toWei("10000000")); // 10mm.
+    assert.equal(await votingToken.methods.balanceOf(account2).call(), toWei("0")); // 0mm.
   });
 
   it("Correctly sends bond to store if voted down", async function () {});


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Setting the spam deletion bond is retroactive and affects previously signalled bonds, resulting in refund inconsistencies.

```
If the owner mistakenly calls setSpamDeletionProposalBond between a spam deletion
request and its execution, the value of the refunded bond will differ from the originally
submitted bond, thereby leading to a loss for either the original requester or the VotingV2
contract.
```

**Summary**

As the auditors suggested, we added a bond attribute to the SpamDeletionRequest struct to keep track of bond values separately from changes to spamDeletionProposalBond.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
