### PR TITLE
fix: [N22]: Fix Typographical errors

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -89,7 +89,7 @@ core's tests. Running these specific tests can be done as follows:
 
 ```bash
 cd ../.. # navigate to the root of the protocol repo
-yarn optimsim-up # start the optimism containers. note this will take a long time as a few containers need to be built
+yarn optimism-up # start the optimism containers. note this will take a long time as a few containers need to be built
 cd ./packages/core # move back to this package
 yarn test-e2e # run the end to end tests against the optimism containers.
 ```

--- a/packages/core/contracts/common/implementation/MultiCaller.sol
+++ b/packages/core/contracts/common/implementation/MultiCaller.sol
@@ -1,4 +1,4 @@
-// This contract is taken from Uniswaps's multi call implementation (https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol)
+// This contract is taken from Uniswap's multi call implementation (https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol)
 // and was modified to be solidity 0.8 compatible. Additionally, the method was restricted to only work with msg.value
 // set to 0 to avoid any nasty attack vectors on function calls that use value sent with deposits.
 pragma solidity ^0.8.0;

--- a/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/DesignatedVotingV2.sol
@@ -51,7 +51,7 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
 
     /**
      * @notice Forwards a commit to Voting.
-     * @param identifier uniquely identifies the feed for this vote. EG BTC/USD price pair.
+     * @param identifier uniquely identifies the feed for this vote. E.G BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
      * @param hash keccak256 hash of the price, salt, voter address, time, ancillaryData, current roundId, identifier.
      */
@@ -68,11 +68,11 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
      * @notice commits a vote and logs an event with a data blob, typically an encrypted version of the vote
      * @dev An encrypted version of the vote is emitted in an event EncryptedVote to allow off-chain infrastructure to
      * retrieve the commit. The contents of encryptedVote are never used on chain: it is purely for convenience.
-     * @param identifier unique price pair identifier. Eg: BTC/USD price pair.
-     * @param time unix timestamp of for the price request.
-     * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
+     * @param identifier unique price pair identifier. E.g: BTC/USD price pair.
+     * @param time unix timestamp the price request.
+     * @param ancillaryData arbitrary data appended to a price request to give the voter's more info from the caller.
      * @param hash keccak256 hash of the price, salt, voter address, time, ancillaryData, current roundId, identifier.
