### PR TITLE
fix: [N09]  unnecessary non-empty return value on success

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -1087,7 +1087,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         if (requestStatus == RequestStatus.Future) return (false, 0, "Price is still to be voted on");
         (bool previouslyResolved, int256 previousPrice) =
             _getPriceFromPreviousVotingContract(identifier, time, ancillaryData);
-        if (previouslyResolved) return (true, previousPrice, "Returned from previous contract");
+        if (previouslyResolved) return (true, previousPrice, "");
         return (false, 0, "Price was never requested");
     }
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ signaled:
```
Per the comment on _getPriceOrError , the string return value should be non-empty only when the function returns false . However, the additional logic to query prices from a previous voting contract via _getPriceFromPreviousVotingContract may return a non- empty string even when the price was successfully retrieved. Because the string message is only used in the error case, users will never see the "Returned from previous contract" string.
Consider returning an empty string when _getPriceOrError returns true .

```


**Summary**

Remove unnecessary non-empty string return value.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
