### PR TITLE
feat: add emergency proposer

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -201,6 +201,7 @@ contract EmergencyProposer is Ownable, Lockable {
      * @param newQuorum the new quorum.
      */
     function setQuorum(uint256 newQuorum) public nonReentrant() onlyOwner() {
+        require(newQuorum != 0, "quorum must be > 0");
         quorum = newQuorum;
         emit QuorumSet(newQuorum);
     }

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.16;
+
+import "./Finder.sol";
+import "./GovernorV2.sol";
+import "./Constants.sol";
+import "../interfaces/OracleAncillaryInterface.sol";
+import "./AdminIdentifierLib.sol";
+import "../../common/implementation/Lockable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title Proposer contract that allows anyone to make governance proposals with a bond.
+ */
+contract EmergencyProposer is Ownable, Lockable {
+    using SafeERC20 for IERC20;
+    IERC20 public immutable token;
+    uint256 public quorum;
+    GovernorV2 public immutable governor;
+    Finder public immutable finder;
+
+    struct EmergencyProposal {
+        address sender;
+        // 64 bits to save a storage slot.
+        uint64 expiryTime;
+        uint256 lockedTokens;
+        GovernorV2.Transaction[] transactions;
+    }
+    mapping(uint256 => EmergencyProposal) public emergencyProposals;
+    uint256 public currentId;
+    address public executor;
+
+    event QuorumSet(uint256 quorum);
+    event EmergencyTransactionsProposed(uint256 indexed id, GovernorV2.Transaction[] transactions);
+    event EmergencyTransactionsRemoved(uint256 indexed id, GovernorV2.Transaction[] transactions);
+    event EmergencyTransactionsSlashed(uint256 indexed id, GovernorV2.Transaction[] transactions);
+    event EmergencyTransactionsExecuted(uint256 indexed id, GovernorV2.Transaction[] transactions);
+
+    /**
+     * @notice Construct the EmergencyProposer contract.
+     * @param _token the ERC20 token that the quorum is in.
+     * @param _quorum the tokens needed to propose.
+     * @param _governor the governor contract that this contract makes proposals to.
+     * @param _finder the finder contract used to look up addresses.
+     */
+    constructor(
+        IERC20 _token,
+        uint256 _quorum,
+        GovernorV2 _governor,
+        Finder _finder,
+        address _executor
+    ) {
+        token = _token;
+        governor = _governor;
+        finder = _finder;
+        executor = _executor;
+        setQuorum(_quorum);
+        transferOwnership(address(_governor));
+    }
+
+    function emergencyPropose(GovernorV2.Transaction[] memory transactions) external nonReentrant() returns (uint256) {
+        token.safeTransferFrom(msg.sender, address(this), quorum);
+        uint256 id = currentId++;
+        emergencyProposals[id] = EmergencyProposal({
+            sender: msg.sender,
+            lockedTokens: quorum,
+            expiryTime: uint64(getCurrentTime()) + 1 weeks,
+            transactions: transactions
+        });
+
+        emit EmergencyTransactionsProposed(id, transactions);
+        return id;
+    }
+
+    function removeProposal(uint256 id) external nonReentrant() {
+        EmergencyProposal storage proposal = emergencyProposals[id];
+        require(proposal.expiryTime < getCurrentTime(), "must be expired to remove");
+        require(msg.sender == proposal.sender || msg.sender == executor, "proposer or executor");
+        require(proposal.lockedTokens != 0, "invalid proposal");
+        token.safeTransfer(proposal.sender, proposal.lockedTokens);
+        delete emergencyProposals[id];
+    }
+
+    function slashProposal(uint256 id) external nonReentrant() onlyOwner() {
+        EmergencyProposal storage proposal = emergencyProposals[id];
+        require(proposal.lockedTokens != 0, "invalid proposal");
+        token.safeTransfer(proposal.sender, (proposal.lockedTokens * 9) / 10);
+        token.safeTransfer(address(governor), proposal.lockedTokens / 10);
+        delete emergencyProposals[id];
+    }
+
+    function executeEmergencyProposal(uint256 id) public payable {
+        require(msg.sender == executor, "must be called by executor");
+
+        EmergencyProposal storage proposal = emergencyProposals[id];
+        require(proposal.lockedTokens != 0, "invalid proposal");
+        require(proposal.expiryTime < getCurrentTime(), "invalid proposal");
+
+        for (uint256 i = 0; i < proposal.transactions.length; i++) {
+            governor.emergencyExecute{ value: address(this).balance }(proposal.transactions[i]);
+        }
+
+        token.safeTransfer(proposal.sender, proposal.lockedTokens);
+        delete emergencyProposals[id];
+    }
+
+    /**
+     * @notice Admin method to set the quorum size.
+     * @dev Admin is intended to be the governance system itself.
+     * @param _quorum the new quorum.
+     */
+    function setQuorum(uint256 _quorum) public nonReentrant() onlyOwner() {
+        quorum = _quorum;
+        emit QuorumSet(_quorum);
+    }
+
+    /**
+     * @notice Returns the current block timestamp.
+     * @dev Can be overridden to control contract time.
+     */
+    function getCurrentTime() public view virtual returns (uint256) {
+        return block.timestamp;
+    }
+}

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -36,7 +36,7 @@ contract EmergencyProposer is Ownable, Lockable {
         uint256 lockedTokens;
         GovernorV2.Transaction[] transactions;
     }
-    mapping(uint256 => EmergencyProposal) public emergencyProposals;
+    EmergencyProposal[] public emergencyProposals;
     uint256 public currentId;
     address public executor;
 
@@ -109,8 +109,8 @@ contract EmergencyProposer is Ownable, Lockable {
      */
     function emergencyPropose(GovernorV2.Transaction[] memory transactions) external nonReentrant() returns (uint256) {
         token.safeTransferFrom(msg.sender, address(this), quorum);
-        uint256 id = currentId++;
-        EmergencyProposal storage proposal = emergencyProposals[id];
+        uint256 id = emergencyProposals.length;
+        EmergencyProposal storage proposal = emergencyProposals.push();
         proposal.sender = msg.sender;
         proposal.lockedTokens = quorum;
         proposal.expiryTime = uint64(getCurrentTime()) + minimumWaitTime;

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -142,10 +142,10 @@ contract EmergencyProposer is Ownable, Lockable {
         require(proposal.expiryTime <= getCurrentTime(), "must be expired to remove");
         require(msg.sender == proposal.sender || msg.sender == executor, "proposer or executor");
         require(proposal.lockedTokens != 0, "invalid proposal");
-        token.safeTransfer(proposal.proposer, proposal.lockedTokens);
+        token.safeTransfer(proposal.sender, proposal.lockedTokens);
         emit EmergencyTransactionsRemoved(
             id,
-            proposal.proposer,
+            proposal.sender,
             msg.sender,
             proposal.expiryTime,
             proposal.lockedTokens,

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -33,6 +33,7 @@ contract EmergencyProposer is Ownable, Lockable {
     address public executor;
 
     event QuorumSet(uint256 quorum);
+    event ExecutorSet(address executor);
     event EmergencyTransactionsProposed(uint256 indexed id, GovernorV2.Transaction[] transactions);
     event EmergencyTransactionsRemoved(uint256 indexed id, GovernorV2.Transaction[] transactions);
     event EmergencyTransactionsSlashed(uint256 indexed id, GovernorV2.Transaction[] transactions);
@@ -55,7 +56,7 @@ contract EmergencyProposer is Ownable, Lockable {
         token = _token;
         governor = _governor;
         finder = _finder;
-        executor = _executor;
+        setExecutor(_executor);
         setQuorum(_quorum);
         transferOwnership(address(_governor));
     }
@@ -114,6 +115,11 @@ contract EmergencyProposer is Ownable, Lockable {
     function setQuorum(uint256 _quorum) public nonReentrant() onlyOwner() {
         quorum = _quorum;
         emit QuorumSet(_quorum);
+    }
+
+    function setExecutor(address _executor) public nonReentrant() onlyOwner() {
+        executor = _executor;
+        emit ExecutorSet(_executor);
     }
 
     /**

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -124,7 +124,7 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice After the proposal is executable, the executor or proposer can use this function to remove the proposal
      * without slashing.
-     * @dev this means that the DVM didn't explicitly reject the proposal. Allowing the executor to slash the quorum
+     * @dev This means that the DVM didn't explicitly reject the proposal. Allowing the executor to slash the quorum
      * would give the executor too much power. So the only control either party has is to remove the proposal,
      * releasing the bond. The proposal should not be removable before its liveness/expiry to ensure the regular Voting
      * system's slash cannot be frontrun.
@@ -150,7 +150,7 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice Before a proposal expires (or after), this method can be used by the owner, which should generally be
      * the GovernorV2 contract, to slash the proposer.
-     * @dev the slash results in the proposer's tokens being sent to the Governor contract.
+     * @dev The slash results in the proposer's tokens being sent to the Governor contract.
      * @param id id of the proposal.
      */
     function slashProposal(uint256 id) external nonReentrant() onlyOwner() {
@@ -170,7 +170,7 @@ contract EmergencyProposer is Ownable, Lockable {
 
     /**
      * @notice After a proposal expires, this method can be used by the executor to execute the proposal.
-     * @dev this method effectively gives the executor veto power over any proposal.
+     * @dev This method effectively gives the executor veto power over any proposal.
      * @param id id of the proposal.
      */
     function executeEmergencyProposal(uint256 id) public payable nonReentrant() {
@@ -198,21 +198,21 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice Admin method to set the quorum (bond) size.
      * @dev Admin is intended to be the governance system.
-     * @param _quorum the new quorum.
+     * @param newQuorum the new quorum.
      */
-    function setQuorum(uint256 _quorum) public nonReentrant() onlyOwner() {
-        quorum = _quorum;
-        emit QuorumSet(_quorum);
+    function setQuorum(uint256 newQuorum) public nonReentrant() onlyOwner() {
+        quorum = newQuorum;
+        emit QuorumSet(newQuorum);
     }
 
     /**
      * @notice Admin method to set the executor address.
      * @dev Admin is intended to be the governance system.
-     * @param _executor the new executor address.
+     * @param newExecutor the new executor address.
      */
-    function setExecutor(address _executor) public nonReentrant() onlyOwner() {
-        executor = _executor;
-        emit ExecutorSet(_executor);
+    function setExecutor(address newExecutor) public nonReentrant() onlyOwner() {
+        executor = newExecutor;
+        emit ExecutorSet(newExecutor);
     }
 
     /**
@@ -220,12 +220,12 @@ contract EmergencyProposer is Ownable, Lockable {
      * @dev Admin is intended to be the governance system. The minumum wait time is added to the current time at the
      * time of the proposal to determine when the proposal will be executable. Any changes to this value after that
      * point will have no impact on the proposal.
-     * @param _minimumWaitTime the new minimum wait time.
+     * @param newMinimumWaitTime the new minimum wait time.
      */
-    function setMinimumWaitTime(uint64 _minimumWaitTime) public nonReentrant() onlyOwner() {
-        require(_minimumWaitTime != 0, "minimumWaitTime == 0");
-        minimumWaitTime = _minimumWaitTime;
-        emit MinimumWaitTimeSet(_minimumWaitTime);
+    function setMinimumWaitTime(uint64 newMinimumWaitTime) public nonReentrant() onlyOwner() {
+        require(newMinimumWaitTime != 0, "minimumWaitTime == 0");
+        minimumWaitTime = newMinimumWaitTime;
+        emit MinimumWaitTimeSet(newMinimumWaitTime);
     }
 
     /**

--- a/packages/core/contracts/oracle/implementation/GovernorV2.sol
+++ b/packages/core/contracts/oracle/implementation/GovernorV2.sol
@@ -41,7 +41,6 @@ contract GovernorV2 is MultiRole, Lockable {
 
     FinderInterface private finder;
     Proposal[] public proposals;
-    address public immutable emergencyProposer;
 
     /****************************************
      *                EVENTS                *
@@ -153,6 +152,11 @@ contract GovernorV2 is MultiRole, Lockable {
         emit ProposalExecuted(id, transactionIndex);
     }
 
+    /**
+     * @notice Emergency execution method that bypasses the voting system to execute a transaction.
+     * @dev This can only be called by the EmergencyProposer.
+     * @param transaction a single transaction to execute.
+     */
     function emergencyExecute(Transaction memory transaction)
         external
         payable

--- a/packages/core/contracts/oracle/implementation/test/EmergencyProposerTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/EmergencyProposerTest.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "../EmergencyProposer.sol";
+import "../../../common/implementation/Testable.sol";
+
+contract EmergencyProposerTest is EmergencyProposer, Testable {
+    constructor(
+        IERC20 _token,
+        uint256 _quorum,
+        GovernorV2 _governor,
+        Finder _finder,
+        address _executor,
+        address _timerAddress
+    ) EmergencyProposer(_token, _quorum, _governor, _finder, _executor) Testable(_timerAddress) {}
+
+    function getCurrentTime() public view override(EmergencyProposer, Testable) returns (uint256) {
+        return Testable.getCurrentTime();
+    }
+}

--- a/packages/core/test/oracle/EmergencyProposer.js
+++ b/packages/core/test/oracle/EmergencyProposer.js
@@ -1,0 +1,311 @@
+const hre = require("hardhat");
+const { getContract, assertEventEmitted, web3 } = hre;
+const { runVotingV2Fixture, interfaceName, didContractThrow } = require("@uma/common");
+const { assert } = require("chai");
+
+const MockOracleGovernance = getContract("MockOracleGovernance");
+const MockOracleAncillary = getContract("MockOracleAncillary");
+const VotingToken = getContract("VotingToken");
+const Finder = getContract("Finder");
+const GovernorV2 = getContract("GovernorV2");
+const EmergencyProposer = getContract("EmergencyProposerTest");
+const ProposerV2 = getContract("ProposerV2Test");
+const Timer = getContract("Timer");
+const IdentifierWhitelist = getContract("IdentifierWhitelist");
+const { toWei, utf8ToHex } = web3.utils;
+
+describe("EmergencyProposer", function () {
+  let accounts;
+  let owner;
+  let submitter;
+  let executor;
+  let rando;
+
+  let proposer;
+  let regularProposer;
+  let bond = toWei("100");
+  let quorum = toWei("1000000");
+  let minimumWaitTime = "604800";
+  const defaultAncillaryData = web3.utils.randomHex(3000);
+
+  let mockOracle;
+  let votingToken;
+  let finder;
+  let governor;
+
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+    [owner, submitter, executor, rando] = accounts;
+    await runVotingV2Fixture(hre);
+    finder = await Finder.deployed();
+    votingToken = await VotingToken.deployed();
+    governor = await GovernorV2.deployed();
+    const timer = await Timer.deployed();
+    const mockOracleAddress = (
+      await MockOracleGovernance.new(finder.options.address, timer.options.address).send({ from: owner })
+    ).options.address;
+    mockOracle = await MockOracleAncillary.at(mockOracleAddress);
+    proposer = await EmergencyProposer.new(
+      votingToken.options.address,
+      quorum,
+      governor.options.address,
+      finder.options.address,
+      executor,
+      timer.options.address
+    ).send({ from: owner });
+    regularProposer = await ProposerV2.new(
+      votingToken.options.address,
+      bond,
+      governor.options.address,
+      finder.options.address,
+      timer.options.address
+    ).send({ from: owner });
+    await finder.methods
+      .changeImplementationAddress(utf8ToHex(interfaceName.Oracle, 64), mockOracle.options.address)
+      .send({ from: owner });
+
+    await governor.methods.resetMember(1, regularProposer.options.address).send({ from: owner });
+    await governor.methods.resetMember(2, proposer.options.address).send({ from: owner });
+    const identifierWhitelist = await IdentifierWhitelist.deployed();
+    await identifierWhitelist.methods.transferOwnership(governor.options.address).send({ from: owner });
+  });
+
+  const passProposal = async (transactions) => {
+    const bond = await regularProposer.methods.bond().call();
+    await votingToken.methods.transfer(submitter, bond).send({ from: owner });
+    await votingToken.methods.approve(regularProposer.options.address, bond).send({ from: submitter });
+    const proposalTx = regularProposer.methods.propose(transactions, defaultAncillaryData);
+    const id = await proposalTx.call({ from: submitter });
+    await proposalTx.send({ from: submitter });
+    const pendingQueries = await mockOracle.methods.getPendingQueries().call();
+    const { identifier, time, ancillaryData } = pendingQueries[pendingQueries.length - 1];
+    await mockOracle.methods.pushPrice(identifier, time, ancillaryData, toWei("1")).send({ from: owner });
+    await regularProposer.methods.resolveProposal(id).send({ from: submitter });
+    await votingToken.methods.transfer(owner, bond).send({ from: submitter });
+    return await governor.methods.executeProposal(id, 0).send({ from: submitter });
+  };
+
+  const setQuorum = async (newQuorum) => {
+    return await passProposal([
+      { data: proposer.methods.setQuorum(newQuorum).encodeABI(), value: 0, to: proposer.options.address },
+    ]);
+  };
+
+  const setMinimumWaitTime = async (newMinimumWaitTime) => {
+    return await passProposal([
+      {
+        data: proposer.methods.setMinimumWaitTime(newMinimumWaitTime).encodeABI(),
+        value: 0,
+        to: proposer.options.address,
+      },
+    ]);
+  };
+
+  const setExecutor = async (newExecutor) => {
+    return await passProposal([
+      { data: proposer.methods.setExecutor(newExecutor).encodeABI(), value: 0, to: proposer.options.address },
+    ]);
+  };
+
+  const slashProposal = async (id) => {
+    return await passProposal([
+      { data: proposer.methods.slashProposal(id).encodeABI(), value: 0, to: proposer.options.address },
+    ]);
+  };
+
+  it("Setting the quorum", async function () {
+    // Quorum should start with the constructed value.
+    assert.equal(await proposer.methods.quorum().call(), quorum);
+
+    // Owner is the only one who can set quorum.
+    assert(await didContractThrow(proposer.methods.setQuorum(toWei("10")).send({ from: submitter })));
+    assert(await didContractThrow(proposer.methods.setQuorum(toWei("10")).send({ from: executor })));
+
+    // Set the quorum to 10.
+    const tx = await setQuorum(toWei("10"));
+    await assertEventEmitted(tx, proposer, "QuorumSet", (event) => event.quorum === toWei("10"));
+    assert.equal(await proposer.methods.quorum().call(), toWei("10"));
+
+    // Reset the quorum for other tests.
+    await setQuorum(quorum);
+  });
+
+  it("Setting the minimumWaitTime", async function () {
+    // minimumWaitTime should start with the default value.
+    assert.equal(await proposer.methods.minimumWaitTime().call(), minimumWaitTime);
+
+    // Owner is the only one who can set the minimumWaitTime.
+    assert(await didContractThrow(proposer.methods.setMinimumWaitTime(toWei("10")).send({ from: submitter })));
+    assert(await didContractThrow(proposer.methods.setMinimumWaitTime(toWei("10")).send({ from: executor })));
+
+    // Set the quorum to 10.
+    const tx = await setMinimumWaitTime("100");
+    await assertEventEmitted(tx, proposer, "MinimumWaitTimeSet", (event) => event.minimumWaitTime.toString() === "100");
+    assert.equal(await proposer.methods.minimumWaitTime().call(), "100");
+
+    // Reset the bond for other tests.
+    await setMinimumWaitTime(minimumWaitTime);
+  });
+
+  it("Setting the executor", async function () {
+    // Executor should start with the default value.
+    assert.equal(await proposer.methods.executor().call(), executor);
+
+    // Owner is the only one who can set executor.
+    assert(await didContractThrow(proposer.methods.setExecutor(rando).send({ from: submitter })));
+    assert(await didContractThrow(proposer.methods.setExecutor(rando).send({ from: executor })));
+
+    // Set the executor to rando.
+    const tx = await setExecutor(rando);
+    await assertEventEmitted(tx, proposer, "ExecutorSet", (event) => event.executor === rando);
+    assert.equal(await proposer.methods.executor().call(), rando);
+
+    // Reset the executor for other tests.
+    await setExecutor(executor);
+  });
+
+  it("Quorum must be paid", async function () {
+    const txn = proposer.methods.emergencyPropose([]);
+
+    // No balance and bond isn't approved.
+    assert(await didContractThrow(txn.send({ from: submitter })));
+
+    // No approval
+    await votingToken.methods.transfer(submitter, quorum).send({ from: owner });
+    assert(await didContractThrow(txn.send({ from: submitter })));
+
+    // Should succeed
+    await votingToken.methods.approve(proposer.options.address, quorum).send({ from: submitter });
+    await txn.send({ from: submitter });
+  });
+
+  it("Successful Proposal", async function () {
+    // Move tokens.
+    await votingToken.methods.transfer(submitter, quorum).send({ from: owner });
+    await votingToken.methods.approve(proposer.options.address, quorum).send({ from: submitter });
+
+    // Build a no-op txn for the governor to execute.
+    const noOpTxnBytes = votingToken.methods.approve(submitter, "0").encodeABI();
+
+    // Grab the proposal id and then send the proposal txn.
+    const txn = proposer.methods.emergencyPropose([{ to: votingToken.options.address, value: 0, data: noOpTxnBytes }]);
+    const id = await txn.call({ from: submitter });
+    await txn.send({ from: submitter });
+
+    // Should have pulled the submitter's tokens.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), "0");
+
+    // Cannot execute before expiry.
+    assert(await didContractThrow(proposer.methods.executeEmergencyProposal(id).send({ from: executor })));
+
+    // Wait through expiry.
+    const currentTime = await proposer.methods.getCurrentTime().call();
+    await proposer.methods
+      .setCurrentTime(Number(currentTime.toString()) + Number(minimumWaitTime))
+      .send({ from: owner });
+
+    // Cannot be executed by other addresses.
+    assert(await didContractThrow(proposer.methods.executeEmergencyProposal(id).send({ from: owner })));
+    assert(await didContractThrow(proposer.methods.executeEmergencyProposal(id).send({ from: rando })));
+    assert(await didContractThrow(proposer.methods.executeEmergencyProposal(id).send({ from: submitter })));
+
+    // Execution should work.
+    const receipt = await proposer.methods.executeEmergencyProposal(id).send({ from: executor });
+
+    // Cannot execute again.
+    assert(await didContractThrow(proposer.methods.executeEmergencyProposal(id).send({ from: executor })));
+
+    // Check that the event resolved as expected for a true value and the bond was repaid to the submitter.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), quorum);
+    await assertEventEmitted(
+      receipt,
+      proposer,
+      "EmergencyProposalExecuted",
+      (event) => event.id === id && event.sender === submitter
+    );
+
+    // Clean up votingToken balance.
+    await votingToken.methods.transfer(owner, quorum).send({ from: submitter });
+  });
+
+  it("Slashed Proposal", async function () {
+    // Move tokens.
+    await votingToken.methods.transfer(submitter, quorum).send({ from: owner });
+    await votingToken.methods.approve(proposer.options.address, quorum).send({ from: submitter });
+
+    // Build a no-op txn for the governor to execute.
+    const noOpTxnBytes = votingToken.methods.approve(submitter, "0").encodeABI();
+
+    // Grab the proposal id and then send the proposal txn.
+    const txn = proposer.methods.emergencyPropose([{ to: votingToken.options.address, value: 0, data: noOpTxnBytes }]);
+    const id = await txn.call({ from: submitter });
+    await txn.send({ from: submitter });
+
+    // Should have pulled the submitter's tokens.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), "0");
+
+    const receipt = await slashProposal(id);
+
+    // Check that the event resolved as expected for a true value and the bond was sent to the Governor.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), "0");
+    assert.equal(await votingToken.methods.balanceOf(governor.options.address).call(), quorum);
+    await assertEventEmitted(
+      receipt,
+      proposer,
+      "EmergencyProposalSlashed",
+      (event) => event.id === id && event.sender === submitter
+    );
+
+    // Verify balanes.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), "0");
+    assert.equal(await votingToken.methods.balanceOf(governor.options.address).call(), quorum);
+  });
+
+  it("Removed Proposal", async function () {
+    // Move tokens.
+    await votingToken.methods.transfer(submitter, quorum).send({ from: owner });
+    await votingToken.methods.approve(proposer.options.address, quorum).send({ from: submitter });
+
+    // Build a no-op txn for the governor to execute.
+    const noOpTxnBytes = votingToken.methods.approve(submitter, "0").encodeABI();
+
+    // Grab the proposal id and then send the proposal txn.
+    const txn = proposer.methods.emergencyPropose([{ to: votingToken.options.address, value: 0, data: noOpTxnBytes }]);
+    const id = await txn.call({ from: submitter });
+    await txn.send({ from: submitter });
+
+    // Should have pulled the submitter's tokens.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), "0");
+
+    // Cannot remove proposal before expiry.
+    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: executor })));
+    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: submitter })));
+
+    // Wait through expiry.
+    const currentTime = await proposer.methods.getCurrentTime().call();
+    await proposer.methods
+      .setCurrentTime(Number(currentTime.toString()) + Number(minimumWaitTime))
+      .send({ from: owner });
+
+    // Only certain addresses can remove proposals.
+    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: rando })));
+    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: owner })));
+    await proposer.methods.removeProposal(id).call({ from: executor });
+    const receipt = await proposer.methods.removeProposal(id).send({ from: submitter });
+
+    // Cannot remove again.
+    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: submitter })));
+
+    // Check that the event resolved as expected for a true value and the bond was repaid to the submitter.
+    assert.equal(await votingToken.methods.balanceOf(submitter).call(), quorum);
+    await assertEventEmitted(
+      receipt,
+      proposer,
+      "EmergencyProposalRemoved",
+      (event) => event.id === id && event.caller === submitter && event.sender === submitter
+    );
+
+    // Clean up votingToken balance.
+    await votingToken.methods.transfer(owner, quorum).send({ from: submitter });
+  });
+});

