### PR TITLE
fix[OA-audit-N14]: Consistent use of named return variables

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -92,7 +92,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @return assertionId unique identifier for this assertion.
      */
 
-    function assertTruthWithDefaults(bytes calldata claim, address asserter) public returns (bytes32 assertionId) {
+    function assertTruthWithDefaults(bytes calldata claim, address asserter) public returns (bytes32) {
         // Note: re-entrancy guard is done in the inner call.
         return
             assertTruth(
@@ -289,7 +289,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @param assertionId unique identifier for the assertion to resolve and return the resolution for.
      * @return resolution of the assertion.
      */
-    function settleAndGetAssertionResult(bytes32 assertionId) public returns (bool resolution) {
+    function settleAndGetAssertionResult(bytes32 assertionId) public returns (bool) {
         // Note: re-entrancy guard is done in the inner settleAssertion call.
         if (!assertions[assertionId].settled) settleAssertion(assertionId);
         return getAssertionResult(assertionId);
@@ -314,7 +314,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @param assertionId unique identifier for the assertion to fetch information for.
      * @return assertion information about the assertion.
      */
-    function getAssertion(bytes32 assertionId) external view returns (Assertion memory assertion) {
+    function getAssertion(bytes32 assertionId) external view returns (Assertion memory) {
         return assertions[assertionId];
     }
 
@@ -324,7 +324,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
      * @param assertionId unique identifier for the assertion to fetch the resolution for.
      * @return resolution of the assertion.
      */
-    function getAssertionResult(bytes32 assertionId) public view returns (bool resolution) {
+    function getAssertionResult(bytes32 assertionId) public view returns (bool) {
         Assertion memory assertion = assertions[assertionId];
         // Return early if not using answer from resolved dispute.
         if (assertion.disputer != address(0) && assertion.escalationManagerSettings.discardOracle) return false;


### PR DESCRIPTION
**Motivation**

OZ identifies the following issue:

```
Within the OptimisticAsserter contract, named return variables are used inconsistently.
```

This PR addresses the above issue by removing the unused named return variables.

Note that `assertTruth` still has to keep named return variable in order to avoid stack too deep error.