### PR TITLE
feat(core): store claimId in oa

### DIFF
--- a/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
+++ b/packages/core/contracts/optimistic-assertor/implementation/OptimisticAssertor.sol
@@ -108,6 +108,7 @@ contract OptimisticAssertor is Lockable, OptimisticAssertorInterface, Ownable {
             bond: bond,
             assertionTime: getCurrentTime(),
             expirationTime: getCurrentTime() + liveness,
+            claimId: keccak256(claim),
             identifier: identifier,
             ssmSettings: SsmSettings({
                 useDisputeResolution: true, // this is the default behavior: if not specified by the Sovereign security manager the assertion will respect the DVM result.

--- a/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
+++ b/packages/core/contracts/optimistic-assertor/interfaces/OptimisticAssertorInterface.sol
@@ -23,6 +23,7 @@ interface OptimisticAssertorInterface {
         uint256 bond;
         uint256 assertionTime; // Time of the assertion.
         uint256 expirationTime;
+        bytes32 claimId;
         bytes32 identifier;
         SsmSettings ssmSettings;
     }


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Some Sovereign Security implementations might want to apply policies per unique claim (e.g. if there is another assertion after dispute).


**Summary**

Stores hashed claim as `claimId` in `Assertion` struct that that can be accessed in `readAssertion` method.




**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


