### PR TITLE
fix: [N11]: Remove magic numbers

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -1004,8 +1004,8 @@ contract VotingV2 is
             _getPriceOrError(identifier, spamDeletionProposals[proposalId].requestTime, "");
         require(hasPrice);
 
-        // If the price is 1e18 then the spam deletion request was correctly voted on to delete the requests.
-        if (resolutionPrice == 1e18) {
+        // If the price is non zero then the spam deletion request was voted up to delete the requests. Execute delete.
+        if (resolutionPrice != 0) {
             // Delete the price requests associated with the spam.
             for (uint256 i = 0; i < spamDeletionProposals[proposalId].spamRequestIndices.length; i = unsafe_inc(i)) {
                 uint64 startIndex = uint64(spamDeletionProposals[proposalId].spamRequestIndices[uint256(i)][0]);


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
In the VotingV2 contract, the function executeSpamDeletion contains the magic value
1e18 which represents a successful vote in favor of a spam deletion request.
Using inline magic values hinders code legibility and increases the chance of introducing
erroneous values.
Consider assigning all magic values to descriptive constants and replacing all semantically
matching occurrences of the value with its respective constant.
```
*Changes implemented in this PR:*
Rather than using a const, as requested, I changed the check to be `resolutionPrice != 0`. This removes the magic number and is actually more correct as _any_ non-zero value is considered "yes" with governance actions, as can be seen [here](https://github.com/UMAprotocol/protocol/blob/baf99022bb69c0744a5b13b26610245c49c74b93/packages/core/contracts/oracle/implementation/GovernorV2.sol#L148) in the governor.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
