### PR TITLE
feat(core): use renamed claimdata library in oa

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/ClaimData.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/ClaimData.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.16;
+
+import { AncillaryData as ClaimData } from "../../common/implementation/AncillaryData.sol";

--- a/packages/core/contracts/optimistic-asserter/implementation/examples/DataAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/examples/DataAsserter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "../../implementation/ClaimData.sol";
 import "../../interfaces/OptimisticAsserterInterface.sol";
-import "../../../common/implementation/AncillaryData.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 // This contract allows assertions on any form of data to be made using the UMA Optimistic Asserter and stores the
@@ -64,15 +64,15 @@ contract DataAsserter {
         assertionId = oa.assertTruth(
             abi.encodePacked(
                 "Data asserted: 0x", // in the example data is type bytes32 so we add the hex prefix 0x.
-                AncillaryData.toUtf8Bytes(data),
+                ClaimData.toUtf8Bytes(data),
                 " for dataId: 0x",
-                AncillaryData.toUtf8Bytes(dataId),
+                ClaimData.toUtf8Bytes(dataId),
                 " and asserter: 0x",
-                AncillaryData.toUtf8BytesAddress(asserter),
+                ClaimData.toUtf8BytesAddress(asserter),
                 " at timestamp: ",
-                AncillaryData.toUtf8BytesUint(block.timestamp),
+                ClaimData.toUtf8BytesUint(block.timestamp),
                 " in the DataAsserter contract at 0x",
-                AncillaryData.toUtf8BytesAddress(address(this)),
+                ClaimData.toUtf8BytesAddress(address(this)),
                 " is valid."
             ),
             asserter,

--- a/packages/core/contracts/optimistic-asserter/implementation/examples/Insurance.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/examples/Insurance.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "../../implementation/ClaimData.sol";
 import "../../interfaces/OptimisticAsserterInterface.sol";
-import "../../../common/implementation/AncillaryData.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 // This Isurance contract enables for the issuance of a single unlimited time policy per event/payout recipient There is
@@ -70,7 +70,7 @@ contract Insurance {
                 "Insurance contract is claiming that insurance event ",
                 policies[policyId].insuredEvent,
                 " had occurred as of ",
-                AncillaryData.toUtf8BytesUint(block.timestamp),
+                ClaimData.toUtf8BytesUint(block.timestamp),
                 "."
             ),
             msg.sender,

--- a/packages/core/contracts/optimistic-asserter/implementation/examples/PredictionMarket.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/examples/PredictionMarket.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../../../common/implementation/AddressWhitelist.sol";
-import "../../../common/implementation/AncillaryData.sol";
 import "../../../common/implementation/ExpandedERC20.sol";
 import "../../../data-verification-mechanism/implementation/Constants.sol";
 import "../../../data-verification-mechanism/interfaces/FinderInterface.sol";
+import "../../implementation/ClaimData.sol";
 import "../../interfaces/OptimisticAsserterInterface.sol";
 import "../../interfaces/OptimisticAsserterCallbackRecipientInterface.sol";
 
@@ -238,7 +238,7 @@ contract PredictionMarket is OptimisticAsserterCallbackRecipientInterface {
         return
             abi.encodePacked(
                 "As of assertion timestamp ",
-                AncillaryData.toUtf8BytesUint(block.timestamp),
+                ClaimData.toUtf8BytesUint(block.timestamp),
                 ", the described prediction market outcome is: ",
                 outcome,
                 ". The market description is: ",


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Usage of AncillaryData library naming in example client contracts would be confusing.

**Summary**

Imports and renames AncillaryData as ClaimData library that can be imported by requesting contracts when manipulating claim bytes data.


**Details**

Optimistic Asserter still uses original AncillaryData library as it does so only in the context of constructing ancillary data when making Oracle request.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested
