### PR TITLE
fix: [L01]: Prevent the governor from proposing emergency actions

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -108,6 +108,7 @@ contract EmergencyProposer is Ownable, Lockable {
      * via the governor contract.
      */
     function emergencyPropose(GovernorV2.Transaction[] memory transactions) external nonReentrant() returns (uint256) {
+        require(msg.sender != address(governor), "Governor cant propose"); // The governor should never be the proposer.
         token.safeTransferFrom(msg.sender, address(this), quorum);
         uint256 id = emergencyProposals.length;
         EmergencyProposal storage proposal = emergencyProposals.push();


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
The EmergencyProposal contract is used to construct an emergency recovery transaction
that bypasses the standard voting process. The intention is to provide an alternate execution
path that can be utilized to fix an incorrectly configured VotingV2 contract.
Any user can propose an emergency transaction via the emergencyPropose function, but
the size of the required bond is expected to be large enough that it is unlikely that an individual
or the UMA team would be able to sufficiently fund the bond amount on their own. Proposals
are executed using the emergencyExecute function in the GovernorV2 contract. The
executor address has the sole ability to call this function, giving it veto power over any
proposal. The UMA team controls the executor address.
There is currently no restriction that would prevent using the standard voting process to create
a transaction that results in the GovernorV2 contract calling the emergencyPropose
function to create a proposal. While this is highly unlikely as this transaction would need to
pass a standard voting process, this could potentially introduce undesired effects and deviate
from the expected functioning of the contract.
An example of an unexpected interaction is that a GovernorV2 emergency proposal can not
be slashed by using the slashProposal function, as the slash mechanism transfers the
slashed amount to the GovernorV2 address.
To avoid unexpected or undesirable behavior, consider preventing the GovernorV2 contract
from being able to execute the emergencyPropose function.
```

solution: block the governor from calling `emergencyPropose`.
