### PR TITLE
feat(core): oa check dvm as oracle at assertion

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -87,6 +87,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
             sovereignSecurityManager: sovereignSecurityManager,
             currency: currency,
             respectDvmOnArbitration: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will respect the DVM result.
+            dvmAsOracle: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will use the DVM as an oracle.
             settled: false,
             settlementResolution: false,
             bond: bond,
@@ -98,6 +99,11 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         // if the Sovereign Security Manager is configured to not allow this assertion, such as if the manager has a
         // configured whitelist and the asserter is not on it.
         assertions[assertionId].respectDvmOnArbitration = _checkIfShouldRespectDvmOnArbitrate(assertionId);
+
+        // Check if the Sovereign Security Manager is configured to use the DVM as an oracle.
+        // TODO: As we are checking this only at assertion time, we can refactor to get all Sovereign Security Manager
+        // settings in one call.
+        assertions[assertionId].dvmAsOracle = _checkIfShouldArbitrateViaDvm(assertionId);
 
         // emit event
 
@@ -201,7 +207,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
     }
 
     function _getOracle(bytes32 assertionId) internal view returns (OracleAncillaryInterface) {
-        if (_checkIfShouldArbitrateViaDvm(assertionId))
+        if (assertions[assertionId].dvmAsOracle)
             return OracleAncillaryInterface(finder.getImplementationAddress(OracleInterfaces.Oracle));
         return OracleAncillaryInterface(address(_getSovereignSecurityManager(assertionId)));
     }

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/OwnerUnplugSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/OwnerUnplugSovereignSecurityManager.sol
@@ -4,8 +4,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./BaseSovereignSecurityManager.sol";
 
 contract OwnerUnplugSovereignSecurityManager is BaseSovereignSecurityManager, Ownable {
-    mapping(bytes32 => bool) shouldUnplugOnAssertionIds;
-
     struct ArbitrationResolution {
         bool valueSet;
         bool resolution;
@@ -14,10 +12,6 @@ contract OwnerUnplugSovereignSecurityManager is BaseSovereignSecurityManager, Ow
     mapping(bytes32 => ArbitrationResolution) arbitrationResolutions;
 
     bool unplugFromDvm;
-
-    function setUnplugOnAssertionId(bytes32 assertionId, bool value) public onlyOwner {
-        shouldUnplugOnAssertionIds[assertionId] = value;
-    }
 
     function setArbitrationResolution(
         bytes32 identifier,
@@ -34,8 +28,7 @@ contract OwnerUnplugSovereignSecurityManager is BaseSovereignSecurityManager, Ow
     }
 
     function shouldArbitrateViaDvm(bytes32 assertionId) public view override returns (bool) {
-        if (unplugFromDvm) return false;
-        return !shouldUnplugOnAssertionIds[assertionId];
+        return !unplugFromDvm;
     }
 
     function getPrice(

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -13,6 +13,7 @@ interface OptimisticAssertorInterface {
         address sovereignSecurityManager;
         IERC20 currency; // ERC20 token used to pay rewards and fees.
         bool respectDvmOnArbitration; // TODO: might be moved to SovereignSecurityManager.
+        bool dvmAsOracle; // True if the DVM is used as an oracle (SovereignSecurityManager on False)
         bool settled; // True if the request is settled.
         bool settlementResolution;
         uint256 bond;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

To reduce complexity and avoid race conditions check to use DVM as Oracle only at assertion time.


**Summary**

Moves check on which Oracle to use (DVM or SMM) at assertion time.


**Details**

This also made `setUnplugOnAssertionId` redundant as it should not be effective after assertion is made.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


