### PR TITLE
feat: add event based fetching for all requests

### DIFF
--- a/packages/sdk/src/oracle/README.md
+++ b/packages/sdk/src/oracle/README.md
@@ -33,6 +33,8 @@ const config:PartialConfig = {
       optimisticOracleAddress: string; // override default oracle address, or provide one if we cannot look it up, ie with testing
       earliestBlockNumber?: number;  // ignore blocks before this block number if specified
       maxEventRangeQuery?: number;  // optimize how quickly the first batch of requests are fetched by restricting the max number of events queried.
+      disableFetchEventBased?: boolean; // disables checking all requests for event based data, which may slow down app or cause high requests
+      fetchEventBasedConcurrency?: number; // set the concurrency for fetching event based data on requests, default 5
     },
     // other chains follow the same configuration schema
   },

--- a/packages/sdk/src/oracle/client.ts
+++ b/packages/sdk/src/oracle/client.ts
@@ -220,7 +220,8 @@ export function factory(
       "poller"
     );
     // updates event based data on all requests
-    !chainConfig.disableFetchEventBased && poller.types.fetchEventBased.create({ chainId: Number(chainId) }, "poller");
+    if (!chainConfig.disableFetchEventBased)
+      poller.types.fetchEventBased.create({ chainId: Number(chainId) }, "poller");
   }
   // create active request poller for all chains. Should only have one of these
   poller.types.pollActiveRequest.create(undefined, "poller");

--- a/packages/sdk/src/oracle/client.ts
+++ b/packages/sdk/src/oracle/client.ts
@@ -219,6 +219,8 @@ export function factory(
       { chainId: Number(chainId), pollRateSec: chainConfig.checkTxIntervalSec },
       "poller"
     );
+    // updates event based data on all requests
+    !chainConfig.disableFetchEventBased && poller.types.fetchEventBased.create({ chainId: Number(chainId) }, "poller");
   }
   // create active request poller for all chains. Should only have one of these
   poller.types.pollActiveRequest.create(undefined, "poller");

--- a/packages/sdk/src/oracle/services/optimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/optimisticOracle.ts
@@ -25,7 +25,7 @@ export class OptimisticOracle implements OracleInterface {
   private upsertRequest = (request: RawRequest): Request => {
     const id = requestId(request);
     const cachedRequest = this.requests[id] || {};
-    const update = { ...cachedRequest, ...request, chainId: this.chainId };
+    const update = { ...cachedRequest, ...request, chainId: this.chainId, eventBased: false };
     this.requests[id] = update;
     return update;
   };

--- a/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
+++ b/packages/sdk/src/oracle/services/skinnyOptimisticOracle.ts
@@ -53,7 +53,7 @@ export class SkinnyOptimisticOracle implements OracleInterface {
   private upsertRequest = (request: Omit<Request, "chainId">): Request => {
     const id = requestId(request);
     const cachedRequest = this.requests[id] || {};
-    const update = { ...cachedRequest, ...request, chainId: this.chainId };
+    const update = { ...cachedRequest, ...request, chainId: this.chainId, eventBased: false };
     this.requests[id] = update;
     return update;
   };

--- a/packages/sdk/src/oracle/services/statemachines/fetchEventBased.ts
+++ b/packages/sdk/src/oracle/services/statemachines/fetchEventBased.ts
@@ -1,0 +1,32 @@
+import bluebird from "bluebird";
+import { Update } from "../update";
+import Store from "../../store";
+import { Handlers as GenericHandlers } from "../../types/statemachine";
+import { ContextClient } from "./utils";
+
+// required exports for state machine
+export type Params = {
+  chainId: number;
+  concurrency?: number;
+  pollRateSec?: number;
+};
+
+export type Memory = undefined;
+
+export function initMemory(): Memory {
+  return undefined;
+}
+
+export function Handlers(store: Store): GenericHandlers<Params, Memory> {
+  const update = new Update(store);
+  return {
+    async start(params: Params, memory: Memory, ctx: ContextClient): Promise<void | undefined> {
+      const { chainId, pollRateSec = 15, concurrency = 5 } = params;
+      const oracle = store.read().oracleService(chainId);
+      const requests = oracle.listRequests();
+      const requestsToFetch = requests.filter((request) => request.eventBased === undefined);
+      await bluebird.map(requestsToFetch, (request) => update.request(request), { concurrency });
+      return ctx.sleep(pollRateSec * 1000);
+    },
+  };
+}

--- a/packages/sdk/src/oracle/services/statemachines/index.ts
+++ b/packages/sdk/src/oracle/services/statemachines/index.ts
@@ -10,6 +10,7 @@ export * as fetchPastEvents from "./fetchPastEvents";
 export * as pollNewEvents from "./pollNewEvents";
 export * as setActiveRequestByTransaction from "./setActiveRequestByTransaction";
 export * as settle from "./settle";
+export * as fetchEventBased from "./fetchEventBased";
 
 export * from "./statemachine";
 export * from "./utils";

--- a/packages/sdk/src/oracle/services/statemachines/statemachine.ts
+++ b/packages/sdk/src/oracle/services/statemachines/statemachine.ts
@@ -17,6 +17,7 @@ import * as pollNewEvents from "./pollNewEvents";
 import * as updateActiveRequest from "./updateActiveRequest";
 import * as settle from "./settle";
 import * as setActiveRequestByTransaction from "./setActiveRequestByTransaction";
+import * as fetchEventBased from "./fetchEventBased";
 
 /**
  * StateMachine. This class will be used to handle all change requests by the user, including setting state which
@@ -55,6 +56,7 @@ export class StateMachine {
     >;
     [ContextType.settle]: ContextManager<settle.Params, settle.Memory>;
     [ContextType.updateActiveRequest]: ContextManager<updateActiveRequest.Params, updateActiveRequest.Memory>;
+    [ContextType.fetchEventBased]: ContextManager<fetchEventBased.Params, fetchEventBased.Memory>;
   };
   constructor(private store: Store) {
     // need to initizlie state types here manually for each new context type
@@ -144,6 +146,12 @@ export class StateMachine {
         ContextType.updateActiveRequest,
         updateActiveRequest.Handlers(store),
         updateActiveRequest.initMemory,
+        this.handleCreate
+      ),
+      [ContextType.fetchEventBased]: new ContextManager<fetchEventBased.Params, fetchEventBased.Memory>(
+        ContextType.fetchEventBased,
+        fetchEventBased.Handlers(store),
+        fetchEventBased.initMemory,
         this.handleCreate
       ),
     };
@@ -280,6 +288,13 @@ export class StateMachine {
         case ContextType.updateActiveRequest: {
           next = await this.types[context.type].step(
             (context as unknown) as Context<updateActiveRequest.Params, updateActiveRequest.Memory>,
+            now
+          );
+          break;
+        }
+        case ContextType.fetchEventBased: {
+          next = await this.types[context.type].step(
+            (context as unknown) as Context<fetchEventBased.Params, fetchEventBased.Memory>,
             now
           );
           break;

--- a/packages/sdk/src/oracle/types/state.ts
+++ b/packages/sdk/src/oracle/types/state.ts
@@ -45,6 +45,7 @@ export type ChainConfig = ChainMetadata & {
   // requests older than this. If not specified, we will lookback to block 0 when considering request history.
   earliestBlockNumber?: number;
   maxEventRangeQuery?: number;
+  disableFetchEventBased?: boolean;
 };
 
 export type InputRequestWithOracleType = InputRequest & { oracleType: OracleType };

--- a/packages/sdk/src/oracle/types/statemachine.ts
+++ b/packages/sdk/src/oracle/types/statemachine.ts
@@ -19,6 +19,7 @@ export enum ContextType {
   setActiveRequestByTransaction = "setActiveRequestByTransaction",
   settle = "settle",
   updateActiveRequest = "updateActiveRequest",
+  fetchEventBased = "fetchEventBased",
 }
 
 export type ContextProps = {


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We need the ability to know if requests have event based expiry in the OO app index page. Currently the index page lists requests based on events, which do not include the event based expiry data. 

**Summary**
This adds a polling command which searches for any requests without event based expiry data, and makes a request to teh contract to fetch it if it doesnt exist. Previously this would only be fetched once a user selected the request and navigated to detail page. 

**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

This was tested locally by integrating it into the frontend. 


