### PR TITLE
fix: [post-audit-feedback]: Address typos and small issues identified before getting full audit feedback

### DIFF
--- a/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/oracle/implementation/EmergencyProposer.sol
@@ -100,7 +100,7 @@ contract EmergencyProposer is Ownable, Lockable {
      * @return uint256 the emergency proposal id.
      */
     function emergencyPropose(GovernorV2.Transaction[] memory transactions) external nonReentrant() returns (uint256) {
-        require(msg.sender != address(governor), "Governor cant propose"); // The governor should never be the proposer.
+        require(msg.sender != address(governor), "Governor can't propose"); // The governor should never be the proposer.
         token.safeTransferFrom(msg.sender, address(this), quorum);
         uint256 id = emergencyProposals.length;
         EmergencyProposal storage proposal = emergencyProposals.push();

--- a/packages/core/contracts/umips/VotingUpgraderV2.sol
+++ b/packages/core/contracts/umips/VotingUpgraderV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity 0.8.16;
 
 import "../oracle/implementation/Finder.sol";
 import "../oracle/implementation/Constants.sol";
@@ -49,7 +49,7 @@ contract VotingUpgraderV2 {
     // Finder contract to push upgrades to.
     Finder public immutable finder;
 
-    // Addresses to upgrade.
+    // Address to upgrade to.
     address public immutable newVoting;
 
     // Additional ownable contracts to transfer ownership of.


### PR DESCRIPTION
**Motivation**

OZ identified the following issues before providing the final audit feedback:
```
small typo in #4151 - "cant"
Also in #4159 it looks like VotingUpgrader.sol was changed instead of VotingUpgraderV2.sol
In #4152 there is still an issue with the line "Addresses to upgrade..." b/c it says "addresses" plural, not "address" singular
```

This PR addresses the 3 issues identified.
