### PR TITLE
fix: [M01]: quorum and wait time validation in setters

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -202,6 +202,7 @@ contract EmergencyProposer is Ownable, Lockable {
      */
     function setQuorum(uint256 newQuorum) public nonReentrant() onlyOwner() {
         require(newQuorum != 0, "quorum must be > 0");
+        require(newQuorum < token.totalSupply(), "quorum must be < totalSupply");
         quorum = newQuorum;
         emit QuorumSet(newQuorum);
     }
@@ -225,6 +226,7 @@ contract EmergencyProposer is Ownable, Lockable {
      */
     function setMinimumWaitTime(uint64 newMinimumWaitTime) public nonReentrant() onlyOwner() {
         require(newMinimumWaitTime != 0, "minimumWaitTime == 0");
+        require(newMinimumWaitTime <= 4 weeks, "minimumWaitTime > 1 month");
         minimumWaitTime = newMinimumWaitTime;
         emit MinimumWaitTimeSet(newMinimumWaitTime);
     }

--- a/packages/core/test/oracle/EmergencyProposer.js
+++ b/packages/core/test/oracle/EmergencyProposer.js
@@ -121,6 +121,9 @@ describe("EmergencyProposer", function () {
     assert(await didContractThrow(proposer.methods.setQuorum(toWei("10")).send({ from: submitter })));
     assert(await didContractThrow(proposer.methods.setQuorum(toWei("10")).send({ from: executor })));
 
+    // Quorum has to be less than total supply
+    assert(await didContractThrow(setQuorum(await votingToken.methods.totalSupply().call())));
+
     // Set the quorum to 10.
     const tx = await setQuorum(toWei("10"));
     await assertEventEmitted(tx, proposer, "QuorumSet", (event) => event.quorum === toWei("10"));
@@ -137,6 +140,10 @@ describe("EmergencyProposer", function () {
     // Owner is the only one who can set the minimumWaitTime.
     assert(await didContractThrow(proposer.methods.setMinimumWaitTime(toWei("10")).send({ from: submitter })));
     assert(await didContractThrow(proposer.methods.setMinimumWaitTime(toWei("10")).send({ from: executor })));
+
+    // Max minimum wait time is 1 month
+    const oneMonthInSeconds = 60 * 60 * 24 * 30;
+    assert(await didContractThrow(setMinimumWaitTime(oneMonthInSeconds + 1)));
 
     // Set the quorum to 10.
     const tx = await setMinimumWaitTime("100");


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ signaled the following issue:
```
The setQuorum function does not validate the size of the bond relative to the supply of the token used for the quorum value. In the case that the quorum is mistakenly set to be larger than the total token supply, no emergency proposal could be created.

The setMinimumWaitTime function does not validate that the newMinimumWaitTime is within a reasonable time frame. In the case that minimumWaitTime is mistakenly set to be a large interval consisting of multiple months or even years, no emergency proposal would pass until the time frame could expire.
```

**Summary**

Add extra validation in quorum and wait minimum time setters.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


