### PR TITLE
fix: wrong slashing sum

### DIFF
--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -355,6 +355,17 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
     }
 
     /**
+     * @notice  Returns the total amount of tokens staked by the voter, after applying updateTrackers. Specifically used
+     * to view cumulative stake + any unapplied slashing as view methods without needing to update the contract.
+     * @param voterAddress the address of the voter.
+     * @return uint256 the total stake.
+     */
+    function getVoterStakePostUpdate(address voterAddress) external returns (uint256) {
+        _updateTrackers(voterAddress);
+        return voterStakes[voterAddress].activeStake + voterStakes[voterAddress].pendingStake;
+    }
+
+    /**
      * @notice Returns the current block timestamp.
      * @dev Can be overridden to control contract time.
      */

--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -357,7 +357,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
 
     /**
      * @notice  Returns the total amount of tokens staked by the voter, after applying updateTrackers. Specifically used
-     * to view cumulative stake + any unapplied slashing as view methods without needing to update the contract.
+     * by offchain applications to simulate the cumulative stake + unapplied slashing updates without sending a transaction.
      * @param voterAddress the address of the voter.
      * @return uint256 the total stake.
      */

--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -292,6 +292,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
         emit SetNewUnstakeCoolDown(newUnstakeCoolDown);
     }
 
+    // Updates an account internal trackers.
     function _updateTrackers(address voterAddress) internal virtual {
         _updateReward(voterAddress);
         _updateActiveStake(voterAddress);

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -498,9 +498,15 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
         // There is a very specific edge case that can occur if the only participates in a vote stakes after the request
         // is created and the request is rolled. If this happens, a request becomes unresolvable due to lastVotingRound
-        // not being correctly updated. To combat this, we can check this assignment here. This is a no-op in all
-        // cases except the edge case specified as this should be assigned correctly elsewhere.
+        // not being correctly updated. To combat this, we can check this assignment here and update the lastVotingRound
+        // accordingly. Additionally, this situation will result in the voter's nextIndexToProcess being larger than the
+        // price request index, As such, this voter will immune to slashing for this round, even though they were able
+        // to vote due to their funds becoming active in the rolling process. If this is the case, we can update the
+        // voters nextIndexToProcess to be the same as the price request index to ensure that this voter is correctly
+        // slashed for participation in this request. This is a no-op in all cases except the edge case specified.
         if (priceRequest.lastVotingRound != currentRoundId) priceRequest.lastVotingRound = uint32(currentRoundId);
+        if (voterStakes[voter].nextIndexToProcess > priceRequest.priceRequestIndex)
+            voterStakes[voter].nextIndexToProcess = priceRequest.priceRequestIndex;
 
         emit VoteCommitted(voter, msg.sender, currentRoundId, identifier, time, ancillaryData);
     }

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -756,6 +756,11 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         super._updateTrackers(voterAddress);
     }
 
+    // Starting index for a staker is the first value that nextIndexToProcess is set to and defines the first index that
+    // a staker is suspectable to receiving slashing on. Note that we offset the length of the pendingPriceRequests
+    // array as you are still suspectable to slashing if you stake for the first time in the commit phase of an active
+    //vote. If you stake during an active reveal then your liquidity will be marked as inactive within Staker.sol until
+    // the its activated in the next round and as such you'll miss out on being slashed for that round.
     function _getStartingIndexForStaker() internal view override returns (uint64) {
         return SafeCast.toUint64(priceRequestIds.length - pendingPriceRequests.length);
     }

