### PR TITLE
feat: export get[name]StaticAddress() from contracts-node

### DIFF
--- a/packages/common/src/hardhat/tasks/artifacts.ts
+++ b/packages/common/src/hardhat/tasks/artifacts.ts
@@ -278,7 +278,7 @@ export type { ${normalizeClassName(contractName)}Web3Events };\n`
     // Creates get[name]Address(chainId) using switch statements.
     // Note: don't export these functions as they are only used internally.
     for (const [name, addressesByChain] of Object.entries(addresses)) {
-      const declaration = `function get${name}StaticAddress(chainId: number): string {\n  switch (chainId.toString()) {\n`;
+      const declaration = `export function get${name}StaticAddress(chainId: number): string {\n  switch (chainId.toString()) {\n`;
       const cases = Object.entries(addressesByChain).map(([chainId, address]) => {
         return `    case "${chainId}":\n      return "${address}";\n`;
       });


### PR DESCRIPTION
**Motivation**

Allow users to get addresses without async calls in contracts-node.


**Summary**

To allow users to access addresses without an async call, this exports the get[name]StaticAddress() function to avoid hardhat resolution.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A