### PR TITLE
feat(core): add custom price identifier to oa (master)

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -11,6 +11,7 @@ import "../../oracle/implementation/Constants.sol";
 import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/AddressWhitelist.sol";
 import "../../oracle/interfaces/OracleAncillaryInterface.sol";
+import "../../oracle/interfaces/IdentifierWhitelistInterface.sol";
 import "../../common/implementation/AncillaryData.sol";
 import "../interfaces/OptimisticAssertorCallbackRecipientInterface.sol";
 import "../interfaces/OptimisticAssertorInterface.sol";
@@ -25,7 +26,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
 
     uint256 public burnedBondPercentage = 0.5e18; //50% of bond is burned.
 
-    bytes32 public identifier = "ASSERT_TRUTH";
+    bytes32 public defaultIdentifier = "ASSERT_TRUTH";
 
     IERC20 public defaultCurrency;
     uint256 public defaultBond;
@@ -62,7 +63,17 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         // If there is a pending assertion with the same configuration (timestamp, claim and default bond prop) then
         // reverts. Internally calls assertTruth(...) with all the associated props.
         // returns the value that assertTruth(...) returns.
-        return assertTruthFor(claim, address(0), address(0), address(0), defaultCurrency, defaultBond, defaultLiveness);
+        return
+            assertTruthFor(
+                claim,
+                address(0),
+                address(0),
+                address(0),
+                defaultCurrency,
+                defaultBond,
+                defaultLiveness,
+                defaultIdentifier
+            );
     }
 
     function assertTruthFor(
@@ -72,12 +83,15 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         address sovereignSecurityManager,
         IERC20 currency,
         uint256 bond,
-        uint256 liveness
+        uint256 liveness,
+        bytes32 identifier
     ) public returns (bytes32) {
         address _proposer = proposer == address(0) ? msg.sender : proposer;
         bytes32 assertionId =
-            _getId(claim, bond, liveness, currency, _proposer, callbackRecipient, sovereignSecurityManager);
+            _getId(claim, bond, liveness, currency, _proposer, callbackRecipient, sovereignSecurityManager, identifier);
+
         require(assertions[assertionId].proposer == address(0), "Assertion already exists");
+        require(_getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(_getCollateralWhitelist().isOnWhitelist(address(currency)), "Unsupported currency");
         require(bond >= getMinimumBond(address(currency)), "Bond amount too low");
 
@@ -86,18 +100,21 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
 
         assertions[assertionId] = Assertion({
             proposer: _proposer,
-            assertingCaller: msg.sender,
             disputer: address(0),
             callbackRecipient: callbackRecipient,
-            sovereignSecurityManager: sovereignSecurityManager,
             currency: currency,
-            useDisputeResolution: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will respect the DVM result.
-            useDvmAsOracle: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will use the DVM as an oracle.
             settled: false,
             settlementResolution: false,
             bond: bond,
             assertionTime: getCurrentTime(),
-            expirationTime: getCurrentTime() + liveness
+            expirationTime: getCurrentTime() + liveness,
+            identifier: identifier,
+            ssmSettings: SsmSettings({
+                useDisputeResolution: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will respect the DVM result.
+                useDvmAsOracle: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will use the DVM as an oracle.
+                sovereignSecurityManager: sovereignSecurityManager,
+                assertingCaller: msg.sender
+            })
         });
 
         SovereignSecurityManagerInterface.AssertionPolicies memory assertionPolicies =
@@ -107,10 +124,10 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         require(assertionPolicies.allowAssertion, "Assertion not allowed");
 
         // Check if the Sovereign Security Manager is configured to arbitrate via DVM
-        assertions[assertionId].useDisputeResolution = assertionPolicies.useDisputeResolution;
+        assertions[assertionId].ssmSettings.useDisputeResolution = assertionPolicies.useDisputeResolution;
 
         // Check if the Sovereign Security Manager is configured to use the DVM as an oracle.
-        assertions[assertionId].useDvmAsOracle = assertionPolicies.useDvmAsOracle;
+        assertions[assertionId].ssmSettings.useDvmAsOracle = assertionPolicies.useDvmAsOracle;
 
         emit AssertionMade(
             assertionId,
@@ -129,7 +146,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
     function getAssertion(bytes32 assertionId) public view returns (bool) {
         Assertion memory assertion = assertions[assertionId];
         // Return early if not using answer from resolved dispute.
-        if (assertion.disputer != address(0) && !assertion.useDisputeResolution) return false;
+        if (assertion.disputer != address(0) && !assertion.ssmSettings.useDisputeResolution) return false;
         require(assertion.settled, "Assertion not settled"); // Revert if assertion not settled.
         return assertion.settlementResolution;
     }
@@ -151,13 +168,17 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
 
         assertion.disputer = _disputer;
 
-        _getOracle(assertionId).requestPrice(identifier, assertion.assertionTime, _stampAssertion(assertionId));
+        _getOracle(assertionId).requestPrice(
+            assertion.identifier,
+            assertion.assertionTime,
+            _stampAssertion(assertionId)
+        );
 
         // Send dispute callback
         _callbackOnAssertionDispute(assertionId);
 
         // Send resolve callback if dispute resolution is discarded
-        if (!assertion.useDisputeResolution) _callbackOnAssertionResolve(assertionId, false);
+        if (!assertion.ssmSettings.useDisputeResolution) _callbackOnAssertionResolve(assertionId, false);
 
         emit AssertionDisputed(assertionId, _disputer);
     }
@@ -178,9 +199,13 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         } else {
             // Dispute, settle with the disputer
             int256 resolvedPrice =
-                _getOracle(assertionId).getPrice(identifier, assertion.assertionTime, _stampAssertion(assertionId)); // Revert if price not resolved.
+                _getOracle(assertionId).getPrice(
+                    assertion.identifier,
+                    assertion.assertionTime,
+                    _stampAssertion(assertionId)
+                ); // Revert if price not resolved.
 
-            assertion.settlementResolution = assertion.useDisputeResolution ? resolvedPrice == 1e18 : false;
+            assertion.settlementResolution = assertion.ssmSettings.useDisputeResolution ? resolvedPrice == 1e18 : false;
             address bondRecipient = resolvedPrice == 1e18 ? assertion.proposer : assertion.disputer;
 
             // todo: should you only play the final fee in the case of a DVM arbitrated dispute?
@@ -190,7 +215,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
             assertion.currency.safeTransfer(bondRecipient, amountToSend);
             assertion.currency.safeTransfer(address(_getStore()), amountToBurn);
 
-            if (assertion.useDisputeResolution)
+            if (assertion.ssmSettings.useDisputeResolution)
                 _callbackOnAssertionResolve(assertionId, assertion.settlementResolution);
 
             emit AssertionSettled(assertionId, bondRecipient, true, assertion.settlementResolution);
@@ -221,12 +246,22 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         IERC20 currency,
         address proposer,
         address callbackRecipient,
-        address sovereignSecurityManager
+        address sovereignSecurityManager,
+        bytes32 identifier
     ) internal pure returns (bytes32) {
         // Returns the unique ID for this assertion. This ID is used to identify the assertion in the Oracle.
         return
             keccak256(
-                abi.encode(claim, bond, liveness, currency, proposer, callbackRecipient, sovereignSecurityManager)
+                abi.encode(
+                    claim,
+                    bond,
+                    liveness,
+                    currency,
+                    proposer,
+                    callbackRecipient,
+                    sovereignSecurityManager,
+                    identifier
+                )
             );
     }
 
@@ -244,12 +279,16 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         return AddressWhitelist(finder.getImplementationAddress(OracleInterfaces.CollateralWhitelist));
     }
 
