### PR TITLE
feat(scripts): Add vote simulation in upgraded DVMv2

### DIFF
--- a/packages/scripts/src/upgrade-tests/voting2/2_Verify.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/2_Verify.ts
@@ -170,7 +170,18 @@ async function main() {
     console.log("✅ New voting keeps track of old voting contract!");
   }
 
-  console.log("\n✅ Verified! The upgrade process ends here.");
+  if (!(await isVotingV2Instance(votingV2.address))) {
+    console.log("\n✅ Verified! The downgrade process ends here.");
+  } else {
+    console.log("\n✅ Verified the upgraded contract state!");
+    console.log("\n❓ OPTIONAL: Simulate basic voting functionality in upgraded state with the following command:");
+    console.log(
+      formatIndentation(
+        `
+      yarn hardhat run ./src/upgrade-tests/voting2/3_SimulateVoting.ts --network localhost`
+      )
+    );
+  }
 
   console.log(
     "\n❓ OPTIONAL: Propose the downgrade to the previous governor, voting and proposer contracts by running the following command:"

--- a/packages/scripts/src/upgrade-tests/voting2/2_Verify.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/2_Verify.ts
@@ -181,33 +181,32 @@ async function main() {
       yarn hardhat run ./src/upgrade-tests/voting2/3_SimulateVoting.ts --network localhost`
       )
     );
+    console.log(
+      "\n❓ OPTIONAL: Propose the downgrade to the previous governor, voting and proposer contracts by running the following command:"
+    );
+    console.log(
+      "⚠️  This downgrade command is intended for testing purposes and should only be used against a fork or testnet. ⚠️"
+    );
+    console.log(
+      formatIndentation(
+        `
+    ${TEST_DOWNGRADE}=1 \\
+    ${EMERGENCY_PROPOSAL}=1 \\
+    ${OLD_CONTRACTS.voting}=${votingV2.address} \\
+    ${NEW_CONTRACTS.voting}=${oldVoting.address} \\
+    ${OLD_CONTRACTS.governor}=${governorV2.address} \\
+    ${NEW_CONTRACTS.governor}=${governor.address} \\
+    ${OLD_CONTRACTS.proposer}=${proposerV2.address} \\
+    ${NEW_CONTRACTS.proposer}=${proposer.address} \\
+    ${NEW_CONTRACTS.emergencyProposer}=${process.env[NEW_CONTRACTS.emergencyProposer]} \\
+    ${EMERGENCY_EXECUTOR}=${process.env[EMERGENCY_EXECUTOR]} \\
+    yarn hardhat run ./src/upgrade-tests/voting2/1_Propose.ts --network ${hre.network.name}
+    
+    Note: Remove ${EMERGENCY_PROPOSAL}=1 if you want to propose the downgrade from the normal proposer contract.
+    `
+      )
+    );
   }
-
-  console.log(
-    "\n❓ OPTIONAL: Propose the downgrade to the previous governor, voting and proposer contracts by running the following command:"
-  );
-  console.log(
-    "⚠️  This downgrade command is intended for testing purposes and should only be used against a fork or testnet. ⚠️"
-  );
-  console.log(
-    formatIndentation(
-      `
-  ${TEST_DOWNGRADE}=1 \\
-  ${EMERGENCY_PROPOSAL}=1 \\
-  ${OLD_CONTRACTS.voting}=${votingV2.address} \\
-  ${NEW_CONTRACTS.voting}=${oldVoting.address} \\
-  ${OLD_CONTRACTS.governor}=${governorV2.address} \\
-  ${NEW_CONTRACTS.governor}=${governor.address} \\
-  ${OLD_CONTRACTS.proposer}=${proposerV2.address} \\
-  ${NEW_CONTRACTS.proposer}=${proposer.address} \\
-  ${NEW_CONTRACTS.emergencyProposer}=${process.env[NEW_CONTRACTS.emergencyProposer]} \\
-  ${EMERGENCY_EXECUTOR}=${process.env[EMERGENCY_EXECUTOR]} \\
-  yarn hardhat run ./src/upgrade-tests/voting2/1_Propose.ts --network ${hre.network.name}
-  
-  Note: Remove ${EMERGENCY_PROPOSAL}=1 if you want to propose the downgrade from the normal proposer contract.
-  `
-    )
-  );
 }
 
 main().then(

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -49,7 +49,7 @@ const voter2RelativeGatFunding = parseEther("0.55");
 const voter3RelativeGatFunding = parseEther("0.5");
 
 // Tested price identifier should be whitelisted.
-const priceIdentifier = formatBytes32String("YES_OR_NO_QUERY");
+const priceIdentifier = formatBytes32String("NUMERICAL");
 
 async function main() {
   // Initiates data request through Optimistic Oracle by requesting, proposing and diputing.
@@ -273,7 +273,7 @@ async function main() {
 
   console.log(" 4. Adding the first data request...");
   const firstRequestData: PriceRequestData = {
-    originalAncillaryData: toUtf8Bytes("Really hard question."),
+    originalAncillaryData: toUtf8Bytes(`q:"Really hard question, maybe 100, maybe 90?"`),
     proposedPrice: "100",
     priceRequest: { identifier: priceIdentifier, time: currentTime } as VotingPriceRequest,
   };
@@ -383,7 +383,7 @@ async function main() {
 
   console.log(" 13. Adding the second data request...");
   const secondRequestData: PriceRequestData = {
-    originalAncillaryData: toUtf8Bytes("Easy question."),
+    originalAncillaryData: toUtf8Bytes(`q:"How much is 60 times two?"`),
     proposedPrice: "120",
     priceRequest: { identifier: priceIdentifier, time: currentTime } as VotingPriceRequest,
   };

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -5,16 +5,8 @@ const { formatEther, parseEther } = hre.ethers.utils;
 import { interfaceName } from "@uma/common";
 import { FinderEthers, StoreEthers, VotingTokenEthers, VotingV2Ethers } from "@uma/contracts-node";
 
-import { getContractInstance } from "../../utils/contracts";
-import { isContractInstance } from "./migrationUtils";
-
-// TODO: import from packages/scripts/src/utils/contracts.ts after PR merged.
-const FOUNDATION_WALLET = "0x7a3A1c2De64f20EB5e916F40D11B01C441b2A8Dc";
-
-// TODO: import from packages/scripts/src/upgrade-tests/voting2/migrationUtils.ts after PR merged.
-const isVotingV2Instance = async (address: string): Promise<boolean> => {
-  return await isContractInstance(address, "stake(uint256)");
-};
+import { FOUNDATION_WALLET, getContractInstance } from "../../utils/contracts";
+import { isVotingV2Instance } from "./migrationUtils";
 
 async function main() {
   console.log("Running Voting Simulation🎭");

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -6,17 +6,13 @@ import { interfaceName } from "@uma/common";
 import { FinderEthers, StoreEthers, VotingTokenEthers, VotingV2Ethers } from "@uma/contracts-node";
 
 import { FOUNDATION_WALLET, getContractInstance } from "../../utils/contracts";
+import { increaseEvmTime } from "../../utils/utils";
 import { isVotingV2Instance } from "./migrationUtils";
 
 // Initial voter balances relative to GAT.
 const voter1RelativeGatFunding = parseEther("0.6");
 const voter2RelativeGatFunding = parseEther("0.55");
 const voter3RelativeGatFunding = parseEther("0.5");
-
-const increaseEvmTime = async (time: number) => {
-  await hre.ethers.provider.send("evm_increaseTime", [time]);
-  await hre.ethers.provider.send("evm_mine", []);
-};
 
 async function main() {
   console.log("🎭 Running Voting Simulation after V2 upgrade");

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -335,7 +335,8 @@ async function main() {
 
   console.log(" 8. Waiting for unstake cooldown...");
   await increaseEvmTime(Number(unstakeCoolDown));
-  console.log(`✅ Unstake colldown of ${Number(unstakeCoolDown)} seconds has passed!`);
+  currentTime = await votingV2.getCurrentTime();
+  console.log(`✅ Time traveled to ${new Date(Number(currentTime.mul(1000))).toUTCString()}.`);
 
   console.log(" 9. Executing unstake");
   await (await votingV2.connect(voter1Signer).executeUnstake()).wait();
@@ -479,7 +480,8 @@ async function main() {
 
   console.log(" 18. Waiting for unstake cooldown...");
   await increaseEvmTime(Number(unstakeCoolDown));
-  console.log(`✅ Unstake colldown of ${Number(unstakeCoolDown)} seconds has passed!`);
+  currentTime = await votingV2.getCurrentTime();
+  console.log(`✅ Time traveled to ${new Date(Number(currentTime.mul(1000))).toUTCString()}.`);
 
   console.log(" 19. Executing unstake");
   await (await votingV2.connect(voter1Signer).executeUnstake()).wait();

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -1,9 +1,17 @@
 const hre = require("hardhat");
+const assert = require("assert").strict;
 
-const { formatEther, parseEther } = hre.ethers.utils;
+const { formatBytes32String, formatEther, keccak256, parseEther, toUtf8Bytes } = hre.ethers.utils;
+const abiCoder = new hre.ethers.utils.AbiCoder();
 
 import { interfaceName } from "@uma/common";
-import { FinderEthers, StoreEthers, VotingTokenEthers, VotingV2Ethers } from "@uma/contracts-node";
+import {
+  FinderEthers,
+  OptimisticOracleV2Ethers,
+  StoreEthers,
+  VotingTokenEthers,
+  VotingV2Ethers,
+} from "@uma/contracts-node";
 
 import { FOUNDATION_WALLET, getContractInstance } from "../../utils/contracts";
 import { increaseEvmTime } from "../../utils/utils";
@@ -14,18 +22,20 @@ const voter1RelativeGatFunding = parseEther("0.6");
 const voter2RelativeGatFunding = parseEther("0.55");
 const voter3RelativeGatFunding = parseEther("0.5");
 
+// Tested price identifier should be whitelisted.
+const priceIdentifier = formatBytes32String("YES_OR_NO_QUERY");
+
 async function main() {
   console.log("🎭 Running Voting Simulation after V2 upgrade");
 
   if (hre.network.name != "localhost") throw new Error("Voting should be only tested in simulation!");
 
   const finder = await getContractInstance<FinderEthers>("Finder");
+  const optimisticOracleV2 = await getContractInstance<OptimisticOracleV2Ethers>("OptimisticOracleV2");
   const store = await getContractInstance<StoreEthers>("Store");
   const votingToken = await getContractInstance<VotingTokenEthers>("VotingToken");
 
-  const votingV2Address = await finder.getImplementationAddress(
-    hre.ethers.utils.formatBytes32String(interfaceName.Oracle)
-  );
+  const votingV2Address = await finder.getImplementationAddress(formatBytes32String(interfaceName.Oracle));
   if (!(await isVotingV2Instance(votingV2Address))) throw new Error("Oracle is not VotingV2 instance!");
 
   const votingV2 = await getContractInstance<VotingV2Ethers>("VotingV2", votingV2Address);
@@ -37,14 +47,14 @@ async function main() {
   let foundationBalance = await votingToken.balanceOf(FOUNDATION_WALLET);
   console.log(` 1. Foundation has ${formatEther(foundationBalance)} UMA, funding requester and voters...`);
 
-  // There will be 3 voters with initial balances set relative to GAT, and for two price
-  // price requests 4 * finalFee amount will be needed.
+  // There will be 3 voters with initial balances set relative to GAT, and for two disputed price
+  // price requests 8 * finalFee amount will be needed (Optimistic Oracle bond defaults to finalFee).
   if (
     foundationBalance.lt(
       gat
         .mul(voter1RelativeGatFunding.add(voter2RelativeGatFunding.add(voter3RelativeGatFunding)))
         .div(parseEther("1"))
-        .add(finalFee.mul(4))
+        .add(finalFee.mul(8))
     )
   )
     throw new Error("Foundation balance too low for simulation!");
@@ -61,7 +71,7 @@ async function main() {
   // Transfering required balances. This assumes recipient accounts did not have more than target amounts before
   // simulation.
   await (
-    await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(4).sub(requesterBalance))
+    await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(8).sub(requesterBalance))
   ).wait();
   await (
     await votingToken
@@ -90,35 +100,76 @@ async function main() {
   console.log(`✅ Voter 2 now has ${formatEther(voter2Balance)} UMA.`);
   console.log(`✅ Voter 3 now has ${formatEther(voter3Balance)} UMA.`);
 
-  console.log(" 2. Voters are approving UMA for staking...");
+  console.log(" 2. Voters are staking all their UMA...");
   await (await votingToken.connect(voter1Signer).approve(votingV2.address, voter1Balance)).wait();
   await (await votingToken.connect(voter2Signer).approve(votingV2.address, voter2Balance)).wait();
   await (await votingToken.connect(voter3Signer).approve(votingV2.address, voter3Balance)).wait();
   console.log("✅ Approvals on VotingV2 done!");
 
-  console.log(" 3. Voters are staking all their UMA...");
   await (await votingV2.connect(voter1Signer).stake(voter1Balance)).wait();
   await (await votingV2.connect(voter2Signer).stake(voter2Balance)).wait();
   await (await votingV2.connect(voter3Signer).stake(voter3Balance)).wait();
   console.log("✅ Voters have staked all their UMA!");
 
-  console.log(" 4. Requesting unstake...");
+  console.log(" 3. Waiting till the start of next voting cycle...");
+  await increaseEvmTime(
+    Number((await votingV2.getRoundEndTime(await votingV2.getCurrentRoundId())).sub(await votingV2.getCurrentTime()))
+  );
+  const firstRequestTimestamp = await votingV2.getCurrentTime();
+  console.log(`✅ Time traveled to ${new Date(Number(firstRequestTimestamp.mul(1000))).toUTCString()}.`);
+
+  console.log(" 4. Adding the first data request...");
+  const firstOOAncillaryData = toUtf8Bytes("Really hard question.");
+  await (
+    await optimisticOracleV2
+      .connect(requesterSigner)
+      .requestPrice(priceIdentifier, firstRequestTimestamp, firstOOAncillaryData, votingToken.address, 0)
+  ).wait();
+  console.log("✅ Submitted data request to Optimistic Oracle.");
+  await (await votingToken.connect(requesterSigner).approve(optimisticOracleV2.address, finalFee.mul(4))).wait();
+  console.log("✅ Approved proposal & dispute bonds.");
+  await (
+    await optimisticOracleV2
+      .connect(requesterSigner)
+      .proposePrice(requesterSigner.address, priceIdentifier, firstRequestTimestamp, firstOOAncillaryData, 100)
+  ).wait();
+  console.log("✅ Proposed price to Optimistic Oracle.");
+  await (
+    await optimisticOracleV2
+      .connect(requesterSigner)
+      .disputePrice(requesterSigner.address, priceIdentifier, firstRequestTimestamp, firstOOAncillaryData)
+  ).wait();
+  console.log("✅ Disputed price to Optimistic Oracle.");
+  const firstVotingAncillaryData = await optimisticOracleV2.stampAncillaryData(
+    firstOOAncillaryData,
+    requesterSigner.address
+  );
+  const firstRequestId = keccak256(
+    abiCoder.encode(["bytes32", "uint256", "bytes"], [priceIdentifier, firstRequestTimestamp, firstVotingAncillaryData])
+  );
+  const firstPriceRequest = await votingV2.priceRequests(firstRequestId);
+  assert.equal(firstPriceRequest.identifier, priceIdentifier);
+  assert.equal(firstPriceRequest.time.toString(), firstRequestTimestamp.toString());
+  assert.equal(firstPriceRequest.ancillaryData, firstVotingAncillaryData);
+  console.log(`✅ Verified the first data request submitted for voting, id ${firstRequestId}`);
+
+  console.log(" 5. Requesting unstake...");
   await (await votingV2.connect(voter1Signer).requestUnstake(voter1Balance)).wait();
   await (await votingV2.connect(voter2Signer).requestUnstake(voter2Balance)).wait();
   await (await votingV2.connect(voter3Signer).requestUnstake(voter3Balance)).wait();
   console.log("✅ Voters requested unstake of all UMA!");
 
-  console.log(" 5. Waiting for unstake cooldown...");
-  await increaseEvmTime(unstakeCoolDown.toNumber());
-  console.log(`✅ Unstake colldown of ${unstakeCoolDown.toNumber()} seconds has passed!`);
+  console.log(" 6. Waiting for unstake cooldown...");
+  await increaseEvmTime(Number(unstakeCoolDown));
+  console.log(`✅ Unstake colldown of ${Number(unstakeCoolDown)} seconds has passed!`);
 
-  console.log(" 6. Executing unstake");
+  console.log(" 7. Executing unstake");
   await (await votingV2.connect(voter1Signer).executeUnstake()).wait();
   await (await votingV2.connect(voter2Signer).executeUnstake()).wait();
   await (await votingV2.connect(voter3Signer).executeUnstake()).wait();
   console.log("✅ Voters have unstaked all UMA!");
 
-  console.log(" 7. Returning all UMA to the foundation...");
+  console.log(" 8. Returning all UMA to the foundation...");
   await votingToken
     .connect(requesterSigner)
     .transfer(foundationSigner.address, await votingToken.balanceOf(requesterSigner.address));

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -8,8 +8,18 @@ import { FinderEthers, StoreEthers, VotingTokenEthers, VotingV2Ethers } from "@u
 import { FOUNDATION_WALLET, getContractInstance } from "../../utils/contracts";
 import { isVotingV2Instance } from "./migrationUtils";
 
+// Initial voter balances relative to GAT.
+const voter1RelativeGatFunding = parseEther("0.6");
+const voter2RelativeGatFunding = parseEther("0.55");
+const voter3RelativeGatFunding = parseEther("0.5");
+
+const increaseEvmTime = async (time: number) => {
+  await hre.ethers.provider.send("evm_increaseTime", [time]);
+  await hre.ethers.provider.send("evm_mine", []);
+};
+
 async function main() {
-  console.log("Running Voting Simulation🎭");
+  console.log("🎭 Running Voting Simulation after V2 upgrade");
 
   if (hre.network.name != "localhost") throw new Error("Voting should be only tested in simulation!");
 
@@ -25,29 +35,43 @@ async function main() {
   const votingV2 = await getContractInstance<VotingV2Ethers>("VotingV2", votingV2Address);
 
   const gat = await votingV2.gat();
+  const unstakeCoolDown = await votingV2.unstakeCoolDown();
   const finalFee = (await store.computeFinalFee(votingToken.address)).rawValue;
 
   let foundationBalance = await votingToken.balanceOf(FOUNDATION_WALLET);
-  console.log(` Foundation has ${formatEther(foundationBalance)} UMA, funding requester and voters...`);
+  console.log(` 1. Foundation has ${formatEther(foundationBalance)} UMA, funding requester and voters...`);
 
-  // There will be 3 voters with balances 0.6, 0.55 and 0.5 relative to GAT (total 1.65 * GAT), and for two price
+  // There will be 3 voters with initial balances set relative to GAT, and for two price
   // price requests 4 * finalFee amount will be needed.
-  if (foundationBalance.lt(gat.mul(parseEther("1.65")).div(parseEther("1")).add(finalFee.mul(4))))
+  if (
+    foundationBalance.lt(
+      gat
+        .mul(voter1RelativeGatFunding.add(voter2RelativeGatFunding.add(voter3RelativeGatFunding)))
+        .div(parseEther("1"))
+        .add(finalFee.mul(4))
+    )
+  )
     throw new Error("Foundation balance too low for simulation!");
 
   const foundationSigner = await hre.ethers.getSigner(FOUNDATION_WALLET);
   const [requesterSigner, voter1Signer, voter2Signer, voter3Signer] = await hre.ethers.getSigners();
 
-  await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(4));
-  await votingToken
-    .connect(foundationSigner)
-    .transfer(voter1Signer.address, gat.mul(parseEther("0.6")).div(parseEther("1")));
-  await votingToken
-    .connect(foundationSigner)
-    .transfer(voter2Signer.address, gat.mul(parseEther("0.55")).div(parseEther("1")));
-  await votingToken
-    .connect(foundationSigner)
-    .transfer(voter3Signer.address, gat.mul(parseEther("0.5")).div(parseEther("1")));
+  await (await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(4))).wait();
+  await (
+    await votingToken
+      .connect(foundationSigner)
+      .transfer(voter1Signer.address, gat.mul(voter1RelativeGatFunding).div(parseEther("1")))
+  ).wait();
+  await (
+    await votingToken
+      .connect(foundationSigner)
+      .transfer(voter2Signer.address, gat.mul(voter2RelativeGatFunding).div(parseEther("1")))
+  ).wait();
+  await (
+    await votingToken
+      .connect(foundationSigner)
+      .transfer(voter3Signer.address, gat.mul(voter3RelativeGatFunding).div(parseEther("1")))
+  ).wait();
 
   const [requesterBalance, voter1Balance, voter2Balance, voter3Balance] = await Promise.all(
     [requesterSigner, voter1Signer, voter2Signer, voter3Signer].map((signer) => {
@@ -55,12 +79,40 @@ async function main() {
     })
   );
 
-  console.log(`  Requester now has ${formatEther(requesterBalance)} UMA.`);
-  console.log(`  Voter 1 now has ${formatEther(voter1Balance)} UMA.`);
-  console.log(`  Voter 2 now has ${formatEther(voter2Balance)} UMA.`);
-  console.log(`  Voter 3 now has ${formatEther(voter3Balance)} UMA.`);
+  console.log(`✅ Requester now has ${formatEther(requesterBalance)} UMA.`);
+  console.log(`✅ Voter 1 now has ${formatEther(voter1Balance)} UMA.`);
+  console.log(`✅ Voter 2 now has ${formatEther(voter2Balance)} UMA.`);
+  console.log(`✅ Voter 3 now has ${formatEther(voter3Balance)} UMA.`);
 
-  console.log(" Returning all UMA to the foundation...");
+  console.log(" 2. Voters are approving UMA for staking...");
+  await (await votingToken.connect(voter1Signer).approve(votingV2.address, voter1Balance)).wait();
+  await (await votingToken.connect(voter2Signer).approve(votingV2.address, voter2Balance)).wait();
+  await (await votingToken.connect(voter3Signer).approve(votingV2.address, voter3Balance)).wait();
+  console.log("✅ Approvals on VotingV2 done!");
+
+  console.log(" 3. Voters are staking all their UMA...");
+  await (await votingV2.connect(voter1Signer).stake(voter1Balance)).wait();
+  await (await votingV2.connect(voter2Signer).stake(voter2Balance)).wait();
+  await (await votingV2.connect(voter3Signer).stake(voter3Balance)).wait();
+  console.log("✅ Voters have staked all their UMA!");
+
+  console.log(" 4. Requesting unstake...");
+  await (await votingV2.connect(voter1Signer).requestUnstake(voter1Balance)).wait();
+  await (await votingV2.connect(voter2Signer).requestUnstake(voter2Balance)).wait();
+  await (await votingV2.connect(voter3Signer).requestUnstake(voter3Balance)).wait();
+  console.log("✅ Voters requested unstake of all UMA!");
+
+  console.log(" 5. Waiting for unstake cooldown...");
+  await increaseEvmTime(unstakeCoolDown.toNumber());
+  console.log(`✅ Unstake colldown of ${unstakeCoolDown.toNumber()} seconds has passed!`);
+
+  console.log(" 6. Executing unstake");
+  await (await votingV2.connect(voter1Signer).executeUnstake()).wait();
+  await (await votingV2.connect(voter2Signer).executeUnstake()).wait();
+  await (await votingV2.connect(voter3Signer).executeUnstake()).wait();
+  console.log("✅ Voters have unstaked all UMA!");
+
+  console.log(" 7. Returning all UMA to the foundation...");
   await votingToken
     .connect(requesterSigner)
     .transfer(foundationSigner.address, await votingToken.balanceOf(requesterSigner.address));
@@ -75,7 +127,9 @@ async function main() {
     .transfer(foundationSigner.address, await votingToken.balanceOf(voter3Signer.address));
 
   foundationBalance = await votingToken.balanceOf(FOUNDATION_WALLET);
-  console.log(` Foundation has ${formatEther(foundationBalance)} UMA.`);
+  console.log(`✅ Foundation has ${formatEther(foundationBalance)} UMA.`);
+
+  console.log("\n✅ Verified! The upgraded DVM is functional.");
 }
 
 main().then(

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -1,3 +1,9 @@
+// This script verifies that basic voting functionality works correctly in the upgraded state.
+// It can be run against a mainnet fork by spinning a node in a separate terminal with:
+// HARDHAT_CHAIN_ID=1 yarn hardhat node --fork https://mainnet.infura.io/v3/<YOUR-INFURA-KEY> --port 9545 --no-deploy
+// and then running this script with:
+// yarn hardhat run ./src/upgrade-tests/voting2/3_SimulateVoting.ts --network localhost
+
 const hre = require("hardhat");
 const assert = require("assert").strict;
 

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -1,0 +1,97 @@
+const hre = require("hardhat");
+
+const { formatEther, parseEther } = hre.ethers.utils;
+
+import { interfaceName } from "@uma/common";
+import { FinderEthers, StoreEthers, VotingTokenEthers, VotingV2Ethers } from "@uma/contracts-node";
+
+import { getContractInstance } from "../../utils/contracts";
+import { isContractInstance } from "./migrationUtils";
+
+// TODO: import from packages/scripts/src/utils/contracts.ts after PR merged.
+const FOUNDATION_WALLET = "0x7a3A1c2De64f20EB5e916F40D11B01C441b2A8Dc";
+
+// TODO: import from packages/scripts/src/upgrade-tests/voting2/migrationUtils.ts after PR merged.
+const isVotingV2Instance = async (address: string): Promise<boolean> => {
+  return await isContractInstance(address, "stake(uint256)");
+};
+
+async function main() {
+  console.log("Running Voting Simulation🎭");
+
+  if (hre.network.name != "localhost") throw new Error("Voting should be only tested in simulation!");
+
+  const finder = await getContractInstance<FinderEthers>("Finder");
+  const store = await getContractInstance<StoreEthers>("Store");
+  const votingToken = await getContractInstance<VotingTokenEthers>("VotingToken");
+
+  const votingV2Address = await finder.getImplementationAddress(
+    hre.ethers.utils.formatBytes32String(interfaceName.Oracle)
+  );
+  if (!(await isVotingV2Instance(votingV2Address))) throw new Error("Oracle is not VotingV2 instance!");
+
+  const votingV2 = await getContractInstance<VotingV2Ethers>("VotingV2", votingV2Address);
+
+  const gat = await votingV2.gat();
+  const finalFee = (await store.computeFinalFee(votingToken.address)).rawValue;
+
+  let foundationBalance = await votingToken.balanceOf(FOUNDATION_WALLET);
+  console.log(` Foundation has ${formatEther(foundationBalance)} UMA, funding requester and voters...`);
+
+  // There will be 3 voters with balances 0.6, 0.55 and 0.5 relative to GAT (total 1.65 * GAT), and for two price
+  // price requests 4 * finalFee amount will be needed.
+  if (foundationBalance.lt(gat.mul(parseEther("1.65")).div(parseEther("1")).add(finalFee.mul(4))))
+    throw new Error("Foundation balance too low for simulation!");
+
+  const foundationSigner = await hre.ethers.getSigner(FOUNDATION_WALLET);
+  const [requesterSigner, voter1Signer, voter2Signer, voter3Signer] = await hre.ethers.getSigners();
+
+  await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(4));
+  await votingToken
+    .connect(foundationSigner)
+    .transfer(voter1Signer.address, gat.mul(parseEther("0.6")).div(parseEther("1")));
+  await votingToken
+    .connect(foundationSigner)
+    .transfer(voter2Signer.address, gat.mul(parseEther("0.55")).div(parseEther("1")));
+  await votingToken
+    .connect(foundationSigner)
+    .transfer(voter3Signer.address, gat.mul(parseEther("0.5")).div(parseEther("1")));
+
+  const [requesterBalance, voter1Balance, voter2Balance, voter3Balance] = await Promise.all(
+    [requesterSigner, voter1Signer, voter2Signer, voter3Signer].map((signer) => {
+      return votingToken.balanceOf(signer.address);
+    })
+  );
+
+  console.log(`  Requester now has ${formatEther(requesterBalance)} UMA.`);
+  console.log(`  Voter 1 now has ${formatEther(voter1Balance)} UMA.`);
+  console.log(`  Voter 2 now has ${formatEther(voter2Balance)} UMA.`);
+  console.log(`  Voter 3 now has ${formatEther(voter3Balance)} UMA.`);
+
+  console.log(" Returning all UMA to the foundation...");
+  await votingToken
+    .connect(requesterSigner)
+    .transfer(foundationSigner.address, await votingToken.balanceOf(requesterSigner.address));
+  await votingToken
+    .connect(voter1Signer)
+    .transfer(foundationSigner.address, await votingToken.balanceOf(voter1Signer.address));
+  await votingToken
+    .connect(voter2Signer)
+    .transfer(foundationSigner.address, await votingToken.balanceOf(voter2Signer.address));
+  await votingToken
+    .connect(voter3Signer)
+    .transfer(foundationSigner.address, await votingToken.balanceOf(voter3Signer.address));
+
+  foundationBalance = await votingToken.balanceOf(FOUNDATION_WALLET);
+  console.log(` Foundation has ${formatEther(foundationBalance)} UMA.`);
+}
+
+main().then(
+  () => {
+    process.exit(0);
+  },
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -56,24 +56,34 @@ async function main() {
   const foundationSigner = await hre.ethers.getSigner(FOUNDATION_WALLET);
   const [requesterSigner, voter1Signer, voter2Signer, voter3Signer] = await hre.ethers.getSigners();
 
-  await (await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(4))).wait();
+  let [requesterBalance, voter1Balance, voter2Balance, voter3Balance] = await Promise.all(
+    [requesterSigner, voter1Signer, voter2Signer, voter3Signer].map((signer) => {
+      return votingToken.balanceOf(signer.address);
+    })
+  );
+
+  // Transfering required balances. This assumes recipient accounts did not have more than target amounts before
+  // simulation.
   await (
-    await votingToken
-      .connect(foundationSigner)
-      .transfer(voter1Signer.address, gat.mul(voter1RelativeGatFunding).div(parseEther("1")))
+    await votingToken.connect(foundationSigner).transfer(requesterSigner.address, finalFee.mul(4).sub(requesterBalance))
   ).wait();
   await (
     await votingToken
       .connect(foundationSigner)
-      .transfer(voter2Signer.address, gat.mul(voter2RelativeGatFunding).div(parseEther("1")))
+      .transfer(voter1Signer.address, gat.mul(voter1RelativeGatFunding).div(parseEther("1").sub(voter1Balance)))
   ).wait();
   await (
     await votingToken
       .connect(foundationSigner)
-      .transfer(voter3Signer.address, gat.mul(voter3RelativeGatFunding).div(parseEther("1")))
+      .transfer(voter2Signer.address, gat.mul(voter2RelativeGatFunding).div(parseEther("1").sub(voter2Balance)))
+  ).wait();
+  await (
+    await votingToken
+      .connect(foundationSigner)
+      .transfer(voter3Signer.address, gat.mul(voter3RelativeGatFunding).div(parseEther("1").sub(voter3Balance)))
   ).wait();
 
-  const [requesterBalance, voter1Balance, voter2Balance, voter3Balance] = await Promise.all(
+  [requesterBalance, voter1Balance, voter2Balance, voter3Balance] = await Promise.all(
     [requesterSigner, voter1Signer, voter2Signer, voter3Signer].map((signer) => {
       return votingToken.balanceOf(signer.address);
     })

--- a/packages/scripts/src/upgrade-tests/voting2/readme.md
+++ b/packages/scripts/src/upgrade-tests/voting2/readme.md
@@ -91,3 +91,9 @@ GOVERNOR_ADDRESS=<OPTIONAL-GOVERNOR-ADDRESS> \
 VOTING_ADDRESS=<OPTONAL-VOTING-ADDRESS>\
 yarn hardhat run ./src/upgrade-tests/voting2/2_Verify.ts --network localhost
 ```
+
+2.5 Simulate basic voting functionality if in the upgraded state:
+
+```
+yarn hardhat run ./src/upgrade-tests/voting2/3_SimulateVoting.ts --network localhost
+```


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

As part of DVMv2 upgrade testing make sure that new contracts are functional.


**Summary**

Additional vote simulation checks that it is possible to stake/unstake, claim rewards and resolve regular price requests in DVMv2.


**Details**

- 3 voter accounts are funded with each one below GAT and every two exceeding GAT
- 3 Voters stake UMA
- Requester initiates regular data request through Optimistic Oracle
- Price request is not resolved due to only 1 voter participating
- All voters unstake, claim rewards and restake
- Verify rewards are correct
- Requester initiates second data request
- Price is resolved on both requests and available to requester
- Verify slashing is applied correctly and unstake all UMA


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

