### PR TITLE
fix[OA-audit-N11]: Declare functions as external

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -92,7 +92,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @return assertionId unique identifier for this assertion.
      */
 
-    function assertTruthWithDefaults(bytes calldata claim, address asserter) public returns (bytes32 assertionId) {
+    function assertTruthWithDefaults(bytes calldata claim, address asserter) external returns (bytes32 assertionId) {
         // Note: re-entrancy guard is done in the inner call.
         return
             assertTruth(
@@ -214,7 +214,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @param assertionId unique identifier for the assertion to dispute.
      * @param disputer receives bonds back at settlement.
      */
-    function disputeAssertion(bytes32 assertionId, address disputer) public nonReentrant {
+    function disputeAssertion(bytes32 assertionId, address disputer) external nonReentrant {
         require(disputer != address(0), "Disputer cant be 0");
         Assertion storage assertion = assertions[assertionId];
         require(assertion.asserter != address(0), "Assertion does not exist");
@@ -289,7 +289,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @param assertionId unique identifier for the assertion to resolve and return the resolution for.
      * @return resolution of the assertion.
      */
-    function settleAndGetAssertionResult(bytes32 assertionId) public returns (bool resolution) {
+    function settleAndGetAssertionResult(bytes32 assertionId) external returns (bool resolution) {
         // Note: re-entrancy guard is done in the inner settleAssertion call.
         if (!assertions[assertionId].settled) settleAssertion(assertionId);
         return getAssertionResult(assertionId);


### PR DESCRIPTION
**Motivation**

OZ identifies the following issue:

```
Below is a list of functions that have public visibility that can be limited to external visibility in the OptimisticAsserter contract:
- assertTruthWithDefaults
- disputeAssertion
- settleAndGetAssertionResult
```

This PR addresses the above issue by changing the visibility of these functions to external.