### PR TITLE
feat: add additional props to assertionId

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -265,12 +265,21 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
         address callbackRecipient,
         address escalationManager,
         bytes32 identifier
-    ) internal pure returns (bytes32) {
+    ) internal view returns (bytes32) {
         // Returns the unique ID for this assertion. This ID is used to identify the assertion in the Oracle.
         return
             keccak256(
-                // TODO change order of abi.encode arguments to do potential gas savings
-                abi.encode(claim, bond, liveness, currency, callbackRecipient, escalationManager, identifier)
+                abi.encode(
+                    claim,
+                    bond,
+                    liveness,
+                    currency,
+                    callbackRecipient,
+                    escalationManager,
+                    identifier,
+                    getCurrentTime(),
+                    msg.sender
+                )
             );
     }
 

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
@@ -21,12 +21,12 @@ contract OptimisticAsserterEvents is Common {
                 abi.encode(
                     falseClaimAssertion,
                     defaultBond,
+                    uint64(timer.getCurrentTime()),
                     defaultLiveness,
                     address(defaultCurrency),
                     address(0),
                     address(0),
                     defaultIdentifier,
-                    timer.getCurrentTime(),
                     TestAddress.account1
                 )
             );

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
@@ -25,7 +25,9 @@ contract OptimisticAsserterEvents is Common {
                     address(defaultCurrency),
                     address(0),
                     address(0),
-                    defaultIdentifier
+                    defaultIdentifier,
+                    timer.getCurrentTime(),
+                    TestAddress.account1
                 )
             );
 

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -23,7 +23,9 @@ contract SimpleAssertionsWithClaimOnly is Common {
                     address(defaultCurrency),
                     address(0),
                     address(0),
-                    defaultIdentifier
+                    defaultIdentifier,
+                    timer.getCurrentTime(),
+                    TestAddress.account1
                 )
             );
 

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -19,12 +19,12 @@ contract SimpleAssertionsWithClaimOnly is Common {
                 abi.encode(
                     trueClaimAssertion,
                     defaultBond,
+                    uint64(timer.getCurrentTime()),
                     defaultLiveness,
                     address(defaultCurrency),
                     address(0),
                     address(0),
                     defaultIdentifier,
-                    timer.getCurrentTime(),
                     TestAddress.account1
                 )
             );


### PR DESCRIPTION
**Motivation**

We should have additional props in assertionIds to avoid collisions. This PR adds both the caller and the block timestamp to the calling ID.
