### PR TITLE
fix(coingecko): Remove getContractPrices usd constraint

### DIFF
--- a/packages/sdk/src/coingecko/coingecko.ts
+++ b/packages/sdk/src/coingecko/coingecko.ts
@@ -68,7 +68,7 @@ class Coingecko {
     // annoying, but have to type this to iterate over entries
     type Result = {
       [address: string]: {
-        [currency: string]: number;  // usd, eth, ...
+        [currency: string]: number; // usd, eth, ...
         last_updated_at: number;
       };
     };

--- a/packages/sdk/src/coingecko/coingecko.ts
+++ b/packages/sdk/src/coingecko/coingecko.ts
@@ -68,7 +68,7 @@ class Coingecko {
     // annoying, but have to type this to iterate over entries
     type Result = {
       [address: string]: {
-        usd: number;
+        [currency: string]: number;  // usd, eth, ...
         last_updated_at: number;
       };
     };
@@ -78,7 +78,7 @@ class Coingecko {
       )}&vs_currencies=${currency}&include_last_updated_at=true`
     );
     return Object.entries(result).map(([key, value]) => {
-      return { address: lookup[key], timestamp: value.last_updated_at, price: value.usd };
+      return { address: lookup[key], timestamp: value.last_updated_at, price: value[currency] };
     });
   }
 


### PR DESCRIPTION
**Motivation**
The Across v1 bots submit a single price request per ERC20 token. This
is suspected to cause sporadic rate-limiting by CoinGecko. I am testing
a change to consolidate the price requests, so that we have the option
of reducing our load on CoinGecko.


**Summary**
Modify the Result type definition to be less strict about the specific
field(s) that are returned by CoinGecko.


**Testing**
Check a box to describe how you tested these changes and list the
steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested

 Steps:
 - SDK unit test.
 - Ran the Across insured-bridge-relayer bot.