### PR TITLE
fix[OA-audit-N05]: Address argument name mismatches between interface and implementation

### DIFF
--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -52,7 +52,7 @@ interface OptimisticAsserterInterface {
 
     function getAssertionResult(bytes32 assertionId) external view returns (bool);
 
-    function getMinimumBond(address currencyAddress) external view returns (uint256);
+    function getMinimumBond(address currency) external view returns (uint256);
 
     event AssertionMade(
         bytes32 indexed assertionId,


### PR DESCRIPTION
**Motivation**
OZ identified the following issues:
```
The argument to the getMinimumBond function in the OptimisticAsserterInterface
interface is named currencyAddress , but it is named currency in the
OptimisticAsserter contract on line 358.
For clarity, consider renaming one of the arguments so the interface matches the
implementation.
```
This PR addresses this by implementing the change requested.
