### PR TITLE
fix[OA-audit-L05]: Address lack of check for final fee when adding currency to whitelist cache

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -461,7 +461,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
         if (cachedCurrencies[currency].isWhitelisted) return true;
         cachedCurrencies[currency].isWhitelisted = _getCollateralWhitelist().isOnWhitelist(currency);
         cachedCurrencies[currency].finalFee = _getStore().computeFinalFee(currency).rawValue;
-        return cachedCurrencies[currency].isWhitelisted;
+        return cachedCurrencies[currency].isWhitelisted && cachedCurrencies[currency].finalFee > 0;
     }
 
     function _callbackOnAssertionResolve(bytes32 assertionId, bool assertedTruthfully) internal {


### PR DESCRIPTION

**Motivation**

OZ identified the following issue:
```
When a currency is whitelisted and cached in the OptimisticAsserter contract, it is
assumed that the Store contract will have a final fee set for the currency address. If the final
fee has not been set, then assertions can be posted without a bond.
Prior to whitelisting a currency, consider adding a check that ensures the final fee from the
Store contract is non-zero in the syncUmaParams and _validateAndCacheCurrency
functions.
```
This PR addresses this by modifying the `_validateAndCacheCurrency` method to ensure that the final fee is NOT set to 0 when adding a currency to the whitelist.
