### PR TITLE
feat (optimistic-governor): Add OptimisticGovernorCreator contract

### DIFF
--- a/packages/core/contracts/zodiac/OptimisticGovernorCreator.sol
+++ b/packages/core/contracts/zodiac/OptimisticGovernorCreator.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./OptimisticGovernor.sol";
+
+/**
+ * @title Optimistic Governor Factory Contract
+ * @notice Factory contract to create new instances of optimistic governor contracts.
+ */
+contract OptimisticGovernorCreator {
+    event CreatedOptimisticGovernor(OptimisticGovernor optimisticGovernor);
+
+    /**
+     * @notice The Optimistic Governor constructor performs validations on input params. These are not repeated in this contract.
+     */
+    function createOptimisticGovernor(
+        address finder,
+        address owner,
+        address collateral,
+        uint256 bondAmount,
+        string memory rules,
+        bytes32 identifier,
+        uint64 liveness
+    ) public returns (OptimisticGovernor optimisticGovernor) {
+        optimisticGovernor = new OptimisticGovernor(finder, owner, collateral, bondAmount, rules, identifier, liveness);
+        emit CreatedOptimisticGovernor(optimisticGovernor);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Alex Gaines <againes@umaproject.org>

Motivation

Due to using reentrancy guards in the Optimistic Governor contract, the Optimistic Governor contract is incompatible with Zodiac proxy contracts (https://forum.openzeppelin.com/t/using-reentrancy-guard-with-proxies/31063). Therefore, the `OptimisticGovernorCreator` in this PR will be used for optimistic governor deployments. An added motivation for using the factory is that it will make tracking optimistic governor deployments / TVL easier.

Summary

The `OptimisticGovernorCreator` contract only has one function that creates a new instance of the optimistic governor with the optimistic governor constructor performing validations on input parameters.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested