### PR TITLE
fix: [N05]: Remove redundant WithdrawnRewards event emission

### DIFF
--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -204,8 +204,8 @@ contract Staker is StakerInterface, Ownable {
         if (tokensToMint > 0) {
             voterStake.outstandingRewards = 0;
             require(votingToken.mint(msg.sender, tokensToMint), "Voting token issuance failed");
+            emit WithdrawnRewards(msg.sender, tokensToMint);
         }
-        emit WithdrawnRewards(msg.sender, tokensToMint);
         return (tokensToMint);
     }
 


### PR DESCRIPTION

**Motivation**

*OZ identified the following issue:*
```
The withdrawRewards function in the Staker contract emits a WithdrawnRewards
event to log the minting of rewards tokens to the voter than called the function. However, the
event is emitted outside the if block that checks for a non-zero value of tokensToMint . If
no rewards are minted, the WithdrawnRewards event will be logged even though no state
change occurred, wasting gas and possibly leading to confusion.
Consider only emitted the WithdrawnRewards event when tokensToMint is not zero.
```

*This PR implements the following solution:*
Moving of this event back into the if/else block.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
