### PR TITLE
fix: [L10] unlocked solidity version pragma

### DIFF
--- a/packages/core/contracts/oracle/implementation/test/EmergencyProposerTest.sol
+++ b/packages/core/contracts/oracle/implementation/test/EmergencyProposerTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity 0.8.16;
 
 import "../EmergencyProposer.sol";
 import "../../../common/implementation/Testable.sol";

--- a/packages/core/contracts/umips/VotingUpgrader.sol
+++ b/packages/core/contracts/umips/VotingUpgrader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity 0.8.16;
 
 import "../oracle/implementation/Finder.sol";
 import "../oracle/implementation/Constants.sol";


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

In the latest audit OZ signaled that the following contracts had an old pragma version:

- EmergencyProposerTest.sol
- VotingUpgraderV2.sol


**Summary**

Update the pragma version to `0.8.16` in the contracts listed above. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
