### PR TITLE
fix: Fix MerkleDistributor unit tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,3 @@
 [submodule "packages/core/temp/lib/forge-std"]
 	path = packages/core/temp/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/forge-std"]
-	branch = v1.2.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "packages/core/temp/lib/forge-std"]
 	path = packages/core/temp/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/forge-std"]
+	branch = v1.2.0

--- a/packages/core/test/hardhat/merkle-distributor/MerkleDistributor.js
+++ b/packages/core/test/hardhat/merkle-distributor/MerkleDistributor.js
@@ -24,7 +24,7 @@ let windowIndex;
 
 const sampleIpfsHash = "QmfVMHgoWpTSZqovo7vhM7Wcmz6EeX4QBYbCk4DZTNM8u3";
 
-const hashFn = (buffer) => buffer.toString("hex")
+const hashFn = (buffer) => buffer.toString("hex");
 // For a recipient object, create the leaf to be part of the merkle tree. The leaf is simply a hash of the packed
 // account and the amount.
 const createLeaf = (recipient) => {
@@ -211,7 +211,10 @@ describe("MerkleDistributor.js", function () {
 
         // Generate leafs for each recipient. This is simply the hash of each component of the payout from above.
         rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
-        merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
+        merkleTree = new MerkleTree(
+          rewardLeafs.map((item) => item.leaf),
+          hashFn
+        );
 
         // Seed the merkleDistributor with the root of the tree and additional information.
         await merkleDistributor.methods
@@ -329,7 +332,10 @@ describe("MerkleDistributor.js", function () {
         // increment the index for this new root.
         rewardRecipients = createRewardRecipientsFromSampleData(SamplePayouts);
         let otherRewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
-        let otherMerkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
+        let otherMerkleTree = new MerkleTree(
+          rewardLeafs.map((item) => item.leaf),
+          hashFn
+        );
         await merkleDistributor.methods
           .setWindow(
             SamplePayouts.totalRewardsDistributed,
@@ -522,7 +528,12 @@ describe("MerkleDistributor.js", function () {
           rewardLeafs.push(_rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) })));
         });
         rewardLeafs.forEach((_rewardLeafs) => {
-          merkleTrees.push(new MerkleTree(_rewardLeafs.map((item) => item.leaf), hashFn));
+          merkleTrees.push(
+            new MerkleTree(
+              _rewardLeafs.map((item) => item.leaf),
+              hashFn
+            )
+          );
         });
 
         // Seed the merkleDistributor with the root of the tree and additional information.
@@ -617,12 +628,18 @@ describe("MerkleDistributor.js", function () {
         // Set two windows with trivial one leaf trees.
         const reward1Recipients = [{ account: accounts[3], amount: window1RewardAmount.toString(), accountIndex: 1 }];
         const reward2Recipients = [{ account: accounts[3], amount: window2RewardAmount.toString(), accountIndex: 1 }];
-        const merkleTree1 = new MerkleTree(reward1Recipients.map((item) => createLeaf(item)), hashFn);
+        const merkleTree1 = new MerkleTree(
+          reward1Recipients.map((item) => createLeaf(item)),
+          hashFn
+        );
         const nextWindowIndex = (await merkleDistributor.methods.nextCreatedIndex().call()).toString();
         await merkleDistributor.methods
           .setWindow(window1RewardAmount, rewardToken.options.address, merkleTree1.getRoot(), "")
           .send({ from: accounts[0] });
-        const merkleTree2 = new MerkleTree(reward2Recipients.map((item) => createLeaf(item)), hashFn);
+        const merkleTree2 = new MerkleTree(
+          reward2Recipients.map((item) => createLeaf(item)),
+          hashFn
+        );
         await merkleDistributor.methods
           .setWindow(window2RewardAmount, rewardToken.options.address, merkleTree2.getRoot(), "")
           .send({ from: accounts[0] });
@@ -707,7 +724,12 @@ describe("MerkleDistributor.js", function () {
 
         // Generate leafs for each recipient for the underfunded reward set.
         rewardLeafs.push(rewardRecipients[underfundedWindowIndex].map((item) => ({ ...item, leaf: createLeaf(item) })));
-        merkleTrees.push(new MerkleTree(rewardLeafs[underfundedWindowIndex].map((item) => item.leaf)), hashFn);
+        merkleTrees.push(
+          new MerkleTree(
+            rewardLeafs[underfundedWindowIndex].map((item) => item.leaf),
+            hashFn
+          )
+        );
 
         // Fund rewards window with the same Merkle tree, but insufficient funding.
         const insufficientTotalRewards = toBN(SamplePayouts.totalRewardsDistributed).sub(toBN("1"));
@@ -773,7 +795,10 @@ describe("MerkleDistributor.js", function () {
         const _claimData = { ...claimData, accountIndex: i, account: _claimAccount };
         rewardLeafs.push({ ..._claimData, leaf: createLeaf(_claimData) });
       }
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
+      merkleTree = new MerkleTree(
+        rewardLeafs.map((item) => item.leaf),
+        hashFn
+      );
     });
 
     beforeEach(async function () {
@@ -1038,7 +1063,10 @@ describe("MerkleDistributor.js", function () {
 
       // Generate leafs for each recipient. This is simply the hash of each component of the payout from above.
       rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
+      merkleTree = new MerkleTree(
+        rewardLeafs.map((item) => item.leaf),
+        hashFn
+      );
     });
     it("Only owner can call", async function () {
       assert(
@@ -1112,7 +1140,10 @@ describe("MerkleDistributor.js", function () {
       rewardRecipients = createRewardRecipientsFromSampleData(SamplePayouts);
       rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
 
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
+      merkleTree = new MerkleTree(
+        rewardLeafs.map((item) => item.leaf),
+        hashFn
+      );
 
       await merkleDistributor.methods
         .setWindow(

--- a/packages/core/test/hardhat/merkle-distributor/MerkleDistributor.js
+++ b/packages/core/test/hardhat/merkle-distributor/MerkleDistributor.js
@@ -1,9 +1,8 @@
 const hre = require("hardhat");
 const { getContract, assertEventEmitted } = hre;
-const { MerkleTree } = require("@uma/merkle-distributor");
 const SamplePayouts = require("./SamplePayout.json");
 const { toBN, toWei, utf8ToHex, padRight } = web3.utils;
-const { MAX_UINT_VAL, didContractThrow } = require("@uma/common");
+const { MAX_UINT_VAL, didContractThrow, MerkleTree } = require("@uma/common");
 const { assert } = require("chai");
 const Promise = require("bluebird");
 
@@ -25,6 +24,7 @@ let windowIndex;
 
 const sampleIpfsHash = "QmfVMHgoWpTSZqovo7vhM7Wcmz6EeX4QBYbCk4DZTNM8u3";
 
+const hashFn = (buffer) => buffer.toString("hex")
 // For a recipient object, create the leaf to be part of the merkle tree. The leaf is simply a hash of the packed
 // account and the amount.
 const createLeaf = (recipient) => {
@@ -93,7 +93,10 @@ describe("MerkleDistributor.js", function () {
       rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
 
       // Build the merkle tree from an array of hashes from each recipient.
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf));
+      merkleTree = new MerkleTree(
+        rewardLeafs.map((item) => item.leaf),
+        hashFn
+      );
 
       // Expect this merkle root to be at the first index.
       windowIndex = 0;
@@ -208,7 +211,7 @@ describe("MerkleDistributor.js", function () {
 
         // Generate leafs for each recipient. This is simply the hash of each component of the payout from above.
         rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
-        merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf));
+        merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
 
         // Seed the merkleDistributor with the root of the tree and additional information.
         await merkleDistributor.methods
@@ -326,7 +329,7 @@ describe("MerkleDistributor.js", function () {
         // increment the index for this new root.
         rewardRecipients = createRewardRecipientsFromSampleData(SamplePayouts);
         let otherRewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
-        let otherMerkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf));
+        let otherMerkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
         await merkleDistributor.methods
           .setWindow(
             SamplePayouts.totalRewardsDistributed,
@@ -519,7 +522,7 @@ describe("MerkleDistributor.js", function () {
           rewardLeafs.push(_rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) })));
         });
         rewardLeafs.forEach((_rewardLeafs) => {
-          merkleTrees.push(new MerkleTree(_rewardLeafs.map((item) => item.leaf)));
+          merkleTrees.push(new MerkleTree(_rewardLeafs.map((item) => item.leaf), hashFn));
         });
 
         // Seed the merkleDistributor with the root of the tree and additional information.
@@ -614,12 +617,12 @@ describe("MerkleDistributor.js", function () {
         // Set two windows with trivial one leaf trees.
         const reward1Recipients = [{ account: accounts[3], amount: window1RewardAmount.toString(), accountIndex: 1 }];
         const reward2Recipients = [{ account: accounts[3], amount: window2RewardAmount.toString(), accountIndex: 1 }];
-        const merkleTree1 = new MerkleTree(reward1Recipients.map((item) => createLeaf(item)));
+        const merkleTree1 = new MerkleTree(reward1Recipients.map((item) => createLeaf(item)), hashFn);
         const nextWindowIndex = (await merkleDistributor.methods.nextCreatedIndex().call()).toString();
         await merkleDistributor.methods
           .setWindow(window1RewardAmount, rewardToken.options.address, merkleTree1.getRoot(), "")
           .send({ from: accounts[0] });
-        const merkleTree2 = new MerkleTree(reward2Recipients.map((item) => createLeaf(item)));
+        const merkleTree2 = new MerkleTree(reward2Recipients.map((item) => createLeaf(item)), hashFn);
         await merkleDistributor.methods
           .setWindow(window2RewardAmount, rewardToken.options.address, merkleTree2.getRoot(), "")
           .send({ from: accounts[0] });
@@ -704,7 +707,7 @@ describe("MerkleDistributor.js", function () {
 
         // Generate leafs for each recipient for the underfunded reward set.
         rewardLeafs.push(rewardRecipients[underfundedWindowIndex].map((item) => ({ ...item, leaf: createLeaf(item) })));
-        merkleTrees.push(new MerkleTree(rewardLeafs[underfundedWindowIndex].map((item) => item.leaf)));
+        merkleTrees.push(new MerkleTree(rewardLeafs[underfundedWindowIndex].map((item) => item.leaf)), hashFn);
 
         // Fund rewards window with the same Merkle tree, but insufficient funding.
         const insufficientTotalRewards = toBN(SamplePayouts.totalRewardsDistributed).sub(toBN("1"));
@@ -770,7 +773,7 @@ describe("MerkleDistributor.js", function () {
         const _claimData = { ...claimData, accountIndex: i, account: _claimAccount };
         rewardLeafs.push({ ..._claimData, leaf: createLeaf(_claimData) });
       }
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf));
+      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
     });
 
     beforeEach(async function () {
@@ -1035,7 +1038,7 @@ describe("MerkleDistributor.js", function () {
 
       // Generate leafs for each recipient. This is simply the hash of each component of the payout from above.
       rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf));
+      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
     });
     it("Only owner can call", async function () {
       assert(
@@ -1109,7 +1112,7 @@ describe("MerkleDistributor.js", function () {
       rewardRecipients = createRewardRecipientsFromSampleData(SamplePayouts);
       rewardLeafs = rewardRecipients.map((item) => ({ ...item, leaf: createLeaf(item) }));
 
-      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf));
+      merkleTree = new MerkleTree(rewardLeafs.map((item) => item.leaf), hashFn);
 
       await merkleDistributor.methods
         .setWindow(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,7 +2412,7 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/providers@5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.4.4":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -12134,17 +12134,6 @@ ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.3, ethereumjs-util@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz#a6885bcdd92045b06f596c7626c3e89ab3312458"
   integrity sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==
-  dependencies:
-    "@types/bn.js" "^5.1.0"
-    bn.js "^5.1.2"
-    create-hash "^1.1.2"
-    ethereum-cryptography "^0.1.3"
-    rlp "^2.2.4"
-
-ethereumjs-util@^7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
-  integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
   dependencies:
     "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"
@@ -22363,7 +22352,7 @@ secp256k1@4.0.2, secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-secp256k1@4.0.3:
+secp256k1@4.0.3, secp256k1@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
   integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
@@ -22385,15 +22374,6 @@ secp256k1@^3.0.1, secp256k1@^3.7.1:
     elliptic "^6.5.2"
     nan "^2.14.0"
     safe-buffer "^5.1.2"
-
-secp256k1@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
-  integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
-  dependencies:
-    elliptic "^6.5.4"
-    node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.0"
 
 seedrandom@3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Current tests import MerkleTree from @uma/merkle-distrbutor which is a deprecated package. This PR imports MerkleTree from @uma/common and uses the latest MerkleTree class