### PR TITLE
fix: [L10]: Withdraw role is not configured

### DIFF
--- a/packages/core/contracts/oracle/implementation/DesignatedVotingV2Factory.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingV2Factory.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "../../common/implementation/Withdrawable.sol";
 import "./DesignatedVotingV2.sol";
 
 /**
  * @title Factory to deploy new instances of DesignatedVotingV2 and look up previously deployed instances.
  * @dev Allows off-chain infrastructure to look up a hot wallet's deployed DesignatedVoting contract.
  */
-contract DesignatedVotingV2Factory is Withdrawable {
+contract DesignatedVotingV2Factory {
     address private finder;
     mapping(address => DesignatedVotingV2) public designatedVotingContracts;
 


### PR DESCRIPTION
**Motivation**

*OZ identified the following issue:*
```
The DesignatedVotingV2Factory contract inherits from the Withdrawable contract, a
base contract which provides the ability to create a Withdraw role and assign it to one or more
addresses to grant them the ability to withdraw ETH or ERC20 tokens from the contract by
using the corresponding withdraw and withdrawErc20 functions.
The Withdrawable contract provides two functions for configuring this role,
_createWithdrawRole and setWithdrawRole , and the documentation for these
functions indicates that one or the other must be called by the derived contract
( DesignatedVotingV2Factory in this case) in order for withdraws to function properly.
However, the DesignatedVotingV2Factory contract does not call either function,
rendering the withdraw and withdrawErc20 functions inoperable.
Given the intended purpose of the DesignatedVotingV2Factory contract, it does not
appear that it requires the Withdrawable feature. Consider removing the inheritance from
Withdrawable and the corresponding import of Withdrawable.sol .
```

*Solution presented in this PR:*
As recommended, the Withdrawable contract is removed from the `VotingV2` inheritance path.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
