### PR TITLE
fix: [N21]: Too many digits in numeric literals

### DIFF
--- a/packages/core/contracts/oracle/implementation/SlashingLibrary.sol
+++ b/packages/core/contracts/oracle/implementation/SlashingLibrary.sol
@@ -16,7 +16,7 @@ contract SlashingLibrary {
     ) public pure returns (uint256) {
         // This number is equal to the slash amount needed to cancel an APY of 20%
         // if 10 votes are cast each month for a year. 0.2/(10*12)= ~0.0016
-        return 1600000000000000;
+        return 0.0016e18;
     }
 
     /**
@@ -48,7 +48,7 @@ contract SlashingLibrary {
     ) public pure returns (uint256) {
         // This number is equal to the slash amount needed to cancel an APY of 20%
         // if 10 votes are cast each month for a year. 0.2/(10*12)= ~0.0016
-        return 1600000000000000;
+        return 0.0016e18;
     }
 
     /**


### PR DESCRIPTION
**Motivation**

*OZ identified the following optimization in code readability:*
```
Within the SlashingLibrary contract, the functions calcWrongVoteSlashPerToken
and calcNoVoteSlashPerToken both return a hard-coded value of 1600000000000000 .
Numeric literals with a large number of digits are more difficult to interpret, requiring the reader
or reviewer to count the number of digits to ensure correctness.
Solidity supports scientific notation representation for large values. Consider replacing these
integer values with their more compact equivalent representation 1.6e15 .
```

*This PR impelements the changes requested*


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [X]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested

