### PR TITLE
feat(core): whitelist assertors by msg.sender

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -53,6 +53,10 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         emit AssertionDefaultsSet(_defaultCurrency, _defaultBond, _defaultLiveness);
     }
 
+    function readAssertion(bytes32 assertionId) external view returns (Assertion memory) {
+        return assertions[assertionId];
+    }
+
     function assertTruth(bytes memory claim) public returns (bytes32) {
         // The simplest form of assertion. Bond currency and bond amount default to WETH and WETH final fee.
         // If there is a pending assertion with the same configuration (timestamp, claim and default bond prop) then
@@ -83,7 +87,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
 
         assertions[assertionId] = Assertion({
             proposer: proposer == address(0) ? msg.sender : proposer,
-            msgSender: msg.sender,
+            assertingCaller: msg.sender,
             disputer: address(0),
             callbackRecipient: callbackRecipient,
             sovereignSecurityManager: sovereignSecurityManager,

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistedSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistedSovereignSecurityManager.sol
@@ -2,18 +2,22 @@ pragma solidity 0.8.16;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./BaseSovereignSecurityManager.sol";
+import "../../interfaces/OptimisticAssertorInterface.sol";
 
 contract WhitelistedSovereignSecurityManager is BaseSovereignSecurityManager, Ownable {
-    mapping(address => bool) whitelistedOriginatingProposers;
+    mapping(address => bool) whitelistedAssertingCallers;
 
-    function setOriginatingProposerInWhitelist(address proposer, bool value) public onlyOwner {
-        whitelistedOriginatingProposers[proposer] = value;
+    function setAssertingCallerInWhitelist(address assertingCaller, bool value) public onlyOwner {
+        whitelistedAssertingCallers[assertingCaller] = value;
     }
 
     function getAssertionPolicies(bytes32 assertionId) public view override returns (AssertionPolicies memory) {
+        OptimisticAssertorInterface optimisticAssertor = OptimisticAssertorInterface(msg.sender);
         return
             AssertionPolicies({
-                allowAssertion: whitelistedOriginatingProposers[tx.origin],
+                allowAssertion: whitelistedAssertingCallers[
+                    optimisticAssertor.readAssertion(assertionId).assertingCaller
+                ],
                 useDvmAsOracle: true,
                 useDisputeResolution: true
             });

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -8,7 +8,7 @@ interface OptimisticAssertorInterface {
         address proposer; // Address of the proposer.
         // TODO: consider naming proposer->asserter.
         address disputer; // Address of the disputer.
-        address msgSender; // Address that called into the OA contract.
+        address assertingCaller; // Address that called into the OA contract.
         address callbackRecipient; // Address that receives the callback.
         address sovereignSecurityManager;
         IERC20 currency; // ERC20 token used to pay rewards and fees.
@@ -20,6 +20,8 @@ interface OptimisticAssertorInterface {
         uint256 assertionTime; // Time of the assertion.
         uint256 expirationTime;
     }
+
+    function readAssertion(bytes32 assertionId) external view returns (Assertion memory);
 
     event AssertionMade(
         bytes32 assertionId,


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Whitelisting by tx.origin relies on wallets not being compromised, thus use msg.sender instead.

**Summary**

Whitelisted Sovereign Security Manager uses msg.sender as stored by Optimistic Assertor when checking against whitelist.


**Details**

Implemented new `readAssertion` getter function in Optimistic Assertor so that SSM can retrieve stored parameters by `assertionId`.

Also renamed `msgSender` property to `assertingCaller` so that it is not confusing when SSM gets Optimistic Asserter from `msg.sender` to make `readAssertion` callback.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested
