### PR TITLE
feat: Add unique session ID to new Logger

### DIFF
--- a/packages/financial-templates-lib/src/logger/Logger.ts
+++ b/packages/financial-templates-lib/src/logger/Logger.ts
@@ -52,8 +52,10 @@ export function createNewLogger(
   transportsConfig = {},
   botIdentifier = process.env.BOT_IDENTIFIER || "NO_BOT_ID"
 ): AugmentedLogger {
+  const sessionId = Date.now();
   const logger = winston.createLogger({
     level: "debug",
+    defaultMeta: { sessionId },
     format: winston.format.combine(
       winston.format(botIdentifyFormatter(botIdentifier))(),
       winston.format((logEntry) => logEntry)(),


### PR DESCRIPTION
Can be used to identify logs more easily in GCP with overlapping serverless runs

