### PR TITLE
fix: add new voting v2 address goerli

### DIFF
--- a/packages/core/networks/5.json
+++ b/packages/core/networks/5.json
@@ -41,7 +41,7 @@
   },
   {
     "contractName": "VotingV2",
-    "address": "0x3682754e0f5bDC9f6045413729E2d463e08272D7"
+    "address": "0xb3282F95baA909D4CB99568ADA45aE5D632b96DC"
   },
   {
     "contractName": "VotingToken",


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

During my tests in the previous deployment, I accidentally allowed the pricing request with index 0 to roll; this prevents the slashing mechanism from performing properly and must be avoided. For this reason I have had to deploy a new contract.

In this last deployment I have deployed with the starting request index argument greater than zero, this prevents the above problem from occurring. This also ensures that in the mainnet deployment we are safe from these problems. 


**Summary**

Deployed new voting v2 contract


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested