### PR TITLE
fix: [DVM2.0] deleting rolled spam requests

### DIFF
--- a/packages/common/src/HardhatConfig.ts
+++ b/packages/common/src/HardhatConfig.ts
@@ -42,7 +42,7 @@ export function getHardhatConfig(
   require("@nomiclabs/hardhat-etherscan");
   require("@nomiclabs/hardhat-ethers");
   require("hardhat-deploy");
-  // require("hardhat-gas-reporter");
+  require("hardhat-gas-reporter");
   require("./gckms/KeyInjectorPlugin");
   require("hardhat-tracer");
 
@@ -93,7 +93,7 @@ export function getHardhatConfig(
         gasPrice: "auto",
         initialBaseFeePerGas: 1_000_000_000,
         gas: 11500000,
-        blockGasLimit: 30_000_000,
+        blockGasLimit: 15_000_000,
         timeout: 1800000,
         testBlacklist,
         allowUnlimitedContractSize: true,

--- a/packages/common/src/HardhatConfig.ts
+++ b/packages/common/src/HardhatConfig.ts
@@ -42,7 +42,7 @@ export function getHardhatConfig(
   require("@nomiclabs/hardhat-etherscan");
   require("@nomiclabs/hardhat-ethers");
   require("hardhat-deploy");
-  require("hardhat-gas-reporter");
+  // require("hardhat-gas-reporter");
   require("./gckms/KeyInjectorPlugin");
   require("hardhat-tracer");
 
@@ -93,7 +93,7 @@ export function getHardhatConfig(
         gasPrice: "auto",
         initialBaseFeePerGas: 1_000_000_000,
         gas: 11500000,
-        blockGasLimit: 15_000_000,
+        blockGasLimit: 30_000_000,
         timeout: 1800000,
         testBlacklist,
         allowUnlimitedContractSize: true,

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -919,7 +919,6 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             // rolled & then deleted vote. This happens due to the executeSpamDeletion setting the skippedRequestIndexes
             // to consider the rolled value on deletion without re-indexing the same requestIndex (which is what happens
             // during the normal rolling process and is why we increment +1 in the above ternary operator).
-            //
             if (nextIndex >= priceRequestIds.length) nextIndex = priceRequestIds.length - 1;
 
             if (

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -45,8 +45,9 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         // Each request has a unique requestIndex number that is used to order all requests. This is the index within
         // the priceRequestIds array and is incremented on each request.
         uint64 priceRequestIndex;
-        // Timestamp that should be used when evaluating the request. Note: this is a uint64 to allow better variable
-        // packing while still leaving more than ample room for timestamps to stretch far into the future.
+        // Timestamp that should be used when evaluating the request.
+        // Note: this is a uint64 to allow better variable packing while still leaving more than ample room for
+        // timestamps to stretch far into the future.
         uint64 time;
         // Identifier that defines how the voters should resolve the request.
         bytes32 identifier;
@@ -955,11 +956,11 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     /**
      * @notice Declare a specific price requests range to be spam and request its deletion.
-     * @dev note that this method should almost never be used. The bond to call this should be set to a very large
-     * number (say 10k UMA) as it could be abused if set too low. Function constructs a price request that, if passed,
-     * enables pending requests to be disregarded by the contract.
-     * @param spamRequestIndices list of request indices to be declared as spam. Each element is a pair of uint256s
-     * representing the start and end of the range.
+     * @dev note that this method should almost never be used. The bond to call this should be set to
+     * a very large number (say 10k UMA) as it could be abused if set too low. Function constructs a price
+     * request that, if passed, enables pending requests to be disregarded by the contract.
+     * @param spamRequestIndices list of request indices to be declared as spam. Each element is a
+     * pair of uint256s representing the start and end of the range.
      */
     function signalRequestsAsSpamForDeletion(uint256[2][] calldata spamRequestIndices)
         external

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -752,10 +752,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
      * @param indexTo last price request index to update the trackers for.
      */
     function updateTrackersRange(address voterAddress, uint256 indexTo) external {
-        require(
-            voterStakes[voterAddress].nextIndexToProcess < indexTo && indexTo <= priceRequestIds.length,
-            "Invalid indexTo"
-        );
+        require(voterStakes[voterAddress].nextIndexToProcess < indexTo && indexTo <= priceRequestIds.length);
 
         _updateAccountSlashingTrackers(voterAddress, indexTo);
     }
@@ -980,8 +977,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             require(
                 spamRequestIndex[0] <= spamRequestIndex[1] &&
                     spamRequestIndex[1] < priceRequestIds.length &&
-                    spamRequestIndex[1] > runningValidationIndex,
-                "Invalid spam request index"
+                    spamRequestIndex[1] > runningValidationIndex
             );
 
             runningValidationIndex = spamRequestIndex[1];
@@ -1014,14 +1010,14 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
      */
 
     function executeSpamDeletion(uint256 proposalId) external nonReentrant() {
-        require(spamDeletionProposals[proposalId].executed == false, "Proposal already executed");
+        require(spamDeletionProposals[proposalId].executed == false);
         spamDeletionProposals[proposalId].executed = true;
 
         bytes32 identifier = SpamGuardIdentifierLib._constructIdentifier(SafeCast.toUint32(proposalId));
 
         (bool hasPrice, int256 resolutionPrice, ) =
             _getPriceOrError(identifier, spamDeletionProposals[proposalId].requestTime, "");
-        require(hasPrice, "Spam proposal has not resolved");
+        require(hasPrice);
 
         // If the price is non zero then the spam deletion request was voted up to delete the requests. Execute delete.
         if (resolutionPrice != 0) {

--- a/packages/core/test/hardhat/data-verification-mechanism/SpamGuard.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/SpamGuard.js
@@ -752,7 +752,7 @@ describe("SpamGuard", function () {
     await moveToNextRound(voting, accounts[0]);
     assert.equal(await voting.methods.getNumberOfPriceRequests().call(), numberOfRequests);
 
-    // From testing this directly, it is known that we can execute a spam deletion of all the request in one go. To
+    // From testing this directly, it is known that we can't execute a spam deletion for all the request in one go. To
     // Deal with this, we need to split this up over 3 spam deletion request so they can be executed separately later.
     const time = await voting.methods.getCurrentTime().call();
     await voting.methods.signalRequestsAsSpamForDeletion([[0, 333]]).send({ from: account1 });

--- a/packages/core/test/hardhat/data-verification-mechanism/SpamGuard.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/SpamGuard.js
@@ -521,6 +521,7 @@ describe("SpamGuard", function () {
     await voting.methods.commitVote(spamDeleteIdentifier, signalDeleteTime, hash1).send({ from: account2 });
 
     // There should now be 5 requests as the commit triggered update trackers adding 2 rolled spam requests.
+    // TODO: Check if this really should be the expected behavior.
     assert.equal(await voting.methods.getNumberOfPriceRequests().call(), 5);
 
     // Reveal the spam deletion vote.
@@ -566,7 +567,7 @@ describe("SpamGuard", function () {
 
     // Update trackers should not add any new requests as the spam requests were deleted.
     await voting.methods.updateTrackers(account2).send({ from: account2 });
-    // assert.equal(await voting.methods.getNumberOfPriceRequests().call(), 5);
+    assert.equal(await voting.methods.getNumberOfPriceRequests().call(), 5);
 
     // There should still be no pending requests.
     assert.equal((await voting.methods.getPendingRequests().call()).length, 0);
@@ -578,25 +579,25 @@ describe("SpamGuard", function () {
         { identifier: spamIdentifier, time: time + 1 },
       ])
       .call();
-    // assert.equal(statuses[0].status, "0");
-    // assert.equal(statuses[1].status, "0");
-    // assert.equal(statuses[0].lastVotingRound, "0");
-    // assert.equal(statuses[1].lastVotingRound, "0");
+    assert.equal(statuses[0].status, "0");
+    assert.equal(statuses[1].status, "0");
+    assert.equal(statuses[0].lastVotingRound, "0");
+    assert.equal(statuses[1].lastVotingRound, "0");
 
     // Also all gettable spam request struct elements should still be initialized to defaults.
     spamRequest1 = await voting.methods.priceRequests(spamRequestId1).call();
     spamRequest2 = await voting.methods.priceRequests(spamRequestId2).call();
-    // assert.equal(spamRequest1.lastVotingRound, "0");
+    assert.equal(spamRequest1.lastVotingRound, "0");
     assert.isFalse(spamRequest1.isGovernance);
     assert.equal(spamRequest1.pendingRequestIndex, "0");
-    // assert.equal(spamRequest1.priceRequestIndex, "0");
+    assert.equal(spamRequest1.priceRequestIndex, "0");
     assert.equal(spamRequest1.time, "0");
     assert.equal(spamRequest1.identifier, padRight(utf8ToHex(""), 64));
     assert.isNull(spamRequest1.ancillaryData);
-    // assert.equal(spamRequest2.lastVotingRound, "0");
+    assert.equal(spamRequest2.lastVotingRound, "0");
     assert.isFalse(spamRequest2.isGovernance);
     assert.equal(spamRequest2.pendingRequestIndex, "0");
-    // assert.equal(spamRequest2.priceRequestIndex, "0");
+    assert.equal(spamRequest2.priceRequestIndex, "0");
     assert.equal(spamRequest2.time, "0");
     assert.equal(spamRequest2.identifier, padRight(utf8ToHex(""), 64));
     assert.isNull(spamRequest2.ancillaryData);


### PR DESCRIPTION
**Motivation**

After experimenting with the combination of rolled votes + spam deletion requests we identified a subtle issue if you try and delete a rolled spam vote wherein the voting contract would: a) not correctly update the jump mapping and b) re-euqnue spam deletion requests within the pending requests array.

To address this, this PR adds a small logic change and additional unit tests to better accommodate spam deletion + rolled votes. This is critical as in the event that spam is created and UMA governance is too slow to initiate a deletion _before_ voting begins on the spam (i.e dont submit the spam deletion request within the [minRollToNextRoundLength](https://github.com/UMAprotocol/protocol/blob/25d22a9088a64da8f6783130c65d717a9104015d/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol#L233) period) we could hit a situation quite easily where we need to first _roll_ spam and _then_ delete it. In practice, this could look something like this:
1) right before cycle C0 ends, and before `phaseEndTime-minRollToNextRoundLength`, a spammer submits a large number of requests.
2) governance misses the chance to signal for these to be deleted in the next round (within the `minRollToNextRoundLength`). this could also happen if `minRollToNextRoundLength` is set to 0.
3) the next cycle C1 starts. now, The spam votes are available to be voted on. However, UMA voters _know_ these are spam and dont want to vote on them. During C1 someone submits a spam deletion request to remove these from the voting system.
4) the voting round ends without any spam meeting the GAT.
5) Now, we are in C2. The spam was enqued in C0, not settled in C1 and is now voted on again in C2, along with the spam deletion request. This amounts to the spam rolling. The voting contracts should enable voters to _only_ vote on the spam deletion request in C2, without voting on any of the spam, and then in C3 when the spam deletion request settles and is executed all spam should be removed from the contracts.
6) Critically at this point **no voters should need to traversed by any other voters as the spam was removed**. I.e the cost of using the voting system (and updating trackers) should not be affected at all removal of the spam, even though it was rolled.