### PR TITLE
Fix(CI): Change node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   checkout_and_install:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17.0
     working_directory: ~/protocol
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
             - ~/.ssh
   build:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17.0
     working_directory: ~/protocol
     resource_class: large
     steps:
@@ -44,7 +44,7 @@ jobs:
             - ~/.ssh
   lint:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17.0
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -66,7 +66,7 @@ jobs:
           configuration_path: /home/circleci/protocol/.circleci/lerna_config.yml
   coverage:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17.0
     working_directory: ~/protocol
     steps:
       - checkout
@@ -79,7 +79,7 @@ jobs:
           path: packages/core/coverage
   publish:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17.0
     working_directory: ~/protocol
     steps:
       - add_ssh_keys:

--- a/ci/tests/test-financial-templates-lib.sh
+++ b/ci/tests/test-financial-templates-lib.sh
@@ -3,7 +3,7 @@
 cat << EOF
   test-financial-templates-lib-hardhat:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:16.17.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-financial-templates-lib.sh
+++ b/ci/tests/test-financial-templates-lib.sh
@@ -3,7 +3,7 @@
 cat << EOF
   test-financial-templates-lib-hardhat:
     docker:
-      - image: circleci/node:16.17.0
+      - image: cimg/node:16.17.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-liquidator.sh
+++ b/ci/tests/test-liquidator.sh
@@ -3,7 +3,7 @@
 cat << EOF
   test-liquidator-package:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:16.17.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-liquidator.sh
+++ b/ci/tests/test-liquidator.sh
@@ -3,7 +3,7 @@
 cat << EOF
   test-liquidator-package:
     docker:
-      - image: circleci/node:16.17.0
+      - image: cimg/node:16.17.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-not-required.sh
+++ b/ci/tests/test-not-required.sh
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   tests-required:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:16.17.0
     steps:
       - run:
           name: Test dependencies

--- a/ci/tests/test-not-required.sh
+++ b/ci/tests/test-not-required.sh
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   tests-required:
     docker:
-      - image: circleci/node:16.17.0
+      - image: cimg/node:16.17.0
     steps:
       - run:
           name: Test dependencies

--- a/ci/tests/test-packages.sh
+++ b/ci/tests/test-packages.sh
@@ -5,7 +5,7 @@ PACKAGE=$1
 cat << EOF
   test-${PACKAGE:5}:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:16.17.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-packages.sh
+++ b/ci/tests/test-packages.sh
@@ -5,7 +5,7 @@ PACKAGE=$1
 cat << EOF
   test-${PACKAGE:5}:
     docker:
-      - image: circleci/node:16.17.0
+      - image: cimg/node:16.17.0
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-required.sh
+++ b/ci/tests/test-required.sh
@@ -3,7 +3,7 @@
 cat << EOF
   tests-required:
     docker:
-      - image: circleci/node:16.17.0
+      - image: cimg/node:16.17.0
     steps:
       - run:
           name: Test dependencies

--- a/ci/tests/test-required.sh
+++ b/ci/tests/test-required.sh
@@ -3,7 +3,7 @@
 cat << EOF
   tests-required:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:16.17.0
     steps:
       - run:
           name: Test dependencies


### PR DESCRIPTION
**Motivation**

[Node LTS version](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-10-25-version-18120-hydrogen-lts-ruyadorno-and-rafaelgss) changed recently, and some packages still using old LTS. Version is now fixed on code.

Signed-off-by: Evaldo Felipe [contato@evaldofelipe.com](mailto:contato@evaldofelipe.com)


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
