### PR TITLE
fix: [L04]: Incorrect documentation for voting commit hash

### DIFF
--- a/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
@@ -53,7 +53,7 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
      * @notice Forwards a commit to Voting.
      * @param identifier uniquely identifies the feed for this vote. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
-     * @param hash the keccak256 hash of the price you want to vote for and a random integer salt value.
+     * @param hash keccak256 hash of the price, salt, voter address, time, ancillaryData, current roundId, identifier.
      */
     function commitVote(
         bytes32 identifier,
@@ -66,12 +66,12 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
 
     /**
      * @notice commits a vote and logs an event with a data blob, typically an encrypted version of the vote
-     * @dev An encrypted version of the vote is emitted in an event `EncryptedVote` to allow off-chain infrastructure to
-     * retrieve the commit. The contents of `encryptedVote` are never used on chain: it is purely for convenience.
+     * @dev An encrypted version of the vote is emitted in an event EncryptedVote to allow off-chain infrastructure to
+     * retrieve the commit. The contents of encryptedVote are never used on chain: it is purely for convenience.
      * @param identifier unique price pair identifier. Eg: BTC/USD price pair.
      * @param time unix timestamp of for the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
-     * @param hash keccak256 hash of the price you want to vote for and a `int256 salt`.
+     * @param hash keccak256 hash of the price, salt, voter address, time, ancillaryData, current roundId, identifier.
      * @param encryptedVote offchain encrypted blob containing the voters amount, time and salt.
      */
     function commitAndEmitEncryptedVote(
@@ -88,8 +88,8 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
      * @notice Forwards a reveal to Voting.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
-     * @param price used along with the `salt` to produce the `hash` during the commit phase.
-     * @param salt used along with the `price` to produce the `hash` during the commit phase.
+     * @param price voted on during the commit phase.
+     * @param salt value used to hide the commitment price during the commit phase.
      */
     function revealVote(
         bytes32 identifier,

--- a/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
@@ -106,7 +106,7 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
      * @dev Rewards are added to the tokens already held by this contract.
      * @return amount of rewards that the user should receive.
      */
-    function retrieveRewards() public onlyRoleHolder(uint256(Roles.Voter)) returns (uint256) {
+    function withdrawAndRestakeRewards() public onlyRoleHolder(uint256(Roles.Voter)) returns (uint256) {
         StakerInterface voting = StakerInterface(address(_getVotingContract()));
         uint256 rewardsMinted = voting.withdrawRewards();
         IERC20(address(voting.votingToken())).approve(address(voting), rewardsMinted);

--- a/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
@@ -106,7 +106,7 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
      * @dev Rewards are added to the tokens already held by this contract.
      * @return amount of rewards that the user should receive.
      */
-    function withdrawAndRestakeRewards() public onlyRoleHolder(uint256(Roles.Voter)) returns (uint256) {
+    function retrieveRewards() public onlyRoleHolder(uint256(Roles.Voter)) returns (uint256) {
         StakerInterface voting = StakerInterface(address(_getVotingContract()));
         uint256 rewardsMinted = voting.withdrawRewards();
         IERC20(address(voting.votingToken())).approve(address(voting), rewardsMinted);

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -49,8 +49,8 @@ contract VotingV2 is
         uint32 lastVotingRound;
         // Denotes whether this is a governance request or not.
         bool isGovernance;
-        // The pendingRequestIndex in the `pendingPriceRequests` that references this PriceRequest. A value of UINT_MAX
-        // means that this PriceRequest is resolved and has been cleaned up from `pendingPriceRequests`.
+        // The pendingRequestIndex in the pendingPriceRequests that references this PriceRequest. A value of UINT_MAX
+        // means that this PriceRequest is resolved and has been cleaned up from pendingPriceRequests.
         uint64 pendingRequestIndex;
         // Each request has a unique requestIndex number that is used to order all requests. This is the index within
         // the priceRequestIds array and is incremented on each request.
@@ -73,7 +73,7 @@ contract VotingV2 is
     }
 
     struct VoteSubmission {
-        bytes32 commit; // A bytes32 of `0` indicates no commit or a commit that was already revealed.
+        bytes32 commit; // A bytes32 of 0 indicates no commit or a commit that was already revealed.
         bytes32 revealHash; // The hash of the value that was revealed. This is only used for computation of rewards.
     }
 
@@ -289,7 +289,7 @@ contract VotingV2 is
      ****************************************/
 
     /**
-     * @notice Enqueues a request (if a request isn't already present) for the `identifier`, `time` pair.
+     * @notice Enqueues a request (if a request isn't already present) for the identifier, time pair.
      * @dev Time must be in the past and the identifier must be supported. The length of the ancillary data
      * is limited such that this method abides by the EVM transaction gas limit.
      * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
@@ -305,7 +305,7 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Enqueues a governance action request (if a request isn't already present) for `identifier`, `time` pair.
+     * @notice Enqueues a governance action request (if a request isn't already present) for identifier, time pair.
      * @dev Time must be in the past and the identifier must be supported. The length of the ancillary data
      * is limited such that this method abides by the EVM transaction gas limit.
      * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
@@ -321,7 +321,7 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Enqueues a request (if a request isn't already present) for the given `identifier`, `time` pair.
+     * @notice Enqueues a request (if a request isn't already present) for the given identifier, time pair.
      * @dev Time must be in the past and the identifier must be supported. The length of the ancillary data is limited
      * such that this method abides by the EVM transaction gas limit.
      * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
@@ -386,7 +386,7 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Whether the price for `identifier` and `time` is available.
+     * @notice Whether the price for identifier and time is available.
      * @dev Time must be in the past and the identifier must be supported.
      * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
      * @param time unix timestamp of for the price request.
@@ -408,7 +408,7 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Gets the price for `identifier` and `time` if it has already been requested and resolved.
+     * @notice Gets the price for identifier and time if it has already been requested and resolved.
      * @dev If the price is not available, the method reverts.
      * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
      * @param time unix timestamp of for the price request.
@@ -476,8 +476,8 @@ contract VotingV2 is
      ****************************************/
 
     /**
-     * @notice Commit a vote for a price request for `identifier` at `time`.
-     * @dev `identifier`, `time` must correspond to a price request that's currently in the commit phase.
+     * @notice Commit a vote for a price request for identifier at time.
+     * @dev identifier, time must correspond to a price request that's currently in the commit phase.
      * Commits can be changed.
      * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s
      * expected behavior, voters should never reuse salts. If someone else is able to guess the voted price and knows
@@ -485,7 +485,7 @@ contract VotingV2 is
      * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
-     * @param hash keccak256 hash of the `price`, `salt`, voter `address`, `time`, current `roundId`, and `identifier`.
+     * @param hash keccak256 hash of the price, salt, voter address, time, ancillaryData, current roundId, identifier.
      */
     function commitVote(
         bytes32 identifier,
@@ -522,9 +522,9 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Reveal a previously committed vote for `identifier` at `time`.
-     * @dev The revealed `price`, `salt`, `address`, `time`, `roundId`, and `identifier`, must hash to the latest `hash`
-     * that `commitVote()` was called with. Only the committer can reveal their vote.
+     * @notice Reveal a previously committed vote for identifier at time.
+     * @dev The revealed price, salt, voter address, time, ancillaryData, current roundId, identifier must hash to the
+     * latest hash that commitVote() was called with. Only the committer can reveal their vote.
      * @param identifier voted on in the commit phase. EG BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
      * @param price voted on during the commit phase.
@@ -583,12 +583,12 @@ contract VotingV2 is
 
     /**
      * @notice commits a vote and logs an event with a data blob, typically an encrypted version of the vote
-     * @dev An encrypted version of the vote is emitted in an event `EncryptedVote` to allow off-chain infrastructure to
-     * retrieve the commit. The contents of `encryptedVote` are never used on chain: it is purely for convenience.
+     * @dev An encrypted version of the vote is emitted in an event EncryptedVote to allow off-chain infrastructure to
+     * retrieve the commit. The contents of encryptedVote are never used on chain: it is purely for convenience.
      * @param identifier unique price pair identifier. Eg: BTC/USD price pair.
      * @param time unix timestamp of for the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
-     * @param hash keccak256 hash of the price you want to vote for and a `int256 salt`.
+     * @param hash keccak256 hash of the price you want to vote for and a int256 salt.
      * @param encryptedVote offchain encrypted blob containing the voters amount, time and salt.
      */
     function commitAndEmitEncryptedVote(
@@ -653,14 +653,14 @@ contract VotingV2 is
 
     /**
      * @notice Gets the queries that are being voted on this round.
-     * @return pendingRequests array containing identifiers of type `PendingRequest`.
+     * @return pendingRequests array containing identifiers of type PendingRequest.
      */
     function getPendingRequests() public view override returns (PendingRequestAncillary[] memory) {
         uint256 blockTime = getCurrentTime();
         uint256 currentRoundId = voteTiming.computeCurrentRoundId(blockTime);
 
         // Solidity memory arrays aren't resizable (and reading storage is expensive). Hence this hackery to filter
-        // `pendingPriceRequests` only to those requests that have an Active RequestStatus.
+        // pendingPriceRequests only to those requests that have an Active RequestStatus.
         PendingRequestAncillary[] memory unresolved = new PendingRequestAncillary[](pendingPriceRequests.length);
         uint256 numUnresolved = 0;
 

--- a/packages/core/test/oracle/DesignatedVotingV2.js
+++ b/packages/core/test/oracle/DesignatedVotingV2.js
@@ -214,10 +214,10 @@ describe("DesignatedVotingV2", function () {
     );
 
     // Retrieve rewards and check that rewards accrued to the `designatedVoting` contract.
-    assert(await didContractThrow(designatedVoting.methods.withdrawAndRestakeRewards().send({ from: tokenOwner })));
-    assert(await didContractThrow(designatedVoting.methods.withdrawAndRestakeRewards().send({ from: umaAdmin })));
+    assert(await didContractThrow(designatedVoting.methods.retrieveRewards().send({ from: tokenOwner })));
+    assert(await didContractThrow(designatedVoting.methods.retrieveRewards().send({ from: umaAdmin })));
 
-    await designatedVoting.methods.withdrawAndRestakeRewards().send({ from: voter });
+    await designatedVoting.methods.retrieveRewards().send({ from: voter });
     // We should see the cumulative staked amount go up by the amount of the rewards. We had advanced time one phase and
     // one voting round. This should result in an expected reward of the emission rate times the delta in time as this
     // was the only staker they get the full reward amount.

--- a/packages/core/test/oracle/DesignatedVotingV2.js
+++ b/packages/core/test/oracle/DesignatedVotingV2.js
@@ -214,10 +214,10 @@ describe("DesignatedVotingV2", function () {
     );
 
     // Retrieve rewards and check that rewards accrued to the `designatedVoting` contract.
-    assert(await didContractThrow(designatedVoting.methods.retrieveRewards().send({ from: tokenOwner })));
-    assert(await didContractThrow(designatedVoting.methods.retrieveRewards().send({ from: umaAdmin })));
+    assert(await didContractThrow(designatedVoting.methods.withdrawAndRestakeRewards().send({ from: tokenOwner })));
+    assert(await didContractThrow(designatedVoting.methods.withdrawAndRestakeRewards().send({ from: umaAdmin })));
 
-    await designatedVoting.methods.retrieveRewards().send({ from: voter });
+    await designatedVoting.methods.withdrawAndRestakeRewards().send({ from: voter });
     // We should see the cumulative staked amount go up by the amount of the rewards. We had advanced time one phase and
     // one voting round. This should result in an expected reward of the emission rate times the delta in time as this
     // was the only staker they get the full reward amount.


### PR DESCRIPTION
**Motivation**

*OZ identified the following issue:*
```
In order to submit a vote on a price request, the voter must construct an off-chain hash by
encoding the following data in order and then computing the keccak256 hash: price , salt ,
voterAddress , time , ancillaryData , currentRoundId , and identifier . This can
be seen in lines 559-563 of the VotingV2 contract's revealVote function, where the
contract constructs a reveal hash that should match the one that was committed:
require(
keccak256(abi.encodePacked(price, salt, msg.sender, time, ancillaryData,
currentRoundId, identifier)) ==
voteSubmission.commit,
"Revealed data != commit hash"
);
The structure of the commit hash is described in the docstrings of several functions within the
DesignatedVotingV2 and VotingV2 contracts. However, none of these docstrings
appears to describe the format of the hash correctly:
In DesignatedVotingV2.sol :
line 56: The commitVote docstring describes the input hash as "the keccak256
hash of the price you want to vote for and a random integer salt value". This
description omits the required voterAddress , time , ancillaryData ,
currentRoundId , and identifier .
line 74: The commitAndEmitEncryptedVote docstring describes the input
hash as "keccak256 hash of the price you want to vote for and a int256 salt".
This description omits the required voterAddress , time , ancillaryData ,
currentRoundId , and identifier .
line 91: The revealVote docstring describes the input price as "used along
with the salt to produce the hash during the commit phase". This description
is technically correct but implies these are the only two values required, omitting
voterAddress , time , ancillaryData , currentRoundId , and
identifier .
line 92: The revealVote docstring describes the input salt as "used along
with the price to produce the hash during the commit phase". This description
is technically correct but implies these are the only two values required, omitting
voterAddress , time , ancillaryData , currentRoundId , and
identifier .
In VotingV2.sol :
line 488 : The commitVote docstring describes the input hash as "keccak256
hash of the price , salt , voter address , time , current roundId , and
identifier ". This description omits the required ancillaryData variable.
line 526: The revealVote docstring states that "The revealed price , salt ,
address , time , roundId , and identifier , must hash to the latest hash ".
This comment omits the requires ancillaryData variable.

Furthermore, while the type of all the encoded values can be deduced by examining the input
parameters and body of the revealVote function, this type information is not explicitly
provided to voters in the documentation of the commit functions where the hash is inputted.
An incorrectly formatted commit hash can lead to a voter being slashed when the
revealVote function attempts to re-create the submitted hash and fails.
To avoid any misunderstanding about the hash encoding and the potential for unintentional
wrong votes, consider carefully documenting the exact format of the commit hash in all
docstrings where it is referenced.
```

*Solution added in this PR:*
This PR addresses the issue by refining the comments relating the the commit hash and associated inputs. Additionally, all `'` chars were removed when refrencing variables in comments as we no longer do this throughout the protocol repo and other UMA contracts.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
