### PR TITLE
fix: [L04]: add missing docstrings

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -106,6 +106,7 @@ contract EmergencyProposer is Ownable, Lockable {
      * @dev Caller of this method must approve (and have) quorum amount of token to be pulled from their wallet.
      * @param transactions array of transactions to be executed in the emergency action. When executed, will be sent
      * via the governor contract.
+     * @return uint256 the emergency proposal id.
      */
     function emergencyPropose(GovernorV2.Transaction[] memory transactions) external nonReentrant() returns (uint256) {
         token.safeTransferFrom(msg.sender, address(this), quorum);

--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -128,7 +128,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
         _stakeTo(msg.sender, recipient, amount);
     }
 
-    // Pull an "amount" of votingToken from the "from" chosen wallet and stakes them for the "recipient" address.
+    // Pull an amount of votingToken from the from address and stakes them for the recipient address.
     // If we are in an active reveal phase the stake amount will be added to the pending stake.
     // If not, the stake amount will be added to the active stake.
     function _stakeTo(

--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -128,6 +128,9 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
         _stakeTo(msg.sender, recipient, amount);
     }
 
+    // Pull an "amount" of votingToken from the "from" chosen wallet and stakes them for the "recipient" address.
+    // If we are in an active reveal phase the stake amount will be added to the pending stake.
+    // If not, the stake amount will be added to the active stake.
     function _stakeTo(
         address from,
         address recipient,

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -239,6 +239,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
      * @param _finder keeps track of all contracts within the system based on their interfaceName.
      * Must be set to 0x0 for production environments that use live time.
      * @param _slashingLibrary contract used to calculate voting slashing penalties based on voter participation.
+     * @param _previousVotingContract previous voting contract address.
      */
     constructor(
         uint256 _emissionRate,
@@ -1032,6 +1033,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
      * @param voterAddress voter for which rewards will be retrieved. Does not have to be the caller.
      * @param roundId the round from which voting rewards will be retrieved from.
      * @param toRetrieve array of PendingRequests which rewards are retrieved from.
+     * @return uint256 the amount of rewards.
      */
     function retrieveRewardsOnMigratedVotingContract(
         address voterAddress,
@@ -1091,6 +1093,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         return (false, 0, "Price was never requested");
     }
 
+    // Check the previousVotingContract to see if a given price request was resolved.
+    // Returns true or false, and the resolved price or zero, depending on whether it was found or not.
     function _getPriceFromPreviousVotingContract(
         bytes32 identifier,
         uint256 time,


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ signaled that some functions were missing docstrings:
```
In PR #4110:
• The _stakeTo function in the Staker contract has no docstring In PR #4118:
• The _previousVotingContract parameter has no corresponding @param line in the VotingV2 constructor docstring
• The _getPriceFromPreviousVotingContract function in VotingV2 has no docstring
In PR #4128:
• The emergencyPropose function in EmergencyProposer returns a value but its
docstring has no corresponding @return line 
In PR #4135:
• The retrieveRewardsOnMigratedVotingContract function in VotingV2 returns a value but its docstring has no corresponding @return line
```

Oz also pointed out the following functions but it has been decided not to add docstring in the test contracts:
```
In PR #4128:
• The getCurrentTime function in VotingV2Test has no docstring
• The commitVote function in VotingV2Test lost its docstring when it was relocated
from VotingV2.sol
• The revealVote function in VotingV2Test lost its docstring when it was relocated from VotingV2.sol
• The commitAndEmitEncryptedVote function in VotingV2Test lost its docstring when it was relocated from VotingV2.sol
• The getPendingPriceRequestsArray function in VotingV2Test has no docstring
• The getPriceRequestStatuses function in VotingV2Test lost its docstring when it was relocated from VotingV2.sol
```


**Summary**

Add the missing docstrings in non-test contracts

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested

