### PR TITLE
improve(sdk): fix abi issue, fix e2e tests, remove oracle addresses

### DIFF
--- a/packages/sdk/src/clients/optimisticOracleV2/client.e2e.ts
+++ b/packages/sdk/src/clients/optimisticOracleV2/client.e2e.ts
@@ -3,19 +3,27 @@ import assert from "assert";
 import * as Client from "./client";
 import { ethers } from "ethers";
 
-const address = "0xA0Ae6609447e57a42c51B50EAe921D701823FFAe";
+const address = "0xee3afe347d5c74317041e2618c49534daf887c24";
+const requester = "0x3BFf7fD5AACb1a22e1dd3ddbd8cfB8622A9E9A5B";
+const identifier = "0x4d584e5553440000000000000000000000000000000000000000000000000000";
+const ancillaryData = "0x00";
+const timestamp = 1659179901;
+assert(process.env.PROVIDER_URL_137, "requires PROVIDER_URL_137");
 // these require integration testing, skip for ci
 describe("OptimisticOracleV2", function () {
   let client: Client.Instance;
   test("inits", function () {
-    const provider = ethers.providers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+    const provider = ethers.providers.getDefaultProvider(process.env.PROVIDER_URL_137);
     client = Client.connect(address, provider);
     assert.ok(client);
   });
   test("getEventState", async function () {
     const events = await client.queryFilter({});
     const state = await Client.getEventState(events);
-    // no requests yet
-    assert.ok(Object.values(state.requests || {}).length >= 0);
+    assert.ok(Object.values(state.requests || {}).length);
+  });
+  test("get request", async function () {
+    const request = await client.getRequest(requester, identifier, timestamp, ancillaryData);
+    assert.ok(request);
   });
 });

--- a/packages/sdk/src/clients/optimisticOracleV2/client.ts
+++ b/packages/sdk/src/clients/optimisticOracleV2/client.ts
@@ -37,6 +37,15 @@ export type RequestKey = {
   timestamp: number;
   ancillaryData: string;
 };
+export type RequestSettings = {
+  eventBased: boolean; // True if the request is set to be event-based.
+  refundOnDispute: boolean; // True if the requester should be refunded their reward on dispute.
+  callbackOnPriceProposed: boolean; // True if callbackOnPriceProposed callback is required.
+  callbackOnPriceDisputed: boolean; // True if callbackOnPriceDisputed callback is required.
+  callbackOnPriceSettled: boolean; // True if callbackOnPriceSettled callback is required.
+  bond: BigNumber; // Bond that the proposer and disputer must pay on top of the final fee.
+  customLiveness: BigNumber; // Custom liveness value set by the requester.
+};
 export type Request = RequestKey &
   // this is partial since we dont know what events we have to populate parts of this
   Partial<{
@@ -64,6 +73,7 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestSettings: RequestSettings;
   }>;
 
 export interface EventState {

--- a/packages/sdk/src/oracle/optimisticFactory.ts
+++ b/packages/sdk/src/oracle/optimisticFactory.ts
@@ -1,5 +1,5 @@
 import { Client, factory } from "./client";
-import { OptimisticOracle, getOptimisticOracleAddress } from "./services/optimisticOracle";
+import { OptimisticOracle } from "./services/optimisticOracle";
 import { SortedRequests } from "./services/sortedRequests";
 import { DefaultConfig, getMulticall2Address } from "./utils";
 import { state } from "./types";
@@ -12,7 +12,6 @@ export default (
 ): Client => {
   const fullConfig = DefaultConfig({
     getMulticall2Address,
-    getOptimisticOracleAddress,
   })({ ...config }, state.OracleType.Optimistic);
   return factory(fullConfig, emit, OptimisticOracle, sortedRequests);
 };

--- a/packages/sdk/src/oracle/optimisticV2Factory.ts
+++ b/packages/sdk/src/oracle/optimisticV2Factory.ts
@@ -1,5 +1,5 @@
 import { Client, factory } from "./client";
-import { OptimisticOracleV2, getOptimisticOracleAddress } from "./services/optimisticOracleV2";
+import { OptimisticOracleV2 } from "./services/optimisticOracleV2";
 import { SortedRequests } from "./services/sortedRequests";
 import { DefaultConfig, getMulticall2Address } from "./utils";
 import { state } from "./types";
@@ -12,7 +12,6 @@ export default (
 ): Client => {
   const fullConfig = DefaultConfig({
     getMulticall2Address,
-    getOptimisticOracleAddress,
   })({ ...config }, state.OracleType.OptimisticV2);
   return factory(fullConfig, emit, OptimisticOracleV2, sortedRequests);
 };

--- a/packages/sdk/src/oracle/services/optimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracle.ts
@@ -1,41 +1,13 @@
 import { optimisticOracle } from "../../clients";
 import { BigNumberish, Provider, Signer, TransactionResponse, Log, TransactionReceipt } from "../types/ethers";
 import type { OracleInterface, RequestKey, OracleProps, Request } from "../types/interfaces";
-import { requestId, insertOrderedAscending, eventKey, isUnique, getAddress } from "../utils";
+import { requestId, insertOrderedAscending, eventKey, isUnique } from "../utils";
 
 import { RequestPrice, ProposePrice, DisputePrice, Settle } from "../../clients/optimisticOracle";
 
 export type OptimisticOracleEvent = RequestPrice | ProposePrice | DisputePrice | Settle;
 
 export type { RequestPrice, ProposePrice, DisputePrice, Settle };
-
-// this had to be copied in because interfaces in contracts-frontend and contracts-node are different
-// The frontend cant use contracts-node because async calls are required for addresses, when testing in node
-// we arent able to import contracts-frontend.
-export function getOptimisticOracleAddress(chainId: number): string {
-  switch (chainId.toString()) {
-    case "1":
-      return getAddress("0xc43767f4592df265b4a9f1a398b97ff24f38c6a6");
-    case "4":
-      return getAddress("0x3746badD4d6002666dacd5d7bEE19f60019A8433");
-    case "10":
-      return getAddress("0x56e2d1b8C7dE8D11B282E1b4C924C32D91f9102B");
-    case "42":
-      return getAddress("0xB1d3A89333BBC3F5e98A991d6d4C1910802986BC");
-    case "100":
-      return getAddress("0xd2ecb3afe598b746F8123CaE365a598DA831A449");
-    case "137":
-      return getAddress("0xBb1A8db2D4350976a11cdfA60A1d43f97710Da49");
-    case "288":
-      return getAddress("0x7da554228555C8Bf3748403573d48a2138C6b848");
-    case "42161":
-      return getAddress("0x031A7882cE3e8b4462b057EBb0c3F23Cd731D234");
-    case "80001":
-      return getAddress("0xAB75727d4e89A7f7F04f57C00234a35950527115");
-    default:
-      throw new Error(`No address found for deployment OptimisticOracle on chainId ${chainId}`);
-  }
-}
 
 export class OptimisticOracle implements OracleInterface {
   private readonly contract: optimisticOracle.Instance;

--- a/packages/sdk/src/oracle/services/optimisticOracleV2.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracleV2.ts
@@ -1,49 +1,28 @@
 // This is almost a direct copy of the OO v1 service, just with updated abis and different contract addresses
-import { optimisticOracle } from "../../clients";
 import { BigNumberish, Provider, Signer, TransactionResponse, Log, TransactionReceipt } from "../types/ethers";
 import type { OracleInterface, RequestKey, OracleProps, Request } from "../types/interfaces";
-import { requestId, insertOrderedAscending, eventKey, isUnique, getAddress } from "../utils";
+import { requestId, insertOrderedAscending, eventKey, isUnique } from "../utils";
 
-import { RequestPrice, ProposePrice, DisputePrice, Settle } from "../../clients/optimisticOracleV2";
+import {
+  RequestPrice,
+  ProposePrice,
+  DisputePrice,
+  Settle,
+  connect,
+  Instance,
+  getEventState,
+} from "../../clients/optimisticOracleV2";
 
 export type OptimisticOracleEvent = RequestPrice | ProposePrice | DisputePrice | Settle;
 
 export type { RequestPrice, ProposePrice, DisputePrice, Settle };
 
-// this had to be copied in because interfaces in contracts-frontend and contracts-node are different
-// The frontend cant use contracts-node because async calls are required for addresses, when testing in node
-// we arent able to import contracts-frontend.
-export function getOptimisticOracleAddress(chainId: number): string {
-  switch (chainId.toString()) {
-    case "1":
-      return getAddress("0xA0Ae6609447e57a42c51B50EAe921D701823FFAe");
-    case "5":
-      return getAddress("0x3C8a21099C202003Ec6f050Eb24F8f24a3828Ad3");
-    case "10":
-      return getAddress("0x255483434aba5a75dc60c1391bB162BCd9DE2882");
-    case "137":
-      return getAddress("0xee3afe347d5c74317041e2618c49534daf887c24");
-    case "288":
-      return getAddress("0xb2b5C1b17B19d92CC4fC1f026B2133259e3ccd41");
-    case "416":
-      return getAddress("0x28077B47Cd03326De7838926A63699849DD4fa87");
-    case "42161":
-      return getAddress("0x88Ad27C41AD06f01153E7Cd9b10cBEdF4616f4d5");
-    case "43114":
-      return getAddress("0x28077B47Cd03326De7838926A63699849DD4fa87");
-    case "9001":
-      return getAddress("0xd2ecb3afe598b746F8123CaE365a598DA831A449");
-    default:
-      throw new Error(`No address found for deployment OptimisticOracle on chainId ${chainId}`);
-  }
-}
-
 export class OptimisticOracleV2 implements OracleInterface {
-  private readonly contract: optimisticOracle.Instance;
+  private readonly contract: Instance;
   private readonly events: OptimisticOracleEvent[] = [];
   private requests: Record<string, Request> = {};
   constructor(protected provider: Provider, protected address: string, public readonly chainId: number) {
-    this.contract = optimisticOracle.connect(address, provider);
+    this.contract = connect(address, provider);
   }
   private upsertRequest = (request: Omit<Request, "chainId">): Request => {
     const id = requestId(request);
@@ -76,7 +55,7 @@ export class OptimisticOracleV2 implements OracleInterface {
         insertOrderedAscending(this.events, event, eventKey);
       }
     });
-    const { requests = {} } = optimisticOracle.getEventState(this.events);
+    const { requests = {} } = getEventState(this.events);
     Object.values(requests).map((request) => this.upsertRequest(request));
   };
   async fetchRequest({ requester, identifier, timestamp, ancillaryData }: RequestKey): Promise<Request> {
@@ -94,7 +73,7 @@ export class OptimisticOracleV2 implements OracleInterface {
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey
   ): Promise<TransactionResponse> {
-    const contract = optimisticOracle.connect(this.address, signer);
+    const contract = connect(this.address, signer);
     const tx = await contract.disputePrice(requester, identifier, timestamp, ancillaryData);
     this.setDisputeHash({ requester, identifier, timestamp, ancillaryData }, tx.hash);
     return tx;
@@ -104,7 +83,7 @@ export class OptimisticOracleV2 implements OracleInterface {
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
     price: BigNumberish
   ): Promise<TransactionResponse> {
-    const contract = optimisticOracle.connect(this.address, signer);
+    const contract = connect(this.address, signer);
     const tx = await contract.proposePrice(requester, identifier, timestamp, ancillaryData, price);
     this.setProposeHash({ requester, identifier, timestamp, ancillaryData }, tx.hash);
     return tx;
@@ -113,7 +92,7 @@ export class OptimisticOracleV2 implements OracleInterface {
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey
   ): Promise<TransactionResponse> {
-    const contract = optimisticOracle.connect(this.address, signer);
+    const contract = connect(this.address, signer);
     const tx = await contract.settle(requester, identifier, timestamp, ancillaryData);
     this.setSettleHash({ requester, identifier, timestamp, ancillaryData }, tx.hash);
     return tx;

--- a/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { skinnyOptimisticOracle as optimisticOracle } from "../../clients";
 import { BigNumberish, Provider, Signer, TransactionResponse, Log, TransactionReceipt } from "../types/ethers";
 import type { OracleInterface, RequestKey, OracleProps, Request } from "../types/interfaces";
-import { requestId, insertOrderedAscending, eventKey, isUnique, getAddress } from "../utils";
+import { requestId, insertOrderedAscending, eventKey, isUnique } from "../utils";
 
 import {
   RequestPrice,
@@ -15,21 +15,6 @@ import {
 export type OptimisticOracleEvent = RequestPrice | ProposePrice | DisputePrice | Settle;
 
 export type { RequestPrice, ProposePrice, DisputePrice, Settle };
-
-export function getOptimisticOracleAddress(chainId: number): string {
-  switch (chainId.toString()) {
-    case "1":
-      return getAddress("0xeE3Afe347D5C74317041E2618C49534dAf887c24");
-    case "4":
-      return getAddress("0xAbE04Ace666294aefD65F991d78CE9F9218aFC67");
-    case "42":
-      return getAddress("0xB1d3A89333BBC3F5e98A991d6d4C1910802986BC");
-    case "100":
-      return getAddress("0xAa04b5D40574Fb8C001249B24d1c6B35a207F0bD");
-    default:
-      throw new Error(`No address found for deployment Skinny Optimistic Oracle on chainId ${chainId}`);
-  }
-}
 
 function validateSolidityRequest(request: Request): SolidityRequest {
   assert(request.proposer, "Missing proposer");

--- a/packages/sdk/src/oracle/services/statemachines/setActiveRequestByTransaction.ts
+++ b/packages/sdk/src/oracle/services/statemachines/setActiveRequestByTransaction.ts
@@ -17,6 +17,7 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       // have to do all of this to fetch the identifier, ancData, requester and timestamp from the request
       const provider = store.read().provider(chainId);
       const receipt = await provider.getTransactionReceipt(transactionHash);
+      assert(receipt, "Unable to find transaction receipt from hash: " + transactionHash);
       const oracleAddress = store.read().oracleAddress(chainId);
       // filter out logs that originate from oracle contract
       const oracleLogs = receipt.logs.filter((log) => log.address.toLowerCase() === oracleAddress.toLowerCase());

--- a/packages/sdk/src/oracle/services/tests/skinnyOracle.e2e.ts
+++ b/packages/sdk/src/oracle/services/tests/skinnyOracle.e2e.ts
@@ -2,12 +2,12 @@ import dotenv from "dotenv";
 import assert from "assert";
 import { ethers } from "ethers";
 import { Provider } from "@ethersproject/providers";
-import { SkinnyOptimisticOracle, getOptimisticOracleAddress } from "../skinnyOptimisticOracle";
+import { SkinnyOptimisticOracle } from "../skinnyOptimisticOracle";
 
 dotenv.config();
 
 // mainnet test only
-const ooAddress = getOptimisticOracleAddress(1);
+const ooAddress = "0xeE3Afe347D5C74317041E2618C49534dAf887c24";
 const request = {
   requester: "0x7355Efc63Ae731f584380a9838292c7046c1e433",
   identifier: "0x49535f52454c41595f56414c4944000000000000000000000000000000000000",

--- a/packages/sdk/src/oracle/skinnyFactory.ts
+++ b/packages/sdk/src/oracle/skinnyFactory.ts
@@ -1,5 +1,5 @@
 import { Client, factory } from "./client";
-import { SkinnyOptimisticOracle, getOptimisticOracleAddress } from "./services/skinnyOptimisticOracle";
+import { SkinnyOptimisticOracle } from "./services/skinnyOptimisticOracle";
 import { SortedRequests } from "./services/sortedRequests";
 import { DefaultConfig, getMulticall2Address } from "./utils";
 import { state } from "./types";
@@ -12,7 +12,6 @@ export default (
 ): Client => {
   const fullConfig = DefaultConfig({
     getMulticall2Address,
-    getOptimisticOracleAddress,
   })({ ...config }, state.OracleType.Skinny);
   return factory(fullConfig, emit, SkinnyOptimisticOracle, sortedRequests);
 };

--- a/packages/sdk/src/oracle/tests/optimisticV2.e2e.ts
+++ b/packages/sdk/src/oracle/tests/optimisticV2.e2e.ts
@@ -2,25 +2,23 @@ import dotenv from "dotenv";
 import assert from "assert";
 
 import { Client } from "../client";
-import factory from "../optimisticFactory";
-import { getFlags } from "../utils";
+import factory from "../optimisticV2Factory";
+import { getFlags, getAddress } from "../utils";
 import Store from "../store";
 import * as types from "../types";
 
 dotenv.config();
-assert(process.env.CUSTOM_NODE_URL, "requires CUSTOM_NODE_URL");
+assert(process.env.PROVIDER_URL_137, "requires PROVIDER_URL_137");
 
-const multicall2Address = "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696";
-const optimisticOracleAddress = "0xC43767F4592DF265B4a9F1a398B97fF24F38C6A6";
-const providerUrl = process.env.CUSTOM_NODE_URL;
-const chainId = 1;
+const optimisticOracleAddress = getAddress("0xee3afe347d5c74317041e2618c49534daf887c24");
+const providerUrl = process.env.PROVIDER_URL_137;
+const chainId = 137;
 
 export const config = {
   chains: {
     [chainId]: {
       chainName: "eth",
       optimisticOracleAddress,
-      multicall2Address,
       // dont know why typescript cant figure this out
       rpcUrls: [providerUrl] as [string],
       blockExplorerUrls: ["a"] as [string],
@@ -33,19 +31,20 @@ export const config = {
   },
 };
 
-const address = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
+const address = getAddress("0xee3afe347d5c74317041e2618c49534daf887c24");
 const signer = {} as types.ethers.JsonRpcSigner;
 const provider = {} as types.ethers.Web3Provider;
 
 const request = {
-  requester: "0xb8b3583f143b3a4c2aa052828d8809b0818a16e9",
-  identifier: "0x554D415553440000000000000000000000000000000000000000000000000000",
-  timestamp: 1638453600,
-  ancillaryData: "0x747761704C656E6774683A33363030",
+  address: "0xee3afe347d5c74317041e2618c49534daf887c24",
+  requester: "0x3BFf7fD5AACb1a22e1dd3ddbd8cfB8622A9E9A5B",
+  identifier: "0x4d584e5553440000000000000000000000000000000000000000000000000000",
+  ancillaryData: "0x00",
+  timestamp: 1659179901,
   chainId,
 };
 
-describe("Oracle Client", function () {
+describe("Oracle V2 Client", function () {
   let client: Client;
   let store: Store;
   beforeAll(function () {
@@ -86,42 +85,10 @@ describe("Oracle Client", function () {
     assert.ok(!result[types.state.Flag.WrongChain]);
     assert.ok(!result[types.state.Flag.MissingRequest]);
     assert.ok(!result[types.state.Flag.MissingUser]);
-    assert.ok(!result[types.state.Flag.CanPropose]);
+    assert.ok(result[types.state.Flag.CanPropose]);
     assert.ok(!result[types.state.Flag.CanDispute]);
     assert.ok(!result[types.state.Flag.CanSettle]);
-    assert.ok(result[types.state.Flag.RequestSettled]);
-    assert.ok(result[types.state.Flag.InsufficientApproval]);
-  });
-  test("setActiveRequestByTransaction", async function (done) {
-    const transactionHash = "0x91720719f4768e10849ebb5f41690488f7060e10534c5c4f15e69b7dc494502a";
-    const chainId = 1;
-    const id = client.setActiveRequestByTransaction({ transactionHash, chainId });
-    const expectedExpiration = 1630368843;
-
-    const stop = setInterval(() => {
-      const result = store.read().command(id);
-      if (result.done) {
-        assert.ok(!result.error);
-        assert.ok(store.read().request());
-        assert.equal(store.read().request().expirationTime, expectedExpiration);
-        clearInterval(stop);
-        done();
-      }
-    }, 1000);
-  });
-  test("setActiveRequestByTransaction failure", async function (done) {
-    const transactionHash = "0x91720719f4768e10849ebb5f41690488f7060e10534c5c4f15e69b7dc494502a";
-    const chainId = 1;
-    const eventIndex = 1;
-    const id = client.setActiveRequestByTransaction({ transactionHash, chainId, eventIndex });
-
-    const stop = setInterval(() => {
-      const result = store.read().command(id);
-      if (result.done) {
-        assert.ok(result.error);
-        clearInterval(stop);
-        done();
-      }
-    }, 1000);
+    assert.ok(!result[types.state.Flag.RequestSettled]);
+    assert.ok(!result[types.state.Flag.InsufficientApproval]);
   });
 });

--- a/packages/sdk/src/oracle/types/interfaces.ts
+++ b/packages/sdk/src/oracle/types/interfaces.ts
@@ -1,5 +1,5 @@
 import { BigNumberish, BigNumber, Signer, TransactionResponse, TransactionReceipt, Provider } from "../types/ethers";
-import { RequestState, RequestKey, Request as RequestFromEvent } from "../../clients/optimisticOracle";
+import { RequestState, RequestKey, Request as RequestFromEvent } from "../../clients/optimisticOracleV2";
 import { Client } from "../client";
 import { OracleType } from "../types/state";
 

--- a/packages/sdk/src/oracle/types/state.ts
+++ b/packages/sdk/src/oracle/types/state.ts
@@ -51,10 +51,7 @@ export type InputRequestWithOracleType = InputRequest & { oracleType: OracleType
 export type RequestWithOracleType = Request & { oracleType: OracleType };
 export type RequestsWithOracleType = RequestWithOracleType[];
 // partial config lets user omit some fields which we can infer internally using contracts-frontend
-export type PartialChainConfig = PartialBy<
-  ChainConfig,
-  "optimisticOracleAddress" | "chainId" | "checkTxIntervalSec" | "earliestBlockNumber"
->;
+export type PartialChainConfig = PartialBy<ChainConfig, "chainId" | "checkTxIntervalSec" | "earliestBlockNumber">;
 
 export enum OracleType {
   Optimistic = "Optimistic",

--- a/packages/sdk/src/oracle/utils.ts
+++ b/packages/sdk/src/oracle/utils.ts
@@ -116,10 +116,9 @@ export function getMulticall2Address(chainId: number): string {
 type AddressGetter = (chainId: number) => string;
 interface AddressGetters {
   getMulticall2Address: AddressGetter;
-  getOptimisticOracleAddress: AddressGetter;
 }
 
-export const DefaultChainConfig = ({ getMulticall2Address, getOptimisticOracleAddress }: AddressGetters) => (
+export const DefaultChainConfig = ({ getMulticall2Address }: AddressGetters) => (
   chainId: number,
   chainConfig: PartialChainConfig
 ): ChainConfig => {
@@ -130,15 +129,12 @@ export const DefaultChainConfig = ({ getMulticall2Address, getOptimisticOracleAd
     // ignore, multicall optional
   }
 
-  // dont ignore error, oracle required
-  const optimisticOracleAddress = chainConfig.optimisticOracleAddress || getOptimisticOracleAddress(chainId);
   const checkTxIntervalSec = chainConfig.checkTxIntervalSec || 5;
 
   return {
     ...chainConfig,
     chainId,
     multicall2Address,
-    optimisticOracleAddress,
     checkTxIntervalSec,
   };
 };


### PR DESCRIPTION
BREAKING CHANGE: oracle addresses are now required in configuration

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
There were various issues we needed to correct in sdk:

1. optimistic oracle v2 is missing requestSettings on the request object
2. end to end client tests failing
3. hardcoded oracle addresses out of date, these are dangerous if not constantly maintained and should be explicitly specified by frontend client

**Summary**
There was a typo when including the oraclev2 client into the oraclev2 service, thats been corrected. All address lookups for oracle addresses have been removed. Oracle client e2e tests were fixed to run and a optimistic v2 test added for polygon. 


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


