### PR TITLE
fix(core) address oa proposer address bug

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -74,8 +74,9 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         uint256 bond,
         uint256 liveness
     ) public returns (bytes32) {
+        address _proposer = proposer == address(0) ? msg.sender : proposer;
         bytes32 assertionId =
-            _getId(claim, bond, liveness, currency, proposer, callbackRecipient, sovereignSecurityManager);
+            _getId(claim, bond, liveness, currency, _proposer, callbackRecipient, sovereignSecurityManager);
         require(assertions[assertionId].proposer == address(0)); // Revert if assertion already exists.
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
         uint256 finalFee = _getStore().computeFinalFee(address(currency)).rawValue;
@@ -85,7 +86,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         currency.safeTransferFrom(msg.sender, address(this), bond);
 
         assertions[assertionId] = Assertion({
-            proposer: proposer == address(0) ? msg.sender : proposer,
+            proposer: _proposer,
             assertingCaller: msg.sender,
             disputer: address(0),
             callbackRecipient: callbackRecipient,
@@ -115,7 +116,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         emit AssertionMade(
             assertionId,
             claim,
-            proposer,
+            _proposer,
             callbackRecipient,
             sovereignSecurityManager,
             currency,

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -27,7 +27,7 @@ interface OptimisticAssertorInterface {
         bytes32 assertionId,
         bytes claim,
         address indexed proposer,
-        address indexed callbackRecipient,
+        address callbackRecipient,
         address indexed sovereignSecurityManager,
         IERC20 currency,
         uint256 bond,

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAsserter.Lifecycle.t.sol
@@ -23,7 +23,6 @@ contract SimpleAssertionsWithClaimOnly is Test {
         uint256 bond,
         uint256 expirationTime
     );
-    event PriceRequestAdded(address indexed requester, bytes32 indexed identifier, uint256 time, bytes ancillaryData);
     event AssertionDisputed(bytes32 indexed assertionId, address indexed disputer);
     event AssertionSettled(
         bytes32 indexed assertionId,
@@ -31,6 +30,7 @@ contract SimpleAssertionsWithClaimOnly is Test {
         bool disputed,
         bool settlementResolution
     );
+    event PriceRequestAdded(address indexed requester, bytes32 indexed identifier, uint256 time, bytes ancillaryData);
 
     function setUp() public {
         OptimisticAssertorFixture.OptimisticAsserterContracts memory oaContracts =


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Proposer address was not stored when not provided explicitly.


**Summary**

Store msg.sender when zero address passed as proposer.


**Details**

Also added tests for expected event logs.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

