### PR TITLE
feat: add asserter argument to assertTruthWithDefaults

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -66,12 +66,12 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
         return assertions[assertionId];
     }
 
-    function assertTruthWithDefaults(bytes calldata claim) public returns (bytes32) {
+    function assertTruthWithDefaults(bytes calldata claim, address asserter) public returns (bytes32) {
         // Note: re-entrancy guard is done in the inner call.
         return
             assertTruth(
                 claim,
-                msg.sender, // asserter
+                asserter, // asserter
                 address(0), // callbackRecipient
                 address(0), // escalationManager
                 defaultLiveness,

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -36,7 +36,7 @@ interface OptimisticAsserterInterface {
 
     function getAssertion(bytes32 assertionId) external view returns (Assertion memory);
 
-    function assertTruthWithDefaults(bytes memory claim) external returns (bytes32);
+    function assertTruthWithDefaults(bytes memory claim, address asserter) external returns (bytes32);
 
     function assertTruth(
         bytes memory claim,

--- a/packages/core/test/foundry/optimistic-asserter/Common.sol
+++ b/packages/core/test/foundry/optimistic-asserter/Common.sol
@@ -173,7 +173,7 @@ contract Common is Test {
             address(optimisticAsserter),
             optimisticAsserter.getMinimumBond(address(defaultCurrency))
         );
-        assertionId = optimisticAsserter.assertTruthWithDefaults(claim);
+        assertionId = optimisticAsserter.assertTruthWithDefaults(claim, asserter);
         vm.stopPrank();
     }
 

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Events.t.sol
@@ -46,7 +46,7 @@ contract OptimisticAsserterEvents is Common {
         );
 
         // Account1 asserts a false claim.
-        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(falseClaimAssertion);
+        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(falseClaimAssertion, TestAddress.account1);
         vm.stopPrank();
 
         // Dispute should emit logs on Optimistic Asserter and Oracle.

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.Lifecycle.t.sol
@@ -29,7 +29,7 @@ contract SimpleAssertionsWithClaimOnly is Common {
                 )
             );
 
-        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(trueClaimAssertion);
+        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(trueClaimAssertion, TestAddress.account1);
         assertEq(assertionId, expectedAssertionId);
         vm.stopPrank();
 
@@ -55,7 +55,8 @@ contract SimpleAssertionsWithClaimOnly is Common {
         defaultCurrency.approve(address(optimisticAsserter), defaultBond);
 
         // Account1 asserts a false claim.
-        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(bytes(falseClaimAssertion));
+        bytes32 assertionId =
+            optimisticAsserter.assertTruthWithDefaults(bytes(falseClaimAssertion), TestAddress.account1);
         vm.stopPrank();
 
         // The assertion gets disputed by the disputer, account2.

--- a/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/OptimisticAsserter.SsPolicy.t.sol
@@ -16,7 +16,7 @@ contract EscalationManagerPolicyEnforced is Common {
 
     function testDefaultPolicy() public {
         vm.prank(TestAddress.account1);
-        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(trueClaimAssertion);
+        bytes32 assertionId = optimisticAsserter.assertTruthWithDefaults(trueClaimAssertion, TestAddress.account1);
         OptimisticAsserterInterface.Assertion memory assertion = optimisticAsserter.getAssertion(assertionId);
         assertFalse(assertion.escalationManagerSettings.discardOracle);
         assertFalse(assertion.escalationManagerSettings.arbitrateViaEscalationManager);


### PR DESCRIPTION
**Motivation**

Method is more useful when the caller can pass the asserter in.


**Summary**

Added an asserter argument to assertTruthWithDefaults.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
