### PR TITLE
fix: [N12]: Address Misleading documentation

### DIFF
--- a/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
@@ -18,7 +18,7 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
      ****************************************/
 
     enum Roles {
-        Owner, // Can set the Voter role. Is also permanently permissioned as the minter role.
+        Owner, // Can set the Voter role.
         Voter // Can vote through this contract.
     }
 

--- a/packages/core/contracts/oracle/implementation/SlashingLibrary.sol
+++ b/packages/core/contracts/oracle/implementation/SlashingLibrary.sol
@@ -52,7 +52,7 @@ contract SlashingLibrary {
     }
 
     /**
-     * @notice Calculates all slashing trackers in one go to decrease cross-chain calls needed.
+     * @notice Calculates all slashing trackers in one go to decrease cross-contract calls needed.
      * @param totalStaked The total amount of tokens staked.
      * @param totalVotes The total amount of votes.
      * @param totalCorrectVotes The total amount of correct votes.

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -159,7 +159,6 @@ contract VotingV2 is
         uint256 bond;
     }
 
-    // Maps round numbers to the spam deletion request.
     SpamDeletionRequest[] public spamDeletionProposals;
 
     /****************************************
@@ -715,7 +714,8 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Returns the current round ID, as a function of the current time.
+     * @notice Returns the round end time, as a function of the round number.
+     * @param roundId representing the unique round ID.
      * @return uint256 representing the unique round ID.
      */
     function getRoundEndTime(uint256 roundId) public view returns (uint256) {
@@ -765,7 +765,6 @@ contract VotingV2 is
 
     /**
      * @notice Resets the Gat percentage. Note: this change only applies to rounds that have not yet begun.
-     * @dev This method is public because calldata structs are not currently supported by solidity.
      * @param newGat sets the next round's Gat.
      */
     function setGat(uint256 newGat) public override onlyOwner {


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
The code base contains multiple occurrences of misleading or incorrect documentation:
In the contract DesignatedVotingV2 , the comment on line 21 "Is also permanently
permissioned as the minter role" appears to be a copy & paste error as a minting
function is not part of the contract. Consider removing the comment.
```

*Changes implemented in this PR:*
Misleading comments were either fixed or removed (when not required).

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested

