### PR TITLE
fix[OA-audit-N10]: Fix redundant code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/core/temp/lib/forge-std"]
+	path = packages/core/temp/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/core/temp/lib/forge-std"]
-	path = packages/core/temp/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "packages/core/temp/lib/forge-std"]
 	path = packages/core/temp/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-  

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "packages/core/temp/lib/forge-std"]
 	path = packages/core/temp/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+  

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -465,21 +465,23 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
     }
 
     function _callbackOnAssertionResolve(bytes32 assertionId, bool assertedTruthfully) internal {
-        if (assertions[assertionId].callbackRecipient != address(0))
-            OptimisticAsserterCallbackRecipientInterface(assertions[assertionId].callbackRecipient)
-                .assertionResolvedCallback(assertionId, assertedTruthfully);
-        if (_getEscalationManager(assertionId) != address(0))
-            EscalationManagerInterface(_getEscalationManager(assertionId)).assertionResolvedCallback(
+        address callbackRecipient = assertions[assertionId].callbackRecipient;
+        address escalationManager = _getEscalationManager(assertionId);
+        if (callbackRecipient != address(0))
+            OptimisticAsserterCallbackRecipientInterface(callbackRecipient).assertionResolvedCallback(
                 assertionId,
                 assertedTruthfully
             );
+        if (escalationManager != address(0))
+            EscalationManagerInterface(escalationManager).assertionResolvedCallback(assertionId, assertedTruthfully);
     }
 
     function _callbackOnAssertionDispute(bytes32 assertionId) internal {
-        if (assertions[assertionId].callbackRecipient != address(0))
-            OptimisticAsserterCallbackRecipientInterface(assertions[assertionId].callbackRecipient)
-                .assertionDisputedCallback(assertionId);
-        if (_getEscalationManager(assertionId) != address(0))
-            EscalationManagerInterface(_getEscalationManager(assertionId)).assertionDisputedCallback(assertionId);
+        address callbackRecipient = assertions[assertionId].callbackRecipient;
+        address escalationManager = _getEscalationManager(assertionId);
+        if (callbackRecipient != address(0))
+            OptimisticAsserterCallbackRecipientInterface(callbackRecipient).assertionDisputedCallback(assertionId);
+        if (escalationManager != address(0))
+            EscalationManagerInterface(escalationManager).assertionDisputedCallback(assertionId);
     }
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -464,23 +464,17 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
     }
 
     function _callbackOnAssertionResolve(bytes32 assertionId, bool assertedTruthfully) internal {
-        address callbackRecipient = assertions[assertionId].callbackRecipient;
-        address escalationManager = _getEscalationManager(assertionId);
-        if (callbackRecipient != address(0))
-            OptimisticAsserterCallbackRecipientInterface(callbackRecipient).assertionResolvedCallback(
-                assertionId,
-                assertedTruthfully
-            );
-        if (escalationManager != address(0))
-            EscalationManagerInterface(escalationManager).assertionResolvedCallback(assertionId, assertedTruthfully);
+        address cr = assertions[assertionId].callbackRecipient;
+        address em = _getEscalationManager(assertionId);
+        if (cr != address(0))
+            OptimisticAsserterCallbackRecipientInterface(cr).assertionResolvedCallback(assertionId, assertedTruthfully);
+        if (em != address(0)) EscalationManagerInterface(em).assertionResolvedCallback(assertionId, assertedTruthfully);
     }
 
     function _callbackOnAssertionDispute(bytes32 assertionId) internal {
-        address callbackRecipient = assertions[assertionId].callbackRecipient;
-        address escalationManager = _getEscalationManager(assertionId);
-        if (callbackRecipient != address(0))
-            OptimisticAsserterCallbackRecipientInterface(callbackRecipient).assertionDisputedCallback(assertionId);
-        if (escalationManager != address(0))
-            EscalationManagerInterface(escalationManager).assertionDisputedCallback(assertionId);
+        address cr = assertions[assertionId].callbackRecipient;
+        address em = _getEscalationManager(assertionId);
+        if (cr != address(0)) OptimisticAsserterCallbackRecipientInterface(cr).assertionDisputedCallback(assertionId);
+        if (em != address(0)) EscalationManagerInterface(em).assertionDisputedCallback(assertionId);
     }
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -203,8 +203,6 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
             currency,
             bond
         );
-
-        return assertionId;
     }
 
     /**

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
@@ -16,7 +16,7 @@ contract BaseEscalationManager is EscalationManagerInterface {
      * @param assertionId the assertionId to get the assertion policy for.
      * @return the assertion policy for the given assertionId.
      */
-    function getAssertionPolicy(bytes32 assertionId) public view virtual override returns (AssertionPolicy memory) {
+    function getAssertionPolicy(bytes32 assertionId) public view virtual returns (AssertionPolicy memory) {
         return
             AssertionPolicy({
                 blockAssertion: false,
@@ -33,7 +33,7 @@ contract BaseEscalationManager is EscalationManagerInterface {
      * @param disputeCaller the caller of the dispute function.
      * @return bool if the dispute is allowed, false otherwise.
      */
-    function isDisputeAllowed(bytes32 assertionId, address disputeCaller) public view virtual override returns (bool) {
+    function isDisputeAllowed(bytes32 assertionId, address disputeCaller) public view virtual returns (bool) {
         return true;
     }
 
@@ -49,7 +49,7 @@ contract BaseEscalationManager is EscalationManagerInterface {
         bytes32 identifier,
         uint256 time,
         bytes memory ancillaryData
-    ) public view virtual override returns (int256) {}
+    ) public view virtual returns (int256) {}
 
     /**
      * @notice Implements price requesting logic for the escalation manager. This function is called by the Optimistic
@@ -62,13 +62,13 @@ contract BaseEscalationManager is EscalationManagerInterface {
         bytes32 identifier,
         uint256 time,
         bytes memory ancillaryData
-    ) public virtual override {
+    ) public virtual {
         emit PriceRequestAdded(identifier, time, ancillaryData);
     }
 
     // Callback function that is called by Optimistic Asserter when an assertion is resolved.
-    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public virtual override {}
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public virtual {}
 
     // Callback function that is called by Optimistic Asserter when an assertion is disputed.
-    function assertionDisputedCallback(bytes32 assertionId) public virtual override {}
+    function assertionDisputedCallback(bytes32 assertionId) public virtual {}
 }

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
@@ -121,7 +121,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
         bool _arbitrateViaEscalationManager,
         bool _discardOracle
     ) public onlyOwner {
-        require(!_blockByAsserter || (_blockByAsserter && _blockByAssertingCaller), "Cannot block only by asserter");
+        require(!_blockByAsserter || _blockByAssertingCaller, "Cannot block only by asserter");
         blockByAssertingCaller = _blockByAssertingCaller;
         blockByAsserter = _blockByAsserter;
         validateDisputers = _validateDisputers;

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
@@ -86,7 +86,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
         uint256 time,
         bytes memory ancillaryData
     ) public view override returns (int256) {
-        bytes32 requestId = keccak256(abi.encode(identifier, time, ancillaryData));
+        bytes32 requestId = getRequestId(identifier, time, ancillaryData);
         require(arbitrationResolutions[requestId].valueSet, "Arbitration resolution not set");
         if (arbitrationResolutions[requestId].resolution) return 1e18;
         return 0;
@@ -152,7 +152,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
         bytes memory ancillaryData,
         bool arbitrationResolution
     ) public onlyOwner {
-        bytes32 requestId = keccak256(abi.encode(identifier, time, ancillaryData));
+        bytes32 requestId = getRequestId(identifier, time, ancillaryData);
         arbitrationResolutions[requestId] = ArbitrationResolution(true, arbitrationResolution);
         emit ArbitrationResolutionSet(identifier, time, ancillaryData, arbitrationResolution);
     }
@@ -184,6 +184,21 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
     function setWhitelistedAsserters(address asserter, bool value) public onlyOwner {
         whitelistedAsserters[asserter] = value;
         emit AsserterWhitelistSet(asserter, value);
+    }
+
+    /**
+     * @notice Calculates price request identifier for a given identifier, time, and ancillary data.
+     * @param identifier uniquely identifies the price requested.
+     * @param time unix timestamp of the price request.
+     * @param ancillaryData arbitrary data appended to a price request to give the voters more info from the caller.
+     * @return price request identifier.
+     */
+    function getRequestId(
+        bytes32 identifier,
+        uint256 time,
+        bytes memory ancillaryData
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(identifier, time, ancillaryData));
     }
 
     // Checks if an assertion is blocked depending on the blockByAssertingCaller / blockByAsserter settings and the


### PR DESCRIPTION
**Motivation**

OZ identifies the following issue:

```
Consider addressing the following instances of redundant code within the codebase:
- The override keyword can be removed from all functions in the BaseEscalationManager contract.
- Consider deduplicating this code by creating a shared getRequestId function. Additionally, consider making this function publicly available for user convenience.
- Within the FullPolicyEscalationManger contract, the require statement in the configureEscalationManager function can be simplified
- Consider modifying the existing _getEscalationManager function to return an address type, and using it in all the identified locations other than line 435 to perform the escalationManager lookup
- In the _callbackOnAssertionResolve and _callbackOnAssertionDispute functions within the OptimisticAsserter contract, the lookup of  recipients happens twice within each function's scope.
- The return statement in the assertTruth function is redundant because assertionId is a named return variable in the function specification
```

This PR addresses the above issues by simplifying code.