### PR TITLE
fix[OA-audit-N12]: Typographical errors

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -119,17 +119,17 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * recipient _must_ implement these callbacks and not revert or the assertion resolution will be blocked.
      * @param escalationManager if configured, this address will control escalation properties of the assertion. This
      * means a) choosing to arbitrate via the UMA DVM, b) choosing to discard assertions on dispute, or choosing to
-     * validate disputes. Combining these, the asserter can define their own security properties the assertion.
+     * validate disputes. Combining these, the asserter can define their own security properties for the assertion.
      * escalationManager also _must_ implement the same callbacks as callbackRecipient.
      * @param liveness time to wait before the assertion can be resolved. Assertion can be disputed in this time.
      * @param currency bond currency pulled from the caller and held in escrow until the assertion is resolved.
      * @param bond amount of currency to pull from the caller and hold in escrow until the assertion is resolved. This
      * must be >= getMinimumBond(address(currency)).
-     * @param identifier UMA DVM identifier to use for price requests in the event of a dispute. Must be a pre-approved.
+     * @param identifier UMA DVM identifier to use for price requests in the event of a dispute. Must be pre-approved.
      * @param domainId optional domain that can be used to relate this assertion to others in the escalationManager and
      * can be used by the configured escalationManager to define custom behavior for groups of assertions. This is
      * typically used for "escalation games" by changing bonds or other assertion properties based on the other
-     * assertions that have come before. If not needed this value should be bytes32 to save gas.
+     * assertions that have come before. If not needed this value should be 0 to save gas.
      */
     function assertTruth(
         bytes memory claim,
@@ -177,7 +177,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
             require(!assertionPolicy.blockAssertion, "Assertion not allowed"); // Check if the assertion is permitted.
             EscalationManagerSettings storage emSettings = assertions[assertionId].escalationManagerSettings;
             (emSettings.arbitrateViaEscalationManager, emSettings.discardOracle, emSettings.validateDisputers) = (
-                // Choose which oracle to arbitrate disputes via. If Set to true then the escalation manager will
+                // Choose which oracle to arbitrate disputes via. If set to true then the escalation manager will
                 // arbitrate disputes. Else, the DVM arbitrates disputes. This lets integrations "unplug" the DVM.
                 assertionPolicy.arbitrateViaEscalationManager,
                 // Choose whether to discard the Oracle result. If true then "throw away" the assertion. To get an
@@ -215,7 +215,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @param disputer receives bonds back at settlement.
      */
     function disputeAssertion(bytes32 assertionId, address disputer) public nonReentrant {
-        require(disputer != address(0), "Disputer cant be 0");
+        require(disputer != address(0), "Disputer can't be 0");
         Assertion storage assertion = assertions[assertionId];
         require(assertion.asserter != address(0), "Assertion does not exist");
         require(assertion.disputer == address(0), "Assertion already disputed");

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/BaseEscalationManager.sol
@@ -31,7 +31,7 @@ contract BaseEscalationManager is EscalationManagerInterface {
      * if the dispute should be allowed based on the escalation policy.
      * @param assertionId the assertionId to validate the dispute for.
      * @param disputeCaller the caller of the dispute function.
-     * @return bool if the dispute is allowed, false otherwise.
+     * @return bool true if the dispute is allowed, false otherwise.
      */
     function isDisputeAllowed(bytes32 assertionId, address disputeCaller) public view virtual override returns (bool) {
         return true;
@@ -53,7 +53,7 @@ contract BaseEscalationManager is EscalationManagerInterface {
 
     /**
      * @notice Implements price requesting logic for the escalation manager. This function is called by the Optimistic
-     * on dispute and is constructed to mimic that of the UMA DVM interface.
+     * Asserter on dispute and is constructed to mimic that of the UMA DVM interface.
      * @param identifier the identifier to fetch the price for.
      * @param time the time to fetch the price for.
      * @param ancillaryData ancillary data of the price being requested.

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
@@ -9,7 +9,7 @@ import "../../interfaces/OptimisticAsserterInterface.sol";
  * resolutions for the Escalation Manager. Optionally, assertion blocking can be enabled using a whitelist of
  * assertingCallers or assertingCallers and asserters. On the other hand, it enables the determination of whether to
  * arbitrate via the escalation manager as opposed to the DVM, whether to disregard the resolution of a potential
- * dispute arbitrated by the Oracle, and whether to restrict who can register disputes via a whitelistedDisputeCallers.
+ * dispute arbitrated by the Oracle, and whether to restrict who can register disputes via whitelistedDisputeCallers.
  * @dev If nothing is configured using the setters and configureEscalationManager method upon deployment, the
  * FullPolicyEscalationManager will return a default policy with all values set to false.
  */
@@ -98,7 +98,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
      * @param assertionId the ID of the assertion to check the disputerCaller for.
      * @param disputeCaller the address of the disputeCaller to check.
      * @return true if the disputerCaller is authorised to dispute the assertion.
-     * @dev In order for this function to be used by the Optimistic Assertor, validateDisputers must be set to true.
+     * @dev In order for this function to be used by the Optimistic Asserter, validateDisputers must be set to true.
      */
     function isDisputeAllowed(bytes32 assertionId, address disputeCaller) public view override returns (bool) {
         return whitelistedDisputeCallers[disputeCaller];
@@ -158,7 +158,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
     }
 
     /**
-     * @notice Adds a disputerCaller to the whitelist of disputers that can file disputes.
+     * @notice Adds a disputeCaller to the whitelist of disputers that can file disputes.
      * @param disputeCaller the address of the disputeCaller to add.
      * @dev This function is only used if validateDisputers is set to true.
      */

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -7,7 +7,7 @@ interface OptimisticAsserterInterface {
     struct EscalationManagerSettings {
         bool arbitrateViaEscalationManager; // False if the DVM is used as an oracle (EscalationManager on True).
         bool discardOracle; // False if Oracle result is used for resolving assertion after dispute.
-        bool validateDisputers; // True if the SS isDisputeAllowed should be checked on disputes.
+        bool validateDisputers; // True if the EM isDisputeAllowed should be checked on disputes.
         address assertingCaller;
         address escalationManager;
     }


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ identifies the following issue:
```
Consider correcting the following typographical errors:
In BaseEscalationManager.sol :
Line 34: "if the dispute" should be "true if the dispute".
Line 55: "Optimistic" should be "Optimistic Asserter".
In FullPolicyEscalationManager.sol :
Line 12: "a whitelistedDisputeCallers" should be "whitelistedDisputeCallers".
Line 101: "Assertor" should be "Asserter".
Line 161: "disputerCaller" should be "disputeCaller".
In OptimisticAsserter.sol :
Line 122: "security properties the assertion" should be "security properties for the
assertion".
Line 128: "Must be a pre-approved." is an incomplete sentence.
Line 132: "should be bytes32" should be "0".
Line 180: "Set" should be "set".
Line 218: "cant" should be "can't".
In OptimisticAsserterInterface.sol :
Line 10: "SS" should be "SSM". EDIT: IT SHOULD BE EM
```


**Summary**

Fix typographical errors
