### PR TITLE
fix(sdk): fix failing lookup for skinny oo by tx hash

### DIFF
--- a/packages/sdk/src/clients/skinnyOptimisticOracle/client.ts
+++ b/packages/sdk/src/clients/skinnyOptimisticOracle/client.ts
@@ -85,7 +85,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       if (!state.requests) state.requests = {};
       state.requests[id] = {
         // need to maintain previous state in case it exists
-        ...(state.requests[id] || {}),
+        ...state.requests[id],
         ...request,
         requester,
         identifier,
@@ -103,7 +103,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
-        ...(state.requests[id] || {}),
+        ...state.requests[id],
         ...request,
         requester,
         identifier,
@@ -121,7 +121,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
-        ...(state.requests[id] || {}),
+        ...state.requests[id],
         ...request,
         requester,
         identifier,
@@ -139,7 +139,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
-        ...(state.requests[id] || {}),
+        ...state.requests[id],
         ...request,
         requester,
         identifier,

--- a/packages/sdk/src/clients/skinnyOptimisticOracle/client.ts
+++ b/packages/sdk/src/clients/skinnyOptimisticOracle/client.ts
@@ -84,6 +84,8 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
+        // need to maintain previous state in case it exists
+        ...(state.requests[id] || {}),
         ...request,
         requester,
         identifier,
@@ -101,6 +103,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
+        ...(state.requests[id] || {}),
         ...request,
         requester,
         identifier,
@@ -118,6 +121,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
+        ...(state.requests[id] || {}),
         ...request,
         requester,
         identifier,
@@ -135,6 +139,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
       const id = requestId(typedEvent.args);
       if (!state.requests) state.requests = {};
       state.requests[id] = {
+        ...(state.requests[id] || {}),
         ...request,
         requester,
         identifier,

--- a/packages/sdk/src/oracle/services/optimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracle.ts
@@ -29,7 +29,7 @@ export class OptimisticOracle implements OracleInterface {
     this.requests[id] = update;
     return update;
   };
-  private makeEventFromLog = (log: Log) => {
+  parseLog = (log: Log) => {
     const description = this.contract.interface.parseLog(log);
     return {
       ...log,
@@ -105,7 +105,7 @@ export class OptimisticOracle implements OracleInterface {
     };
   }
   updateFromTransactionReceipt(receipt: TransactionReceipt): void {
-    const events = receipt.logs.map((log) => this.makeEventFromLog(log));
+    const events = receipt.logs.map((log) => this.parseLog(log));
     this.updateFromEvents((events as unknown[]) as OptimisticOracleEvent[]);
   }
   listRequests(): Request[] {

--- a/packages/sdk/src/oracle/services/optimisticOracleV2.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracleV2.ts
@@ -32,15 +32,6 @@ export class OptimisticOracleV2 implements OracleInterface {
     this.requests[id] = update;
     return update;
   };
-  private makeEventFromLog = (log: Log) => {
-    const description = this.contract.interface.parseLog(log);
-    return {
-      ...log,
-      ...description,
-      event: description.name,
-      eventSignature: description.signature,
-    };
-  };
   private setDisputeHash({ requester, identifier, timestamp, ancillaryData }: RequestKey, hash: string): Request {
     return this.upsertRequest({ requester, identifier, timestamp, ancillaryData, disputeTx: hash });
   }
@@ -65,6 +56,15 @@ export class OptimisticOracleV2 implements OracleInterface {
     return this.upsertRequest({ ...request, state, requester, identifier, timestamp, ancillaryData });
   }
 
+  parseLog = (log: Log) => {
+    const description = this.contract.interface.parseLog(log);
+    return {
+      ...log,
+      ...description,
+      event: description.name,
+      eventSignature: description.signature,
+    };
+  };
   getRequest(key: RequestKey): Request {
     const id = requestId(key);
     const request = this.requests[id] || key;
@@ -108,7 +108,7 @@ export class OptimisticOracleV2 implements OracleInterface {
     };
   }
   updateFromTransactionReceipt(receipt: TransactionReceipt): void {
-    const events = receipt.logs.map((log) => this.makeEventFromLog(log));
+    const events = receipt.logs.map((log) => this.parseLog(log));
     this.updateFromEvents((events as unknown[]) as OptimisticOracleEvent[]);
   }
   listRequests(): Request[] {

--- a/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
@@ -57,15 +57,6 @@ export class SkinnyOptimisticOracle implements OracleInterface {
     this.requests[id] = update;
     return update;
   };
-  private makeEventFromLog = (log: Log) => {
-    const description = this.contract.interface.parseLog(log);
-    return {
-      ...log,
-      ...description,
-      event: description.name,
-      eventSignature: description.signature,
-    };
-  };
   private setDisputeHash({ requester, identifier, timestamp, ancillaryData }: RequestKey, hash: string): Request {
     return this.upsertRequest({ requester, identifier, timestamp, ancillaryData, disputeTx: hash });
   }
@@ -89,6 +80,15 @@ export class SkinnyOptimisticOracle implements OracleInterface {
     return this.getRequest(key);
   }
 
+  parseLog = (log: Log) => {
+    const description = this.contract.interface.parseLog(log);
+    return {
+      ...log,
+      ...description,
+      event: description.name,
+      eventSignature: description.signature,
+    };
+  };
   getRequest(key: RequestKey): Request {
     const id = requestId(key);
     const request = this.requests[id] || key;
@@ -135,7 +135,7 @@ export class SkinnyOptimisticOracle implements OracleInterface {
     };
   }
   updateFromTransactionReceipt(receipt: TransactionReceipt): void {
-    const events = receipt.logs.map((log) => this.makeEventFromLog(log));
+    const events = receipt.logs.map((log) => this.parseLog(log));
     this.updateFromEvents((events as unknown[]) as OptimisticOracleEvent[]);
   }
   listRequests(): Request[] {

--- a/packages/sdk/src/oracle/types/ethers.ts
+++ b/packages/sdk/src/oracle/types/ethers.ts
@@ -14,3 +14,4 @@ export type SerializableEvent = Omit<
 
 // taken from ethers code https://github.com/ethers-io/ethers.js/blob/master/packages/abi/src.ts/interface.ts#L654
 export type Log = Parameters<Interface["parseLog"]>[0];
+export type ParsedLog = ReturnType<Interface["parseLog"]>;

--- a/packages/sdk/src/oracle/types/interfaces.ts
+++ b/packages/sdk/src/oracle/types/interfaces.ts
@@ -1,4 +1,13 @@
-import { BigNumberish, BigNumber, Signer, TransactionResponse, TransactionReceipt, Provider } from "../types/ethers";
+import {
+  BigNumberish,
+  BigNumber,
+  Signer,
+  TransactionResponse,
+  TransactionReceipt,
+  Provider,
+  Log,
+  ParsedLog,
+} from "../types/ethers";
 import { RequestState, RequestKey } from "../../clients/optimisticOracle";
 import { Client } from "../client";
 import { OracleType } from "../types/state";
@@ -65,6 +74,7 @@ export interface OracleInterface {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
   getProps: () => Promise<OracleProps>;
   listRequests: () => Requests;
+  parseLog: (log: Log) => ParsedLog;
 }
 
 export type ClientTable = {


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

1. Disputes are unable to be viewed in the OO UI using the url by transaction hash method.
2. Proposer tx hash missing from requests

**Summary**

Needed to update our oracle interface to include a way to parse logs from a transaction receipt. Previously we never changed the contract instance based on which oracle was in use (v1,v2 or skinny). This caused an issue when decoding skinny logs.  The fix was to add a function to decode logs in the oo interface and use it in our `setActiveRequestByTransaction` handler.

after this issue was fixed, a new one surfaced where trnasaction hashes were missing from request objects. this was an issue with decoding events and not copying over the previously decoded request object, thereby losing accumulated data. 


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

Tested this by integrating it into the OO UI to verify fix