-     * @param encryptedVote offchain encrypted blob containing the voters amount, time and salt.
+     * @param encryptedVote offchain encrypted blob containing the voter's amount, time and salt.
      */
     function commitAndEmitEncryptedVote(
         bytes32 identifier,
@@ -86,7 +86,7 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
 
     /**
      * @notice Forwards a reveal to Voting.
-     * @param identifier voted on in the commit phase. EG BTC/USD price pair.
+     * @param identifier voted on in the commit phase. E.G BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
      * @param price voted on during the commit phase.
      * @param salt value used to hide the commitment price during the commit phase.

--- a/packages/core/contracts/oracle/implementation/GovernorV2.sol
+++ b/packages/core/contracts/oracle/implementation/GovernorV2.sol
@@ -95,7 +95,7 @@ contract GovernorV2 is MultiRole, Testable {
         uint256 time = getCurrentTime();
 
         // Note: doing all of this array manipulation manually is necessary because directly setting an array of
-        // structs in storage to an an array of structs in memory is currently not implemented in solidity :/.
+        // structs in storage to an array of structs in memory is currently not implemented in solidity :/.
 
         // Add a zero-initialized element to the proposals array.
         proposals.push();

--- a/packages/core/contracts/oracle/implementation/ProposerV2.sol
+++ b/packages/core/contracts/oracle/implementation/ProposerV2.sol
@@ -112,7 +112,7 @@ contract ProposerV2 is Ownable, Testable, Lockable {
 
     /**
      * @notice Admin method to set the bond amount.
-     * @dev Admin is intended to be the governance system, itself.
+     * @dev Admin is intended to be the governance system itself.
      * @param _bond the new bond.
      */
     function setBond(uint256 _bond) public nonReentrant() onlyOwner() {

--- a/packages/core/contracts/oracle/implementation/SlashingLibrary.sol
+++ b/packages/core/contracts/oracle/implementation/SlashingLibrary.sol
@@ -56,7 +56,7 @@ contract SlashingLibrary {
      * @param totalStaked The total amount of tokens staked.
      * @param totalVotes The total amount of votes.
      * @param totalCorrectVotes The total amount of correct votes.
-     * @return  wrongVoteSlashPerToken The amount of tokens to slash for voting wrong.
+     * @return wrongVoteSlashPerToken The amount of tokens to slash for voting wrong.
      * @return noVoteSlashPerToken The amount of tokens to slash for not voting.
      */
     function calcSlashing(

--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
- * @title Staking contract enabling UMA to be locked up by stakers to earn a prorate share of a fixed emission rate.
+ * @title Staking contract enabling UMA to be locked up by stakers to earn a pro rate share of a fixed emission rate.
  * @dev Handles the staking, unstaking and reward retrieval logic.
  */
 contract Staker is StakerInterface, Ownable {
@@ -50,7 +50,7 @@ contract Staker is StakerInterface, Ownable {
         uint256 amount,
         uint256 voterActiveStake,
         uint256 voterPendingStake,
-        uint256 voterPendingUnStake,
+        uint256 voterPendingUnstake,
         uint256 cumulativeActiveStake,
         uint256 cumulativePendingStake
     );
@@ -88,9 +88,8 @@ contract Staker is StakerInterface, Ownable {
 
     /**
      * @notice Construct the Staker contract
-     * @param _emissionRate amount of voting tokens that are emitted per second, split prorate to stakers.
+     * @param _emissionRate amount of voting tokens that are emitted per second, split pro rate to stakers.
      * @param _unstakeCoolDown time that a voter must wait to unstake after requesting to unstake.
-     *  to be voted on in the next round. If after this, the request is rolled to a round after the next round.
      * @param _votingToken address of the UMA token contract used to commit votes.
      */
     constructor(
@@ -108,7 +107,7 @@ contract Staker is StakerInterface, Ownable {
      ****************************************/
 
     /**
-     * @notice Pulls tokens from users wallet and stakes them. If we are in a active reveal phase the stake amount will
+     * @notice Pulls tokens from users wallet and stakes them. If we are in an active reveal phase the stake amount will
      * be added to the pending stake. If not, the stake amount will be added to the active stake.
      * @param amount the amount of tokens to stake.
      */
@@ -172,8 +171,7 @@ contract Staker is StakerInterface, Ownable {
 
     /**
      * @notice  Execute a previously requested unstake. Requires the unstake time to have passed.
-     * @dev If a staker requested an unstake and time > unstakeRequestTime then send funds to staker. Note that this
-     * method assumes that the `updateTrackers().
+     * @dev If a staker requested an unstake and time > unstakeRequestTime then send funds to staker.
      */
     function executeUnstake() public override {
         VoterStake storage voterStake = voterStakes[msg.sender];
@@ -227,8 +225,8 @@ contract Staker is StakerInterface, Ownable {
 
     /**
      * @notice  Set the token's emission rate, the number of voting tokens that are emitted per second per staked token,
-     * split prorate to stakers.
-     * @param _emissionRate the new amount of voting tokens that are emitted per second, split prorate to stakers.
+     * split pro rate to stakers.
+     * @param _emissionRate the new amount of voting tokens that are emitted per second, split pro rate to stakers.
      */
     function setEmissionRate(uint256 _emissionRate) public onlyOwner {
         _updateReward(address(0));

--- a/packages/core/contracts/oracle/implementation/VoteTimingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VoteTimingV2.sol
@@ -28,7 +28,7 @@ library VoteTimingV2 {
     }
 
     /**
-     * @notice Computes the roundID based off the current time as floor(timestamp/roundLength).
+     * @notice Computes the round ID based off the current time as floor(timestamp/roundLength).
      * @dev The round ID depends on the global timestamp but not on the lifetime of the system.
      * The consequence is that the initial round ID starts at an arbitrary number (that increments, as expected, for subsequent rounds) instead of zero or one.
      * @param data input data object.
@@ -41,7 +41,7 @@ library VoteTimingV2 {
     }
 
     /**
-     * @notice compute the round end time as a function of the round Id.
+     * @notice compute the round end time as a function of the round ID.
      * @param data input data object.
      * @param roundId uniquely identifies the current round.
      * @return timestamp unix time of when the current round will end.

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -49,14 +49,14 @@ contract VotingV2 is
         uint32 lastVotingRound;
         // Denotes whether this is a governance request or not.
         bool isGovernance;
-        // The pendingRequestIndex in the pendingPriceRequests that references this PriceRequest. A value of UINT_MAX
+        // The pendingRequestIndex in the pendingPriceRequests that references this PriceRequest. A value of UINT64_MAX
         // means that this PriceRequest is resolved and has been cleaned up from pendingPriceRequests.
         uint64 pendingRequestIndex;
         // Each request has a unique requestIndex number that is used to order all requests. This is the index within
         // the priceRequestIds array and is incremented on each request.
         uint64 priceRequestIndex;
         // Timestamp that should be used when evaluating the request.
-        // Note: this is a uint56 to allow better variable packing while still leaving more than ample room for
+        // Note: this is a uint64 to allow better variable packing while still leaving more than ample room for
         // timestamps to stretch far into the future.
         uint64 time;
         // Identifier that defines how the voters should resolve the request.
@@ -293,7 +293,7 @@ contract VotingV2 is
      * @notice Enqueues a request (if a request isn't already present) for the identifier, time pair.
      * @dev Time must be in the past and the identifier must be supported. The length of the ancillary data
      * is limited such that this method abides by the EVM transaction gas limit.
-     * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
+     * @param identifier uniquely identifies the price requested. E.g. BTC/USD (encoded as bytes32) could be requested.
      * @param time unix timestamp for the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
      */
@@ -309,7 +309,7 @@ contract VotingV2 is
      * @notice Enqueues a governance action request (if a request isn't already present) for identifier, time pair.
      * @dev Time must be in the past and the identifier must be supported. The length of the ancillary data
      * is limited such that this method abides by the EVM transaction gas limit.
-     * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
+     * @param identifier uniquely identifies the price requested. E.g. BTC/USD (encoded as bytes32) could be requested.
      * @param time unix timestamp for the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
      */
@@ -325,7 +325,7 @@ contract VotingV2 is
      * @notice Enqueues a request (if a request isn't already present) for the given identifier, time pair.
      * @dev Time must be in the past and the identifier must be supported. The length of the ancillary data is limited
      * such that this method abides by the EVM transaction gas limit.
-     * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
+     * @param identifier uniquely identifies the price requested. E.g. BTC/USD (encoded as bytes32) could be requested.
      * @param time unix timestamp for the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
      * @param isGovernance indicates whether the request is for a governance action.
@@ -389,8 +389,8 @@ contract VotingV2 is
     /**
      * @notice Whether the price for identifier and time is available.
      * @dev Time must be in the past and the identifier must be supported.
-     * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
-     * @param time unix timestamp of for the price request.
+     * @param identifier uniquely identifies the price requested. E.g. BTC/USD (encoded as bytes32) could be requested.
+     * @param time unix timestamp of the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
      * @return _hasPrice bool if the DVM has resolved to a price for the given identifier and timestamp.
      */
@@ -411,8 +411,8 @@ contract VotingV2 is
     /**
      * @notice Gets the price for identifier and time if it has already been requested and resolved.
      * @dev If the price is not available, the method reverts.
-     * @param identifier uniquely identifies the price requested. eg BTC/USD (encoded as bytes32) could be requested.
-     * @param time unix timestamp of for the price request.
+     * @param identifier uniquely identifies the price requested. E.g. BTC/USD (encoded as bytes32) could be requested.
+     * @param time unix timestamp of the price request.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
      * @return int256 representing the resolved price for the given identifier and timestamp.
      */
@@ -436,7 +436,7 @@ contract VotingV2 is
     /**
      * @notice Gets the status of a list of price requests, identified by their identifier and time.
      * @dev If the status for a particular request is NotRequested, the lastVotingRound will always be 0.
-     * @param requests array of type PendingRequest which includes an identifier and timestamp for each request.
+     * @param requests array of type PendingRequestAncillary which includes an identifier and timestamp for each request.
      * @return requestStates a list, in the same order as the input list, giving the status of each of the specified price requests.
      */
     function getPriceRequestStatuses(PendingRequestAncillary[] memory requests)
@@ -483,7 +483,7 @@ contract VotingV2 is
      * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s
      * expected behavior, voters should never reuse salts. If someone else is able to guess the voted price and knows
      * that a salt will be reused, then they can determine the vote pre-reveal.
-     * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
+     * @param identifier uniquely identifies the committed vote. E.g. BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
      * @param hash keccak256 hash of the price, salt, voter address, time, ancillaryData, current roundId, identifier.
@@ -526,7 +526,7 @@ contract VotingV2 is
      * @notice Reveal a previously committed vote for identifier at time.
      * @dev The revealed price, salt, voter address, time, ancillaryData, current roundId, identifier must hash to the
      * latest hash that commitVote() was called with. Only the committer can reveal their vote.
-     * @param identifier voted on in the commit phase. EG BTC/USD price pair.
+     * @param identifier voted on in the commit phase. E.g. BTC/USD price pair.
      * @param time specifies the unix timestamp of the price being voted on.
      * @param price voted on during the commit phase.
      * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
@@ -583,14 +583,14 @@ contract VotingV2 is
     }
 
     /**
-     * @notice commits a vote and logs an event with a data blob, typically an encrypted version of the vote
+     * @notice Commits a vote and logs an event with a data blob, typically an encrypted version of the vote
      * @dev An encrypted version of the vote is emitted in an event EncryptedVote to allow off-chain infrastructure to
      * retrieve the commit. The contents of encryptedVote are never used on chain: it is purely for convenience.
-     * @param identifier unique price pair identifier. Eg: BTC/USD price pair.
-     * @param time unix timestamp of for the price request.
-     * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
+     * @param identifier unique price pair identifier. E.g. BTC/USD price pair.
+     * @param time unix timestamp of the price request.
+     * @param ancillaryData arbitrary data appended to a price request to give the voter's more info from the caller.
      * @param hash keccak256 hash of the price you want to vote for and a int256 salt.
-     * @param encryptedVote offchain encrypted blob containing the voters amount, time and salt.
+     * @param encryptedVote offchain encrypted blob containing the voter's amount, time and salt.
      */
     function commitAndEmitEncryptedVote(
         bytes32 identifier,
@@ -628,9 +628,9 @@ contract VotingV2 is
     }
 
     /**
-     * @notice Sets the delegator of a voter. Acts to accept a delegation. The delegate can only vote for delegator if
-     * the delegator also selected the delegate to do so (two way relationship needed).
-     * @param delegator the address of the delegate.
+     * @notice Sets the delegator of a voter. Acts to accept a delegation. The delegate can only vote for the delegator
+     * if the delegator also selected the delegate to do so (two-way relationship needed).
+     * @param delegator the address of the delegator.
      */
     function setDelegator(address delegator) public {
         delegateToStaker[msg.sender] = delegator;
@@ -868,7 +868,7 @@ contract VotingV2 is
                     continue;
                 }
                 // Else, we are simply evaluating a request that is still actively being voted on. In this case, break as
-                // all subsequent requests within the array must be in the same state and cant have any slashing applied.
+                // all subsequent requests within the array must be in the same state and can't have any slashing applied.
                 break;
             }
 
@@ -902,14 +902,12 @@ contract VotingV2 is
                             voteInstance.resultComputation.totalVotes)) +
                         ((wrongVoteSlashPerToken * (voteInstance.resultComputation.totalVotes - totalCorrectVotes)))) /
                         1e18;
-
                 slash += int256(((voterStake.activeStake * totalSlashed)) / totalCorrectVotes);
             }
 
             // If this is not the last price request to apply and the next request in the batch is from a subsequent
             // round then apply the slashing now. Else, do nothing and apply the slashing after the loop concludes.
             // This acts to apply slashing within a round as independent actions: multiple votes within the same round
-
             // should not impact each other but subsequent rounds should impact each other. We need to consider the
             // deletedRequests mapping when finding the next index as the next request may have been deleted or rolled.
             uint256 nextRequestIndex =
@@ -945,10 +943,10 @@ contract VotingV2 is
      ****************************************/
 
     /**
-     * @notice Declare a specific price requests range to be spam and request it's deletion.
+     * @notice Declare a specific price requests range to be spam and request its deletion.
      * @dev note that this method should almost never be used. The bond to call this should be set to
      * a very large number (say 10k UMA) as it could be abused if set too low. Function constructs a price
-     * request that, if passed, enables pending requests to be diregarded by the contract.
+     * request that, if passed, enables pending requests to be disregarded by the contract.
      * @param spamRequestIndices list of request indices to be declared as spam. Each element is a
      * pair of uint256s representing the start and end of the range.
      */
@@ -961,7 +959,7 @@ contract VotingV2 is
             uint256[2] memory spamRequestIndex = spamRequestIndices[i];
 
             // Check request end index is greater than start index, endIndex is less than the total number of requests,
-            // and validate index continuity (each sequential element within the spamRequestIndices array is sequently
+            // and validate index continuity (each sequential element within the spamRequestIndices array is sequential
             // and increasing in size).
             require(
                 spamRequestIndex[0] <= spamRequestIndex[1] &&
@@ -1137,7 +1135,7 @@ contract VotingV2 is
         // If it's not resolvable return false.
         if (!isResolvable) return false;
 
-        // Else, the request is resolvable. Remove the element from the pending request and update pendingRequestIndex
+        // Else, the request is resolvable. Remove the element from the pending requests and update pendingRequestIndex
         // within the price request struct to make the next entry into this method a no-op for this request.
         uint256 lastIndex = pendingPriceRequests.length - 1;
         PriceRequest storage lastPriceRequest = priceRequests[pendingPriceRequests[lastIndex]];

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -23,7 +23,7 @@ import "./VoteTimingV2.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
- * @title VotingV2 contract for UMA's DVM mechanism.
+ * @title VotingV2 contract for the UMA DVM.
  * @dev Handles receiving and resolving price requests via a commit-reveal voting schelling scheme.
  */
 
@@ -619,7 +619,7 @@ contract VotingV2 is
 
     /**
      * @notice Sets the delegate of a voter. This delegate can vote on behalf of the staker. The staker will still own
-     * all staked balances, receive rewards and be slashed based on the actors of the delegate. Intended use is using a
+     * all staked balances, receive rewards and be slashed based on the actions of the delegate. Intended use is using a
      * low-security available wallet for voting while keeping access to staked amounts secure by a more secure wallet.
      * @param delegate the address of the delegate.
      */
@@ -654,7 +654,7 @@ contract VotingV2 is
 
     /**
      * @notice Gets the queries that are being voted on this round.
-     * @return pendingRequests array containing identifiers of type PendingRequest.
+     * @return pendingRequests array containing identifiers of type PendingRequestAncillary.
      */
     function getPendingRequests() public view override returns (PendingRequestAncillary[] memory) {
         uint256 blockTime = getCurrentTime();

--- a/packages/core/contracts/oracle/interfaces/VotingAncillaryInterface.sol
+++ b/packages/core/contracts/oracle/interfaces/VotingAncillaryInterface.sol
@@ -46,7 +46,7 @@ abstract contract VotingAncillaryInterface {
      * @dev Since transaction data is public, the salt will be revealed with the vote. While this is the system’s expected behavior,
      * voters should never reuse salts. If someone else is able to guess the voted price and knows that a salt will be reused, then
      * they can determine the vote pre-reveal.
-     * @param identifier uniquely identifies the committed vote. EG BTC/USD price pair.
+     * @param identifier uniquely identifies the committed vote. E.G. BTC/USD price pair.
      * @param time unix timestamp of the price being voted on.
      * @param hash keccak256 hash of the `price`, `salt`, voter `address`, `time`, current `roundId`, and `identifier`.
      */
@@ -70,7 +70,7 @@ abstract contract VotingAncillaryInterface {
      * @notice commits a vote and logs an event with a data blob, typically an encrypted version of the vote
      * @dev An encrypted version of the vote is emitted in an event `EncryptedVote` to allow off-chain infrastructure to
      * retrieve the commit. The contents of `encryptedVote` are never used on chain: it is purely for convenience.
-     * @param identifier unique price pair identifier. Eg: BTC/USD price pair.
+     * @param identifier unique price pair identifier. E.g. BTC/USD price pair.
      * @param time unix timestamp of for the price request.
      * @param hash keccak256 hash of the price you want to vote for and a `int256 salt`.
      * @param encryptedVote offchain encrypted blob containing the voters amount, time and salt.


### PR DESCRIPTION
**Motivation**

*OZ identified the following issues:*
```
Consider addressing the following typographical errors:
In DesignatedVotingV2.sol :
line 54: "EG" should be "E.g."
line 71: "Eg:" should be "E.g."
line 72: "of for the price request" should be "of the price request"
line 75: "voters" should be "voter's"
line 89: "EG" should be "E.g."
In GovernorV2.sol :
line 98: "an an array" should be "an array"
In ProposerV2.sol :
line 115: "system, itself" should be "system itself"
In SlashingLibrary.sol :
line 59: Remove space before "wrongVoteSlashPerToken"
In Staker.sol :
line 13: "prorate" should be "pro rata"
line 53: "voterPendingUnStake" should be "voterPendingUnstake"
line 91: "prorate" should be "pro rata"
line 93: Remove erroneous comment line
line 111: "a active reveal" should be "an active reveal"
line 175-176: Remove the incomplete sentence that begins with "Note that this..."
line 230: "prorate" should be "pro rata"
line 231: "prorate" should be "pro rata"
In VoteTimingV2.sol :
line 31: "roundID" should be "round ID"
line 44: "round Id" should be "round ID" (or roundId )
In VotingV2.sol :
line 26: "UMA's DVM mechanism" should be "UMA's DVM" (mechanism is
redundant)
line 52: "UINT_MAX" should be "UINT64_MAX"
line 59: "uint56" should be "uint64"
line 295: "eg" should be "E.g."
line 311: "eg" should be "E.g."
line 327: "eg" should be "E.g."
line 391: "eg" should be "E.g."
line 413: "eg" should be "E.g."
line 485: "EG" should be "E.g."
line 528: "EG" should be "E.g."
line 585: "commits" should be "Commits"
line 588: "Eg:" should be "E.g."
line 589: "of for the price request" should be "of the price request"
line 592: "voters" should be "voter's"
line 621: "actors" should be "actions"
line 630: "for delegator" should be "for the delegator"
line 631: "two way" should be "two-way"
line 632: "of the delegate" should be "of the delegator"
line 656: "of type PendingRequest " should be "of type
PendingRequestAncillary "
line 866: "cant" should be "can't"
line 943: "it's" should be "its"
line 907: Remove blank line
line 946: "diregarded" should be "disregarded"
line 959: "sequently" should be "sequential"
line 1134: "pending request" should be "pending requests"

Additionally, some errors were found in out-of-scope files:
In packages/core/README.md :
line 92: "optimsim-up" should be "optimism-up"
In packages/core/contracts/common/implementation/MultiCaller.sol :
line 1: "Uniswaps's" should be "Uniswap's"
In packages/core/test/oracle/VotingV2.js :
line 2300: "i.e" should be "i.e."
line 2481: "cant" should be "can't"
line 2482: "cant" should be "can't"
line 2630: "Dont" should be "Don't"
line 2708: "cant" should be "cant"
line 2815: "dont" should be "don't"
line 2857: "i.e" should be "i.e."
```

*This PR addresses the issues indentifed in the issue*.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested

