### PR TITLE
fix[OA-audit-N13]: Remove unused import

### DIFF
--- a/packages/core/contracts/optimistic-asserter/interfaces/EscalationManagerInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/EscalationManagerInterface.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.16;
 
 import "./OptimisticAsserterCallbackRecipientInterface.sol";
-import "./OptimisticAsserterInterface.sol";
 
 interface EscalationManagerInterface is OptimisticAsserterCallbackRecipientInterface {
     struct AssertionPolicy {


### PR DESCRIPTION
**Motivation**

OZ identifies the following issue:

```
In EscalationManagerInterface.sol , the import OptimisticAsserterInterface.sol is unused and could be removed.
```

This PR addresses the above issue by removing the unused import.