### PR TITLE
fix: price request index bug

### DIFF
--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -978,8 +978,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             require(
                 spamRequestIndex[0] <= spamRequestIndex[1] &&
                     spamRequestIndex[1] < priceRequestIds.length &&
-                    spamRequestIndex[1] > runningValidationIndex,
-                "Invalid spam request index"
+                    spamRequestIndex[1] > runningValidationIndex
             );
 
             runningValidationIndex = spamRequestIndex[1];

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -822,6 +822,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
                 requestIndex = skippedRequestIndexes[requestIndex];
                 continue;
             }
+
             PriceRequest storage priceRequest = priceRequests[priceRequestIds[requestIndex]];
             VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
 

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -812,7 +812,9 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         // If the voter has not yet staked, we must get the starting index to avoid utilising the default 0 index, which
         // would lead to unitialized price requests being processed in the following loop.
         uint64 nextIndexToProcess =
-            voterStake.nextIndexToProcess == 0 ? _getStartingIndexForStaker() : voterStake.nextIndexToProcess;
+            voterStake.nextIndexToProcess == 0 && voterStake.stake == 0
+                ? _getStartingIndexForStaker()
+                : voterStake.nextIndexToProcess;
         for (
             uint64 requestIndex = nextIndexToProcess;
             requestIndex < indexTo;

--- a/packages/core/contracts/oracle/implementation/VotingV2.sol
+++ b/packages/core/contracts/oracle/implementation/VotingV2.sol
@@ -810,7 +810,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         int256 slash = voterStake.unappliedSlash; // Load in any unapplied slashing from the previous iteration.
 
         // If the voter has not yet staked, we must get the starting index to avoid utilising the default 0 index, which
-        // would lead to unitialized price requests in the following loop.
+        // would lead to unitialized price requests being processed in the following loop.
         uint64 nextIndexToProcess =
             voterStake.nextIndexToProcess == 0 ? _getStartingIndexForStaker() : voterStake.nextIndexToProcess;
         for (


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Fixes the bug identified in https://github.com/UMAprotocol/protocol/pull/4210


**Summary**

Calculate the `nextIndexToProcess` to be utilised during `_updateAccountSlashingTrackers()` based on whether the `voterAddress` has never staked or has already staked. This method prevents the problem in which non-staked users might enqueue empty requests to `priceRequestsIds`

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [X]  All existing tests pass
- [ ]  Untested
