### PR TITLE
fix: [N10]: Unnecessary public visability in executeEmergencyProposal

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -173,7 +173,7 @@ contract EmergencyProposer is Ownable, Lockable {
      * @dev This method effectively gives the executor veto power over any proposal.
      * @param id id of the proposal.
      */
-    function executeEmergencyProposal(uint256 id) public payable nonReentrant() {
+    function executeEmergencyProposal(uint256 id) external payable nonReentrant() {
         require(msg.sender == executor, "must be called by executor");
 
         EmergencyProposal storage proposal = emergencyProposals[id];


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
In the EmergencyProposer contract, the executeEmergencyProposal function has
public visibility. This is not required as the function is not called within the contract.
Consider changing the visibility of the executeEmergencyProposal function to
external.
```

**This PR updates the contracts, as requested**.