+    function _getIdentifierWhitelist() internal view returns (IdentifierWhitelistInterface) {
+        return IdentifierWhitelistInterface(finder.getImplementationAddress(OracleInterfaces.IdentifierWhitelist));
+    }
+
     function _getStore() internal view returns (StoreInterface) {
         return StoreInterface(finder.getImplementationAddress(OracleInterfaces.Store));
     }
 
     function _getOracle(bytes32 assertionId) internal view returns (OracleAncillaryInterface) {
-        if (assertions[assertionId].useDvmAsOracle)
+        if (assertions[assertionId].ssmSettings.useDvmAsOracle)
             return OracleAncillaryInterface(finder.getImplementationAddress(OracleInterfaces.Oracle));
         return OracleAncillaryInterface(address(_getSovereignSecurityManager(assertionId)));
     }
@@ -259,7 +298,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         view
         returns (SovereignSecurityManagerInterface)
     {
-        return SovereignSecurityManagerInterface(assertions[assertionId].sovereignSecurityManager);
+        return SovereignSecurityManagerInterface(assertions[assertionId].ssmSettings.sovereignSecurityManager);
     }
 
     function _getAssertionPolicies(bytes32 assertionId)
@@ -267,7 +306,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
         view
         returns (SovereignSecurityManagerInterface.AssertionPolicies memory)
     {
-        address ssm = assertions[assertionId].sovereignSecurityManager;
+        address ssm = assertions[assertionId].ssmSettings.sovereignSecurityManager;
         if (ssm == address(0)) return SovereignSecurityManagerInterface.AssertionPolicies(true, true, true);
         return SovereignSecurityManagerInterface(ssm).getAssertionPolicies(assertionId);
     }

