### PR TITLE
fix: add missing transfer of voting token

### DIFF
--- a/packages/scripts/src/upgrade-tests/voting2/0_Deploy.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/0_Deploy.ts
@@ -53,7 +53,7 @@ async function main() {
     phaseLength,
     minRollToNextRoundLength,
     gat.toString(),
-    "0", // Starting request index of 0 (no offset).
+    "0", // Starting request index of 0 (no offset). TODO change this to the correct number
     votingToken.address,
     finder.address,
     slashingLibrary.address,

--- a/packages/scripts/src/upgrade-tests/voting2/2_Verify.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/2_Verify.ts
@@ -9,7 +9,14 @@
 const hre = require("hardhat");
 const assert = require("assert").strict;
 
-import { FinderEthers, getAbi, GovernorEthers, VotingEthers, VotingV2Ethers__factory } from "@uma/contracts-node";
+import {
+  FinderEthers,
+  getAbi,
+  GovernorEthers,
+  VotingEthers,
+  VotingTokenEthers,
+  VotingV2Ethers__factory,
+} from "@uma/contracts-node";
 
 import { getContractInstance } from "../../utils/contracts";
 import { getMultiRoleContracts, getOwnableContracts } from "./migrationUtils";
@@ -36,6 +43,7 @@ async function main() {
   const finder = await getContractInstance<FinderEthers>("Finder");
   const governor = await getContractInstance<GovernorEthers>("Governor");
   const oldVoting = await getContractInstance<VotingEthers>("Voting");
+  const votingToken = await getContractInstance<VotingTokenEthers>("VotingToken");
 
   const votingV2Factory: VotingV2Ethers__factory = await getContractFactory("VotingV2");
   const votingV2 = await votingV2Factory.attach(votingV2Address);
@@ -81,6 +89,10 @@ async function main() {
   assert.equal(await oldVoting.owner(), governorV2Address);
   assert.equal(await finder.owner(), governorV2Address);
   console.log("✅ Old Voting & finder correctly transferred ownership back to governor v2!");
+
+  console.log(" 5. Governor v2 is the owner of the voting token...");
+  assert.equal((await votingToken.getMember(0)).toLowerCase(), governorV2Address.toLowerCase());
+  console.log("✅ Voting token owner role correctly set!");
 
   console.log("Verified!");
 }


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

During my latest tests I realised that the upgrade process was missing the transfer of the owner role of the Voting Token to the new GovernorV2.

We did transfer the old Governor ownership to the GovernorV2 so this situation could have been recoverable but it's obviously a problem that we need to fix and we address in this PR.

Additionally, in the current state, after the migration to the GovernorV2 and VotingV2, the GovernorV2 roles are set like this:
`GovernorV2.Roles.Owner`: `deployer_address` (Used when running [0_Deploy.ts](https://github.com/UMAprotocol/protocol/blob/67df04f9ccaeed055e123485db1bd235d591cd96/packages/scripts/src/upgrade-tests/voting2/0_Deploy.ts))
`GovernorV2.Roles.Proposer`: `deployer_address` (Used when running [0_Deploy.ts](https://github.com/UMAprotocol/protocol/blob/67df04f9ccaeed055e123485db1bd235d591cd96/packages/scripts/src/upgrade-tests/voting2/0_Deploy.ts))

We probably should add a final step where the `GovernorV2.Roles.Owner` is transfered to the GovernorV2 address and the `GovernorV2.Roles.Proposer` to a new `ProposerV2` that needs to be deployed. This PR doesn't cover this part.

**Summary**

- Add missing step in 1_Propose to transfer the Owner role of the Voting Token to the GovernorV2
- Add verification step to verify the Voting Token Owner role
