### PR TITLE
fix: [N09]: Address inconsistent Events

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -196,10 +196,10 @@ contract VotingV2 is
     );
 
     event PriceRequestAdded(
-        address requester,
+        address indexed requester,
         uint256 indexed roundId,
         bytes32 indexed identifier,
-        uint256 indexed time,
+        uint256 time,
         uint256 requestIndex,
         bytes ancillaryData,
         bool isGovernance
@@ -209,6 +209,7 @@ contract VotingV2 is
         uint256 indexed roundId,
         bytes32 indexed identifier,
         uint256 time,
+        uint256 requestIndex,
         int256 price,
         bytes ancillaryData
     );
@@ -1150,6 +1151,7 @@ contract VotingV2 is
             priceRequest.lastVotingRound,
             priceRequest.identifier,
             priceRequest.time,
+            priceRequest.priceRequestIndex,
             resolvedPrice,
             priceRequest.ancillaryData
         );


### PR DESCRIPTION
**Motivation**

OZ identified the following:
```
Within the VotingV2 contract, the PriceRequestAdded event applies the indexed
keyword to the time variable but not the requester variable. All other events within this
contract that emit a time value do not apply indexing to it, and all other events apply indexing
to any addresses they emit, except this one.
To use indexing consistently, in the PriceRequestAdded event consider removing the
indexed keyword from time and adding it to requester .
```
*This PR implements:*
Requested changes and the addition of `uint256 requestIndex` to `PriceResolved`.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
