### PR TITLE
fix: residual active stake naming

### DIFF
--- a/packages/core/contracts/oracle/implementation/Staker.sol
+++ b/packages/core/contracts/oracle/implementation/Staker.sol
@@ -110,7 +110,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
 
     // Pull an amount of votingToken from the from address and stakes them for the recipient address.
     // If we are in an active reveal phase the stake amount will be added to the pending stake.
-    // If not, the stake amount will be added to the active stake.
+    // If not, the stake amount will be added to the stake.
     function _stakeTo(
         address from,
         address recipient,

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -69,7 +69,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     struct Round {
         uint256 gat; // GAT is the required number of tokens to vote to not roll the vote.
-        uint256 cumulativeActiveStakeAtRound; // Total staked tokens at the start of the round.
+        uint256 cumulativeStakeAtRound; // Total staked tokens at the start of the round.
     }
 
     // Represents the status a price request has.
@@ -690,7 +690,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
         uint256 totalVotes = voteInstance.resultComputation.totalVotes;
         uint256 totalCorrectVotes = voteInstance.resultComputation.getTotalCorrectlyVotedTokens();
-        uint256 stakedAtRound = rounds[priceRequest.lastVotingRound].cumulativeActiveStakeAtRound;
+        uint256 stakedAtRound = rounds[priceRequest.lastVotingRound].cumulativeStakeAtRound;
 
         (uint256 wrongVoteSlash, uint256 noVoteSlash) =
             slashingLibrary.calcSlashing(stakedAtRound, totalVotes, totalCorrectVotes, priceRequest.isGovernance);
@@ -795,12 +795,12 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     function _computePendingStakes(address voterAddress, uint256 amount) internal override {
         if (_inActiveReveal()) {
             uint256 currentRoundId = getCurrentRoundId();
-            // We now can freeze the round variables as we do not want the cumulativeActiveStakeAtRound to change based on the stakes
+            // We now can freeze the round variables as we do not want the cumulativeStakeAtRound to change based on the stakes
             // during the active reveal phase. This only happens if the first action within the active reveal is someone staking, rather
             // than someone revealing their vote.
             _freezeRoundVariables(currentRoundId);
             // Finally increment the pending stake for the voter by the amount to stake. Together with the omission
-            // of the new stakes from the cumulativeActiveStakeAtRound for this round, this ensures that the
+            // of the new stakes from the cumulativeStakeAtRound for this round, this ensures that the
             // pending stakes of any voter are not included in the slashing calculation for this round.
             _setPendingStake(voterAddress, currentRoundId, amount);
         }
@@ -871,14 +871,14 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
             (uint256 wrongVoteSlashPerToken, uint256 noVoteSlashPerToken) =
                 slashingLibrary.calcSlashing(
-                    rounds[priceRequest.lastVotingRound].cumulativeActiveStakeAtRound,
+                    rounds[priceRequest.lastVotingRound].cumulativeStakeAtRound,
                     voteInstance.resultComputation.totalVotes,
                     totalCorrectVotes,
                     priceRequest.isGovernance
                 );
 
             // During this round's tracker calculation, we deduct the pending stake from the voter's total stake.
-            // Also, the pending stakes of voters in a given round are excluded from the cumulativeActiveStakeAtRound;
+            // Also, the pending stakes of voters in a given round are excluded from the cumulativeStakeAtRound;
             // _computePendingStakes handles this. Thus, the voter's stakes during the active reveal phase of this round
             // won't be included in the slashes calculations.
             uint256 effectiveStake = voterStake.stake - voterStake.pendingStakes[priceRequest.lastVotingRound];
@@ -899,7 +899,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
                 // and the total slashed for voting incorrectly. Use this to work out the stakers prorate share.
                 uint256 totalSlashed =
                     ((noVoteSlashPerToken *
-                        (rounds[priceRequest.lastVotingRound].cumulativeActiveStakeAtRound -
+                        (rounds[priceRequest.lastVotingRound].cumulativeStakeAtRound -
                             voteInstance.resultComputation.totalVotes)) +
                         ((wrongVoteSlashPerToken * (voteInstance.resultComputation.totalVotes - totalCorrectVotes)))) /
                         1e18;
@@ -1184,7 +1184,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             rounds[roundId].gat = gat;
 
             // Store the cumulativeStake at this roundId to work out slashing and voting trackers.
-            rounds[roundId].cumulativeActiveStakeAtRound = cumulativeStake;
+            rounds[roundId].cumulativeStakeAtRound = cumulativeStake;
         }
     }
 

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -217,7 +217,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     event SpamDeletionProposalBondChanged(uint256 newBond);
 
-    event VoterSlashed(address indexed voter, int256 slashedTokens, uint256 postActiveStake);
+    event VoterSlashed(address indexed voter, int256 slashedTokens, uint256 postStake);
 
     event SignaledRequestsAsSpamForDeletion(
         uint256 indexed proposalId,


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

I have found residual mentions of the concept of active stake that got unnoticed in the latest changes.

Additionally, because we are approaching the bytecode limit for deployment and `allowUnlimitedContractSize` is enabled, I've included a test in VotingV2 to prevent modifications from going beyond the limit unintentionally.

**Summary**

- Refactor: rename variables
- Add bytecode limit test

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested