### PR TITLE
feat(core): add whitelist proposer ssm

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./BaseSovereignSecurityManager.sol";
 import "../../interfaces/OptimisticAssertorInterface.sol";
 
-contract WhitelistedSovereignSecurityManager is BaseSovereignSecurityManager, Ownable {
+contract WhitelistCallerSovereignSecurityManager is BaseSovereignSecurityManager, Ownable {
     mapping(address => bool) whitelistedAssertingCallers;
 
     function setAssertingCallerInWhitelist(address assertingCaller, bool value) public onlyOwner {

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
@@ -9,7 +9,7 @@ contract WhitelistProposerSovereignSecurityManager is BaseSovereignSecurityManag
     // Security of returning correct policy depends on requesting contract passing msg.sender as proposer.
     address public assertingCaller;
 
-    mapping(address => bool) whitelistedProposers;
+    mapping(address => bool) public whitelistedProposers;
 
     event AssertingCallerSet(address indexed assertingCaller);
 

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
@@ -1,0 +1,45 @@
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./BaseSovereignSecurityManager.sol";
+import "../../interfaces/OptimisticAssertorInterface.sol";
+
+contract WhitelistProposerSovereignSecurityManager is BaseSovereignSecurityManager, Ownable {
+    // Address of linked requesting contract. Before this is set via setAssertingCaller all assertions will be blocked.
+    // Security of returning correct policy depends on requesting contract passing msg.sender as proposer.
+    address public assertingCaller;
+
+    mapping(address => bool) whitelistedProposers;
+
+    event AssertingCallerSet(address indexed assertingCaller);
+
+    // Set the address of the contract that will be allowed to use Optimistic Assertor.
+    // This can only be set once. We do not set this at constructor just to allow for some flexibility in the ordering
+    // of how contracts are deployed.
+    function setAssertingCaller(address _assertingCaller) public onlyOwner {
+        require(_assertingCaller != address(0), "Invalid asserting caller");
+        require(assertingCaller == address(0), "Asserting caller already set");
+        assertingCaller = _assertingCaller;
+        emit AssertingCallerSet(_assertingCaller);
+    }
+
+    function setProposerInWhitelist(address proposer, bool value) public onlyOwner {
+        whitelistedProposers[proposer] = value;
+    }
+
+    function getAssertionPolicies(bytes32 assertionId) public view override returns (AssertionPolicies memory) {
+        OptimisticAssertorInterface optimisticAssertor = OptimisticAssertorInterface(msg.sender);
+        OptimisticAssertorInterface.Assertion memory assertion = optimisticAssertor.readAssertion(assertionId);
+        bool allow = _checkIfAssertionAllowed(assertion);
+        return AssertionPolicies({ allowAssertion: allow, useDvmAsOracle: true, useDisputeResolution: true });
+    }
+
+    function _checkIfAssertionAllowed(OptimisticAssertorInterface.Assertion memory assertion)
+        internal
+        view
+        returns (bool)
+    {
+        if (assertion.assertingCaller != assertingCaller) return false; // Only allow assertions through linked client contract.
+        return whitelistedProposers[assertion.proposer]; // Return if proposer is whitelisted.
+    }
+}

--- a/packages/core/test/foundry/optimistic-assertor/Common.sol
+++ b/packages/core/test/foundry/optimistic-assertor/Common.sol
@@ -55,6 +55,8 @@ contract Common is Test {
         bool settlementResolution
     );
 
+    event AssertingCallerSet(address indexed assertingCaller);
+
     // Common setup function, re-used in most tests.
     function _commonSetup() public {
         OptimisticAssertorFixture.OptimisticAssertorContracts memory oaContracts =

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistCallerSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistCallerSovereignSecurityManager.t.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.0;
 
 import "../Common.sol";
-import "../../../../contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistedSovereignSecurityManager.sol";
+import "../../../../contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol";
 
-contract WhitelistedSovereignSecurityManagerTest is Common {
-    WhitelistedSovereignSecurityManager ssm;
+contract WhitelistCallerSovereignSecurityManagerTest is Common {
+    WhitelistCallerSovereignSecurityManager ssm;
 
     function setUp() public {
-        ssm = new WhitelistedSovereignSecurityManager();
+        ssm = new WhitelistCallerSovereignSecurityManager();
     }
 
     function test_AssertingCallerWhitelist() public {

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistProposerSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistProposerSovereignSecurityManager.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../Common.sol";
+import "../../../../contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol";
+
+contract WhitelistProposerSovereignSecurityManagerTest is Common {
+    WhitelistProposerSovereignSecurityManager ssm;
+
+    bytes32 assertionId = "test";
+
+    function setUp() public {
+        ssm = new WhitelistProposerSovereignSecurityManager();
+    }
+
+    function test_RevertIf_NotOwner() public {
+        vm.startPrank(TestAddress.account1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        ssm.setProposerInWhitelist(TestAddress.account1, true);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        ssm.setAssertingCaller(mockAssertingCallerAddress);
+        vm.stopPrank();
+    }
+
+    function test_RevertIf_InvalidAssertingCaller() public {
+        vm.expectRevert("Invalid asserting caller");
+        ssm.setAssertingCaller(address(0));
+    }
+
+    function test_SetAssertingCaller() public {
+        vm.expectEmit(true, true, true, true);
+        emit AssertingCallerSet(mockAssertingCallerAddress);
+        ssm.setAssertingCaller(mockAssertingCallerAddress);
+        assertEq(ssm.assertingCaller(), mockAssertingCallerAddress);
+    }
+
+    function test_RevertIf_RepeatSetAssertingCaller() public {
+        ssm.setAssertingCaller(mockAssertingCallerAddress);
+
+        vm.expectRevert("Asserting caller already set");
+        ssm.setAssertingCaller(mockAssertingCallerAddress);
+    }
+
+    function test_ProposerNotOnWhitelist() public {
+        ssm.setAssertingCaller(mockAssertingCallerAddress);
+
+        _mockReadAssertion(assertionId, mockAssertingCallerAddress, TestAddress.account1);
+
+        // If the proposer is not whitelisted, then the assertion should not be allowed.
+        assertFalse(ssm.whitelistedProposers(TestAddress.account1));
+        vm.prank(mockOptimisticAssertorAddress);
+        SovereignSecurityManagerInterface.AssertionPolicies memory policy = ssm.getAssertionPolicies(assertionId);
+        assertFalse(policy.allowAssertion);
+
+        vm.clearMockedCalls();
+    }
+
+    function test_ProposerOnWhitelist() public {
+        ssm.setAssertingCaller(mockAssertingCallerAddress);
+
+        _mockReadAssertion(assertionId, mockAssertingCallerAddress, TestAddress.account1);
+
+        // If the proposer is whitelisted, then the assertion should be allowed.
+        ssm.setProposerInWhitelist(TestAddress.account1, true);
+        assertTrue(ssm.whitelistedProposers(TestAddress.account1));
+        vm.prank(mockOptimisticAssertorAddress);
+        SovereignSecurityManagerInterface.AssertionPolicies memory policy = ssm.getAssertionPolicies(assertionId);
+        assertTrue(policy.allowAssertion);
+
+        vm.clearMockedCalls();
+    }
+
+    function test_BlockAssertingCallerNotSet() public {
+        ssm.setProposerInWhitelist(TestAddress.account1, true);
+        assertTrue(ssm.whitelistedProposers(TestAddress.account1));
+
+        _mockReadAssertion(assertionId, TestAddress.account1, TestAddress.account1);
+
+        vm.prank(mockOptimisticAssertorAddress);
+        SovereignSecurityManagerInterface.AssertionPolicies memory policy = ssm.getAssertionPolicies(assertionId);
+        assertFalse(policy.allowAssertion);
+    }
+
+    function _mockReadAssertion(
+        bytes32 assertionId,
+        address assertingCaller,
+        address proposer
+    ) internal {
+        OptimisticAssertorInterface.Assertion memory assertion;
+        assertion.assertingCaller = assertingCaller;
+        assertion.proposer = proposer;
+        vm.mockCall(
+            mockOptimisticAssertorAddress,
+            abi.encodeWithSelector(OptimisticAssertorInterface.readAssertion.selector, assertionId),
+            abi.encode(assertion)
+        );
+    }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Users of Optimistic Asserter might want to allow only whitelisted proposers.

**Summary**

Adds whitelisted proposer checking Sovereign Security Manager.


**Details**

Owner of SSM should also register expected requesting contract as it is supposed to correctly pass its `msg.sender` as `proposer` field when calling `assertTruthFor`.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

