### PR TITLE
chore: Export MerkleTree from /common

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uma/common",
-  "version": "2.28.2",
+  "version": "2.28.3",
   "description": "Common js utilities used by other UMA packages",
   "homepage": "http://umaproject.org",
   "license": "AGPL-3.0-or-later",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ export * from "./gckms/ManagedSecretProvider";
 export * from "./gckms/utils";
 export * from "./FileHelpers";
 export * from "./MetaMaskTruffleProvider";
+export * from "./MerkleTree";
 export * from "./ProviderUtils";
 export * from "./HardhatConfig";
 export * from "./RetryProvider";


### PR DESCRIPTION
Can now import `MerkleTree` from `@uma/common`