### PR TITLE
fix(sdk)!: fix missing bond on oo v2 request

### DIFF
--- a/packages/sdk/src/clients/optimisticOracleV2/client.ts
+++ b/packages/sdk/src/clients/optimisticOracleV2/client.ts
@@ -59,8 +59,6 @@ export type Request = RequestKey &
     expirationTime: BigNumber;
     reward: BigNumber;
     finalFee: BigNumber;
-    bond: BigNumber;
-    customLiveness: BigNumber;
     price: BigNumber;
     payout: BigNumber;
     state: RequestState;

--- a/packages/sdk/src/oracle/README.md
+++ b/packages/sdk/src/oracle/README.md
@@ -34,6 +34,7 @@ const config:PartialConfig = {
       earliestBlockNumber?: number;  // ignore blocks before this block number if specified
       maxEventRangeQuery?: number;  // optimize how quickly the first batch of requests are fetched by restricting the max number of events queried.
     },
+    // other chains follow the same configuration schema
   },
 };
 

--- a/packages/sdk/src/oracle/services/optimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracle.ts
@@ -3,7 +3,13 @@ import { BigNumberish, Provider, Signer, TransactionResponse, Log, TransactionRe
 import type { OracleInterface, RequestKey, OracleProps, Request } from "../types/interfaces";
 import { requestId, insertOrderedAscending, eventKey, isUnique } from "../utils";
 
-import { RequestPrice, ProposePrice, DisputePrice, Settle } from "../../clients/optimisticOracle";
+import {
+  RequestPrice,
+  ProposePrice,
+  DisputePrice,
+  Settle,
+  Request as RawRequest,
+} from "../../clients/optimisticOracle";
 
 export type OptimisticOracleEvent = RequestPrice | ProposePrice | DisputePrice | Settle;
 
@@ -16,7 +22,7 @@ export class OptimisticOracle implements OracleInterface {
   constructor(protected provider: Provider, protected address: string, public readonly chainId: number) {
     this.contract = optimisticOracle.connect(address, provider);
   }
-  private upsertRequest = (request: Omit<Request, "chainId">): Request => {
+  private upsertRequest = (request: RawRequest): Request => {
     const id = requestId(request);
     const cachedRequest = this.requests[id] || {};
     const update = { ...cachedRequest, ...request, chainId: this.chainId };

--- a/packages/sdk/src/oracle/services/optimisticOracleV2.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracleV2.ts
@@ -11,6 +11,7 @@ import {
   connect,
   Instance,
   getEventState,
+  Request as RawRequest,
 } from "../../clients/optimisticOracleV2";
 
 export type OptimisticOracleEvent = RequestPrice | ProposePrice | DisputePrice | Settle;
@@ -24,10 +25,10 @@ export class OptimisticOracleV2 implements OracleInterface {
   constructor(protected provider: Provider, protected address: string, public readonly chainId: number) {
     this.contract = connect(address, provider);
   }
-  private upsertRequest = (request: Omit<Request, "chainId">): Request => {
+  private upsertRequest = (request: RawRequest): Request => {
     const id = requestId(request);
     const cachedRequest = this.requests[id] || {};
-    const update = { ...cachedRequest, ...request, chainId: this.chainId };
+    const update = { ...cachedRequest, ...request, ...(request.requestSettings || {}), chainId: this.chainId };
     this.requests[id] = update;
     return update;
   };

--- a/packages/sdk/src/oracle/tests/optimisticV2.e2e.ts
+++ b/packages/sdk/src/oracle/tests/optimisticV2.e2e.ts
@@ -89,6 +89,6 @@ describe("Oracle V2 Client", function () {
     assert.ok(!result[types.state.Flag.CanDispute]);
     assert.ok(!result[types.state.Flag.CanSettle]);
     assert.ok(!result[types.state.Flag.RequestSettled]);
-    assert.ok(!result[types.state.Flag.InsufficientApproval]);
+    assert.ok(result[types.state.Flag.InsufficientApproval]);
   });
 });

--- a/packages/sdk/src/oracle/types/interfaces.ts
+++ b/packages/sdk/src/oracle/types/interfaces.ts
@@ -1,16 +1,53 @@
 import { BigNumberish, BigNumber, Signer, TransactionResponse, TransactionReceipt, Provider } from "../types/ethers";
-import { RequestState, RequestKey, Request as RequestFromEvent } from "../../clients/optimisticOracleV2";
+import { RequestState, RequestKey } from "../../clients/optimisticOracle";
 import { Client } from "../client";
 import { OracleType } from "../types/state";
+
+// This object diverges from the v1 and v2 request shapes. This is to normalize
+// the data into a common shape. This has pitfalls and will be problematic if oracle implementations
+// diverge too much, but so far it seems ok
+export type Request = RequestKey & {
+  chainId: number;
+} & Partial<{
+    // this is partial since we dont know what events we have to populate parts of this
+    proposer: string;
+    disputer: string;
+    currency: string;
+    settled: boolean;
+    proposedPrice: BigNumber;
+    resolvedPrice: BigNumber;
+    expirationTime: BigNumber;
+    reward: BigNumber;
+    finalFee: BigNumber;
+    price: BigNumber;
+    payout: BigNumber;
+    state: RequestState;
+    // metadata about the transaction that triggered the state changes
+    requestTx: string;
+    proposeTx: string;
+    disputeTx: string;
+    settleTx: string;
+    requestBlockNumber: number;
+    proposeBlockNumber: number;
+    disputeBlockNumber: number;
+    settleBlockNumber: number;
+    // oo v2 fields moved here from settings object
+    bond: BigNumber;
+    customLiveness: BigNumber;
+    eventBased: boolean; // True if the request is set to be event-based.
+    refundOnDispute: boolean; // True if the requester should be refunded their reward on dispute.
+    callbackOnPriceProposed: boolean; // True if callbackOnPriceProposed callback is required.
+    callbackOnPriceDisputed: boolean; // True if callbackOnPriceDisputed callback is required.
+    callbackOnPriceSettled: boolean; // True if callbackOnPriceSettled callback is required.
+  }>;
+
+export type Requests = Request[];
 
 export { RequestState, RequestKey };
 
 export interface OracleProps {
   defaultLiveness: BigNumber;
 }
-
-export type Request = RequestFromEvent & { chainId: number };
-export type Requests = Request[];
 
 export interface NewOracle {
   new (provider: Provider, address: string, chainId: number): OracleInterface;


### PR DESCRIPTION
BREAKING CHANGE: Request object shape has been modified to normalize v1 and v2 request data

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
There were issues in the UI with failing transactions due to a missing bond amount on oo v2 requests. 


**Summary**

Turns out several fields on the v1 request were moved to the v2 request settings object.  These missing fields caused certain logic to be skipped leading to a bad UI state where you could propose before you approved or had insufficient balance. The solution was to create a normalized request object, flattening the data more like v1 which works with exsiting logic. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
