### PR TITLE
fix: copy logs when changing BNs to strings

### DIFF
--- a/packages/financial-templates-lib/src/logger/Formatters.ts
+++ b/packages/financial-templates-lib/src/logger/Formatters.ts
@@ -58,7 +58,7 @@ const iterativelyReplaceBigNumbers = (obj: Record<string | symbol, any>) => {
   });
 
   // This will catch any values that were changed by value _or_ by reference.
-  // If not changes were detected, no copy is needed and it is fine to discard the copy and return the original object.
+  // If no changes were detected, no copy is needed and it is fine to discard the copy and return the original object.
   const copyNeeded = replacements.some(([key, value]) => obj[key] !== value);
 
   // Only copy if something changed. Otherwise, return the original object.

--- a/packages/financial-templates-lib/src/logger/Formatters.ts
+++ b/packages/financial-templates-lib/src/logger/Formatters.ts
@@ -14,8 +14,16 @@ export function errorStackTracerFormatter(logEntry: LogEntry) {
 // make it more readable. If something goes wrong in parsing the object (it's too large or something else) then simply
 // return the original log entry without modifying it.
 export function bigNumberFormatter(logEntry: LogEntry) {
+  type SymbolRecord = Record<string | symbol, any>;
   try {
-    return iterativelyReplaceBigNumbers(logEntry) as LogEntry;
+    // Out is the original object if and only if one or more BigNumbers were replaced.
+    const out = iterativelyReplaceBigNumbers(logEntry);
+
+    // Because winston depends on some non-enumerable symbol properties, we explicitly copy those over, as they are not
+    // handled in iterativelyReplaceBigNumbers. This only needs to happen if logEntry is being replaced.
+    if (out !== logEntry)
+      Object.getOwnPropertySymbols(logEntry).map((symbol) => (out[symbol] = (logEntry as SymbolRecord)[symbol]));
+    return out as LogEntry;
   } catch (_) {
     return logEntry;
   }
@@ -39,8 +47,10 @@ export function botIdentifyFormatter(botIdentifier: string) {
 }
 
 // Traverse a potentially nested object and replace any element that is either a Ethers BigNumber or web3 BigNumber
-// with the string version of it for easy logging. Note does pass by reference by modifying the original object.
-const iterativelyReplaceBigNumbers = (obj: { [key: string]: any }) => {
+// with the string version of it for easy logging.
+const iterativelyReplaceBigNumbers = (obj: Record<string | symbol, any>) => {
+  // This does a DFS, recursively calling this function to find the desired value for each key.
+  // It doesn't modify the original object. Instead, it creates an array of keys and updated values.
   const replacements = Object.entries(obj).map(([key, value]): [string, any] => {
     if (BigNumber.isBigNumber(value) || web3.utils.isBN(value)) return [key, value.toString()];
     else if (typeof value === "object" && value !== null) return [key, iterativelyReplaceBigNumbers(value)];
@@ -48,6 +58,7 @@ const iterativelyReplaceBigNumbers = (obj: { [key: string]: any }) => {
   });
 
   // This will catch any values that were changed by value _or_ by reference.
+  // If not changes were detected, no copy is needed and it is fine to discard the copy and return the original object.
   const copyNeeded = replacements.some(([key, value]) => obj[key] !== value);
 
   // Only copy if something changed. Otherwise, return the original object.

--- a/packages/financial-templates-lib/test/logger/BigNumberFormatter.js
+++ b/packages/financial-templates-lib/test/logger/BigNumberFormatter.js
@@ -1,0 +1,67 @@
+const { assert } = require("chai");
+const { bigNumberFormatter } = require("../../dist/logger/Formatters.js");
+const { BigNumber } = require("ethers");
+const Web3 = require("web3");
+const { toBN } = Web3.utils;
+const { cloneDeep } = require("lodash");
+
+describe("BigNumberFormatter", async function () {
+  it("Should replace all BigNumbers", async function () {
+    const sample = {
+      bn1: BigNumber.from(10),
+      nested: { bn2: BigNumber.from(100), doubleNested: { bn3: toBN("1000") } },
+    };
+
+    assert.deepEqual(bigNumberFormatter(sample), { bn1: "10", nested: { bn2: "100", doubleNested: { bn3: "1000" } } });
+  });
+
+  it("Non BNs are not modified and the original object is not changed", async function () {
+    const sample = { val: null, nested: { val: 100, doubleNested: { val: undefined }, val2: "1000" } };
+
+    const shallowCopy = sample;
+
+    assert.deepEqual(bigNumberFormatter(sample), sample);
+    assert.equal(bigNumberFormatter(sample), shallowCopy);
+    assert.equal(shallowCopy, sample);
+  });
+
+  it("Only parts of the object that involve BNs are deep copied", async function () {
+    const sample = {
+      val: null,
+      nested: { val: 100, doubleNested: { val: undefined }, val2: "1000" },
+      nested2: { val: BigNumber.from(100), doubleNested: { val: undefined }, val2: toBN("1000") },
+    };
+
+    const shallowCopy = sample;
+    const deepCopy = cloneDeep(sample);
+    const nestedShallowCopy = sample.nested;
+    const nestedDeepCopy = cloneDeep(sample.nested);
+    const nested2ShallowCopy = sample.nested2;
+    const nested2DeepCopy = cloneDeep(sample.nested2);
+
+    const output = bigNumberFormatter(sample);
+
+    // The BigNumbers/BNs should have been coverted correctly.
+    assert.deepEqual(output, {
+      val: null,
+      nested: { val: 100, doubleNested: { val: undefined }, val2: "1000" },
+      nested2: { val: "100", doubleNested: { val: undefined }, val2: "1000" },
+    });
+
+    // The nested sub-object should still be the same reference and should not have been modified.
+    assert.equal(output.nested, nestedShallowCopy);
+    assert.deepEqual(output.nested, nestedDeepCopy);
+
+    // The nested2 sub-object contained BNs so it should not be the same reference and the original reference shouldn't
+    // be modified.
+    assert.notEqual(output.nested2, nested2ShallowCopy);
+    assert.notDeepEqual(output.nested2, nested2DeepCopy);
+    assert.deepEqual(nested2ShallowCopy, nested2DeepCopy);
+
+    // The top level object contained BNs so it should not be the same reference and the original reference shouldn't
+    // be modified.
+    assert.notEqual(output, shallowCopy);
+    assert.notDeepEqual(output, deepCopy);
+    assert.deepEqual(shallowCopy, deepCopy);
+  });
+});

--- a/packages/financial-templates-lib/test/logger/BigNumberFormatter.js
+++ b/packages/financial-templates-lib/test/logger/BigNumberFormatter.js
@@ -5,8 +5,8 @@ const Web3 = require("web3");
 const { toBN } = Web3.utils;
 const { cloneDeep } = require("lodash");
 
-describe("BigNumberFormatter", async function () {
-  it("Should replace all BigNumbers", async function () {
+describe("BigNumberFormatter", function () {
+  it("Should replace all BigNumbers", function () {
     const sample = {
       bn1: BigNumber.from(10),
       nested: { bn2: BigNumber.from(100), doubleNested: { bn3: toBN("1000") } },
@@ -15,17 +15,21 @@ describe("BigNumberFormatter", async function () {
     assert.deepEqual(bigNumberFormatter(sample), { bn1: "10", nested: { bn2: "100", doubleNested: { bn3: "1000" } } });
   });
 
-  it("Non BNs are not modified and the original object is not changed", async function () {
+  it("Non BNs are not modified and the original object is not changed", function () {
     const sample = { val: null, nested: { val: 100, doubleNested: { val: undefined }, val2: "1000" } };
 
     const shallowCopy = sample;
+    const deepCopy = cloneDeep(sample);
 
-    assert.deepEqual(bigNumberFormatter(sample), sample);
-    assert.equal(bigNumberFormatter(sample), shallowCopy);
+    const output = bigNumberFormatter(sample);
+
+    // All references and values should be unchanged.
+    assert.deepEqual(output, deepCopy);
+    assert.equal(output, shallowCopy);
     assert.equal(shallowCopy, sample);
   });
 
-  it("Only parts of the object that involve BNs are deep copied", async function () {
+  it("Only parts of the object that involve BNs are deep copied", function () {
     const sample = {
       val: null,
       nested: { val: 100, doubleNested: { val: undefined }, val2: "1000" },


### PR DESCRIPTION
**Motivation**

The logger is currently modifying objects that are passed to it when it contains a BigNumber or BN.

**Summary**

This change updates the logger to detect when a nested value has changed and then copying all containing objects recursively.

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
