### PR TITLE
fix[OA-audit-N15]: Use of magic numbers

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -43,6 +43,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
     uint256 public burnedBondPercentage; // Percentage of the bond that is paid to the UMA store if the assertion is disputed.
 
     bytes32 public constant defaultIdentifier = "ASSERT_TRUTH";
+    int256 public constant numericalTrue = 1e18; // Numerical representation of true.
     IERC20 public defaultCurrency;
     uint64 public defaultLiveness;
 
@@ -263,9 +264,9 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
 
             // If set to discard settlement resolution then false. Else, use oracle value to find resolution.
             if (assertion.escalationManagerSettings.discardOracle) assertion.settlementResolution = false;
-            else assertion.settlementResolution = resolvedPrice == 1e18;
+            else assertion.settlementResolution = resolvedPrice == numericalTrue;
 
-            address bondRecipient = resolvedPrice == 1e18 ? assertion.asserter : assertion.disputer;
+            address bondRecipient = resolvedPrice == numericalTrue ? assertion.asserter : assertion.disputer;
 
             // If set to use UMA DVM as oracle then oracleFee must be sent to UMA Store contract. Else, if not using UMA
             // DVM then the bond is returned to the correct party (asserter or disputer).

--- a/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/escalation-manager/FullPolicyEscalationManager.sol
@@ -35,6 +35,8 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
 
     event AsserterWhitelistSet(address asserter, bool whitelisted);
 
+    int256 public constant numericalTrue = 1e18; // Numerical representation of true.
+
     bool public blockByAssertingCaller; // True if assertions are allowed only by whitelisted asserting callers.
 
     bool public blockByAsserter; // True if assertions are allowed only by whitelisted asserters.
@@ -88,7 +90,7 @@ contract FullPolicyEscalationManager is BaseEscalationManager, Ownable {
     ) public view override returns (int256) {
         bytes32 requestId = keccak256(abi.encode(identifier, time, ancillaryData));
         require(arbitrationResolutions[requestId].valueSet, "Arbitration resolution not set");
-        if (arbitrationResolutions[requestId].resolution) return 1e18;
+        if (arbitrationResolutions[requestId].resolution) return numericalTrue;
         return 0;
     }
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ identifies the following issue:
```
The OptimisticAsserter and FullPolicyEscalationManager contracts use the
constant value 1e18 in the settleAssertion and getPrice functions without
documenting the value's meaning.
Literal values in the codebase without an explained meaning make the code harder to
understand and maintain, thus hindering the experience of developers, auditors, and external
contributors alike. To improve the code's readability and facilitate refactoring, consider defining
a constant for every magic number, giving it a clear and self-explanatory name.
```

**Summary**

Add constant variable representing the numerical true value