--- a/packages/core/test/oracle/GovernorV2.js
+++ b/packages/core/test/oracle/GovernorV2.js
@@ -35,6 +35,7 @@ describe("GovernorV2", function () {
   let proposer;
   let account2;
   let account3;
+  let emergencyProposer;
 
   const constructTransferTransaction = (destination, amount) => {
     return testToken.methods.transfer(destination, amount).encodeABI();
@@ -42,7 +43,7 @@ describe("GovernorV2", function () {
 
   before(async function () {
     accounts = await web3.eth.getAccounts();
-    [proposer, account2, account3] = accounts;
+    [proposer, account2, account3, emergencyProposer] = accounts;
     await runVotingV2Fixture(hre);
     voting = await VotingV2.deployed();
     supportedIdentifiers = await IdentifierWhitelist.deployed();
@@ -69,6 +70,9 @@ describe("GovernorV2", function () {
     // environment, so ownership must be transferred.
 
     await voting.methods.transferOwnership(governorV2.options.address).send({ from: accounts[0] });
+
+    // Set the emergency proposer address.
+    await governorV2.methods.resetMember(2, emergencyProposer).send({ from: proposer });
   });
 
   beforeEach(async () => {
@@ -87,6 +91,31 @@ describe("GovernorV2", function () {
         governorV2.methods
           .propose([{ to: testToken.options.address, value: 0, data: txnData }], defaultAncillaryData)
           .send({ from: account2 })
+      )
+    );
+  });
+
+  it("Emergency execution permissions", async function () {
+    const txnData = constructTransferTransaction(proposer, "0");
+    assert(
+      await didContractThrow(
+        governorV2.methods
+          .emergencyExecute({ to: testToken.options.address, value: 0, data: txnData })
+          .send({ from: proposer })
+      )
+    );
+    assert(
+      await didContractThrow(
+        governorV2.methods
+          .emergencyExecute({ to: testToken.options.address, value: 0, data: txnData })
+          .send({ from: account2 })
+      )
+    );
+    assert(
+      await didContractThrow(
+        governorV2.methods
+          .emergencyExecute({ to: testToken.options.address, value: 0, data: txnData })
+          .send({ from: account3 })
       )
     );
   });
@@ -646,6 +675,26 @@ describe("GovernorV2", function () {
     const startingBalance = await testToken.methods.balanceOf(proposer).call();
     assert(await didContractThrow(governorV2.methods.executeProposal(id, 0).send({ from: accounts[0] })));
     assert.equal((await testToken.methods.balanceOf(proposer).call()).toString(), startingBalance.toString());
+  });
+
+  it("Emergency Execution", async function () {
+    // Issue some test tokens to the governorV2 address.
+    await testToken.methods.allocateTo(governorV2.options.address, toWei("1")).send({ from: accounts[0] });
+
+    // Construct the transaction data to send the newly minted tokens to proposer.
+    const txnData = constructTransferTransaction(proposer, toWei("1"));
+
+    // Check to make sure that the tokens get transferred at the time of execution.
+    const startingBalance = toBN(await testToken.methods.balanceOf(proposer).call());
+
+    await governorV2.methods
+      .emergencyExecute({ to: testToken.options.address, value: 0, data: txnData })
+      .send({ from: emergencyProposer });
+
+    assert.equal(
+      (await testToken.methods.balanceOf(proposer).call()).toString(),
+      startingBalance.add(toBN(toWei("1"))).toString()
+    );
   });
 
   it("Events", async function () {

--- a/packages/core/test/oracle/ProposerV2.js
+++ b/packages/core/test/oracle/ProposerV2.js
@@ -80,7 +80,7 @@ describe("ProposerV2", function () {
     assert.equal(await proposer.methods.bond().call(), bond);
 
     // Owner is the only one who can set bond.
-    await didContractThrow(proposer.methods.setBond(toWei("10")).send({ from: submitter }));
+    assert(await didContractThrow(proposer.methods.setBond(toWei("10")).send({ from: submitter })));
 
     // Set the bond to 10.
     const tx = await changeBond(toWei("10"));
@@ -95,11 +95,11 @@ describe("ProposerV2", function () {
     const txn = proposer.methods.propose([], defaultAncillaryData);
 
     // No balance and bond isn't approved.
-    await didContractThrow(txn.send({ from: submitter }));
+    assert(await didContractThrow(txn.send({ from: submitter })));
 
     // No approval
     await votingToken.methods.transfer(submitter, bond).send({ from: owner });
-    await didContractThrow(txn.send({ from: submitter }));
+    assert(await didContractThrow(txn.send({ from: submitter })));
 
     // Should succeed
     await votingToken.methods.approve(proposer.options.address, bond).send({ from: submitter });
@@ -170,7 +170,7 @@ describe("ProposerV2", function () {
     const pendingQueries = await mockOracle.methods.getPendingQueries().call();
     const { identifier, time, ancillaryData } = pendingQueries[pendingQueries.length - 1];
     await mockOracle.methods.pushPrice(identifier, time, ancillaryData, toWei("0")).send({ from: owner });
-    await didContractThrow(governor.methods.executeProposal(id, 0).send({ from: rando }));
+    assert(await didContractThrow(governor.methods.executeProposal(id, 0).send({ from: rando })));
 
     // Resolve the proposal in the proposer.
     const receipt = await proposer.methods.resolveProposal(id).send({ from: owner });


### PR DESCRIPTION
**Motivation**

We'd like to have a system for emergency proposals in case the DVM breaks.

**Summary**

This adds an EmergencyProposer contract that mirrors the proposer contract, but can perform unilateral actions on the Governor without DVM approval.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
N/A
