### PR TITLE
fix: fix JSON assumption in #4201

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -490,7 +490,7 @@ function _getWeb3AndUrlForBot(botConfig) {
 
 function _getBlockNumberOnChainIdMultiChain(botConfig, chainId) {
   const urls = botConfig?.environmentVariables?.[`NODE_URLS_${chainId}`]
-    ? JSON.parse(botConfig.environmentVariables[`NODE_URLS_${chainId}`])
+    ? botConfig.environmentVariables[`NODE_URLS_${chainId}`]
     : botConfig?.environmentVariables?.[`NODE_URL_${chainId}`];
   if (!urls)
     throw new Error(


### PR DESCRIPTION
**Motivation**

#4201 broke the Hub in the serverless orchestration package.


**Summary**

This fixes that code by reading the array directly rather than assuming the value is a JSON field.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
