### PR TITLE
fix(financial-templates-lib): fix incorrect severity setting on pdv2 …

### DIFF
--- a/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
+++ b/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
@@ -5,6 +5,7 @@ import * as ss from "superstruct";
 
 type TransportOptions = ConstructorParameters<typeof Transport>[0];
 export type Severity = "critical" | "error" | "warning" | "info";
+export type Action = "trigger" | "acknowledge" | "resolve";
 
 const Config = ss.object({
   integrationKey: ss.string(),
@@ -45,10 +46,10 @@ export class PagerDutyV2Transport extends Transport {
       await event({
         data: {
           routing_key,
-          event_action: "trigger",
+          event_action: "trigger" as Action,
           payload: {
             summary: `${info.level}: ${info.at} ⭢ ${info.message}`,
-            severity: PagerDutyV2Transport.convertLevelToSeverity(this.level),
+            severity: PagerDutyV2Transport.convertLevelToSeverity(info.level),
             source: info["bot-identifier"] ? info["bot-identifier"] : undefined,
             // we can put any structured data in here as long as it is can be repped as json
             custom_details: info,


### PR DESCRIPTION
…events

Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Pagerduty is not picking up correct severity on log events.


**Summary**

Turns out we were using the wrong "level" variable when setting severity. This fixes it and was tested with an external pagerduty script to see that the severity is properly set. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

