### PR TITLE
feat(core): add custom price identifier to oa

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -11,6 +11,7 @@ import "../../oracle/implementation/Constants.sol";
 import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/AddressWhitelist.sol";
 import "../../oracle/interfaces/OracleAncillaryInterface.sol";
+import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
 import "../../common/implementation/AncillaryData.sol";
 import "../interfaces/OptimisticAssertorCallbackRecipientInterface.sol";
 import "../interfaces/OptimisticAssertorInterface.sol";
@@ -90,6 +91,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
             _getId(claim, bond, liveness, currency, _proposer, callbackRecipient, sovereignSecurityManager, identifier);
 
         require(assertions[assertionId].proposer == address(0), "Assertion already exists");
+        require(_getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
         require(
             (bond * burnedBondPercentage) / 1e18 >= _getStore().computeFinalFee(address(currency)).rawValue,
@@ -274,6 +276,10 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
 
     function _getCollateralWhitelist() internal view returns (AddressWhitelist) {
         return AddressWhitelist(finder.getImplementationAddress(OracleInterfaces.CollateralWhitelist));
+    }
+
+    function _getIdentifierWhitelist() internal view returns (IdentifierWhitelistInterface) {
+        return IdentifierWhitelistInterface(finder.getImplementationAddress(OracleInterfaces.IdentifierWhitelist));
     }
 
     function _getStore() internal view returns (StoreInterface) {

--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -87,7 +87,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
     ) public returns (bytes32) {
         address _proposer = proposer == address(0) ? msg.sender : proposer;
         bytes32 assertionId =
-            _getId(claim, bond, liveness, currency, _proposer, callbackRecipient, sovereignSecurityManager);
+            _getId(claim, bond, liveness, currency, _proposer, callbackRecipient, sovereignSecurityManager, identifier);
 
         require(assertions[assertionId].proposer == address(0), "Assertion already exists");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
@@ -243,12 +243,22 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         IERC20 currency,
         address proposer,
         address callbackRecipient,
-        address sovereignSecurityManager
+        address sovereignSecurityManager,
+        bytes32 identifier
     ) internal pure returns (bytes32) {
         // Returns the unique ID for this assertion. This ID is used to identify the assertion in the Oracle.
         return
             keccak256(
-                abi.encode(claim, bond, liveness, currency, proposer, callbackRecipient, sovereignSecurityManager)
+                abi.encode(
+                    claim,
+                    bond,
+                    liveness,
+                    currency,
+                    proposer,
+                    callbackRecipient,
+                    sovereignSecurityManager,
+                    identifier
+                )
             );
     }
 

--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -102,6 +102,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         assertions[assertionId] = Assertion({
             proposer: _proposer,
             disputer: address(0),
+            callbackRecipient: callbackRecipient,
             currency: currency,
             settled: false,
             settlementResolution: false,
@@ -114,7 +115,6 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
                 useDisputeResolution: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will respect the DVM result.
                 useDvmAsOracle: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will use the DVM as an oracle.
                 sovereignSecurityManager: sovereignSecurityManager,
-                callbackRecipient: callbackRecipient,
                 assertingCaller: msg.sender
             })
         });
@@ -294,14 +294,17 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
     }
 
     function _callbackOnAssertionResolve(bytes32 assertionId, bool assertedTruthfully) internal {
-        if (assertions[assertionId].ssmSettings.callbackRecipient != address(0))
-            OptimisticAssertorCallbackRecipientInterface(assertions[assertionId].ssmSettings.callbackRecipient)
-                .assertionResolved(assertionId, assertedTruthfully);
+        if (assertions[assertionId].callbackRecipient != address(0))
+            OptimisticAssertorCallbackRecipientInterface(assertions[assertionId].callbackRecipient).assertionResolved(
+                assertionId,
+                assertedTruthfully
+            );
     }
 
     function _callbackOnAssertionDispute(bytes32 assertionId) internal {
-        if (assertions[assertionId].ssmSettings.callbackRecipient != address(0))
-            OptimisticAssertorCallbackRecipientInterface(assertions[assertionId].ssmSettings.callbackRecipient)
-                .assertionDisputed(assertionId);
+        if (assertions[assertionId].callbackRecipient != address(0))
+            OptimisticAssertorCallbackRecipientInterface(assertions[assertionId].callbackRecipient).assertionDisputed(
+                assertionId
+            );
     }
 }

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/SuperbondSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/SuperbondSovereignSecurityManager.sol
@@ -96,7 +96,7 @@ contract SuperbondSovereignSecurityManager is BaseSovereignSecurityManager, Owna
         // application specific checks before making the assertion. Since assertions are changing claim bonding trackers
         // in this SSM that might affect other assertions, restricting assertingCaller allows avoiding interference
         // with client application.
