### PR TITLE
feat(core): default false ss policy properties

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -113,9 +113,9 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
             expirationTime: getCurrentTime() + liveness,
             claimId: keccak256(claim),
             identifier: identifier,
-            ssSettings: SsSettings({ // TODO [GAS] rename these variables to default to false
-                discardOracle: false, // this is the default behavior: if not specified by the Sovereign security the assertion will respect the Oracle result.
+            ssSettings: SsSettings({
                 arbitrateViaSs: false, // this is the default behavior: if not specified by the Sovereign security the assertion will use the DVM as an oracle.
+                discardOracle: false, // this is the default behavior: if not specified by the Sovereign security the assertion will respect the Oracle result.
                 validateDisputers: false, // this is the default behavior: if not specified by the Sovereign security the disputer will not be validated.
                 sovereignSecurity: sovereignSecurity,
                 assertingCaller: msg.sender
@@ -128,9 +128,9 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         require(!assertionPolicy.blockAssertion, "Assertion not allowed");
 
         SsSettings storage ssSettings = assertions[assertionId].ssSettings;
-        (ssSettings.discardOracle, ssSettings.arbitrateViaSs, ssSettings.validateDisputers) = (
-            assertionPolicy.discardOracle, // Discard Oracle result if specified by the SS.
+        (ssSettings.arbitrateViaSs, ssSettings.discardOracle, ssSettings.validateDisputers) = (
             assertionPolicy.arbitrateViaSs, // Use SS as an oracle if specified by the SS.
+            assertionPolicy.discardOracle, // Discard Oracle result if specified by the SS.
             assertionPolicy.validateDisputers // Validate the disputers if specified by the SS.
         );
 

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -125,7 +125,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         SovereignSecurityInterface.AssertionPolicy memory assertionPolicy = _getAssertionPolicy(assertionId);
 
         // Check if the assertion is allowed by the sovereign security.
-        require(assertionPolicy.allowAssertion, "Assertion not allowed");
+        require(!assertionPolicy.blockAssertion, "Assertion not allowed");
 
         SsSettings storage ssSettings = assertions[assertionId].ssSettings;
         (ssSettings.useDisputeResolution, ssSettings.useDvmAsOracle, ssSettings.validateDisputers) = (
@@ -319,7 +319,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable {
         returns (SovereignSecurityInterface.AssertionPolicy memory)
     {
         address ss = assertions[assertionId].ssSettings.sovereignSecurity;
-        if (ss == address(0)) return SovereignSecurityInterface.AssertionPolicy(true, true, true, false); // TODO update with default values
+        if (ss == address(0)) return SovereignSecurityInterface.AssertionPolicy(false, true, true, false); // TODO update with default values
         return SovereignSecurityInterface(ss).getAssertionPolicy(assertionId);
     }
 

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/BaseSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/BaseSovereignSecurity.sol
@@ -8,7 +8,7 @@ contract BaseSovereignSecurity is SovereignSecurityInterface {
     function getAssertionPolicy(bytes32 assertionId) public view virtual override returns (AssertionPolicy memory) {
         return
             AssertionPolicy({
-                allowAssertion: true,
+                blockAssertion: false,
                 useDvmAsOracle: true,
                 useDisputeResolution: true,
                 validateDisputers: false

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/BaseSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/BaseSovereignSecurity.sol
@@ -10,7 +10,7 @@ contract BaseSovereignSecurity is SovereignSecurityInterface {
             AssertionPolicy({
                 blockAssertion: false,
                 arbitrateViaSs: false,
-                useDisputeResolution: true,
+                discardOracle: false,
                 validateDisputers: false
             });
     }

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/BaseSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/BaseSovereignSecurity.sol
@@ -9,7 +9,7 @@ contract BaseSovereignSecurity is SovereignSecurityInterface {
         return
             AssertionPolicy({
                 blockAssertion: false,
-                useDvmAsOracle: true,
+                arbitrateViaSs: false,
                 useDisputeResolution: true,
                 validateDisputers: false
             });

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerDiscardOracleSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerDiscardOracleSovereignSecurity.sol
@@ -14,7 +14,7 @@ contract OwnerDiscardOracleSovereignSecurity is BaseSovereignSecurity, Ownable {
         return
             AssertionPolicy({
                 blockAssertion: false,
-                useDvmAsOracle: true,
+                arbitrateViaSs: false,
                 useDisputeResolution: !discardOracle,
                 validateDisputers: false
             });

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerDiscardOracleSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerDiscardOracleSovereignSecurity.sol
@@ -13,7 +13,7 @@ contract OwnerDiscardOracleSovereignSecurity is BaseSovereignSecurity, Ownable {
     function getAssertionPolicy(bytes32 assertionId) public view override returns (AssertionPolicy memory) {
         return
             AssertionPolicy({
-                allowAssertion: true,
+                blockAssertion: false,
                 useDvmAsOracle: true,
                 useDisputeResolution: !discardOracle,
                 validateDisputers: false

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerDiscardOracleSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerDiscardOracleSovereignSecurity.sol
@@ -15,7 +15,7 @@ contract OwnerDiscardOracleSovereignSecurity is BaseSovereignSecurity, Ownable {
             AssertionPolicy({
                 blockAssertion: false,
                 arbitrateViaSs: false,
-                useDisputeResolution: !discardOracle,
+                discardOracle: discardOracle,
                 validateDisputers: false
             });
     }

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerSelectOracleSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerSelectOracleSovereignSecurity.sol
@@ -32,7 +32,7 @@ contract OwnerSelectOracleSovereignSecurity is BaseSovereignSecurity, Ownable {
             AssertionPolicy({
                 blockAssertion: false,
                 arbitrateViaSs: arbitrateViaSs,
-                useDisputeResolution: true,
+                discardOracle: false,
                 validateDisputers: false
             });
     }

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerSelectOracleSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerSelectOracleSovereignSecurity.sol
@@ -30,7 +30,7 @@ contract OwnerSelectOracleSovereignSecurity is BaseSovereignSecurity, Ownable {
     function getAssertionPolicy(bytes32 assertionId) public view override returns (AssertionPolicy memory) {
         return
             AssertionPolicy({
-                allowAssertion: true,
+                blockAssertion: false,
                 useDvmAsOracle: !arbitrateViaSs,
                 useDisputeResolution: true,
                 validateDisputers: false

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerSelectOracleSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/OwnerSelectOracleSovereignSecurity.sol
@@ -31,7 +31,7 @@ contract OwnerSelectOracleSovereignSecurity is BaseSovereignSecurity, Ownable {
         return
             AssertionPolicy({
                 blockAssertion: false,
-                useDvmAsOracle: !arbitrateViaSs,
+                arbitrateViaSs: arbitrateViaSs,
                 useDisputeResolution: true,
                 validateDisputers: false
             });

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistAsserterSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistAsserterSovereignSecurity.sol
@@ -30,22 +30,22 @@ contract WhitelistAsserterSovereignSecurity is BaseSovereignSecurity, Ownable {
     function getAssertionPolicy(bytes32 assertionId) public view override returns (AssertionPolicy memory) {
         OptimisticAsserterInterface optimisticAsserter = OptimisticAsserterInterface(msg.sender);
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
-        bool allow = _checkIfAssertionAllowed(assertion);
+        bool blocked = _checkIfAssertionBlocked(assertion);
         return
             AssertionPolicy({
-                allowAssertion: allow,
+                blockAssertion: blocked,
                 useDvmAsOracle: true,
                 useDisputeResolution: true,
                 validateDisputers: false
             });
     }
 
-    function _checkIfAssertionAllowed(OptimisticAsserterInterface.Assertion memory assertion)
+    function _checkIfAssertionBlocked(OptimisticAsserterInterface.Assertion memory assertion)
         internal
         view
         returns (bool)
     {
-        if (assertion.ssSettings.assertingCaller != assertingCaller) return false; // Only allow assertions through linked client contract.
-        return whitelistedAsserters[assertion.asserter]; // Return if asserter is whitelisted.
+        if (assertion.ssSettings.assertingCaller != assertingCaller) return true; // Only allow assertions through linked client contract.
+        return !whitelistedAsserters[assertion.asserter]; // Return if asserter is not whitelisted.
     }
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistAsserterSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistAsserterSovereignSecurity.sol
@@ -35,7 +35,7 @@ contract WhitelistAsserterSovereignSecurity is BaseSovereignSecurity, Ownable {
             AssertionPolicy({
                 blockAssertion: blocked,
                 arbitrateViaSs: false,
-                useDisputeResolution: true,
+                discardOracle: false,
                 validateDisputers: false
             });
     }

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistAsserterSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistAsserterSovereignSecurity.sol
@@ -34,7 +34,7 @@ contract WhitelistAsserterSovereignSecurity is BaseSovereignSecurity, Ownable {
         return
             AssertionPolicy({
                 blockAssertion: blocked,
-                useDvmAsOracle: true,
+                arbitrateViaSs: false,
                 useDisputeResolution: true,
                 validateDisputers: false
             });

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistCallerSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistCallerSovereignSecurity.sol
@@ -18,7 +18,7 @@ contract WhitelistCallerSovereignSecurity is BaseSovereignSecurity, Ownable {
                 blockAssertion: !whitelistedAssertingCallers[
                     optimisticAsserter.getAssertion(assertionId).ssSettings.assertingCaller
                 ],
-                useDvmAsOracle: true,
+                arbitrateViaSs: false,
                 useDisputeResolution: true,
                 validateDisputers: false
             });

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistCallerSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistCallerSovereignSecurity.sol
@@ -19,7 +19,7 @@ contract WhitelistCallerSovereignSecurity is BaseSovereignSecurity, Ownable {
                     optimisticAsserter.getAssertion(assertionId).ssSettings.assertingCaller
                 ],
                 arbitrateViaSs: false,
-                useDisputeResolution: true,
+                discardOracle: false,
                 validateDisputers: false
             });
     }

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistCallerSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistCallerSovereignSecurity.sol
@@ -15,7 +15,7 @@ contract WhitelistCallerSovereignSecurity is BaseSovereignSecurity, Ownable {
         OptimisticAsserterInterface optimisticAsserter = OptimisticAsserterInterface(msg.sender);
         return
             AssertionPolicy({
-                allowAssertion: whitelistedAssertingCallers[
+                blockAssertion: !whitelistedAssertingCallers[
                     optimisticAsserter.getAssertion(assertionId).ssSettings.assertingCaller
                 ],
                 useDvmAsOracle: true,

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistDisputerSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistDisputerSovereignSecurity.sol
@@ -11,7 +11,7 @@ contract WhitelistDisputerSovereignSecurity is BaseSovereignSecurity, Ownable {
         return
             AssertionPolicy({
                 blockAssertion: false,
-                useDvmAsOracle: true,
+                arbitrateViaSs: false,
                 useDisputeResolution: true,
                 validateDisputers: true
             });

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistDisputerSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistDisputerSovereignSecurity.sol
@@ -10,7 +10,7 @@ contract WhitelistDisputerSovereignSecurity is BaseSovereignSecurity, Ownable {
     function getAssertionPolicy(bytes32 assertionId) public view override returns (AssertionPolicy memory) {
         return
             AssertionPolicy({
-                allowAssertion: true,
+                blockAssertion: false,
                 useDvmAsOracle: true,
                 useDisputeResolution: true,
                 validateDisputers: true

--- a/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistDisputerSovereignSecurity.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/sovereign-security/WhitelistDisputerSovereignSecurity.sol
@@ -12,7 +12,7 @@ contract WhitelistDisputerSovereignSecurity is BaseSovereignSecurity, Ownable {
             AssertionPolicy({
                 blockAssertion: false,
                 arbitrateViaSs: false,
-                useDisputeResolution: true,
+                discardOracle: false,
                 validateDisputers: true
             });
     }

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface OptimisticAsserterInterface {
     struct SsSettings {
-        bool useDisputeResolution; // True if Oracle result is used for resolving assertion after dispute.
+        bool discardOracle; // False if Oracle result is used for resolving assertion after dispute.
         bool arbitrateViaSs; // False if the DVM is used as an oracle (SovereignSecurity on True).
         bool validateDisputers; // True if the SS isDisputeAllowed should be checked on disputes.
         address sovereignSecurity;

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -5,8 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface OptimisticAsserterInterface {
     struct SsSettings {
-        bool discardOracle; // False if Oracle result is used for resolving assertion after dispute.
         bool arbitrateViaSs; // False if the DVM is used as an oracle (SovereignSecurity on True).
+        bool discardOracle; // False if Oracle result is used for resolving assertion after dispute.
         bool validateDisputers; // True if the SS isDisputeAllowed should be checked on disputes.
         address sovereignSecurity;
         address assertingCaller;

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 interface OptimisticAsserterInterface {
     struct SsSettings {
         bool useDisputeResolution; // True if Oracle result is used for resolving assertion after dispute.
-        bool useDvmAsOracle; // True if the DVM is used as an oracle (SovereignSecurity on False).
+        bool arbitrateViaSs; // False if the DVM is used as an oracle (SovereignSecurity on True).
         bool validateDisputers; // True if the SS isDisputeAllowed should be checked on disputes.
         address sovereignSecurity;
         address assertingCaller;

--- a/packages/core/contracts/optimistic-asserter/interfaces/SovereignSecurityInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/SovereignSecurityInterface.sol
@@ -6,7 +6,7 @@ import "./OptimisticAsserterInterface.sol";
 interface SovereignSecurityInterface {
     struct AssertionPolicy {
         bool blockAssertion;
-        bool useDvmAsOracle;
+        bool arbitrateViaSs;
         bool useDisputeResolution;
         bool validateDisputers;
     }

--- a/packages/core/contracts/optimistic-asserter/interfaces/SovereignSecurityInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/SovereignSecurityInterface.sol
@@ -5,7 +5,7 @@ import "./OptimisticAsserterInterface.sol";
 
 interface SovereignSecurityInterface {
     struct AssertionPolicy {
-        bool allowAssertion;
+        bool blockAssertion;
         bool useDvmAsOracle;
         bool useDisputeResolution;
         bool validateDisputers;

--- a/packages/core/contracts/optimistic-asserter/interfaces/SovereignSecurityInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/SovereignSecurityInterface.sol
@@ -7,7 +7,7 @@ interface SovereignSecurityInterface {
     struct AssertionPolicy {
         bool blockAssertion;
         bool arbitrateViaSs;
-        bool useDisputeResolution;
+        bool discardOracle;
         bool validateDisputers;
     }
 

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -78,7 +78,7 @@ contract Common is Test {
     // Helper functions, re-used in some tests.
     function _mockSsPolicy(
         bool blockAssertion,
-        bool useDvmAsOracle,
+        bool arbitrateViaSs,
         bool useDisputeResolution,
         bool validateDisputers
     ) internal {
@@ -89,7 +89,7 @@ contract Common is Test {
             abi.encode(
                 SovereignSecurityInterface.AssertionPolicy({
                     blockAssertion: blockAssertion,
-                    useDvmAsOracle: useDvmAsOracle,
+                    arbitrateViaSs: arbitrateViaSs,
                     useDisputeResolution: useDisputeResolution,
                     validateDisputers: validateDisputers
                 })

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -79,7 +79,7 @@ contract Common is Test {
     function _mockSsPolicy(
         bool blockAssertion,
         bool arbitrateViaSs,
-        bool useDisputeResolution,
+        bool discardOracle,
         bool validateDisputers
     ) internal {
         // Mock getAssertionPolicy call to block assertion. No need to pass assertionId as mockCall uses loose matching.
@@ -90,7 +90,7 @@ contract Common is Test {
                 SovereignSecurityInterface.AssertionPolicy({
                     blockAssertion: blockAssertion,
                     arbitrateViaSs: arbitrateViaSs,
-                    useDisputeResolution: useDisputeResolution,
+                    discardOracle: discardOracle,
                     validateDisputers: validateDisputers
                 })
             )

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -77,7 +77,7 @@ contract Common is Test {
 
     // Helper functions, re-used in some tests.
     function _mockSsPolicy(
-        bool allowAssertion,
+        bool blockAssertion,
         bool useDvmAsOracle,
         bool useDisputeResolution,
         bool validateDisputers
@@ -88,7 +88,7 @@ contract Common is Test {
             abi.encodePacked(SovereignSecurityInterface.getAssertionPolicy.selector),
             abi.encode(
                 SovereignSecurityInterface.AssertionPolicy({
-                    allowAssertion: allowAssertion,
+                    blockAssertion: blockAssertion,
                     useDvmAsOracle: useDvmAsOracle,
                     useDisputeResolution: useDisputeResolution,
                     validateDisputers: validateDisputers

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
@@ -21,14 +21,14 @@ contract SovereignSecurityPolicyEnforced is Common {
         vm.prank(TestAddress.account1);
         bytes32 assertionId = optimisticAsserter.assertTruth(trueClaimAssertion);
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
-        assertTrue(assertion.ssSettings.useDisputeResolution);
+        assertFalse(assertion.ssSettings.discardOracle);
         assertFalse(assertion.ssSettings.arbitrateViaSs);
         assertFalse(assertion.ssSettings.validateDisputers);
     }
 
     function test_RevertIf_AssertionBlocked() public {
         // Block any assertion.
-        _mockSsPolicy(true, false, true, false);
+        _mockSsPolicy(true, false, false, false);
 
         vm.expectRevert("Assertion not allowed");
         _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -37,7 +37,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_ArbitrateViaSs() public {
         // Use SS as oracle.
-        _mockSsPolicy(false, true, true, false);
+        _mockSsPolicy(false, true, false, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -53,12 +53,12 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DisregardOracle() public {
         // Do not respect Oracle on dispute.
-        _mockSsPolicy(false, false, false, false);
+        _mockSsPolicy(false, false, true, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
-        assertFalse(assertion.ssSettings.useDisputeResolution);
+        assertTrue(assertion.ssSettings.discardOracle);
 
         // Dispute should make assertion false available immediately.
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId, defaultBond);
@@ -114,7 +114,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_CallbackOnDispute() public {
         // Assert with callback recipient and not respecting Oracle.
-        _mockSsPolicy(false, false, false, false);
+        _mockSsPolicy(false, false, true, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(mockedCallbackRecipient, mockedSovereignSecurity);
@@ -129,7 +129,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DoNotValidateDisputers() public {
         // Deafault SS policy do not validate disputers.
-        _mockSsPolicy(false, false, true, false);
+        _mockSsPolicy(false, false, false, false);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
 
@@ -139,7 +139,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_ValidateAndAllowDispute() public {
         // Validate disputers in SS policy and allow disputes.
-        _mockSsPolicy(false, false, true, true);
+        _mockSsPolicy(false, false, false, true);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -150,7 +150,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_RevertIf_DisputeNotAllowed() public {
         // Validate disputers in SS policy and disallow disputes.
-        _mockSsPolicy(false, false, true, true);
+        _mockSsPolicy(false, false, false, true);
         _mockSsDisputerCheck(false);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
@@ -28,7 +28,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_RevertIf_AssertionBlocked() public {
         // Block any assertion.
-        _mockSsPolicy(false, true, true, false);
+        _mockSsPolicy(true, true, true, false);
 
         vm.expectRevert("Assertion not allowed");
         _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -37,7 +37,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DisableDvmAsOracle() public {
         // Use SS as oracle.
-        _mockSsPolicy(true, false, true, false);
+        _mockSsPolicy(false, false, true, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -53,7 +53,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DisregardOracle() public {
         // Do not respect Oracle on dispute.
-        _mockSsPolicy(true, true, false, false);
+        _mockSsPolicy(false, true, false, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -114,7 +114,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_CallbackOnDispute() public {
         // Assert with callback recipient and not respecting Oracle.
-        _mockSsPolicy(true, true, false, false);
+        _mockSsPolicy(false, true, false, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(mockedCallbackRecipient, mockedSovereignSecurity);
@@ -129,7 +129,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DoNotValidateDisputers() public {
         // Deafault SS policy do not validate disputers.
-        _mockSsPolicy(true, true, true, false);
+        _mockSsPolicy(false, true, true, false);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
 
@@ -139,7 +139,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_ValidateAndAllowDispute() public {
         // Validate disputers in SS policy and allow disputes.
-        _mockSsPolicy(true, true, true, true);
+        _mockSsPolicy(false, true, true, true);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -150,7 +150,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_RevertIf_DisputeNotAllowed() public {
         // Validate disputers in SS policy and disallow disputes.
-        _mockSsPolicy(true, true, true, true);
+        _mockSsPolicy(false, true, true, true);
         _mockSsDisputerCheck(false);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
@@ -22,27 +22,27 @@ contract SovereignSecurityPolicyEnforced is Common {
         bytes32 assertionId = optimisticAsserter.assertTruth(trueClaimAssertion);
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
         assertTrue(assertion.ssSettings.useDisputeResolution);
-        assertTrue(assertion.ssSettings.useDvmAsOracle);
+        assertFalse(assertion.ssSettings.arbitrateViaSs);
         assertFalse(assertion.ssSettings.validateDisputers);
     }
 
     function test_RevertIf_AssertionBlocked() public {
         // Block any assertion.
-        _mockSsPolicy(true, true, true, false);
+        _mockSsPolicy(true, false, true, false);
 
         vm.expectRevert("Assertion not allowed");
         _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
         vm.clearMockedCalls();
     }
 
-    function test_DisableDvmAsOracle() public {
+    function test_ArbitrateViaSs() public {
         // Use SS as oracle.
-        _mockSsPolicy(false, false, true, false);
+        _mockSsPolicy(false, true, true, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
-        assertFalse(assertion.ssSettings.useDvmAsOracle);
+        assertTrue(assertion.ssSettings.arbitrateViaSs);
 
         // Dispute, mock resolve assertion truethful through SS as Oracle and verify on Optimistic Asserter.
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId, defaultBond);
@@ -53,7 +53,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DisregardOracle() public {
         // Do not respect Oracle on dispute.
-        _mockSsPolicy(false, true, false, false);
+        _mockSsPolicy(false, false, false, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -114,7 +114,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_CallbackOnDispute() public {
         // Assert with callback recipient and not respecting Oracle.
-        _mockSsPolicy(false, true, false, false);
+        _mockSsPolicy(false, false, false, false);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(mockedCallbackRecipient, mockedSovereignSecurity);
@@ -129,7 +129,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_DoNotValidateDisputers() public {
         // Deafault SS policy do not validate disputers.
-        _mockSsPolicy(false, true, true, false);
+        _mockSsPolicy(false, false, true, false);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
 
@@ -139,7 +139,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_ValidateAndAllowDispute() public {
         // Validate disputers in SS policy and allow disputes.
-        _mockSsPolicy(false, true, true, true);
+        _mockSsPolicy(false, false, true, true);
         _mockSsDisputerCheck(true);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);
@@ -150,7 +150,7 @@ contract SovereignSecurityPolicyEnforced is Common {
 
     function test_RevertIf_DisputeNotAllowed() public {
         // Validate disputers in SS policy and disallow disputes.
-        _mockSsPolicy(false, true, true, true);
+        _mockSsPolicy(false, false, true, true);
         _mockSsDisputerCheck(false);
 
         bytes32 assertionId = _assertWithCallbackRecipientAndSs(address(0), mockedSovereignSecurity);

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/BaseSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/BaseSovereignSecurity.t.sol
@@ -20,7 +20,7 @@ contract BaseSovereignSecurityTest is Common {
     function test_GetAssertionPolicy() public {
         BaseSovereignSecurity.AssertionPolicy memory policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
         assertFalse(policy.blockAssertion);
-        assertTrue(policy.useDvmAsOracle);
+        assertFalse(policy.arbitrateViaSs);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
     }

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/BaseSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/BaseSovereignSecurity.t.sol
@@ -19,7 +19,7 @@ contract BaseSovereignSecurityTest is Common {
 
     function test_GetAssertionPolicy() public {
         BaseSovereignSecurity.AssertionPolicy memory policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
-        assertTrue(policy.allowAssertion);
+        assertFalse(policy.blockAssertion);
         assertTrue(policy.useDvmAsOracle);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/BaseSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/BaseSovereignSecurity.t.sol
@@ -21,7 +21,7 @@ contract BaseSovereignSecurityTest is Common {
         BaseSovereignSecurity.AssertionPolicy memory policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
         assertFalse(policy.blockAssertion);
         assertFalse(policy.arbitrateViaSs);
-        assertTrue(policy.useDisputeResolution);
+        assertFalse(policy.discardOracle);
         assertFalse(policy.validateDisputers);
     }
 

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerDiscardOracleSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerDiscardOracleSovereignSecurity.t.sol
@@ -14,7 +14,7 @@ contract OwnerDiscardOracleSovereignSecurityTest is Common {
     function test_SetDiscardOracle() public {
         OwnerDiscardOracleSovereignSecurity.AssertionPolicy memory policy =
             sovereignSecurity.getAssertionPolicy(bytes32(0));
-        assertTrue(policy.allowAssertion);
+        assertFalse(policy.blockAssertion);
         assertTrue(policy.useDvmAsOracle);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
@@ -22,7 +22,7 @@ contract OwnerDiscardOracleSovereignSecurityTest is Common {
         sovereignSecurity.setDiscardOracle(true);
         policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
 
-        assertTrue(policy.allowAssertion);
+        assertFalse(policy.blockAssertion);
         assertTrue(policy.useDvmAsOracle);
         assertFalse(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerDiscardOracleSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerDiscardOracleSovereignSecurity.t.sol
@@ -16,7 +16,7 @@ contract OwnerDiscardOracleSovereignSecurityTest is Common {
             sovereignSecurity.getAssertionPolicy(bytes32(0));
         assertFalse(policy.blockAssertion);
         assertFalse(policy.arbitrateViaSs);
-        assertTrue(policy.useDisputeResolution);
+        assertFalse(policy.discardOracle);
         assertFalse(policy.validateDisputers);
 
         sovereignSecurity.setDiscardOracle(true);
@@ -24,7 +24,7 @@ contract OwnerDiscardOracleSovereignSecurityTest is Common {
 
         assertFalse(policy.blockAssertion);
         assertFalse(policy.arbitrateViaSs);
-        assertFalse(policy.useDisputeResolution);
+        assertTrue(policy.discardOracle);
         assertFalse(policy.validateDisputers);
     }
 

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerDiscardOracleSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerDiscardOracleSovereignSecurity.t.sol
@@ -15,7 +15,7 @@ contract OwnerDiscardOracleSovereignSecurityTest is Common {
         OwnerDiscardOracleSovereignSecurity.AssertionPolicy memory policy =
             sovereignSecurity.getAssertionPolicy(bytes32(0));
         assertFalse(policy.blockAssertion);
-        assertTrue(policy.useDvmAsOracle);
+        assertFalse(policy.arbitrateViaSs);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
 
@@ -23,7 +23,7 @@ contract OwnerDiscardOracleSovereignSecurityTest is Common {
         policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
 
         assertFalse(policy.blockAssertion);
-        assertTrue(policy.useDvmAsOracle);
+        assertFalse(policy.arbitrateViaSs);
         assertFalse(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
     }

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerSelectOracleSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerSelectOracleSovereignSecurity.t.sol
@@ -31,7 +31,7 @@ contract OwnerSelectOracleSovereignSecurityTest is Common {
             sovereignSecurity.getAssertionPolicy(bytes32(0));
         assertFalse(policy.blockAssertion);
         assertFalse(policy.arbitrateViaSs);
-        assertTrue(policy.useDisputeResolution);
+        assertFalse(policy.discardOracle);
         assertFalse(policy.validateDisputers);
 
         sovereignSecurity.setArbitrateViaSs(true);
@@ -39,7 +39,7 @@ contract OwnerSelectOracleSovereignSecurityTest is Common {
 
         assertFalse(policy.blockAssertion);
         assertTrue(policy.arbitrateViaSs);
-        assertTrue(policy.useDisputeResolution);
+        assertFalse(policy.discardOracle);
         assertFalse(policy.validateDisputers);
     }
 

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerSelectOracleSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerSelectOracleSovereignSecurity.t.sol
@@ -29,7 +29,7 @@ contract OwnerSelectOracleSovereignSecurityTest is Common {
     function test_SetArbitrateViaSs() public {
         OwnerSelectOracleSovereignSecurity.AssertionPolicy memory policy =
             sovereignSecurity.getAssertionPolicy(bytes32(0));
-        assertTrue(policy.allowAssertion);
+        assertFalse(policy.blockAssertion);
         assertTrue(policy.useDvmAsOracle);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
@@ -37,7 +37,7 @@ contract OwnerSelectOracleSovereignSecurityTest is Common {
         sovereignSecurity.setArbitrateViaSs(true);
         policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
 
-        assertTrue(policy.allowAssertion);
+        assertFalse(policy.blockAssertion);
         assertFalse(policy.useDvmAsOracle);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerSelectOracleSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/OwnerSelectOracleSovereignSecurity.t.sol
@@ -30,7 +30,7 @@ contract OwnerSelectOracleSovereignSecurityTest is Common {
         OwnerSelectOracleSovereignSecurity.AssertionPolicy memory policy =
             sovereignSecurity.getAssertionPolicy(bytes32(0));
         assertFalse(policy.blockAssertion);
-        assertTrue(policy.useDvmAsOracle);
+        assertFalse(policy.arbitrateViaSs);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
 
@@ -38,7 +38,7 @@ contract OwnerSelectOracleSovereignSecurityTest is Common {
         policy = sovereignSecurity.getAssertionPolicy(bytes32(0));
 
         assertFalse(policy.blockAssertion);
-        assertFalse(policy.useDvmAsOracle);
+        assertTrue(policy.arbitrateViaSs);
         assertTrue(policy.useDisputeResolution);
         assertFalse(policy.validateDisputers);
     }

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/WhitelistAsserterSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/WhitelistAsserterSovereignSecurity.t.sol
@@ -47,11 +47,11 @@ contract WhitelistAsserterSovereignSecurityTest is Common {
 
         _mockGetAssertion(assertionId, mockAssertingCallerAddress, TestAddress.account1);
 
-        // If the asserter is not whitelisted, then the assertion should not be allowed.
+        // If the asserter is not whitelisted, then the assertion should be blocked.
         assertFalse(sovereignSecurity.whitelistedAsserters(TestAddress.account1));
         vm.prank(mockOptimisticAsserterAddress);
         SovereignSecurityInterface.AssertionPolicy memory policy = sovereignSecurity.getAssertionPolicy(assertionId);
-        assertFalse(policy.allowAssertion);
+        assertTrue(policy.blockAssertion);
 
         vm.clearMockedCalls();
     }
@@ -61,12 +61,12 @@ contract WhitelistAsserterSovereignSecurityTest is Common {
 
         _mockGetAssertion(assertionId, mockAssertingCallerAddress, TestAddress.account1);
 
-        // If the asserter is whitelisted, then the assertion should be allowed.
+        // If the asserter is whitelisted, then the assertion should not be blocked.
         sovereignSecurity.setAsserterInWhitelist(TestAddress.account1, true);
         assertTrue(sovereignSecurity.whitelistedAsserters(TestAddress.account1));
         vm.prank(mockOptimisticAsserterAddress);
         SovereignSecurityInterface.AssertionPolicy memory policy = sovereignSecurity.getAssertionPolicy(assertionId);
-        assertTrue(policy.allowAssertion);
+        assertFalse(policy.blockAssertion);
 
         vm.clearMockedCalls();
     }
@@ -79,7 +79,7 @@ contract WhitelistAsserterSovereignSecurityTest is Common {
 
         vm.prank(mockOptimisticAsserterAddress);
         SovereignSecurityInterface.AssertionPolicy memory policy = sovereignSecurity.getAssertionPolicy(assertionId);
-        assertFalse(policy.allowAssertion);
+        assertTrue(policy.blockAssertion);
     }
 
     function _mockGetAssertion(

--- a/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/WhitelistCallerSovereignSecurity.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/SovereignSecurity/WhitelistCallerSovereignSecurity.t.sol
@@ -14,19 +14,19 @@ contract WhitelistCallerSovereignSecurityTest is Common {
     function test_AssertingCallerWhitelist() public {
         bytes32 assertionId = "test";
 
-        // If the asserting caller is not whitelisted, then the assertion should not be allowed.
+        // If the asserting caller is not whitelisted, then the assertion should be blocked.
         _mockGetAssertionAssertingCaller(mockAssertingCallerAddress, assertionId);
         vm.prank(mockOptimisticAsserterAddress);
         SovereignSecurityInterface.AssertionPolicy memory policyNotWhitelisted =
             sovereignSecurity.getAssertionPolicy(assertionId);
-        assertFalse(policyNotWhitelisted.allowAssertion);
+        assertTrue(policyNotWhitelisted.blockAssertion);
 
-        // If the asserting caller is whitelisted, then the assertion should be allowed.
+        // If the asserting caller is whitelisted, then the assertion should not be blocked.
         sovereignSecurity.setAssertingCallerInWhitelist(mockAssertingCallerAddress, true);
         vm.prank(mockOptimisticAsserterAddress);
         SovereignSecurityInterface.AssertionPolicy memory policyWhitelisted =
             sovereignSecurity.getAssertionPolicy(assertionId);
-        assertTrue(policyWhitelisted.allowAssertion);
+        assertFalse(policyWhitelisted.blockAssertion);
 
         vm.clearMockedCalls();
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Reduce Optimistic Asserter gas costs.


**Summary**

Changes Sovereign Security policy property names so that default values are false.





**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

