### PR TITLE
fix(optimistic-governor): Optimistic Governor re-entrancy guard update

### DIFF
--- a/packages/core/contracts/zodiac/OptimisticGovernor.sol
+++ b/packages/core/contracts/zodiac/OptimisticGovernor.sol
@@ -102,6 +102,7 @@ contract OptimisticGovernor is Module, Lockable {
     }
 
     function setUp(bytes memory initializeParams) public override initializer {
+        _startReentrantGuardDisabled();
         __Ownable_init();
         (
             address _owner,


### PR DESCRIPTION
Signed-off-by: Alex Gaines <againes@umaproject.org>

**Motivation**

This PR intends to fix an issue in the optimistic governor contract whereby it cannot be used as a mastercopy for a proxy because of how the re-entrancy guard is initialized. However, our previously audited version of the [Lockable](https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/common/implementation/Lockable.sol) contract does allow derived contracts to update the _notEntered value.

Our original solution was to create an optimistic governor factory contract with this [PR](https://github.com/UMAprotocol/protocol/pull/4114), however, see the PR comments for rationale on why an update to the contract is more appealing.

**Summary**

In the `setup` method, `_startReentrantGuardDisabled()` is called to set the initializer to true.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #4114
