### PR TITLE
feat(core): implement dispute limiting escalation manager

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -353,22 +353,19 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
 
     function _callbackOnAssertionResolve(bytes32 assertionId, bool assertedTruthfully) internal {
         if (assertions[assertionId].callbackRecipient != address(0))
-            OptimisticAsserterCallbackRecipientInterface(assertions[assertionId].callbackRecipient).assertionResolved(
-                assertionId,
-                assertedTruthfully
-            );
+            OptimisticAsserterCallbackRecipientInterface(assertions[assertionId].callbackRecipient)
+                .assertionResolvedCallback(assertionId, assertedTruthfully);
         if (assertions[assertionId].escalationManagerSettings.escalationManager != address(0))
             EscalationManagerInterface(assertions[assertionId].escalationManagerSettings.escalationManager)
-                .assertionResolved(assertionId, assertedTruthfully);
+                .assertionResolvedCallback(assertionId, assertedTruthfully);
     }
 
     function _callbackOnAssertionDispute(bytes32 assertionId) internal {
         if (assertions[assertionId].callbackRecipient != address(0))
-            OptimisticAsserterCallbackRecipientInterface(assertions[assertionId].callbackRecipient).assertionDisputed(
-                assertionId
-            );
+            OptimisticAsserterCallbackRecipientInterface(assertions[assertionId].callbackRecipient)
+                .assertionDisputedCallback(assertionId);
         if (assertions[assertionId].escalationManagerSettings.escalationManager != address(0))
             EscalationManagerInterface(assertions[assertionId].escalationManagerSettings.escalationManager)
-                .assertionDisputed(assertionId);
+                .assertionDisputedCallback(assertionId);
     }
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
@@ -33,7 +33,7 @@ contract BaseEscalationManager is EscalationManagerInterface {
         emit PriceRequestAdded(identifier, time, ancillaryData);
     }
 
-    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public {}
+    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public virtual override {}
 
-    function assertionDisputed(bytes32 assertionId) public {}
+    function assertionDisputed(bytes32 assertionId) public virtual override {}
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
@@ -33,7 +33,9 @@ contract BaseEscalationManager is EscalationManagerInterface {
         emit PriceRequestAdded(identifier, time, ancillaryData);
     }
 
-    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public virtual override {}
+    // Callback function that is called by Optimistic Asserter when an assertion is resolved.
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public virtual override {}
 
-    function assertionDisputed(bytes32 assertionId) public virtual override {}
+    // Callback function that is called by Optimistic Asserter when an assertion is disputed.
+    function assertionDisputedCallback(bytes32 assertionId) public virtual override {}
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
@@ -1,0 +1,68 @@
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./BaseEscalationManager.sol";
+import "../../interfaces/OptimisticAsserterInterface.sol";
+
+// This Escalation Manager blocks all assertions till the blocking dispute is resolved by Oracle. In order to avoid
+// interference among different applications this Escalation Manager allows assertions only from one requesting contract.
+contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
+    OptimisticAsserterInterface public immutable optimisticAsserter;
+
+    // Address of linked requesting contract. Before this is set via setAssertingCaller all assertions will be blocked.
+    address public assertingCaller;
+
+    bytes32 public disputedAssertionId;
+
+    event AssertingCallerSet(address indexed assertingCaller);
+
+    constructor(address _optimisticAsserter) {
+        optimisticAsserter = OptimisticAsserterInterface(_optimisticAsserter);
+    }
+
+    // Set the address of the contract that will be allowed to use Optimistic Asserter.
+    // This can only be set once. We do not set this at constructor just to allow for some flexibility in the ordering
+    // of how contracts are deployed.
+    function setAssertingCaller(address _assertingCaller) public onlyOwner {
+        require(_assertingCaller != address(0), "Invalid asserting caller");
+        require(assertingCaller == address(0), "Asserting caller already set");
+        assertingCaller = _assertingCaller;
+        emit AssertingCallerSet(_assertingCaller);
+    }
+
+    function getAssertionPolicy(bytes32 assertionId) public view override returns (AssertionPolicy memory) {
+        OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
+        return
+            AssertionPolicy({
+                blockAssertion: _checkIfAssertionBlocked(assertion),
+                arbitrateViaEscalationManager: false,
+                discardOracle: false,
+                validateDisputers: false
+            });
+    }
+
+    function assertionDisputed(bytes32 assertionId) public override {
+        require(msg.sender == address(optimisticAsserter), "Not authorized");
+
+        // Only apply new assertion block if the dispute is related to the linked client contract.
+        if (optimisticAsserter.getAssertion(assertionId).escalationManagerSettings.assertingCaller == assertingCaller) {
+            disputedAssertionId = assertionId;
+        }
+    }
+
+    function assertionResolved(bytes32 assertionId, bool) public override {
+        require(msg.sender == address(optimisticAsserter), "Not authorized");
+
+        // Remove assertion block if the disputed assertion was resolved.
+        if (assertionId == disputedAssertionId) disputedAssertionId = bytes32(0);
+    }
+
+    function _checkIfAssertionBlocked(OptimisticAsserterInterface.Assertion memory assertion)
+        internal
+        view
+        returns (bool)
+    {
+        if (assertion.escalationManagerSettings.assertingCaller != assertingCaller) return true; // Only allow assertions through linked client contract.
+        return disputedAssertionId != bytes32(0); // Block if there is outstanding dispute.
+    }
+}

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
@@ -41,7 +41,8 @@ contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
             });
     }
 
