### PR TITLE
feat(serverless): add ability to specify labeled spoke urls

### DIFF
--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -110,7 +110,11 @@ describe("ServerlessHub.js", function () {
       hubTestPort, // port to run the hub on
       `http://localhost:${spokeTestPort}`, // URL to execute spokes on
       network.config.url, // custom node URL to enable the hub to query block numbers.
-      { printHubConfig: true } // set hub config to print config before execution.
+      { printHubConfig: true }, // set hub config to print config before execution.
+      {
+        small: `http://localhost:${spokeTestPort}`, // URL to execute spokes on
+        large: `http://localhost:${spokeTestPort}`, // URL to execute spokes on
+      }
     );
 
     // Start the serverless spoke instance with the spy logger injected.
@@ -214,6 +218,67 @@ describe("ServerlessHub.js", function () {
     assert.isTrue(spyLogIncludes(hubSpy, -3, startingBlockNumber), "should return block information for chain");
     assert.isTrue(spyLogIncludes(hubSpy, -3, defaultChainId), "should return chain ID");
     assert.isTrue(spyLogIncludes(hubSpy, -4, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
+  });
+  it("ServerlessHub can correctly execute bot with named spokes", async function () {
+    // Set up the environment for testing. For these tests the hub is tested in `localStorage` mode where it will
+    // read in hub configs and previous block numbers from the local storage of machine. This execution mode would be
+    // used by a user running the hub-spoke on their local machine.
+    const testBucket = "test-bucket"; // name of the config bucket.
+    const testConfigFile = "test-config-file"; // name of the config file.
+    const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
+    const defaultConfig = {
+      serverlessCommand: "yarn --silent monitors --network test",
+      environmentVariables: {
+        CUSTOM_NODE_URL: network.config.url,
+        POLLING_DELAY: 0,
+        EMP_ADDRESS: emp.options.address,
+        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
+        MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
+      },
+    };
+    const hubConfig = {
+      // no named spoke
+      testDefaultInstance: defaultConfig,
+      // one named spoke
+      testSmallInstance: { ...defaultConfig, spokeUrlName: "small" },
+      // other named spoke
+      testLargeInstance: { ...defaultConfig, spokeUrlName: "large" },
+    };
+    // Set env variables for the hub to pull from. Add the startingBlockNumber and the hubConfig.
+    setEnvironmentVariable(`lastQueriedBlockNumber-${defaultChainId}-${testConfigFile}`, startingBlockNumber);
+    setEnvironmentVariable(`${testBucket}-${testConfigFile}`, JSON.stringify(hubConfig));
+
+    const validBody = { bucket: testBucket, configFile: testConfigFile };
+    const validResponse = await sendHubRequest(validBody);
+    assert.equal(validResponse.res.statusCode, 200); // no error code
+    assert.isTrue(spyLogIncludes(hubSpy, 4, "serverless spoke using named spoke small"), "should run small instance");
+    assert.isTrue(spyLogIncludes(hubSpy, 5, "serverless spoke using named spoke large"), "should run large instance");
+  });
+  it("ServerlessHub correctly fails with an invalid named spoke", async function () {
+    // Set up the environment for testing. For these tests the hub is tested in `localStorage` mode where it will
+    // read in hub configs and previous block numbers from the local storage of machine. This execution mode would be
+    // used by a user running the hub-spoke on their local machine.
+    const testBucket = "test-bucket"; // name of the config bucket.
+    const testConfigFile = "test-config-file"; // name of the config file.
+    const startingBlockNumber = await web3.eth.getBlockNumber(); // block number to search from for monitor
+    const defaultConfig = {
+      serverlessCommand: "yarn --silent monitors --network test",
+      environmentVariables: {
+        CUSTOM_NODE_URL: network.config.url,
+        POLLING_DELAY: 0,
+        EMP_ADDRESS: emp.options.address,
+        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
+        MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
+      },
+    };
+    const hubConfig = { testInvalidInstance: { ...defaultConfig, spokeUrlName: "invalid" } };
+    // Set env variables for the hub to pull from. Add the startingBlockNumber and the hubConfig.
+    setEnvironmentVariable(`lastQueriedBlockNumber-${defaultChainId}-${testConfigFile}`, startingBlockNumber);
+    setEnvironmentVariable(`${testBucket}-${testConfigFile}`, JSON.stringify(hubConfig));
+
+    const validBody = { bucket: testBucket, configFile: testConfigFile };
+    const response = await sendHubRequest(validBody);
+    assert.equal(response.res.statusCode, 500); // no error code
   });
   it("ServerlessHub correctly deals with rejected spoke calls", async function () {
     // valid config to send but set the spoke to be off-line


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We want to create multiple sizes for spoke pool hardware and configure this from the hub. This will help lower gcp costs.

**Summary**

Add a backward compatible change. env var `SPOKE_URLS` which must be specified as an object keyed by `name` and a value of the spokes url.  This is an optional argument.  To utilize this in the bot, specify in the confige `spokeUrlName` which must match the `name` key in the `SPOKE_URLS` env var.

example:
```js
// in a bot config
{
   "environmentVariables": {
      SPOKE_URLS={"small":"url to small spokes","large":"url to large spokes"}
   },
   spokeUrlName:"small",
}

```

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


