### PR TITLE
fix: [N04]: Correction of Erroneous imports

### DIFF
--- a/packages/core/contracts/oracle/implementation/ProposerV2.sol
+++ b/packages/core/contracts/oracle/implementation/ProposerV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "./Finder.sol";
 import "./GovernorV2.sol";
 import "./Constants.sol";
-import "./Voting.sol";
+import "../interfaces/OracleAncillaryInterface.sol";
 import "./AdminIdentifierLib.sol";
 import "../../common/implementation/Lockable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -85,7 +85,8 @@ contract ProposerV2 is Ownable, Testable, Lockable {
      */
     function resolveProposal(uint256 id) external nonReentrant() {
         BondedProposal memory bondedProposal = bondedProposals[id];
-        Voting voting = Voting(finder.getImplementationAddress(OracleInterfaces.Oracle));
+        OracleAncillaryInterface voting =
+            OracleAncillaryInterface(finder.getImplementationAddress(OracleInterfaces.Oracle));
         require(
             voting.hasPrice(
                 AdminIdentifierLib._constructIdentifier(id),


### PR DESCRIPTION
**Motivation**

*OZ identified the following issue*
```
The ProposalV2 contract erroneously imports Voting.sol instead of VotingV2.sol .
Currently, all function signatures used within ProposalV2 are available in both Voting.sol
and VotingV2.sol , thereby preventing any direct consequences.
Consider upgrading the import to VotingV2.sol for consistency.
```

*Solution implemented in this PR:*
Swapped the import of `Voting.sol` to `OracleAncillaryInterface.sol` which has the required interface for the correct function of `ProposerV2.sol`.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