-    function assertionDisputed(bytes32 assertionId) public override {
+    // Callback function that is called by Optimistic Asserter when an assertion is disputed.
+    function assertionDisputedCallback(bytes32 assertionId) public override {
         require(msg.sender == address(optimisticAsserter), "Not authorized");
 
         // Only apply new assertion block if the dispute is related to the linked client contract.
@@ -50,7 +51,8 @@ contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
         }
     }
 
-    function assertionResolved(bytes32 assertionId, bool) public override {
+    // Callback function that is called by Optimistic Asserter when an assertion is resolved.
+    function assertionResolvedCallback(bytes32 assertionId, bool) public override {
         require(msg.sender == address(optimisticAsserter), "Not authorized");
 
         // Remove assertion block if the disputed assertion was resolved.

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
@@ -6,6 +6,7 @@ import "../../interfaces/OptimisticAsserterInterface.sol";
 
 // This Escalation Manager blocks all assertions till the blocking dispute is resolved by Oracle. In order to avoid
 // interference among different applications this Escalation Manager allows assertions only from one requesting contract.
+// This is useful to create a system where only one assertion dispute can occur at a time.
 contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
     OptimisticAsserterInterface public immutable optimisticAsserter;
 

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
@@ -34,7 +34,7 @@ contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
         return
             AssertionPolicy({
-                blockAssertion: _checkIfAssertionBlocked(assertion),
+                blockAssertion: _checkIfShouldBlockAssertion(assertion),
                 arbitrateViaEscalationManager: false,
                 discardOracle: false,
                 validateDisputers: false
@@ -59,7 +59,7 @@ contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
         if (assertionId == disputedAssertionId) disputedAssertionId = bytes32(0);
     }
 
-    function _checkIfAssertionBlocked(OptimisticAsserterInterface.Assertion memory assertion)
+    function _checkIfShouldBlockAssertion(OptimisticAsserterInterface.Assertion memory assertion)
         internal
         view
         returns (bool)

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol
@@ -32,10 +32,9 @@ contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
     }
 
     function getAssertionPolicy(bytes32 assertionId) public view override returns (AssertionPolicy memory) {
-        OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
         return
             AssertionPolicy({
-                blockAssertion: _checkIfShouldBlockAssertion(assertion),
+                blockAssertion: _checkIfShouldBlockAssertion(assertionId),
                 arbitrateViaEscalationManager: false,
                 discardOracle: false,
                 validateDisputers: false
@@ -60,11 +59,8 @@ contract DisputeLimitingEscalationManager is BaseEscalationManager, Ownable {
         if (assertionId == disputedAssertionId) disputedAssertionId = bytes32(0);
     }
 
-    function _checkIfShouldBlockAssertion(OptimisticAsserterInterface.Assertion memory assertion)
-        internal
-        view
-        returns (bool)
-    {
+    function _checkIfShouldBlockAssertion(bytes32 assertionId) internal view returns (bool) {
+        OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
         if (assertion.escalationManagerSettings.assertingCaller != assertingCaller) return true; // Only allow assertions through linked client contract.
         return disputedAssertionId != bytes32(0); // Block if there is outstanding dispute.
     }

--- a/packages/core/contracts/optimistic-asserter/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/examples/DataAsserter.sol
@@ -88,7 +88,7 @@ contract DataAsserter {
     }
 
     // OptimisticAsserter resolve callback.
-    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public {
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public {
         require(msg.sender == address(oa));
         // If the assertion was true, then the data assertion is resolved.
         if (assertedTruthfully) {
@@ -101,5 +101,5 @@ contract DataAsserter {
 
     // If assertion is disputed, do nothing and wait for resolution.
     // This OptimisticAsserter callback function needs to be defined so the OA doesn't revert when it tries to call it.
-    function assertionDisputed(bytes32 assertionId) public {}
+    function assertionDisputedCallback(bytes32 assertionId) public {}
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/examples/Insurance.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/examples/Insurance.sol
@@ -85,7 +85,7 @@ contract Insurance {
         emit InsurancePayoutRequested(policyId, assertionId);
     }
 
-    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public {
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public {
         require(msg.sender == address(oa));
         // If the assertion was true, then the policy is settled.
         if (assertedTruthfully) {
@@ -93,7 +93,7 @@ contract Insurance {
         }
     }
 
-    function assertionDisputed(bytes32 assertionId) public {}
+    function assertionDisputedCallback(bytes32 assertionId) public {}
 
     function _settlePayout(bytes32 assertionId) internal {
         // If already settled, do nothing. We don't revert because this function is called by the

--- a/packages/core/contracts/optimistic-asserter/implementation/examples/PredictionMarket.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/examples/PredictionMarket.sol
@@ -155,7 +155,7 @@ contract PredictionMarket is OptimisticAsserterCallbackRecipientInterface {
         currency.safeApprove(address(oa), bond);
         assertionId = _assertTruthWithDefaults(claim, bond);
 
-        // Store the asserter and marketId for the assertionResolved callback.
+        // Store the asserter and marketId for the assertionResolvedCallback.
         assertedMarkets[assertionId] = AssertedMarket({ asserter: msg.sender, marketId: marketId });
 
         emit MarketAsserted(marketId, assertedOutcome, assertionId);
@@ -164,7 +164,7 @@ contract PredictionMarket is OptimisticAsserterCallbackRecipientInterface {
     // Callback from settled assertion.
     // If the assertion was resolved true, then the asserter gets the reward and the market is marked as resolved.
     // Otherwise, assertedOutcomeId is reset and the market can be asserted again.
-    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) public {
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public {
         require(msg.sender == address(oa), "Not authorized");
         Market storage market = markets[assertedMarkets[assertionId].marketId];
 
@@ -177,7 +177,7 @@ contract PredictionMarket is OptimisticAsserterCallbackRecipientInterface {
     }
 
     // Dispute callback does nothing.
-    function assertionDisputed(bytes32 assertionId) public {}
+    function assertionDisputedCallback(bytes32 assertionId) public {}
 
     // Mints pair of tokens representing the value of outcome1 and outcome2. Trading of outcome tokens is outside of the
     // scope of this contract. The caller must approve this contract to spend the currency tokens.

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterCallbackRecipientInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterCallbackRecipientInterface.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.16;
 
 interface OptimisticAsserterCallbackRecipientInterface {
-    function assertionResolved(bytes32 assertionId, bool assertedTruthfully) external;
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) external;
 
-    function assertionDisputed(bytes32 assertionId) external;
+    function assertionDisputedCallback(bytes32 assertionId) external;
 }

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -183,7 +183,7 @@ contract Common is Test {
         vm.expectCall(
             callbackRecipient,
             abi.encodeWithSelector(
-                OptimisticAsserterCallbackRecipientInterface.assertionResolved.selector,
+                OptimisticAsserterCallbackRecipientInterface.assertionResolvedCallback.selector,
                 assertionId,
                 assertedTruthfully
             )
@@ -193,7 +193,10 @@ contract Common is Test {
     function _expectAssertionDisputedCallback(address callbackRecipient, bytes32 assertionId) internal {
         vm.expectCall(
             callbackRecipient,
-            abi.encodeWithSelector(OptimisticAsserterCallbackRecipientInterface.assertionDisputed.selector, assertionId)
+            abi.encodeWithSelector(
+                OptimisticAsserterCallbackRecipientInterface.assertionDisputedCallback.selector,
+                assertionId
+            )
         );
     }
 }

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -199,4 +199,14 @@ contract Common is Test {
             )
         );
     }
+
+    function _mockGetAssertionAssertingCaller(address mockAssertingCaller, bytes32 assertionId) public {
+        OptimisticAsserterInterface.Assertion memory assertion;
+        assertion.escalationManagerSettings.assertingCaller = mockAssertingCaller;
+        vm.mockCall(
+            mockOptimisticAsserterAddress,
+            abi.encodeWithSelector(OptimisticAsserterInterface.getAssertion.selector, assertionId),
+            abi.encode(assertion)
+        );
+    }
 }

--- a/packages/core/test/foundry/optimistic-asserter/EscalationManager/DisputeLimitingEscalationManager.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/EscalationManager/DisputeLimitingEscalationManager.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../Common.sol";
+import "../../../../contracts/optimistic-asserter/implementation/escalation-manager/DisputeLimitingEscalationManager.sol";
+
+contract DisputeLimitingEscalationManagerTest is Common {
+    DisputeLimitingEscalationManager escalationManager;
+
+    bytes32 assertionId = "test";
+    bytes32 disputedAssertionId = "disputed";
+
+    function setUp() public {
+        escalationManager = new DisputeLimitingEscalationManager(mockOptimisticAsserterAddress);
+        assertEq(address(escalationManager.optimisticAsserter()), mockOptimisticAsserterAddress);
+    }
+
+    function test_RevertIf_NotOwner() public {
+        vm.prank(TestAddress.account1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        escalationManager.setAssertingCaller(address(0));
+    }
+
+    function test_RevertIf_InvalidAssertingCaller() public {
+        vm.expectRevert("Invalid asserting caller");
+        escalationManager.setAssertingCaller(address(0));
+    }
+
+    function test_SetAssertingCaller() public {
+        vm.expectEmit(true, true, true, true);
+        emit AssertingCallerSet(TestAddress.account1);
+        escalationManager.setAssertingCaller(TestAddress.account1);
+        assertEq(escalationManager.assertingCaller(), TestAddress.account1);
+    }
+
+    function test_RevertIf_RepeatSetAssertingCaller() public {
+        escalationManager.setAssertingCaller(TestAddress.account1);
+
+        vm.expectRevert("Asserting caller already set");
+        escalationManager.setAssertingCaller(TestAddress.account2);
+    }
+
+    function test_RevertIf_UnauthorizedCaller() public {
+        vm.expectRevert("Not authorized");
+        escalationManager.assertionDisputedCallback(disputedAssertionId);
+
+        vm.expectRevert("Not authorized");
+        escalationManager.assertionResolvedCallback(disputedAssertionId, false);
+    }
+
+    function test_BlockAssertingCallerNotSet() public {
+        _mockGetAssertionAssertingCaller(TestAddress.account1, assertionId);
+
+        vm.prank(mockOptimisticAsserterAddress);
+        EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
+        assertTrue(policy.blockAssertion);
+    }
+
+    function test_AllowWithAssertingCallerSet() public {
+        escalationManager.setAssertingCaller(TestAddress.account1);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, assertionId);
+
+        vm.prank(mockOptimisticAsserterAddress);
+        EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
+        assertFalse(policy.blockAssertion);
+    }
+
+    function test_DisputeBlocksAssertions() public {
+        escalationManager.setAssertingCaller(TestAddress.account1);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, disputedAssertionId);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, assertionId);
+
+        vm.startPrank(mockOptimisticAsserterAddress);
+        escalationManager.assertionDisputedCallback(disputedAssertionId);
+        assertEq(escalationManager.disputedAssertionId(), disputedAssertionId);
+
+        // Any other assertion should be blocked.
+        EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
+        assertTrue(policy.blockAssertion);
+        vm.stopPrank();
+    }
+
+    function test_UnrelatedDisputeNotInterfering() public {
+        escalationManager.setAssertingCaller(TestAddress.account1);
+
+        // Dispute will be made on assertion created by different asserting caller.
+        _mockGetAssertionAssertingCaller(TestAddress.account2, disputedAssertionId);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, assertionId);
+
+        vm.prank(mockOptimisticAsserterAddress);
+        escalationManager.assertionDisputedCallback(disputedAssertionId);
+        assertEq(escalationManager.disputedAssertionId(), bytes32(0));
+
+        // Assertion from asserting caller should not be blocked.
+        EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
+        assertFalse(policy.blockAssertion);
+    }
+
+    function test_ResolvedDisputeUnblocksAssertions() public {
+        escalationManager.setAssertingCaller(TestAddress.account1);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, disputedAssertionId);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, assertionId);
+
+        vm.startPrank(mockOptimisticAsserterAddress);
+        escalationManager.assertionDisputedCallback(disputedAssertionId);
+        assertEq(escalationManager.disputedAssertionId(), disputedAssertionId);
+
+        // Resolving dispute should unblock assertions.
+        escalationManager.assertionResolvedCallback(disputedAssertionId, false);
+        vm.stopPrank();
+        assertEq(escalationManager.disputedAssertionId(), bytes32(0));
+        EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
+        assertFalse(policy.blockAssertion);
+    }
+
+    function test_UnrelatedResolvedAssertionNotInterfering() public {
+        escalationManager.setAssertingCaller(TestAddress.account1);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, disputedAssertionId);
+        _mockGetAssertionAssertingCaller(TestAddress.account1, assertionId);
+
+        vm.startPrank(mockOptimisticAsserterAddress);
+        escalationManager.assertionDisputedCallback(disputedAssertionId);
+        assertEq(escalationManager.disputedAssertionId(), disputedAssertionId);
+
+        // Resolving any other assertion than the blocking dispute should not unblock assertions.
+        escalationManager.assertionResolvedCallback(bytes32("other"), false);
+        vm.stopPrank();
+        assertEq(escalationManager.disputedAssertionId(), disputedAssertionId);
+        EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
+        assertTrue(policy.blockAssertion);
+    }
+}

--- a/packages/core/test/foundry/optimistic-asserter/EscalationManager/DisputeLimitingEscalationManager.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/EscalationManager/DisputeLimitingEscalationManager.t.sol
@@ -54,6 +54,9 @@ contract DisputeLimitingEscalationManagerTest is Common {
         vm.prank(mockOptimisticAsserterAddress);
         EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
         assertTrue(policy.blockAssertion);
+        assertFalse(policy.arbitrateViaEscalationManager);
+        assertFalse(policy.discardOracle);
+        assertFalse(policy.validateDisputers);
     }
 
     function test_AllowWithAssertingCallerSet() public {
@@ -63,6 +66,9 @@ contract DisputeLimitingEscalationManagerTest is Common {
         vm.prank(mockOptimisticAsserterAddress);
         EscalationManagerInterface.AssertionPolicy memory policy = escalationManager.getAssertionPolicy(assertionId);
         assertFalse(policy.blockAssertion);
+        assertFalse(policy.arbitrateViaEscalationManager);
+        assertFalse(policy.discardOracle);
+        assertFalse(policy.validateDisputers);
     }
 
     function test_DisputeBlocksAssertions() public {

--- a/packages/core/test/foundry/optimistic-asserter/EscalationManager/WhitelistCallerEscalationManager.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/EscalationManager/WhitelistCallerEscalationManager.t.sol
@@ -36,14 +36,4 @@ contract WhitelistCallerEscalationManagerTest is Common {
         vm.prank(TestAddress.account1);
         escalationManager.setAssertingCallerInWhitelist(TestAddress.account1, true);
     }
-
-    function _mockGetAssertionAssertingCaller(address mockAssertingCaller, bytes32 assertionId) public {
-        OptimisticAsserterInterface.Assertion memory assertion;
-        assertion.escalationManagerSettings.assertingCaller = mockAssertingCaller;
-        vm.mockCall(
-            mockOptimisticAsserterAddress,
-            abi.encodeWithSelector(OptimisticAsserterInterface.getAssertion.selector, assertionId),
-            abi.encode(assertion)
-        );
-    }
 }

--- a/packages/core/test/foundry/optimistic-asserter/examples/PredictionMarket.Assertion.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/examples/PredictionMarket.Assertion.t.sol
@@ -75,7 +75,10 @@ contract PredictionMarketAssertionTest is PredictionMarketTestCommon {
     function test_DisputeCallbackReceived() public {
         bytes32 assertionId = _assertMarket(marketId, outcome1);
 
-        vm.expectCall(address(predictionMarket), abi.encodeCall(predictionMarket.assertionDisputed, (assertionId)));
+        vm.expectCall(
+            address(predictionMarket),
+            abi.encodeCall(predictionMarket.assertionDisputedCallback, (assertionId))
+        );
         _disputeAndGetOracleRequest(assertionId, requiredBond);
     }
 }

--- a/packages/core/test/foundry/optimistic-asserter/examples/PredictionMarket.Resolve.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/examples/PredictionMarket.Resolve.t.sol
@@ -14,11 +14,11 @@ contract PredictionMarketResolveTest is PredictionMarketTestCommon {
         bytes32 assertionId = _assertMarket(marketId, outcome1);
         uint256 asserterBalanceBefore = defaultCurrency.balanceOf(TestAddress.account1);
 
-        // Advance time past liveness and settle the assertion. This should trigger truthful assertionResolved callback.
+        // Advance time past liveness and settle the assertion. This should trigger truthful assertionResolvedCallback.
         timer.setCurrentTime(timer.getCurrentTime() + defaultLiveness);
         vm.expectCall(
             address(predictionMarket),
-            abi.encodeCall(predictionMarket.assertionResolved, (assertionId, true))
+            abi.encodeCall(predictionMarket.assertionResolvedCallback, (assertionId, true))
         );
         assertTrue(optimisticAsserter.settleAndGetAssertionResult(assertionId));
 
@@ -35,12 +35,12 @@ contract PredictionMarketResolveTest is PredictionMarketTestCommon {
         bytes32 assertionId = _assertMarket(marketId, outcome1);
         uint256 asserterBalanceBefore = defaultCurrency.balanceOf(TestAddress.account1);
 
-        // Dispute the assertion, but resolve it true at the Oracle. This should trigger truthful assertionResolved callback.
+        // Dispute the assertion, but resolve it true at the Oracle. This should trigger truthful assertionResolvedCallback.
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId, requiredBond);
         _mockOracleResolved(address(mockOracle), oracleRequest, true);
         vm.expectCall(
             address(predictionMarket),
-            abi.encodeCall(predictionMarket.assertionResolved, (assertionId, true))
+            abi.encodeCall(predictionMarket.assertionResolvedCallback, (assertionId, true))
         );
         assertTrue(optimisticAsserter.settleAndGetAssertionResult(assertionId));
 
@@ -60,12 +60,12 @@ contract PredictionMarketResolveTest is PredictionMarketTestCommon {
         bytes32 assertionId = _assertMarket(marketId, outcome1);
         uint256 pmBalanceBefore = defaultCurrency.balanceOf(address(predictionMarket));
 
-        // Dispute the assertion, but resolve it false at the Oracle. This should trigger false assertionResolved callback.
+        // Dispute the assertion, but resolve it false at the Oracle. This should trigger false assertionResolvedCallback.
         OracleRequest memory oracleRequest = _disputeAndGetOracleRequest(assertionId, requiredBond);
         _mockOracleResolved(address(mockOracle), oracleRequest, false);
         vm.expectCall(
             address(predictionMarket),
-            abi.encodeCall(predictionMarket.assertionResolved, (assertionId, false))
+            abi.encodeCall(predictionMarket.assertionResolvedCallback, (assertionId, false))
         );
         assertFalse(optimisticAsserter.settleAndGetAssertionResult(assertionId));
 


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Demonstrate use of dispute callbacks in Escalation Manager.


**Summary**

This Escalation Manager blocks all assertions till the blocking dispute is resolved by Oracle.


**Details**

 In order to avoid interference among different applications this Escalation Manager allows assertions only from one requesting contract.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

