### PR TITLE
fix: [N06]: Redundant event parameters

### DIFF
--- a/packages/core/test/oracle/EmergencyProposer.js
+++ b/packages/core/test/oracle/EmergencyProposer.js
@@ -221,7 +221,7 @@ describe("EmergencyProposer", function () {
       receipt,
       proposer,
       "EmergencyProposalExecuted",
-      (event) => event.id === id && event.sender === submitter
+      (event) => event.id === id && event.sender === submitter && event.lockedTokens == quorum
     );
 
     // Clean up votingToken balance.
@@ -253,7 +253,7 @@ describe("EmergencyProposer", function () {
       receipt,
       proposer,
       "EmergencyProposalSlashed",
-      (event) => event.id === id && event.sender === submitter
+      (event) => event.id === id && event.sender === submitter && event.lockedTokens == quorum
     );
 
     // Verify balanes.
@@ -302,7 +302,8 @@ describe("EmergencyProposer", function () {
       receipt,
       proposer,
       "EmergencyProposalRemoved",
-      (event) => event.id === id && event.caller === submitter && event.sender === submitter
+      (event) =>
+        event.id === id && event.caller === submitter && event.sender === submitter && event.lockedTokens == quorum
     );
 
     // Clean up votingToken balance.

--- a/packages/core/test/oracle/EmergencyProposer.js
+++ b/packages/core/test/oracle/EmergencyProposer.js
@@ -256,7 +256,7 @@ describe("EmergencyProposer", function () {
       (event) => event.id === id && event.sender === submitter && event.lockedTokens == quorum
     );
 
-    // Verify balanes.
+    // Verify balances.
     assert.equal(await votingToken.methods.balanceOf(submitter).call(), "0");
     assert.equal(await votingToken.methods.balanceOf(governor.options.address).call(), quorum);
   });


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
In the EmergencyProposer contract, the following events all contain a uint256
lockedTokens parameter:
EmergencyProposalRemoved
EmergencyProposalSlashed
EmergencyProposalExecuted

In each case, when these events are emitted, the value of lockedTokens will always be zero,
which effectively provides no information because the value never changes.
```

**Solution:**
This Pr makes no changes to the contract code as we belive this issue is wrong. This PR shows in unit tests how the `lockedTokens` param is non-zero.