--- a/packages/core/contracts/optimistic-assertor/implementation/examples/Insurance.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/Insurance.sol
@@ -13,6 +13,7 @@ contract Insurance {
     IERC20 public immutable defaultCurrency;
     OptimisticAssertorInterface public immutable oa;
     uint256 public constant assertionLiveness = 7200;
+    bytes32 public immutable defaultIdentifier;
 
     struct Policy {
         uint256 insuranceAmount;
@@ -39,6 +40,7 @@ contract Insurance {
     constructor(address _defaultCurrency, address _optimisticAssertor) {
         defaultCurrency = IERC20(_defaultCurrency);
         oa = OptimisticAssertorInterface(_optimisticAssertor);
+        defaultIdentifier = oa.defaultIdentifier();
     }
 
     function issueInsurance(
@@ -76,7 +78,8 @@ contract Insurance {
             address(0), // No sovereign security manager.
             defaultCurrency,
             bond,
-            assertionLiveness
+            assertionLiveness,
+            defaultIdentifier
         );
         assertedPolicies[assertionId] = policyId;
         emit InsurancePayoutRequested(policyId, assertionId);

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistCallerSovereignSecurityManager.sol
@@ -16,7 +16,7 @@ contract WhitelistCallerSovereignSecurityManager is BaseSovereignSecurityManager
         return
             AssertionPolicies({
                 allowAssertion: whitelistedAssertingCallers[
-                    optimisticAssertor.readAssertion(assertionId).assertingCaller
+                    optimisticAssertor.readAssertion(assertionId).ssmSettings.assertingCaller
                 ],
                 useDvmAsOracle: true,
                 useDisputeResolution: true

--- a/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/sovereign-security-manager/WhitelistProposerSovereignSecurityManager.sol
@@ -39,7 +39,7 @@ contract WhitelistProposerSovereignSecurityManager is BaseSovereignSecurityManag
         view
         returns (bool)
     {
-        if (assertion.assertingCaller != assertingCaller) return false; // Only allow assertions through linked client contract.
+        if (assertion.ssmSettings.assertingCaller != assertingCaller) return false; // Only allow assertions through linked client contract.
         return whitelistedProposers[assertion.proposer]; // Return if proposer is whitelisted.
     }
 }

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -26,6 +26,8 @@ interface OptimisticAssertorInterface {
         SsmSettings ssmSettings;
     }
 
+    function defaultIdentifier() external view returns (bytes32);
+
     function readAssertion(bytes32 assertionId) external view returns (Assertion memory);
 
     function assertTruth(bytes memory claim) external returns (bytes32);
@@ -37,7 +39,8 @@ interface OptimisticAssertorInterface {
         address sovereignSecurityManager,
         IERC20 currency,
         uint256 bond,
-        uint256 liveness
+        uint256 liveness,
+        bytes32 identifier
     ) external returns (bytes32);
 
     function getAssertion(bytes32 assertionId) external view returns (bool);

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -4,21 +4,26 @@ pragma solidity 0.8.16;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface OptimisticAssertorInterface {
+    struct SsmSettings {
+        bool useDisputeResolution; // TODO: might be moved to SovereignSecurityManager.
+        bool useDvmAsOracle; // True if the DVM is used as an oracle (SovereignSecurityManager on False)
+        address sovereignSecurityManager;
+        address assertingCaller;
+    }
+
     struct Assertion {
         address proposer; // Address of the proposer.
         // TODO: consider naming proposer->asserter.
         address disputer; // Address of the disputer.
-        address assertingCaller; // Address that called into the OA contract.
         address callbackRecipient; // Address that receives the callback.
-        address sovereignSecurityManager;
         IERC20 currency; // ERC20 token used to pay rewards and fees.
-        bool useDisputeResolution; // TODO: might be moved to SovereignSecurityManager.
-        bool useDvmAsOracle; // True if the DVM is used as an oracle (SovereignSecurityManager on False)
         bool settled; // True if the request is settled.
         bool settlementResolution;
         uint256 bond;
         uint256 assertionTime; // Time of the assertion.
         uint256 expirationTime;
+        bytes32 identifier;
+        SsmSettings ssmSettings;
     }
 
     function readAssertion(bytes32 assertionId) external view returns (Assertion memory);

--- a/packages/core/test/foundry/optimistic-assertor/Common.sol
+++ b/packages/core/test/foundry/optimistic-assertor/Common.sol
@@ -26,6 +26,7 @@ contract Common is Test {
     bytes falseClaimAssertion = bytes("q:'The sky is red'");
     uint256 defaultBond;
     uint256 defaultLiveness;
+    bytes32 defaultIdentifier;
 
     // Mock addresses, used to prank calls.
     address mockOptimisticAssertorAddress = address(0xfa);
@@ -68,6 +69,7 @@ contract Common is Test {
         store = oaContracts.store;
         defaultBond = optimisticAssertor.defaultBond();
         defaultLiveness = optimisticAssertor.defaultLiveness();
+        defaultIdentifier = optimisticAssertor.defaultIdentifier();
     }
 
     // Helper functions, re-used in some tests.
@@ -121,7 +123,8 @@ contract Common is Test {
                 sovereignSecurityManager,
                 defaultCurrency,
                 defaultBond,
-                defaultLiveness
+                defaultLiveness,
+                defaultIdentifier
             );
     }
 
@@ -130,7 +133,7 @@ contract Common is Test {
         OptimisticAssertorInterface.Assertion memory assertion = optimisticAssertor.readAssertion(assertionId);
         OracleRequest memory oracleRequest =
             OracleRequest({
-                identifier: optimisticAssertor.identifier(),
+                identifier: optimisticAssertor.defaultIdentifier(),
                 time: assertion.assertionTime,
                 ancillaryData: optimisticAssertor.stampAssertion(assertionId)
             });

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.EdgeCases.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.EdgeCases.t.sol
@@ -23,6 +23,23 @@ contract InvalidParameters is Common {
         vm.stopPrank();
     }
 
+    function test_RevertIf_UnsupportedIdentifier() public {
+        bytes32 unsupportedIdentifier = "UNSUPPORTED";
+
+        vm.expectRevert("Unsupported identifier");
+        vm.prank(TestAddress.account1);
+        optimisticAssertor.assertTruthFor(
+            trueClaimAssertion,
+            address(0),
+            address(0),
+            address(0),
+            defaultCurrency,
+            defaultBond,
+            defaultLiveness,
+            unsupportedIdentifier
+        );
+    }
+
     function test_RevertIf_UnsupportedCurrency() public {
         // Change the default currency to unsupported token.
         vm.startPrank(TestAddress.owner);
@@ -43,7 +60,8 @@ contract InvalidParameters is Common {
             address(0),
             defaultCurrency,
             0,
-            0
+            0,
+            defaultIdentifier
         );
     }
 

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Events.t.sol
@@ -23,7 +23,8 @@ contract OptimisticAssertorEvents is Common {
                     address(defaultCurrency),
                     TestAddress.account1,
                     address(0),
-                    address(0)
+                    address(0),
+                    defaultIdentifier
                 )
             );
 
@@ -47,7 +48,7 @@ contract OptimisticAssertorEvents is Common {
         vm.expectEmit(true, true, true, true);
         emit PriceRequestAdded(
             address(optimisticAssertor),
-            optimisticAssertor.identifier(),
+            optimisticAssertor.defaultIdentifier(),
             optimisticAssertor.readAssertion(assertionId).assertionTime,
             optimisticAssertor.stampAssertion(assertionId)
         );

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.Lifecycle.t.sol
@@ -23,7 +23,8 @@ contract SimpleAssertionsWithClaimOnly is Common {
                     address(defaultCurrency),
                     TestAddress.account1,
                     address(0),
-                    address(0)
+                    address(0),
+                    defaultIdentifier
                 )
             );
 
@@ -72,7 +73,7 @@ contract SimpleAssertionsWithClaimOnly is Common {
         assertEq(queries.length, 1);
 
         // The query should be for the disputed assertion.
-        assertEq(queries[0].identifier, optimisticAssertor.identifier());
+        assertEq(queries[0].identifier, optimisticAssertor.defaultIdentifier());
         assertEq(queries[0].time, optimisticAssertor.readAssertion(assertionId).assertionTime);
         assertEq(queries[0].ancillaryData, optimisticAssertor.stampAssertion(assertionId));
 

--- a/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.SsmPolicies.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/OptimisticAssertor.SsmPolicies.t.sol
@@ -21,8 +21,8 @@ contract SovereignSecurityManagerPoliciesEnforced is Common {
         vm.prank(TestAddress.account1);
         bytes32 assertionId = optimisticAssertor.assertTruth(trueClaimAssertion);
         OptimisticAssertorInterface.Assertion memory assertion = optimisticAssertor.readAssertion(assertionId);
-        assertTrue(assertion.useDisputeResolution);
-        assertTrue(assertion.useDvmAsOracle);
+        assertTrue(assertion.ssmSettings.useDisputeResolution);
+        assertTrue(assertion.ssmSettings.useDvmAsOracle);
     }
 
     function test_RevertIf_AssertionBlocked() public {
@@ -40,7 +40,7 @@ contract SovereignSecurityManagerPoliciesEnforced is Common {
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSsm(address(0), mockedSovereignSecurityManager);
         OptimisticAssertorInterface.Assertion memory assertion = optimisticAssertor.readAssertion(assertionId);
-        assertFalse(assertion.useDvmAsOracle);
+        assertFalse(assertion.ssmSettings.useDvmAsOracle);
 
         // Dispute, mock resolve assertion truethful through SSM as Oracle and verify on Optimistic Assertor.
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId);
@@ -55,7 +55,7 @@ contract SovereignSecurityManagerPoliciesEnforced is Common {
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSsm(address(0), mockedSovereignSecurityManager);
         OptimisticAssertorInterface.Assertion memory assertion = optimisticAssertor.readAssertion(assertionId);
-        assertFalse(assertion.useDisputeResolution);
+        assertFalse(assertion.ssmSettings.useDisputeResolution);
 
         // Dispute should make assertion false available immediately.
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId);

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistCallerSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistCallerSovereignSecurityManager.t.sol
@@ -39,7 +39,7 @@ contract WhitelistCallerSovereignSecurityManagerTest is Common {
 
     function _mockReadAssertionAssertingCaller(address mockAssertingCaller, bytes32 assertionId) public {
         OptimisticAssertorInterface.Assertion memory assertion;
-        assertion.assertingCaller = mockAssertingCaller;
+        assertion.ssmSettings.assertingCaller = mockAssertingCaller;
         vm.mockCall(
             mockOptimisticAssertorAddress,
             abi.encodeWithSelector(OptimisticAssertorInterface.readAssertion.selector, assertionId),

--- a/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistProposerSovereignSecurityManager.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/SovereignSecurityManagers/WhitelistProposerSovereignSecurityManager.t.sol
@@ -88,7 +88,7 @@ contract WhitelistProposerSovereignSecurityManagerTest is Common {
         address proposer
     ) internal {
         OptimisticAssertorInterface.Assertion memory assertion;
-        assertion.assertingCaller = assertingCaller;
+        assertion.ssmSettings.assertingCaller = assertingCaller;
         assertion.proposer = proposer;
         vm.mockCall(
             mockOptimisticAssertorAddress,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Optimistic Asserter custom price identifier was added in #4254, but was merged in non-master branch.


**Summary**

Adds custom price identifier to Optimistic Asserter master branch.


**Details**

Originally #4254 was opened against [reinis-frp/superbond-ssm](https://github.com/UMAprotocol/protocol/tree/reinis-frp/superbond-ssm) in order to ensure stack too deep errors would be avoided also after #4244 will get merged.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

