### PR TITLE
fix[OA-audit-L03]: Address erronous docstrings and comments

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -84,9 +84,9 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
     }
 
     /**
-     * @notice Asserts a truth about the world, using the default currency and liveness. No callback recipient
-     * or escalation manager is enabled. The caller is the asserter and is expected to provide a bond of the
-     * currencies finalFee/burnedBondPercentage (with burnedBondPercentage set to 50%, the bond is 2x final fee).
+     * @notice Asserts a truth about the world, using the default currency and liveness. No callback recipient or
+     * escalation manager is enabled. The caller is expected to provide a bond of finalFee/burnedBondPercentage
+     * (with burnedBondPercentage set to 50%, the bond is 2x final fee) of the default currency.
      * @dev The caller must approve this contract to spend at least the result of getMinimumBond(defaultCurrency).
      * @param claim the truth claim being asserted. This is an assertion about the world, and is verified by disputers.
      * @return assertionId unique identifier for this assertion.

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
@@ -158,7 +158,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
     }
 
     /**
-     * @notice Adds a disputerCaller to the whitelist of disputers that can file disputes.
+     * @notice Adds/removes a disputerCaller to the whitelist of disputers that can file disputes.
      * @param disputeCaller the address of the disputeCaller to add.
      * @dev This function is only used if validateDisputers is set to true.
      */
@@ -168,7 +168,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
     }
 
     /**
-     * @notice Adds an asserter to the whitelist of assertingCallers that can make assertions.
+     * @notice Adds/removes an asserter to the whitelist of assertingCallers that can make assertions.
      * @param assertingCaller the address of the assertingCaller to add.
      */
     function setWhitelistedAssertingCallers(address assertingCaller, bool value) public onlyOwner {
@@ -177,7 +177,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
     }
 
     /**
-     * @notice Adds an asserter to the whitelist of asserters that can make assertions.
+     * @notice Adds/removes an asserter to the whitelist of asserters that can make assertions.
      * @param asserter the address of the asserter to add.
      * @dev This function must be used in conjunction with setWhitelistedAssertingCallers in order to have an effect.
      */


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
Consider fixing the following docstrings and inline comments:
In OptimisticAsserter.sol , the comment on line 88 claims the caller is the
asserter, but that is not necessarily true.
In FullPolicyEscalationManager.sol , comments on line 161, line 171, and line
180 for the respective setDisputeCallerInWhitelist ,
setWhitelistedAssertingCallers , and setWhitelistedAsserters functions
state "Adds a ... to the whitelist". In reality, the functions can both add and remove from
the whitelists.
```

This PR addresses these issues by fixing the comments.
