### PR TITLE
feat: add setter for burned bond percentage

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -65,8 +65,8 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
     }
 
     function setBurnedBondPercentage(uint256 _burnedBondPercentage) public onlyOwner {
-        require(_burnedBondPercentage <= 1e18, "Burned bond > 1");
-        require(_burnedBondPercentage > 0, "Burned is 0");
+        require(_burnedBondPercentage <= 1e18, "Burned bond percentage > 100");
+        require(_burnedBondPercentage > 0, "Burned bond percentage is 0");
         burnedBondPercentage = _burnedBondPercentage;
         emit BurnedBondPercentageSet(_burnedBondPercentage);
     }
@@ -96,16 +96,8 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         bytes32 identifier
     ) public returns (bytes32) {
         asserter = asserter == address(0) ? msg.sender : asserter;
-        bytes32 assertionId = _getId(
-            claim,
-            bond,
-            liveness,
-            currency,
-            asserter,
-            callbackRecipient,
-            sovereignSecurity,
-            identifier
-        );
+        bytes32 assertionId =
+            _getId(claim, bond, liveness, currency, asserter, callbackRecipient, sovereignSecurity, identifier);
 
         require(assertions[assertionId].asserter == address(0), "Assertion already exists");
         // TODO [GAS] caching identifier whitelist and collateral currency whitelist

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -64,6 +64,13 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         return assertions[assertionId];
     }
 
+    function setBurnedBondPercentage(uint256 _burnedBondPercentage) public onlyOwner {
+        require(_burnedBondPercentage <= 1e18, "Burned bond > 1");
+        require(_burnedBondPercentage > 0, "Burned is 0");
+        burnedBondPercentage = _burnedBondPercentage;
+        emit BurnedBondPercentageSet(_burnedBondPercentage);
+    }
+
     function assertTruth(bytes memory claim) public returns (bytes32) {
         return
             assertTruthFor(
@@ -89,8 +96,16 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         bytes32 identifier
     ) public returns (bytes32) {
         asserter = asserter == address(0) ? msg.sender : asserter;
-        bytes32 assertionId =
-            _getId(claim, bond, liveness, currency, asserter, callbackRecipient, sovereignSecurity, identifier);
+        bytes32 assertionId = _getId(
+            claim,
+            bond,
+            liveness,
+            currency,
+            asserter,
+            callbackRecipient,
+            sovereignSecurity,
+            identifier
+        );
 
         require(assertions[assertionId].asserter == address(0), "Assertion already exists");
         // TODO [GAS] caching identifier whitelist and collateral currency whitelist

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -70,4 +70,6 @@ interface OptimisticAsserterInterface {
     );
 
     event AssertionDefaultsSet(IERC20 defaultCurrency, uint256 defaultBond, uint256 defaultLiveness);
+
+    event BurnedBondPercentageSet(uint256 burnedBondPercentage);
 }

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -161,6 +161,14 @@ contract Common is Test {
         return oracleRequest;
     }
 
+    function _allocateBondAndAssertTruth(address asserter, bytes memory claim) public returns (bytes32 assertionId) {
+        vm.startPrank(asserter);
+        defaultCurrency.allocateTo(asserter, optimisticAsserter.defaultBond());
+        defaultCurrency.approve(address(optimisticAsserter), optimisticAsserter.defaultBond());
+        assertionId = optimisticAsserter.assertTruth(claim);
+        vm.stopPrank();
+    }
+
     function _expectAssertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) internal {
         vm.expectCall(
             mockedCallbackRecipient,

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.EdgeCases.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.EdgeCases.t.sol
@@ -101,4 +101,14 @@ contract InvalidParameters is Common {
         optimisticAsserter.disputeAssertionFor(assertionId, address(0));
         vm.stopPrank();
     }
+
+    function test_RevertIf_BurnedBondPercentageSetOutOfBounds() public {
+        vm.expectRevert("Burned is 0");
+        vm.prank(TestAddress.owner);
+        optimisticAsserter.setBurnedBondPercentage(0);
+
+        vm.expectRevert("Burned bond > 1");
+        vm.prank(TestAddress.owner);
+        optimisticAsserter.setBurnedBondPercentage(2e18);
+    }
 }

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.EdgeCases.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.EdgeCases.t.sol
@@ -103,11 +103,11 @@ contract InvalidParameters is Common {
     }
 
     function test_RevertIf_BurnedBondPercentageSetOutOfBounds() public {
-        vm.expectRevert("Burned is 0");
+        vm.expectRevert("Burned bond percentage is 0");
         vm.prank(TestAddress.owner);
         optimisticAsserter.setBurnedBondPercentage(0);
 
-        vm.expectRevert("Burned bond > 1");
+        vm.expectRevert("Burned bond percentage > 100");
         vm.prank(TestAddress.owner);
         optimisticAsserter.setBurnedBondPercentage(2e18);
     }

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.0;
 import "./Common.sol";
 
 contract OptimisticAsserterEvents is Common {
+    event BurnedBondPercentageSet(uint256 burnedBondPercentage);
+
     function setUp() public {
         _commonSetup();
     }
@@ -62,5 +64,12 @@ contract OptimisticAsserterEvents is Common {
         vm.expectEmit(true, true, true, true);
         emit AssertionSettled(assertionId, TestAddress.account2, true, false);
         assertFalse(optimisticAsserter.settleAndGetAssertionResult(assertionId));
+    }
+
+    function test_BurnedBondPercentageSetEmitted() public {
+        vm.expectEmit(true, true, true, true);
+        emit BurnedBondPercentageSet(0.3e18);
+        vm.prank(TestAddress.owner);
+        optimisticAsserter.setBurnedBondPercentage(0.3e18);
     }
 }

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -130,16 +130,16 @@ contract SimpleAssertionsWithClaimOnly is Common {
             assertEq(defaultCurrency.balanceOf(TestAddress.account1), 0);
 
             // The disputer should have kept their bond and earned 1 - burnedBondPercentage of the asserter's bond.
-            uint256 expectAmount = minimumBond * 2 - (optimisticAsserter.burnedBondPercentage() * minimumBond) / 1e18;
-            assertEq(defaultCurrency.balanceOf(TestAddress.account2) - asserterBalanceBefore, expectAmount);
+            uint256 expectedAmount = minimumBond * 2 - (optimisticAsserter.burnedBondPercentage() * minimumBond) / 1e18;
+            assertEq(defaultCurrency.balanceOf(TestAddress.account2) - asserterBalanceBefore, expectedAmount);
 
-            // // The store should have kept the burnedBondPercentage part of the asserter's bond.
+            // The store should have kept the burnedBondPercentage part of the asserter's bond.
             assertEq(
                 defaultCurrency.balanceOf(address(store)) - storeBalanceBefore,
                 (minimumBond * optimisticAsserter.burnedBondPercentage()) / 1e18
             );
 
-            // // The balance of the optimistic asserter should be zero.
+            // The balance of the optimistic asserter should be zero.
             assertEq(defaultCurrency.balanceOf(address(optimisticAsserter)), 0);
         }
     }

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -124,7 +124,7 @@ contract SimpleAssertionsWithClaimOnly is Common {
             uint256 storeBalanceBefore = defaultCurrency.balanceOf(address(store));
             OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId, minimumBond);
             _mockOracleResolved(address(mockOracle), oracleRequest, false);
-            assertFalse(optimisticAsserter.settleAndGetAssertion(assertionId));
+            assertFalse(optimisticAsserter.settleAndGetAssertionResult(assertionId));
 
             // The asserter should have lost their bond.
             assertEq(defaultCurrency.balanceOf(TestAddress.account1), 0);

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -100,4 +100,47 @@ contract SimpleAssertionsWithClaimOnly is Common {
         // The balance of the optimistic asserter should be zero.
         assertEq(defaultCurrency.balanceOf(address(optimisticAsserter)), 0);
     }
+
+    function test_AssertionWithDifferentBurnedBondPercentage() public {
+        uint64[10] memory burnedBondPercentages =
+            [0.1e18, 0.2e18, 0.3e18, 0.4e18, 0.5e18, 0.6e18, 0.7e18, 0.8e18, 0.9e18, 1e18];
+        for (uint256 i = 0; i < burnedBondPercentages.length; i++) {
+            vm.startPrank(TestAddress.owner);
+            optimisticAsserter.setBurnedBondPercentage(burnedBondPercentages[i]);
+            uint256 minimumBond = optimisticAsserter.getMinimumBond(address(defaultCurrency));
+            optimisticAsserter.setAssertionDefaults(
+                optimisticAsserter.defaultCurrency(),
+                minimumBond,
+                optimisticAsserter.defaultLiveness()
+            );
+            vm.stopPrank();
+            assertEq(optimisticAsserter.burnedBondPercentage(), burnedBondPercentages[i]);
+
+            // Account1 asserts a false claim.
+            bytes32 assertionId = _allocateBondAndAssertTruth(TestAddress.account1, bytes(falseClaimAssertion));
+
+            // Account2 disputes the assertion and the DVM resolves it as false, meaning that the disputer wins.
+            uint256 asserterBalanceBefore = defaultCurrency.balanceOf(TestAddress.account2);
+            uint256 storeBalanceBefore = defaultCurrency.balanceOf(address(store));
+            OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId, minimumBond);
+            _mockOracleResolved(address(mockOracle), oracleRequest, false);
+            assertFalse(optimisticAsserter.settleAndGetAssertion(assertionId));
+
+            // The asserter should have lost their bond.
+            assertEq(defaultCurrency.balanceOf(TestAddress.account1), 0);
+
+            // The disputer should have kept their bond and earned 1 - burnedBondPercentage of the asserter's bond.
+            uint256 expectAmount = minimumBond * 2 - (optimisticAsserter.burnedBondPercentage() * minimumBond) / 1e18;
+            assertEq(defaultCurrency.balanceOf(TestAddress.account2) - asserterBalanceBefore, expectAmount);
+
+            // // The store should have kept the burnedBondPercentage part of the asserter's bond.
+            assertEq(
+                defaultCurrency.balanceOf(address(store)) - storeBalanceBefore,
+                (minimumBond * optimisticAsserter.burnedBondPercentage()) / 1e18
+            );
+
+            // // The balance of the optimistic asserter should be zero.
+            assertEq(defaultCurrency.balanceOf(address(optimisticAsserter)), 0);
+        }
+    }
 }

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Ownership.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Ownership.t.sol
@@ -28,5 +28,12 @@ contract OwnershipTest is Common {
         assertEq(address(optimisticAsserter.defaultCurrency()), TestAddress.random);
         assertEq(optimisticAsserter.defaultBond(), 420);
         assertEq(optimisticAsserter.defaultLiveness(), 69);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        optimisticAsserter.setBurnedBondPercentage(0.3e18);
+
+        vm.prank(TestAddress.owner);
+        optimisticAsserter.setBurnedBondPercentage(0.3e18);
+        assertEq(optimisticAsserter.burnedBondPercentage(), 0.3e18);
     }
 }


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

We need to be able to set the burned bond percentage


**Summary**

- Add only owner burned percentage setter
- Add tests

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
