### PR TITLE
feat: continue adding small OA refinements

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -90,8 +90,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         bytes32 identifier
     ) public returns (bytes32) {
         proposer = proposer == address(0) ? msg.sender : proposer;
-        bytes32 assertionId =
-            _getId(claim, bond, liveness, currency, proposer, callbackRecipient, sovereignSecurity, identifier);
+        bytes32 assertionId = _getId(claim, bond, liveness, currency, callbackRecipient, sovereignSecurity, identifier);
 
         require(assertions[assertionId].proposer == address(0), "Assertion already exists");
         // TODO [GAS] caching identifier whitelist and collateral currency whitelist
@@ -144,6 +143,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
             proposer,
             callbackRecipient,
             sovereignSecurity,
+            msg.sender,
             currency,
             bond,
             assertions[assertionId].expirationTime // TODO [GAS] consider using a memory variable to avoid multiple reads
@@ -257,7 +257,6 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         uint256 bond,
         uint256 liveness,
         IERC20 currency,
-        address proposer,
         address callbackRecipient,
         address sovereignSecurity,
         bytes32 identifier
@@ -266,16 +265,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         return
             keccak256(
                 // TODO change order of abi.encode arguments to do potential gas savings
-                abi.encode(
-                    claim,
-                    bond,
-                    liveness,
-                    currency,
-                    proposer, // TODO get rid of this prop
-                    callbackRecipient,
-                    sovereignSecurity,
-                    identifier
-                )
+                abi.encode(claim, bond, liveness, currency, callbackRecipient, sovereignSecurity, identifier)
             );
     }
 
@@ -284,8 +274,8 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         return
             AncillaryData.appendKeyValueAddress(
                 AncillaryData.appendKeyValueBytes32("", "assertionId", assertionId),
-                "aoRequester", // TODO change this oaAsserter
-                address(this) // TODO change to asserter
+                "oaRequester",
+                assertions[assertionId].proposer
             );
     }
 

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -259,8 +259,8 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         return
             AncillaryData.appendKeyValueAddress(
                 AncillaryData.appendKeyValueBytes32("", "assertionId", assertionId),
-                "oaRequester",
-                assertions[assertionId].proposer
+                "oaAsserter",
+                assertions[assertionId].asserter
             );
     }
 

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -56,6 +56,7 @@ interface OptimisticAsserterInterface {
         address indexed proposer,
         address callbackRecipient,
         address indexed sovereignSecurity,
+        address caller,
         IERC20 currency,
         uint256 bond,
         uint256 expirationTime

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -42,6 +42,7 @@ contract Common is Test {
         address indexed proposer,
         address callbackRecipient,
         address indexed sovereignSecurity,
+        address caller,
         IERC20 currency,
         uint256 bond,
         uint256 expirationTime

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
@@ -21,7 +21,6 @@ contract OptimisticAsserterEvents is Common {
                     defaultBond,
                     defaultLiveness,
                     address(defaultCurrency),
-                    TestAddress.account1,
                     address(0),
                     address(0),
                     defaultIdentifier
@@ -35,6 +34,7 @@ contract OptimisticAsserterEvents is Common {
             TestAddress.account1,
             address(0),
             address(0),
+            TestAddress.account1,
             defaultCurrency,
             defaultBond,
             timer.getCurrentTime() + defaultLiveness

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -21,7 +21,6 @@ contract SimpleAssertionsWithClaimOnly is Common {
                     defaultBond,
                     defaultLiveness,
                     address(defaultCurrency),
-                    TestAddress.account1,
                     address(0),
                     address(0),
                     defaultIdentifier


### PR DESCRIPTION
**Motivation**

This PR adds some additional refinements on the OA. In particular:
- change aoRequester oaAsserter in _stampAssertion
- change address(this) to asserter in stampAssertion
- get rid of proposer prop in getId
- add caller address(msg.sender) to the AssertionMade event.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
