### PR TITLE
feat(serverless-hub): hub should respect NODE_URLS_ env vars

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -488,8 +488,14 @@ function _getWeb3AndUrlForBot(botConfig) {
   }
 }
 
-async function _getBlockNumberOnChainIdMultiChain(botConfig, chainId) {
-  return await new Web3(botConfig?.environmentVariables[`NODE_URL_${chainId}`]).eth.getBlockNumber();
+function _getBlockNumberOnChainIdMultiChain(botConfig, chainId) {
+  if (botConfig?.environmentVariables[`NODE_URLS_${chainId}`]) {
+    const retryConfig = JSON.parse(botConfig.environmentVariables[`NODE_URLS_${chainId}`]).map((url) => ({ url }));
+    const retryWeb3 = new Web3(createBasicProvider(retryConfig));
+    return retryWeb3.eth.getBlockNumber();
+  } else {
+    return new Web3(botConfig?.environmentVariables[`NODE_URL_${chainId}`]).eth.getBlockNumber();
+  }
 }
 
 // Get the latest block number from either `overrideNodeUrl` or `CUSTOM_NODE_URL`. Used to update the `

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -489,13 +489,17 @@ function _getWeb3AndUrlForBot(botConfig) {
 }
 
 function _getBlockNumberOnChainIdMultiChain(botConfig, chainId) {
-  if (botConfig?.environmentVariables[`NODE_URLS_${chainId}`]) {
-    const retryConfig = JSON.parse(botConfig.environmentVariables[`NODE_URLS_${chainId}`]).map((url) => ({ url }));
-    const retryWeb3 = new Web3(createBasicProvider(retryConfig));
-    return retryWeb3.eth.getBlockNumber();
-  } else {
-    return new Web3(botConfig?.environmentVariables[`NODE_URL_${chainId}`]).eth.getBlockNumber();
-  }
+  const urls = botConfig?.environmentVariables?.[`NODE_URLS_${chainId}`]
+    ? JSON.parse(botConfig.environmentVariables[`NODE_URLS_${chainId}`])
+    : botConfig?.environmentVariables?.[`NODE_URL_${chainId}`];
+  if (!urls)
+    throw new Error(
+      `ServerlessHub::_getBlockNumberOnChainIdMultiChain NODE_URLS_${chainId} or NODE_URL_${chainId} in botConfig: ${botConfig}`
+    );
+
+  const retryConfig = lodash.castArray(urls).map((url) => ({ url }));
+  const retryWeb3 = new Web3(createBasicProvider(retryConfig));
+  return retryWeb3.eth.getBlockNumber();
 }
 
 // Get the latest block number from either `overrideNodeUrl` or `CUSTOM_NODE_URL`. Used to update the `


### PR DESCRIPTION
**Motivation**

Some multichain bots use NODE_URLS_ exclusively env variables for an array of node urls rather than NODE_URL_. It would simplify configs if the hub was able to pick up both rather than only supporting NODE_URL_.


**Summary**

Adds NODE_URLS_ support to the hub.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
