### PR TITLE
feat: data asserter contract

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
@@ -18,7 +18,7 @@ contract DataAsserter {
 
     struct DataAssertion {
         bytes32 dataId; // The dataId that was asserted.
-        uint256 data; // This could be an arbitrary data type.
+        bytes32 data; // This could be an arbitrary data type.
         address asserter; // The address that made the assertion.
         bytes32 oaAssertionId; // The optimistic assertor assertion ID.
         bool resolved; // Whether the assertion has been resolved.
@@ -28,9 +28,9 @@ contract DataAsserter {
 
     mapping(bytes32 => DataAssertion) public assertionsData;
 
-    event DataAsserted(bytes32 indexed dataId, uint256 data, address indexed asserter, bytes32 oaAssertionId);
+    event DataAsserted(bytes32 indexed dataId, bytes32 data, address indexed asserter, bytes32 oaAssertionId);
 
-    event DataAssertionResolved(bytes32 indexed dataId, uint256 data, address indexed asserter, bytes32 oaAssertionId);
+    event DataAssertionResolved(bytes32 indexed dataId, bytes32 data, address indexed asserter, bytes32 oaAssertionId);
 
     constructor(address _defaultCurrency, address _optimisticAssertor) {
         defaultCurrency = IERC20(_defaultCurrency);
@@ -39,7 +39,7 @@ contract DataAsserter {
     }
 
     // For a given dataId and asserter, returns a boolean indicating whether the data is accessible and the data itself.
-    function getData(bytes32 dataId, address asserter) public view returns (bool, uint256) {
+    function getData(bytes32 dataId, address asserter) public view returns (bool, bytes32) {
         bytes32 dataAssertionId = getAssertionId(dataId, asserter);
         if (!assertionsData[dataAssertionId].resolved) return (false, 0);
         return (true, assertionsData[dataAssertionId].data);
@@ -48,7 +48,7 @@ contract DataAsserter {
     // Asserts data for a specific dataId on behalf of an asserter address.
     function assertDataFor(
         bytes32 dataId,
-        uint256 data,
+        bytes32 data,
         address asserter
     ) public {
         bytes32 dataAssertionId = getAssertionId(dataId, asserter);

--- a/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
@@ -60,12 +60,15 @@ contract DataAsserter {
         defaultCurrency.safeApprove(address(oa), bond);
         oaAssertionId = oa.assertTruthFor(
             abi.encodePacked(
-                "Data : ",
-                AncillaryData.toUtf8BytesUint(data),
-                " is valid for request 0x",
+                "Data asserted for dataAssertionId: 0x",
                 AncillaryData.toUtf8Bytes(dataAssertionId),
+                " and asserter: 0x",
+                AncillaryData.toUtf8BytesAddress(asserter),
+                " at timestamp: ",
+                AncillaryData.toUtf8BytesUint(block.timestamp),
                 "in the DataAsserter contract at 0x",
-                AncillaryData.toUtf8BytesAddress(address(this))
+                AncillaryData.toUtf8BytesAddress(address(this)),
+                " is valid."
             ),
             asserter,
             address(this),

--- a/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
@@ -64,7 +64,7 @@ contract DataAsserter {
                 AncillaryData.toUtf8BytesUint(data),
                 " is valid for request 0x",
                 AncillaryData.toUtf8Bytes(dataAssertionId),
-                "in the InternalAssertor contract at 0x",
+                "in the DataAsserter contract at 0x",
                 AncillaryData.toUtf8BytesAddress(address(this))
             ),
             asserter,

--- a/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
@@ -39,7 +39,7 @@ contract DataAsserter {
         defaultIdentifier = oa.defaultIdentifier();
     }
 
-    // Returns a bool of whether the data is available and the data.
+    // For a given dataId and asserter, returns a boolean indicating whether the data is accessible and the data itself.
     function getData(bytes32 dataId, address asserter) public view returns (bool, uint256) {
         bytes32 dataAssertionId = getAssertionId(dataId, asserter);
         if (!assertionsResolved[dataAssertionId]) return (false, 0);

--- a/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "../../interfaces/OptimisticAssertorInterface.sol";
+import "../../../common/implementation/AncillaryData.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+// This contract allows assertions on any form of data to be made using the UMA Optimistic Assertor and stores the
+// proposed value so that it may be retrieved on chain. It only enables one assertion per pair of dataId and asserter
+// address. The dataId is intended to be an arbitrary value that uniquely identifies a specific piece of information in
+// the consuming contract and is replaceable. Similarly, any data structure can be used to replace the asserted data.
+contract DataAsserter {
+    using SafeERC20 for IERC20;
+    IERC20 public immutable defaultCurrency;
+    OptimisticAssertorInterface public immutable oa;
+    uint256 public constant assertionLiveness = 7200;
+    bytes32 public immutable defaultIdentifier;
+
+    struct DataAssertion {
+        uint256 data; // This could be any data type.
+        address asserter; // The asserter address, both with the data, they uniquely identify the assertion.
+    }
+
+    mapping(bytes32 => bytes32) public oaIdsToInternalIds;
+
+    mapping(bytes32 => bool) public assertionsResolved;
+
+    mapping(bytes32 => DataAssertion) public assertionsData;
+
+    event DataAsserted(bytes32 indexed dataAssertionId, uint256 data, address indexed asserter);
+
+    event DataAssertionResolved(bytes32 indexed dataAssertionId);
+
+    constructor(address _defaultCurrency, address _optimisticAssertor) {
+        defaultCurrency = IERC20(_defaultCurrency);
+        oa = OptimisticAssertorInterface(_optimisticAssertor);
+        defaultIdentifier = oa.defaultIdentifier();
+    }
+
+    // Returns a bool of whether the data is available and the data.
+    function getData(bytes32 dataId, address asserter) public view returns (bool, uint256) {
+        return _getData(_getAssertionId(dataId, asserter));
+    }
+
+    // Returns a bool of whether the data is available and the data.
+    function getData(bytes32 internalDataId) public view returns (bool, uint256) {
+        return _getData(internalDataId);
+    }
+
+    // Asserts data for a specific dataId on behalf of an asserter address.
+    function assertDataFor(
+        bytes32 dataId, // This could be any data type.
+        uint256 data, // This could be any data type.
+        address asserter
+    ) public returns (bytes32 dataAssertionId, bytes32 oaAssertionId) {
+        dataAssertionId = _getAssertionId(dataId, asserter);
+        require(assertionsData[dataAssertionId].asserter == address(0), "Data already asserted");
+        uint256 bond = oa.getMinimumBond(address(defaultCurrency));
+        defaultCurrency.safeTransferFrom(msg.sender, address(this), bond);
+        defaultCurrency.safeApprove(address(oa), bond);
+        oaAssertionId = oa.assertTruthFor(
+            abi.encodePacked(
+                "Data : ",
+                AncillaryData.toUtf8BytesUint(data),
+                " is valid for request 0x",
+                AncillaryData.toUtf8Bytes(dataAssertionId),
+                "in the InternalAssertor contract at 0x",
+                AncillaryData.toUtf8BytesAddress(address(this))
+            ),
+            asserter,
+            address(this),
+            address(0), // No sovereign security manager.
+            defaultCurrency,
+            bond,
+            assertionLiveness,
+            defaultIdentifier
+        );
+        assertionsData[dataAssertionId] = DataAssertion({ data: data, asserter: asserter });
+        oaIdsToInternalIds[oaAssertionId] = dataAssertionId;
+        emit DataAsserted(dataAssertionId, data, asserter);
+    }
+
+    // OptimisticAssertor callback.
+    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public {
+        require(msg.sender == address(oa));
+        // If the assertion was true, then the data assertion is resolved.
+        if (assertedTruthfully) {
+            assertionsResolved[oaIdsToInternalIds[assertionId]] = true;
+            emit DataAssertionResolved(oaIdsToInternalIds[assertionId]);
+        } else {
+            // Delete the data assertion if it was false so the same asserter can assert it again.
+            delete assertionsData[oaIdsToInternalIds[assertionId]];
+        }
+    }
+
+    // If assertion is disputed, do nothing and wait for resolution.
+    // This OptimisticAssertor callback function needs to be defined so the OA doesn't revert when it tries to call it.
+    function assertionDisputed(bytes32 assertionId) public {}
+
+    function _getData(bytes32 internalDataId) internal view returns (bool, uint256) {
+        if (!assertionsResolved[internalDataId]) return (false, 0);
+        return (true, assertionsData[internalDataId].data);
+    }
+
+    function _getAssertionId(bytes32 dataId, address asserter) internal pure returns (bytes32) {
+        return keccak256(abi.encode(dataId, asserter));
+    }
+}

--- a/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/examples/DataAsserter.sol
@@ -66,7 +66,7 @@ contract DataAsserter {
                     AncillaryData.toUtf8BytesAddress(asserter),
                     " at timestamp: ",
                     AncillaryData.toUtf8BytesUint(block.timestamp),
-                    "in the DataAsserter contract at 0x",
+                    " in the DataAsserter contract at 0x",
                     AncillaryData.toUtf8BytesAddress(address(this)),
                     " is valid."
                 ),

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -30,7 +30,7 @@ contract DataAsserterTest is Common {
         timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
 
         // Settle the assertion.
-        (, , , bytes32 oaAssertionId) =
+        (, , , bytes32 oaAssertionId, ) =
             dataAsserter.assertionsData(dataAsserter.getAssertionId(dataId, TestAddress.account1));
         optimisticAssertor.settleAssertion(oaAssertionId);
 
@@ -49,7 +49,7 @@ contract DataAsserterTest is Common {
         vm.stopPrank(); // Return caller address to standard.
 
         // Dispute assertion with Account2 and DVM votes that the original assertion was true.
-        (, , , bytes32 oaAssertionId) =
+        (, , , bytes32 oaAssertionId, ) =
             dataAsserter.assertionsData(dataAsserter.getAssertionId(dataId, TestAddress.account1));
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
         _mockOracleResolved(address(mockOracle), oracleRequest, true);
@@ -71,14 +71,14 @@ contract DataAsserterTest is Common {
         bytes32 dataAssertionId = dataAsserter.getAssertionId(dataId, TestAddress.account1);
 
         // Dispute assertion with Account2 and DVM votes that the original assertion was wrong.
-        (, , , bytes32 oaAssertionId) = dataAsserter.assertionsData(dataAssertionId);
+        (, , , bytes32 oaAssertionId, ) = dataAsserter.assertionsData(dataAssertionId);
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
         _mockOracleResolved(address(mockOracle), oracleRequest, false);
         assertFalse(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
 
         // Check that the data assertion has been deleted
 
-        (, , , oaAssertionId) = dataAsserter.assertionsData(dataAssertionId);
+        (, , , oaAssertionId, ) = dataAsserter.assertionsData(dataAssertionId);
         assertEq(oaAssertionId, bytes32(0));
 
         (bool dataAvailable, uint256 data) = dataAsserter.getData(dataId, TestAddress.account1);
@@ -98,7 +98,7 @@ contract DataAsserterTest is Common {
         timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
 
         // Settle the assertion.
-        (, , , bytes32 oaAssertionId2) =
+        (, , , bytes32 oaAssertionId2, ) =
             dataAsserter.assertionsData(dataAsserter.getAssertionId(dataId, TestAddress.account1));
         optimisticAssertor.settleAssertion(oaAssertionId2);
 

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -97,21 +97,4 @@ contract DataAsserterTest is Common {
         assertTrue(dataAvailable);
         assertEq(data, correctData);
     }
-
-    function test_RevertIf_AssertionAlreadyExists() public {
-        // Assert data.
-        vm.startPrank(TestAddress.account1);
-        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
-        vm.stopPrank();
-
-        // Assert data again with a different value.
-        vm.startPrank(TestAddress.account1);
-        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        vm.expectRevert("Assertion already exists");
-        dataAsserter.assertDataFor(dataId, incorrectData, TestAddress.account1);
-        vm.stopPrank();
-    }
 }

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -6,8 +6,8 @@ import "../../../../contracts/optimistic-assertor/implementation/examples/DataAs
 contract DataAsserterTest is Common {
     DataAsserter public dataAsserter;
     bytes32 dataId = bytes32("dataId");
-    uint256 correctData = 1000;
-    uint256 incorrectData = 2000;
+    bytes32 correctData = bytes32("correctData");
+    bytes32 incorrectData = bytes32("incorrectData");
 
     function setUp() public {
         _commonSetup();
@@ -23,7 +23,7 @@ contract DataAsserterTest is Common {
         vm.stopPrank(); // Return caller address to standard.
 
         // Assertion data should not be available before the liveness period.
-        (bool dataAvailable, uint256 data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (bool dataAvailable, bytes32 data) = dataAsserter.getData(dataId, TestAddress.account1);
         assertFalse(dataAvailable);
 
         // Move time forward to allow for the assertion to expire.
@@ -55,7 +55,7 @@ contract DataAsserterTest is Common {
         _mockOracleResolved(address(mockOracle), oracleRequest, true);
         assertTrue(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
 
-        (bool dataAvailable, uint256 data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (bool dataAvailable, bytes32 data) = dataAsserter.getData(dataId, TestAddress.account1);
         assertTrue(dataAvailable);
         assertEq(data, correctData);
     }
@@ -81,7 +81,7 @@ contract DataAsserterTest is Common {
         (, , , oaAssertionId, ) = dataAsserter.assertionsData(dataAssertionId);
         assertEq(oaAssertionId, bytes32(0));
 
-        (bool dataAvailable, uint256 data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (bool dataAvailable, bytes32 data) = dataAsserter.getData(dataId, TestAddress.account1);
         assertFalse(dataAvailable);
 
         // Increase time in the evm

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+import "../Common.sol";
+import "../../../../contracts/optimistic-assertor/implementation/examples/DataAsserter.sol";
+
+contract DataAsserterTest is Common {
+    DataAsserter public dataAsserter;
+    bytes32 dataId = bytes32("dataId");
+    uint256 correctData = 1000;
+    uint256 incorrectData = 2000;
+
+    function setUp() public {
+        _commonSetup();
+        dataAsserter = new DataAsserter(address(defaultCurrency), address(optimisticAssertor));
+    }
+
+    function test_DataAssertionNoDispute() public {
+        // Assert data.
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        (bytes32 dataAssertionId, bytes32 oaAssertionId) =
+            dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
+        vm.stopPrank(); // Return caller address to standard.
+
+        // Assertion data should not be available before the liveness period.
+        (bool dataAvailable, uint256 data) = dataAsserter.getData(dataAssertionId);
+        assertFalse(dataAvailable);
+
+        // Move time forward to allow for the assertion to expire.
+        timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
+
+        // Settle the assertion.
+        optimisticAssertor.settleAssertion(oaAssertionId);
+
+        // Data should now be available.
+        (dataAvailable, data) = dataAsserter.getData(dataAssertionId);
+        assertTrue(dataAvailable);
+        assertEq(data, correctData);
+
+        // Test getData overloaded function.
+        (dataAvailable, data) = dataAsserter.getData(dataId, TestAddress.account1);
+        assertTrue(dataAvailable);
+        assertEq(data, correctData);
+    }
+
+    function test_DataAssertionWithWrongDispute() public {
+        // Assert data.
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        (bytes32 dataAssertionId, bytes32 oaAssertionId) =
+            dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
+        vm.stopPrank(); // Return caller address to standard.
+
+        // Dispute assertion with Account2 and DVM votes that the original assertion was true.
+        OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
+        _mockOracleResolved(address(mockOracle), oracleRequest, true);
+        assertTrue(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
+
+        (bool dataAvailable, uint256 data) = dataAsserter.getData(dataAssertionId);
+        assertTrue(dataAvailable);
+        assertEq(data, correctData);
+    }
+
+    function test_DataAssertionWithCorrectDispute() public {
+        // Assert data.
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        (bytes32 dataAssertionId, bytes32 oaAssertionId) =
+            dataAsserter.assertDataFor(dataId, incorrectData, TestAddress.account1);
+        vm.stopPrank(); // Return caller address to standard.
+
+        // Dispute assertion with Account2 and DVM votes that the original assertion was wrong.
+        OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
+        _mockOracleResolved(address(mockOracle), oracleRequest, false);
+        assertFalse(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
+
+        (bool dataAvailable, uint256 data) = dataAsserter.getData(dataAssertionId);
+        assertFalse(dataAvailable);
+
+        // Same asserter should be able to re-assert the correct data.
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        (bytes32 dataAssertionId2, bytes32 oaAssertionId2) =
+            dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
+        vm.stopPrank(); // Return caller address to standard.
+
+        // Move time forward to allow for the assertion to expire.
+        timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
+
+        // Settle the assertion.
+        optimisticAssertor.settleAssertion(oaAssertionId2);
+
+        // Data should now be available.
+        (dataAvailable, data) = dataAsserter.getData(dataAssertionId2);
+        assertTrue(dataAvailable);
+        assertEq(data, correctData);
+    }
+
+    function test_RevertIf_AssertionAlreadyExists() public {
+        // Assert data.
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        (bytes32 dataAssertionId, ) = dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
+        vm.stopPrank();
+
+        // Assert data again with a different value.
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
+        vm.expectRevert("Data already asserted");
+        (bytes32 dataAssertionId2, ) = dataAsserter.assertDataFor(dataId, incorrectData, TestAddress.account1);
+        vm.stopPrank();
+    }
+}

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -30,7 +30,7 @@ contract DataAsserterTest is Common {
         timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
 
         // Settle the assertion.
-        (, bytes32 oaAssertionId) =
+        (, , , bytes32 oaAssertionId) =
             dataAsserter.assertionsData(dataAsserter.getAssertionId(dataId, TestAddress.account1));
         optimisticAssertor.settleAssertion(oaAssertionId);
 
@@ -49,7 +49,7 @@ contract DataAsserterTest is Common {
         vm.stopPrank(); // Return caller address to standard.
 
         // Dispute assertion with Account2 and DVM votes that the original assertion was true.
-        (, bytes32 oaAssertionId) =
+        (, , , bytes32 oaAssertionId) =
             dataAsserter.assertionsData(dataAsserter.getAssertionId(dataId, TestAddress.account1));
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
         _mockOracleResolved(address(mockOracle), oracleRequest, true);
@@ -71,14 +71,14 @@ contract DataAsserterTest is Common {
         bytes32 dataAssertionId = dataAsserter.getAssertionId(dataId, TestAddress.account1);
 
         // Dispute assertion with Account2 and DVM votes that the original assertion was wrong.
-        (, bytes32 oaAssertionId) = dataAsserter.assertionsData(dataAssertionId);
+        (, , , bytes32 oaAssertionId) = dataAsserter.assertionsData(dataAssertionId);
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
         _mockOracleResolved(address(mockOracle), oracleRequest, false);
         assertFalse(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
 
         // Check that the data assertion has been deleted
 
-        (, oaAssertionId) = dataAsserter.assertionsData(dataAssertionId);
+        (, , , oaAssertionId) = dataAsserter.assertionsData(dataAssertionId);
         assertEq(oaAssertionId, bytes32(0));
 
         (bool dataAvailable, uint256 data) = dataAsserter.getData(dataId, TestAddress.account1);
@@ -98,7 +98,7 @@ contract DataAsserterTest is Common {
         timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
 
         // Settle the assertion.
-        (, bytes32 oaAssertionId2) =
+        (, , , bytes32 oaAssertionId2) =
             dataAsserter.assertionsData(dataAsserter.getAssertionId(dataId, TestAddress.account1));
         optimisticAssertor.settleAssertion(oaAssertionId2);
 

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -77,8 +77,15 @@ contract DataAsserterTest is Common {
         _mockOracleResolved(address(mockOracle), oracleRequest, false);
         assertFalse(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
 
+        // Check that the data assertion has been deleted
+        (, address asserter) = dataAsserter.assertionsData(dataAssertionId);
+        assertEq(asserter, address(0));
+
         (bool dataAvailable, uint256 data) = dataAsserter.getData(dataAssertionId);
         assertFalse(dataAvailable);
+
+        // Increase time in the evm
+        vm.warp(block.timestamp + 1);
 
         // Same asserter should be able to re-assert the correct data.
         vm.startPrank(TestAddress.account1);

--- a/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
+++ b/packages/core/test/foundry/optimistic-assertor/examples/DataAsserter.t.sol
@@ -19,21 +19,21 @@ contract DataAsserterTest is Common {
         vm.startPrank(TestAddress.account1);
         defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
         defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        bytes32 oaAssertionId = dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
+        bytes32 assertionId = dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
         vm.stopPrank(); // Return caller address to standard.
 
         // Assertion data should not be available before the liveness period.
-        (bool dataAvailable, bytes32 data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (bool dataAvailable, bytes32 data) = dataAsserter.getData(assertionId);
         assertFalse(dataAvailable);
 
         // Move time forward to allow for the assertion to expire.
         timer.setCurrentTime(timer.getCurrentTime() + dataAsserter.assertionLiveness());
 
         // Settle the assertion.
-        optimisticAssertor.settleAssertion(oaAssertionId);
+        optimisticAssertor.settleAssertion(assertionId);
 
         // Data should now be available.
-        (dataAvailable, data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (dataAvailable, data) = dataAsserter.getData(assertionId);
         assertTrue(dataAvailable);
         assertEq(data, correctData);
     }
@@ -43,15 +43,15 @@ contract DataAsserterTest is Common {
         vm.startPrank(TestAddress.account1);
         defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
         defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        bytes32 oaAssertionId = dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
+        bytes32 assertionId = dataAsserter.assertDataFor(dataId, correctData, TestAddress.account1);
         vm.stopPrank(); // Return caller address to standard.
 
         // Dispute assertion with Account2 and DVM votes that the original assertion was true.
-        OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
+        OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId);
         _mockOracleResolved(address(mockOracle), oracleRequest, true);
-        assertTrue(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
+        assertTrue(optimisticAssertor.settleAndGetAssertion(assertionId));
 
-        (bool dataAvailable, bytes32 data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (bool dataAvailable, bytes32 data) = dataAsserter.getData(assertionId);
         assertTrue(dataAvailable);
         assertEq(data, correctData);
     }
@@ -61,21 +61,19 @@ contract DataAsserterTest is Common {
         vm.startPrank(TestAddress.account1);
         defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
         defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        bytes32 oaAssertionId = dataAsserter.assertDataFor(dataId, incorrectData, TestAddress.account1);
+        bytes32 assertionId = dataAsserter.assertDataFor(dataId, incorrectData, TestAddress.account1);
         vm.stopPrank(); // Return caller address to standard.
 
-        bytes32 dataAssertionId = dataAsserter.getAssertionId(dataId, TestAddress.account1);
-
         // Dispute assertion with Account2 and DVM votes that the original assertion was wrong.
-        OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(oaAssertionId);
+        OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId);
         _mockOracleResolved(address(mockOracle), oracleRequest, false);
-        assertFalse(optimisticAssertor.settleAndGetAssertion(oaAssertionId));
+        assertFalse(optimisticAssertor.settleAndGetAssertion(assertionId));
 
         // Check that the data assertion has been deleted
-        (, , address asserter, ) = dataAsserter.assertionsData(dataAssertionId);
+        (, , address asserter, ) = dataAsserter.assertionsData(assertionId);
         assertEq(asserter, address(0));
 
-        (bool dataAvailable, bytes32 data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (bool dataAvailable, bytes32 data) = dataAsserter.getData(assertionId);
         assertFalse(dataAvailable);
 
         // Increase time in the evm
@@ -95,7 +93,7 @@ contract DataAsserterTest is Common {
         optimisticAssertor.settleAssertion(oaAssertionId2);
 
         // Data should now be available.
-        (dataAvailable, data) = dataAsserter.getData(dataId, TestAddress.account1);
+        (dataAvailable, data) = dataAsserter.getData(oaAssertionId2);
         assertTrue(dataAvailable);
         assertEq(data, correctData);
     }
@@ -112,7 +110,7 @@ contract DataAsserterTest is Common {
         vm.startPrank(TestAddress.account1);
         defaultCurrency.allocateTo(TestAddress.account1, optimisticAssertor.getMinimumBond(address(defaultCurrency)));
         defaultCurrency.approve(address(dataAsserter), optimisticAssertor.getMinimumBond(address(defaultCurrency)));
-        vm.expectRevert("Data already asserted");
+        vm.expectRevert("Assertion already exists");
         dataAsserter.assertDataFor(dataId, incorrectData, TestAddress.account1);
         vm.stopPrank();
     }


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

This contract allows assertions on any form of data to be made using the UMA Optimistic Assertor and stores the
proposed value so that it may be retrieved on chain. It only enables one assertion per pair of dataId and asserter
address. The dataId is intended to be an arbitrary value that uniquely identifies a specific piece of information in
the consuming contract and is replaceable. Similarly, any data structure can be used to replace the asserted data.


**Summary**

- `DataAsserter` contract
- Tests

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
