### PR TITLE
fix: [L02]: _getPriceFromPreviousVotingContract function visibility

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -1095,7 +1095,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         bytes32 identifier,
         uint256 time,
         bytes memory ancillaryData
-    ) public view returns (bool, int256) {
+    ) private view returns (bool, int256) {
         if (address(previousVotingContract) == address(0)) return (false, 0);
 
         if (previousVotingContract.hasPrice(identifier, time, ancillaryData))


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ signaled:
```
In the VotingV2 contract, the function _getPriceFromPreviousVotingContract allows the current voting contract to query and retrieve prices from a previous voting contract. However, the function is defined with public visibility. As a result, this function can be directly called and could be used to bypass the _requireRegisteredContract check used by the onlyRegisteredContract modifier on hasPrice and getPrice . This would unintentionally allow users to access price details from a previous voting contract.
Consider changing the visibility of _getPriceFromPreviousVotingContract from public to private.
```

**Summary**

Change _getPriceFromPreviousVotingContract visibility to private


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
