### PR TITLE
fix: [L08]: improve executeEmergencyProposal docstring

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -104,9 +104,6 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice Propose an emergency admin action to execute on the DVM as a set of proposed transactions.
      * @dev Caller of this method must approve (and have) quorum amount of token to be pulled from their wallet.
-     * @dev If necessary, the first proposal transaction can run an execution of a payable function, but only the first one
-     * can do this. In order to do this, this contract's entire ETH balance will be sent in the first transaction execution.
-     * Details can be found in the executeEmergencyProposal function.
      * @param transactions array of transactions to be executed in the emergency action. When executed, will be sent
      * via the governor contract.
      */
@@ -174,8 +171,9 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice After a proposal expires, this method can be used by the executor to execute the proposal.
      * @dev This method effectively gives the executor veto power over any proposal.
-     * @dev Since the entire ETH balance of the contract is sent in the first transaction, only the first proposal
-     * transaction would be able to run a payble transaction.
+     * @dev The first transaction execution sends the total amount of ETH required to complete all payable
+     * transactions in the Governor. The EmergencyProposer must receive this amount of ETH in advance.
+     * The Governor can then decide how each of the subsequent transactions will use this ETH.
      * @param id id of the proposal.
      */
     function executeEmergencyProposal(uint256 id) public payable nonReentrant() {

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -173,7 +173,7 @@ contract EmergencyProposer is Ownable, Lockable {
      * @dev This method effectively gives the executor veto power over any proposal.
      * @dev The first transaction execution sends the total amount of ETH required to complete all payable
      * transactions in the Governor. The EmergencyProposer must receive this amount of ETH in advance.
-     * The Governor can then decide how each of the subsequent transactions will use this ETH.
+     * The executed transactions are then able to use this ETH by including a nonzero value.
      * @param id id of the proposal.
      */
     function executeEmergencyProposal(uint256 id) public payable nonReentrant() {

--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -104,6 +104,9 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice Propose an emergency admin action to execute on the DVM as a set of proposed transactions.
      * @dev Caller of this method must approve (and have) quorum amount of token to be pulled from their wallet.
+     * @dev If necessary, the first proposal transaction can run an execution of a payable function, but only the first one
+     * can do this. In order to do this, this contract's entire ETH balance will be sent in the first transaction execution.
+     * Details can be found in the executeEmergencyProposal function.
      * @param transactions array of transactions to be executed in the emergency action. When executed, will be sent
      * via the governor contract.
      */
@@ -171,6 +174,8 @@ contract EmergencyProposer is Ownable, Lockable {
     /**
      * @notice After a proposal expires, this method can be used by the executor to execute the proposal.
      * @dev This method effectively gives the executor veto power over any proposal.
+     * @dev Since the entire ETH balance of the contract is sent in the first transaction, only the first proposal
+     * transaction would be able to run a payble transaction.
      * @param id id of the proposal.
      */
     function executeEmergencyProposal(uint256 id) public payable nonReentrant() {


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

In the last audit OZ signaled:
```
In the EmergencyProposal contract, the executeEmergencyProposal function iterates through the transactions submitted 
on the proposal and executes them. However, only the first element in the array is able to execute a payable transaction,
as the first element of the proposed transactions will transfer the entirety of the contract ETH balance, meaning that 
subsequent transactions will have a value of zero.

Consider documenting this behavior thoroughly as it may not be obvious or intuitive to the proposal submitter.
```

**Summary**

Improve `executeEmergencyProposal` & `emergencyPropose` to clarify how the transactions execution work


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
