### PR TITLE
fix: [N04]: Unnecessary modifier in setDelegate and setDelegator

### DIFF
--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -255,7 +255,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * low-security available wallet for voting while keeping access to staked amounts secure by a more secure wallet.
      * @param delegate the address of the delegate.
      */
-    function setDelegate(address delegate) external nonReentrant() {
+    function setDelegate(address delegate) external {
         voterStakes[msg.sender].delegate = delegate;
     }
 
@@ -264,7 +264,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * if the delegator also selected the delegate to do so (two-way relationship needed).
      * @param delegator the address of the delegator.
      */
-    function setDelegator(address delegator) external nonReentrant() {
+    function setDelegator(address delegator) external {
         delegateToStaker[msg.sender] = delegator;
     }
 


### PR DESCRIPTION
**Motivation**
 OZ identified the following issue:
 ```
 In the Staker contract, the functions setDelegate and setDelegator use the
 nonReentrant modifier. This is not required as these two functions are only updating the
 state and cannot be exploited through a reentrancy attack.
 Consider removing the nonReentrant modifier from these functions.
 ```
 This PR removes this modifier on these two functions.
