### PR TITLE
fix[OA-audit-N08]: Fix address multicaller payability

### DIFF
--- a/packages/core/contracts/common/implementation/MultiCaller.sol
+++ b/packages/core/contracts/common/implementation/MultiCaller.sol
@@ -6,8 +6,7 @@ pragma solidity ^0.8.0;
 /// @title MultiCaller
 /// @notice Enables calling multiple methods in a single call to the contract
 contract MultiCaller {
-    function multicall(bytes[] calldata data) external payable returns (bytes[] memory results) {
-        require(msg.value == 0, "Only multicall with 0 value");
+    function multicall(bytes[] calldata data) external returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);


### PR DESCRIPTION
**Motivation**

OZ identifies the following issue: 
```
The multicall function of the MultiCaller contract is declared payable but does not
accept any ETH. In the interest of clarity, consider removing the payable keyword.
```

This PR updates the multicaller contract to remove both the require and the payable keyword.
