### PR TITLE
fix: [M04] improve migration process

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -301,7 +301,7 @@ contract VotingV2 is
         bytes32 identifier,
         uint256 time,
         bytes memory ancillaryData
-    ) public override onlyRegisteredContract() {
+    ) public override onlyIfNotMigrated() onlyRegisteredContract() {
         _requestPrice(identifier, time, ancillaryData, false);
     }
 
@@ -1198,10 +1198,10 @@ contract VotingV2 is
     }
 
     function _requireRegisteredContract() private view {
-        if (migratedAddress != address(0)) require(msg.sender == migratedAddress);
-        else {
-            Registry registry = Registry(finder.getImplementationAddress(OracleInterfaces.Registry));
-            require(registry.isContractRegistered(msg.sender), "Caller must be registered");
-        }
+        Registry registry = Registry(finder.getImplementationAddress(OracleInterfaces.Registry));
+        require(
+            registry.isContractRegistered(msg.sender) || msg.sender == migratedAddress,
+            "Caller must be registered"
+        );
     }
 }

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -1279,11 +1279,13 @@ describe("VotingV2", function () {
     assert(await newVoting.methods.hasPrice(identifier, time1).send({ from: registeredContract }));
 
     // commit/reveal are completely disabled, regardless if called by newVoting.
-    assert(await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: newVoting })));
+    assert(
+      await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: migratedVoting }))
+    );
     assert(await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: account1 })));
 
     // Requesting prices is completely disabled after migration, regardless if called by newVoting.
-    assert(await didContractThrow(newVoting.methods.requestPrice(identifier, time3).send({ from: newVoting })));
+    assert(await didContractThrow(newVoting.methods.requestPrice(identifier, time3).send({ from: migratedVoting })));
     assert(
       await didContractThrow(newVoting.methods.requestPrice(identifier, time3).send({ from: registeredContract }))
     );

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -1212,6 +1212,7 @@ describe("VotingV2", function () {
     const identifier = padRight(utf8ToHex("migration"), 64);
     const time1 = "1000";
     const time2 = "2000";
+    const time3 = "3000";
     // Deploy our own voting because this test case will migrate it.
     const newVoting = await VotingV2.new(
       "640000000000000000", // emission rate
@@ -1273,10 +1274,19 @@ describe("VotingV2", function () {
     assert(await didContractThrow(newVoting.methods.setMigrated(migratedVoting).send({ from: migratedVoting })));
     await newVoting.methods.setMigrated(migratedVoting).send({ from: accounts[0] });
 
-    // Now only new newVoting can call methods.
-    assert(await newVoting.methods.hasPrice(identifier, time1).call({ from: migratedVoting }));
-    assert(await didContractThrow(newVoting.methods.hasPrice(identifier, time1).send({ from: registeredContract })));
+    // Now newVoting and registered contracts can call methods.
+    assert(await newVoting.methods.hasPrice(identifier, time1).send({ from: migratedVoting }));
+    assert(await newVoting.methods.hasPrice(identifier, time1).send({ from: registeredContract }));
+
+    // commit/reveal are completely disabled, regardless if called by newVoting.
+    assert(await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: newVoting })));
     assert(await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: account1 })));
+
+    // Requesting prices is completely disabled after migration, regardless if called by newVoting.
+    assert(await didContractThrow(newVoting.methods.requestPrice(identifier, time3).send({ from: newVoting })));
+    assert(
+      await didContractThrow(newVoting.methods.requestPrice(identifier, time3).send({ from: registeredContract }))
+    );
   });
 
   it("pendingPriceRequests array length", async function () {


### PR DESCRIPTION
**Motivation**

Note: this PR only fixes part of the issue that OZ found. The other portions of the issues did not require fixes, rather they required more explanation of how a migration might work.

```
The onlyRegisteredContract modifier allows forwarding price requests from the
contract deployed at migratedAddress to VotingV2 after migratedAddress has
been set, but the onlyIfNotMigrated modifier prevents anyone from voting on those
requests.
```

**Summary**

This PR does two things:
1. Disables all price request additions after migration.
2. Allows approved contracts to retrieve prices as necessary after migration, as restricting this is unnecessary if requesting new prices is disallowed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