--- a/packages/core/contracts/oracle/implementation/test/ZeroedSlashingLibaryTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/ZeroedSlashingLibaryTest.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.16;
+
+import "../../interfaces/SlashingLibraryInterface.sol";
+
+/**
+ * @title Slashing Library contract that executes no slashing for any actions. Used in tests.
+ */
+
+contract ZeroedSlashingSlashingLibraryTest is SlashingLibraryInterface {
+    function calcWrongVoteSlashPerToken(
+        uint256 totalStaked,
+        uint256 totalVotes,
+        uint256 totalCorrectVotes
+    ) public pure returns (uint256) {
+        return 0;
+    }
+
+    function calcWrongVoteSlashPerTokenGovernance(
+        uint256 totalStaked,
+        uint256 totalVotes,
+        uint256 totalCorrectVotes
+    ) public pure returns (uint256) {
+        return 0;
+    }
+
+    function calcNoVoteSlashPerToken(
+        uint256 totalStaked,
+        uint256 totalVotes,
+        uint256 totalCorrectVotes
+    ) public pure returns (uint256) {
+        return 0;
+    }
+
+    function calcSlashing(
+        uint256 totalStaked,
+        uint256 totalVotes,
+        uint256 totalCorrectVotes,
+        bool isGovernance
+    ) external pure returns (uint256 wrongVoteSlashPerToken, uint256 noVoteSlashPerToken) {
+        return (
+            isGovernance
+                ? calcWrongVoteSlashPerTokenGovernance(totalStaked, totalVotes, totalCorrectVotes)
+                : calcWrongVoteSlashPerToken(totalStaked, totalVotes, totalCorrectVotes),
+            calcNoVoteSlashPerToken(totalStaked, totalVotes, totalCorrectVotes)
+        );
+    }
+}

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -3642,11 +3642,8 @@ describe("VotingV2", function () {
     await moveToNextPhase(voting, accounts[0]);
 
     await voting.methods.stake(toWei("32000000")).send({ from: rand });
-    await voting.methods.updateTrackers(rand).send({ from: rand });
 
     await moveToNextRound(voting, accounts[0]);
-
-    await voting.methods.updateTrackers(rand).send({ from: rand });
 
     let roundId = (await voting.methods.getCurrentRoundId().call()).toString();
     let salt = getRandomSignedInt();

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -3739,7 +3739,6 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]);
 
     // Now, the staker liquidity has become activated (we are no longer in an active reveal phase) due to the roll.
-
     // nextIndexToProcess == 1, so rand won't be slashed for price request 0
     assert.equal((await voting.methods.voterStakes(rand).call()).nextIndexToProcess, "1");
 

--- a/packages/core/test/oracle/VotingV2.js
+++ b/packages/core/test/oracle/VotingV2.js
@@ -3706,5 +3706,10 @@ describe("VotingV2", function () {
 
     // After unstaking all positions the total balance left in the voting contract should be 0.
     assert.equal(await votingToken.methods.balanceOf(voting.options.address).call(), "0");
+
+    // Lastly, sum of all slashing events should add to zero (positive slashing summed should equal negative slash).
+    const events = await voting.getPastEvents("VoterSlashed", { fromBlock: 0, toBlock: "latest" });
+    const sum = events.map((e) => Number(web3.utils.fromWei(e.returnValues.slashedTokens))).reduce((a, b) => a + b, 0);
+    assert.equal(sum, 0);
   });
 });


### PR DESCRIPTION
**Motivation**

There is a known issue with slashing summing intra rolled round. in effect, if a staker stakes during an active reveal round and the vote rolls they can dodge slashing tracker updates. This PR implements a further refinement over the solution proposed in https://github.com/UMAprotocol/protocol/pull/4139

**Summary**

Solution: instead of  [PR4146](https://github.com/UMAprotocol/protocol/pull/4146/files) is modify the _getStartingIndexForStaker function to always subtract the pendingPriceRequests.length  regardless of whether the VotingV2 contract is in active reveal or not. This way each user has the ability to correctly roll (or settle) any pending price requests as necessary without having to add extra logic in commitVote to handle this scenario. There may be concerns about whether this would open users who did not vote on those pending price requests to be slashed (depending on if any of them settle), however the user's stake would be in [pendingStake](https://github.com/UMAprotocol/protocol/blob/e4eb7213f1954afb2fc4d8d4e498562efedfcc1e/packages/core/contracts/oracle/implementation/Staker.sol#L146). Therefore, when _updateTrackers is called and subsequently _updateAccountSlashingTrackers is called a user would not be slashed because pendingStake is not taken into account when calculating slash, and the pendingStake is only moved to activeStake after the slashing trackers are accounted for.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [X]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested