### PR TITLE
fix(financial-templates-lib): prevent disabled config for pdv2 transp…

### DIFF
--- a/packages/financial-templates-lib/package.json
+++ b/packages/financial-templates-lib/package.json
@@ -21,6 +21,7 @@
     "moment-timezone": "^0.5.33",
     "node-fetch": "^2.6.0",
     "node-pagerduty": "^1.2.0",
+    "superstruct": "^0.16.4",
     "web3": "^1.6.0",
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0"

--- a/packages/financial-templates-lib/src/logger/Logger.ts
+++ b/packages/financial-templates-lib/src/logger/Logger.ts
@@ -47,10 +47,6 @@ export interface AugmentedLogger extends _Logger {
   isFlushed: boolean;
 }
 
-export interface AugmentedLogger extends _Logger {
-  isFlushed: boolean;
-}
-
 export function createNewLogger(
   injectedTransports: Transport[] = [],
   transportsConfig = {},

--- a/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
+++ b/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
@@ -1,4 +1,5 @@
 // This transport enables winston logging to send messages to pager duty v2 api.
+import assert from "assert";
 import Transport from "winston-transport";
 import { event } from "@pagerduty/pdjs";
 
@@ -14,6 +15,8 @@ export class PagerDutyV2Transport extends Transport {
   private readonly integrationKey: string;
   private readonly customServices: { [key: string]: string };
   constructor(winstonOpts: TransportOptions, { integrationKey, customServices = {} }: Config) {
+    // we check this even though its strongly typed because typescript is incorrectly allowing json parsed env.
+    assert(integrationKey, "Pagerduty V2 Transport requires integrationKey");
     super(winstonOpts);
     this.integrationKey = integrationKey;
     this.customServices = customServices;

--- a/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
+++ b/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
@@ -1,24 +1,27 @@
 // This transport enables winston logging to send messages to pager duty v2 api.
 import Transport from "winston-transport";
 import { event } from "@pagerduty/pdjs";
-import * as ss from 'superstruct'
+import * as ss from "superstruct";
 
 type TransportOptions = ConstructorParameters<typeof Transport>[0];
 export type Severity = "critical" | "error" | "warning" | "info";
 
 const Config = ss.object({
   integrationKey: ss.string(),
-  customServices: ss.optional(ss.record(ss.string(),ss.string()))
-})
-export type Config = ss.Infer<typeof Config>
+  customServices: ss.optional(ss.record(ss.string(), ss.string())),
+});
+export type Config = ss.Infer<typeof Config>;
+
+// this turns an unknown ( like json parsed data) into a config, or throws an error
+export function createConfig(config: unknown): Config {
+  return ss.create(config, Config);
+}
 
 export class PagerDutyV2Transport extends Transport {
   private readonly integrationKey: string;
   private readonly customServices: { [key: string]: string };
-  constructor(winstonOpts: TransportOptions, unknownConfig:unknown) {
-    // we check this even though its strongly typed because typescript is incorrectly allowing json parsed env.
+  constructor(winstonOpts: TransportOptions, { integrationKey, customServices = {} }: Config) {
     super(winstonOpts);
-    const {integrationKey,customServices={}} = ss.create(unknownConfig,Config)
     this.integrationKey = integrationKey;
     this.customServices = customServices;
   }

--- a/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
+++ b/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
@@ -1,23 +1,24 @@
 // This transport enables winston logging to send messages to pager duty v2 api.
-import assert from "assert";
 import Transport from "winston-transport";
 import { event } from "@pagerduty/pdjs";
+import * as ss from 'superstruct'
 
 type TransportOptions = ConstructorParameters<typeof Transport>[0];
 export type Severity = "critical" | "error" | "warning" | "info";
 
-interface Config {
-  integrationKey: string;
-  customServices?: { [key: string]: string };
-}
+const Config = ss.object({
+  integrationKey: ss.string(),
+  customServices: ss.optional(ss.record(ss.string(),ss.string()))
+})
+export type Config = ss.Infer<typeof Config>
 
 export class PagerDutyV2Transport extends Transport {
   private readonly integrationKey: string;
   private readonly customServices: { [key: string]: string };
-  constructor(winstonOpts: TransportOptions, { integrationKey, customServices = {} }: Config) {
+  constructor(winstonOpts: TransportOptions, unknownConfig:unknown) {
     // we check this even though its strongly typed because typescript is incorrectly allowing json parsed env.
-    assert(integrationKey, "Pagerduty V2 Transport requires integrationKey");
     super(winstonOpts);
+    const {integrationKey,customServices={}} = ss.create(unknownConfig,Config)
     this.integrationKey = integrationKey;
     this.customServices = customServices;
   }

--- a/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
+++ b/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
@@ -10,6 +10,11 @@ const Config = ss.object({
   integrationKey: ss.string(),
   customServices: ss.optional(ss.record(ss.string(), ss.string())),
 });
+// Config object becomes a type
+// {
+//   integrationKey: string;
+//   customServices?: Record<string,string>;
+// }
 export type Config = ss.Infer<typeof Config>;
 
 // this turns an unknown ( like json parsed data) into a config, or throws an error

--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -80,20 +80,12 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
         )
       );
     }
-    // typescript is not properly typing this as a parsed json string should be "unknown",
-    // but we are relying on this quirk throughout this file. The PD v2 transport class will check
-    // that the config is valid or throw an error to prevent errors while running.
     const pagerDutyV2Config =
       transportsConfig.pagerDutyV2Config ?? JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null");
     // If there is a Pagerduty V2 API key then add the pagerduty winston transport.
     if (pagerDutyV2Config) {
-      try {
-        transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2Config));
-      } catch (err) {
-        if (err instanceof Error) {
-          console.warn("Pagerduty V2 Config not added due to error: ", err.message);
-        }
-      }
+      // this will throw an error if an invalid configuration is present
+      transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2Config));
     }
   }
   return transports;

--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -80,14 +80,20 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
         )
       );
     }
+    // typescript is not properly typing this as a parsed json string should be "unknown",
+    // but we are relying on this quirk throughout this file. The PD v2 transport class will check
+    // that the config is valid or throw an error to prevent errors while running.
+    const pagerDutyV2Config =
+      transportsConfig.pagerDutyV2Config ?? JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null");
     // If there is a Pagerduty V2 API key then add the pagerduty winston transport.
-    if (transportsConfig.pagerDutyV2Config || process.env.PAGER_DUTY_V2_CONFIG) {
-      transports.push(
-        new PagerDutyV2Transport(
-          { level: "warn" },
-          transportsConfig.pagerDutyV2Config ?? JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null")
-        )
-      );
+    if (pagerDutyV2Config) {
+      try {
+        transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2Config));
+      } catch (err) {
+        if (err instanceof Error) {
+          console.warn("Pagerduty V2 Config not added due to error: ", err.message);
+        }
+      }
     }
   }
   return transports;

--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -84,16 +84,14 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
       );
     }
 
-    // to disable pdv2, pass in a "disabled=true" in configs or env. Configs get merged rather than replaced as was the
-    // convention in previous transports.
-    const { disabled: pagerDutyV2Disabled = false, ...pagerDutyV2Config } = {
-      ...JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null"),
-      ...transportsConfig.pagerDutyV2Config,
-    };
-    // If there is a Pagerduty V2 API key then add the pagerduty winston transport.
-    if (Object.keys(pagerDutyV2Config).length > 0 && !pagerDutyV2Disabled) {
+    if (transportsConfig.pagerDutyV2Config || process.env.PAGER_DUTY_V2_CONFIG) {
+      // to disable pdv2, pass in a "disabled=true" in configs or env.
+      const { disabled = false, ...pagerDutyV2Config } =
+        transportsConfig.pagerDutyV2Config ?? JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null");
       // this will throw an error if an invalid configuration is present
-      transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2CreateConfig(pagerDutyV2Config)));
+      if (!disabled) {
+        transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2CreateConfig(pagerDutyV2Config)));
+      }
     }
   }
   return transports;

--- a/packages/financial-templates-lib/src/logger/Transports.ts
+++ b/packages/financial-templates-lib/src/logger/Transports.ts
@@ -7,7 +7,11 @@ import { createConsoleTransport } from "./ConsoleTransport";
 import { createJsonTransport } from "./JsonTransport";
 import { createSlackTransport } from "./SlackTransport";
 import { PagerDutyTransport } from "./PagerDutyTransport";
-import { PagerDutyV2Transport } from "./PagerDutyV2Transport";
+import {
+  PagerDutyV2Transport,
+  Config as PagerDutyV2Config,
+  createConfig as pagerDutyV2CreateConfig,
+} from "./PagerDutyV2Transport";
 import { DiscordTransport } from "./DiscordTransport";
 import type Transport from "winston-transport";
 import dotenv from "dotenv";
@@ -19,7 +23,6 @@ const argv = minimist(process.argv.slice(), {});
 type SlackConfig = Parameters<typeof createSlackTransport>[0];
 type DiscordConfig = ConstructorParameters<typeof DiscordTransport>[1];
 type PagerDutyConfig = ConstructorParameters<typeof PagerDutyTransport>[1];
-type PagerDutyV2Config = ConstructorParameters<typeof PagerDutyV2Transport>[1];
 
 interface TransportsConfig {
   environment?: string;
@@ -80,12 +83,17 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
         )
       );
     }
-    const pagerDutyV2Config =
-      transportsConfig.pagerDutyV2Config ?? JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null");
+
+    // to disable pdv2, pass in a "disabled=true" in configs or env. Configs get merged rather than replaced as was the
+    // convention in previous transports.
+    const { disabled: pagerDutyV2Disabled = false, ...pagerDutyV2Config } = {
+      ...JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null"),
+      ...transportsConfig.pagerDutyV2Config,
+    };
     // If there is a Pagerduty V2 API key then add the pagerduty winston transport.
-    if (pagerDutyV2Config) {
+    if (Object.keys(pagerDutyV2Config).length > 0 && !pagerDutyV2Disabled) {
       // this will throw an error if an invalid configuration is present
-      transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2Config));
+      transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2CreateConfig(pagerDutyV2Config)));
     }
   }
   return transports;

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleEventClient.js
@@ -267,19 +267,14 @@ describe("OptimisticOracleEventClient.js", function () {
       .send({ from: disputer });
     await pushPrice(correctPrice);
 
-    console.log("A");
     disputeV2Txn1 = await optimisticOracleV2.methods
       .disputePrice(requester, identifier, requestTime + 2, defaultAncillaryData)
       .send({ from: disputer });
-    console.log("B");
     await pushPrice(correctPrice);
-    console.log("C");
     disputeV2Txn2 = await optimisticOracleV2.methods
       .disputePrice(requester, identifier, requestTime + 3, defaultAncillaryData)
       .send({ from: disputer });
-    console.log("D");
     await pushPrice(correctPrice);
-    console.log("E");
 
     skinnyDisputeTxn1 = await skinnyOptimisticOracle.methods
       .disputePrice(

--- a/yarn.lock
+++ b/yarn.lock
@@ -23608,6 +23608,11 @@ superagent@^3.8.3:
     qs "^6.5.1"
     readable-stream "^2.3.5"
 
+superstruct@^0.16.4:
+  version "0.16.4"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.4.tgz#84c80753a3376e16ef5a4f8dafa1e06767ba8e81"
+  integrity sha512-PGf1ZSWwbOb33efMX5Jq/JUM5UpCOk1p3/6jPS6o8mcPy9vd2XXOiEXDKwWOETpnzAvjkXcryL+l+jhvkDaizQ==
+
 supertest@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"


### PR DESCRIPTION
…ort from continually erroring

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
As a convention we are overriding pagerduty configs with `{}` to disable them. A side effect of this is to still enable the pagerduty transport, but throw errors with an invalid config for every new log before it can be submitted to pagerduty. We want to prevent these errors from happening.

**Summary**

This change only affects the pd v2 transport. Now if the logger is configured with an invalid or empty pd v2 config, it will log a warning saying that it was not added as a transport and why.  That will be the only error on startup, and will be effectively disabled and silent from then on.

**other note**
The way we are disabling pagerduty smells, we should probably be providing an explit "disable" option and merging that into the config, rather than overwriting the config it with an empty object and relying on typescripts bad compiling to let that go through as a valid config. As a result this causes runtime errors that are forced to be caught in the transport to prevent the app from crashing.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
