### PR TITLE
feat(core): implement ssm able to discard disputed assertions

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/OwnerDiscardOracleSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/OwnerDiscardOracleSovereignSecurityManager.sol
@@ -1,0 +1,16 @@
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./BaseSovereignSecurityManager.sol";
+
+contract OwnerDiscardOracleSovereignSecurityManager is BaseSovereignSecurityManager, Ownable {
+    bool public discardOracle;
+
+    function setDiscardOracle(bool value) public onlyOwner {
+        discardOracle = value;
+    }
+
+    function getAssertionPolicies(bytes32 assertionId) public view override returns (AssertionPolicies memory) {
+        return AssertionPolicies({ allowAssertion: true, useDvmAsOracle: true, useDisputeResolution: !discardOracle });
+    }
+}

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/OwnerDiscardOracleSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/OwnerDiscardOracleSovereignSecurityManager.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../Common.sol";
+import "../../../../contracts/optimistic-assertor/implementation/sovereign-security-manager/OwnerDiscardOracleSovereignSecurityManager.sol";
+
+contract OwnerDiscardOracleSovereignSecurityManagerTest is Common {
+    OwnerDiscardOracleSovereignSecurityManager ssm;
+
+    function setUp() public {
+        ssm = new OwnerDiscardOracleSovereignSecurityManager();
+    }
+
+    function test_SetDiscardOracle() public {
+        OwnerDiscardOracleSovereignSecurityManager.AssertionPolicies memory policies =
+            ssm.getAssertionPolicies(bytes32(0));
+        assertTrue(policies.allowAssertion);
+        assertTrue(policies.useDvmAsOracle);
+        assertTrue(policies.useDisputeResolution);
+
+        ssm.setDiscardOracle(true);
+        policies = ssm.getAssertionPolicies(bytes32(0));
+
+        assertTrue(policies.allowAssertion);
+        assertTrue(policies.useDvmAsOracle);
+        assertFalse(policies.useDisputeResolution);
+    }
+
+    function test_RevertIf_NotOwner() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(TestAddress.account1);
+        ssm.setDiscardOracle(true);
+    }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Users of Optimistic Assertor might want to discard Oracle result on disputes.


**Summary**

Adds Sovereign Security Manager where its owner can control whether disputed assertions can still be resolved as true via Oracle arbitration or Optimistic Asserter uses resolved answer only for bond settlement.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