-        if (assertion.assertingCaller != assertingCaller) return false;
+        if (assertion.ssmSettings.assertingCaller != assertingCaller) return false;
 
         if (superBonds[assertion.currency] == 0) return false; // Only allow assertions for currencies with a super bond set.
         ClaimBonding storage claimBonding = claimBondings[assertion.claimId];

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol
@@ -16,7 +16,7 @@ contract WhitelistCallerSovereignSecurityManager is BaseSovereignSecurityManager
         return
             AssertionPolicies({
                 allowAssertion: whitelistedAssertingCallers[
-                    optimisticAssertor.readAssertion(assertionId).assertingCaller
+                    optimisticAssertor.readAssertion(assertionId).ssmSettings.assertingCaller
                 ],
                 useDvmAsOracle: true,
                 useDisputeResolution: true

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
@@ -39,7 +39,7 @@ contract WhitelistProposerSovereignSecurityManager is BaseSovereignSecurityManag
         view
         returns (bool)
     {
-        if (assertion.assertingCaller != assertingCaller) return false; // Only allow assertions through linked client contract.
+        if (assertion.ssmSettings.assertingCaller != assertingCaller) return false; // Only allow assertions through linked client contract.
         return whitelistedProposers[assertion.proposer]; // Return if proposer is whitelisted.
     }
 }

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -9,13 +9,13 @@ interface OptimisticAssertorInterface {
         bool useDvmAsOracle; // True if the DVM is used as an oracle (SovereignSecurityManager on False)
         address sovereignSecurityManager;
         address assertingCaller;
-        address callbackRecipient;
     }
 
     struct Assertion {
         address proposer; // Address of the proposer.
         // TODO: consider naming proposer->asserter.
         address disputer; // Address of the disputer.
+        address callbackRecipient; // Address that receives the callback.
         IERC20 currency; // ERC20 token used to pay rewards and fees.
         bool settled; // True if the request is settled.
         bool settlementResolution;

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -24,6 +24,7 @@ interface OptimisticAssertorInterface {
         uint256 expirationTime;
         bytes32 claimId;
         SsmSettings ssmSettings;
+        bytes32 identifier;
     }
 
     function readAssertion(bytes32 assertionId) external view returns (Assertion memory);

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -7,15 +7,15 @@ interface OptimisticAssertorInterface {
     struct SsmSettings {
         bool useDisputeResolution; // TODO: might be moved to SovereignSecurityManager.
         bool useDvmAsOracle; // True if the DVM is used as an oracle (SovereignSecurityManager on False)
+        address sovereignSecurityManager;
+        address assertingCaller;
+        address callbackRecipient;
     }
 
     struct Assertion {
         address proposer; // Address of the proposer.
         // TODO: consider naming proposer->asserter.
         address disputer; // Address of the disputer.
-        address assertingCaller; // Address that called into the OA contract.
-        address callbackRecipient; // Address that receives the callback.
-        address sovereignSecurityManager;
         IERC20 currency; // ERC20 token used to pay rewards and fees.
         bool settled; // True if the request is settled.
         bool settlementResolution;
@@ -23,8 +23,8 @@ interface OptimisticAssertorInterface {
         uint256 assertionTime; // Time of the assertion.
         uint256 expirationTime;
         bytes32 claimId;
-        SsmSettings ssmSettings;
         bytes32 identifier;
+        SsmSettings ssmSettings;
     }
 
     function readAssertion(bytes32 assertionId) external view returns (Assertion memory);

--- a/packages/core/test/foundry/optimistic-assertor/Common.sol
+++ b/packages/core/test/foundry/optimistic-assertor/Common.sol
@@ -26,6 +26,7 @@ contract Common is Test {
     bytes falseClaimAssertion = bytes("q:'The sky is red'");
     uint256 defaultBond;
     uint256 defaultLiveness;
+    bytes32 defaultIdentifier;
 
     // Mock addresses, used to prank calls.
     address mockOptimisticAssertorAddress = address(0xfa);
@@ -70,6 +71,7 @@ contract Common is Test {
         store = oaContracts.store;
         defaultBond = optimisticAssertor.defaultBond();
         defaultLiveness = optimisticAssertor.defaultLiveness();
+        defaultIdentifier = optimisticAssertor.defaultIdentifier();
     }
 
     // Helper functions, re-used in some tests.
@@ -123,7 +125,8 @@ contract Common is Test {
                 sovereignSecurityManager,
                 defaultCurrency,
                 defaultBond,
-                defaultLiveness
+                defaultLiveness,
+                defaultIdentifier
             );
     }
 
@@ -132,7 +135,7 @@ contract Common is Test {
         OptimisticAssertorInterface.Assertion memory assertion = optimisticAssertor.readAssertion(assertionId);
         OracleRequest memory oracleRequest =
             OracleRequest({
-                identifier: optimisticAssertor.identifier(),
+                identifier: optimisticAssertor.defaultIdentifier(),
                 time: assertion.assertionTime,
                 ancillaryData: optimisticAssertor.stampAssertion(assertionId)
             });

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.EdgeCases.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.EdgeCases.t.sol
@@ -23,6 +23,23 @@ contract InvalidParameters is Common {
         vm.stopPrank();
     }
 
+    function test_RevertIf_UnsupportedIdentifier() public {
+        bytes32 unsupportedIdentifier = "UNSUPPORTED";
+
+        vm.expectRevert("Unsupported identifier");
+        vm.prank(TestAddress.account1);
+        optimisticAssertor.assertTruthFor(
+            trueClaimAssertion,
+            address(0),
+            address(0),
+            address(0),
+            defaultCurrency,
+            defaultBond,
+            defaultLiveness,
+            unsupportedIdentifier
+        );
+    }
+
     function test_RevertIf_UnsupportedCurrency() public {
         // Change the default currency to unsupported token.
         vm.startPrank(TestAddress.owner);

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.EdgeCases.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.EdgeCases.t.sol
@@ -43,7 +43,8 @@ contract InvalidParameters is Common {
             address(0),
             defaultCurrency,
             0,
-            0
+            0,
+            defaultIdentifier
         );
     }
 

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Events.t.sol
@@ -23,7 +23,8 @@ contract OptimisticAssertorEvents is Common {
                     address(defaultCurrency),
                     TestAddress.account1,
                     address(0),
-                    address(0)
+                    address(0),
+                    defaultIdentifier
                 )
             );
 

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Events.t.sol
@@ -47,7 +47,7 @@ contract OptimisticAssertorEvents is Common {
         vm.expectEmit(true, true, true, true);
         emit PriceRequestAdded(
             address(optimisticAssertor),
-            optimisticAssertor.identifier(),
+            optimisticAssertor.defaultIdentifier(),
             optimisticAssertor.readAssertion(assertionId).assertionTime,
             optimisticAssertor.stampAssertion(assertionId)
         );

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Lifecycle.t.sol
@@ -23,7 +23,8 @@ contract SimpleAssertionsWithClaimOnly is Common {
                     address(defaultCurrency),
                     TestAddress.account1,
                     address(0),
-                    address(0)
+                    address(0),
+                    defaultIdentifier
                 )
             );
 

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Lifecycle.t.sol
@@ -72,7 +72,7 @@ contract SimpleAssertionsWithClaimOnly is Common {
         assertEq(queries.length, 1);
 
         // The query should be for the disputed assertion.
-        assertEq(queries[0].identifier, optimisticAssertor.identifier());
+        assertEq(queries[0].identifier, optimisticAssertor.defaultIdentifier());
         assertEq(queries[0].time, optimisticAssertor.readAssertion(assertionId).assertionTime);
         assertEq(queries[0].ancillaryData, optimisticAssertor.stampAssertion(assertionId));
 

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/SuperbondOracleSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/SuperbondOracleSovereignSecurityManager.t.sol
@@ -254,7 +254,7 @@ contract SuperbondOracleSovereignSecurityManagerTest is Common {
         bytes memory claim
     ) internal {
         OptimisticAssertorInterface.Assertion memory assertion;
-        assertion.assertingCaller = assertingCaller;
+        assertion.ssmSettings.assertingCaller = assertingCaller;
         assertion.currency = currency;
         assertion.bond = bond;
         assertion.claimId = keccak256(claim);

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistCallerSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistCallerSovereignSecurityManager.t.sol
@@ -39,7 +39,7 @@ contract WhitelistCallerSovereignSecurityManagerTest is Common {
 
     function _mockReadAssertionAssertingCaller(address mockAssertingCaller, bytes32 assertionId) public {
         OptimisticAssertorInterface.Assertion memory assertion;
-        assertion.assertingCaller = mockAssertingCaller;
+        assertion.ssmSettings.assertingCaller = mockAssertingCaller;
         vm.mockCall(
             mockOptimisticAssertorAddress,
             abi.encodeWithSelector(OptimisticAssertorInterface.readAssertion.selector, assertionId),

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistProposerSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistProposerSovereignSecurityManager.t.sol
@@ -88,7 +88,7 @@ contract WhitelistProposerSovereignSecurityManagerTest is Common {
         address proposer
     ) internal {
         OptimisticAssertorInterface.Assertion memory assertion;
-        assertion.assertingCaller = assertingCaller;
+        assertion.ssmSettings.assertingCaller = assertingCaller;
         assertion.proposer = proposer;
         vm.mockCall(
             mockOptimisticAssertorAddress,


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Some applications might need assertion rules defined in their custom price identifier.


**Summary**

Adds ability to pass custom price identifier for the assertion.


**Details**

This also moves `sovereignSecurityManager` and `assertingCaller` under `ssmSettings` properties to avoid stack too deep error.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


