### PR TITLE
fix[OA-audit-N03]: Always send oracle fee to the Store

### DIFF
--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -272,7 +272,7 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
 
             // Pay out the oracle fee and remaining bonds to the correct party. Note: the oracle fee is sent to the
             // Store contract, even if the escalation manager is used to arbitrate disputes.
-            if (oracleFee > 0) assertion.currency.safeTransfer(address(_getStore()), oracleFee);
+            assertion.currency.safeTransfer(address(_getStore()), oracleFee);
             assertion.currency.safeTransfer(bondRecipient, bondRecipientAmount);
 
             if (!assertion.escalationManagerSettings.discardOracle)

--- a/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
+++ b/packages/core/contracts/optimistic-asserter/implementation/OptimisticAsserter.sol
@@ -266,13 +266,12 @@ contract OptimisticAsserter is OptimisticAsserterInterface, Lockable, Ownable, M
 
             address bondRecipient = resolvedPrice == numericalTrue ? assertion.asserter : assertion.disputer;
 
-            // If set to use UMA DVM as oracle then oracleFee must be sent to UMA Store contract. Else, if not using UMA
-            // DVM then the bond is returned to the correct party (asserter or disputer).
+            // Calculate oracle fee and the remaining amount of bonds to send to the correct party (asserter or disputer).
             uint256 oracleFee = (burnedBondPercentage * assertion.bond) / 1e18;
-            if (assertion.escalationManagerSettings.arbitrateViaEscalationManager) oracleFee = 0;
             uint256 bondRecipientAmount = assertion.bond * 2 - oracleFee;
 
-            // Send tokens. If the DVM is used as an oracle then send the oracleFee to the Store.
+            // Pay out the oracle fee and remaining bonds to the correct party. Note: the oracle fee is sent to the
+            // Store contract, even if the escalation manager is used to arbitrate disputes.
             if (oracleFee > 0) assertion.currency.safeTransfer(address(_getStore()), oracleFee);
             assertion.currency.safeTransfer(bondRecipient, bondRecipientAmount);
 

--- a/packages/core/test/foundry/optimistic-asserter/integration-tests/FullPolicyEscalationManager.Arbitrate.t.sol
+++ b/packages/core/test/foundry/optimistic-asserter/integration-tests/FullPolicyEscalationManager.Arbitrate.t.sol
@@ -57,8 +57,8 @@ contract FullPolicyEscalationManagerArbitrateTest is FullPolicyEscalationManager
         _defaultSaveBalancesBeforeSettle();
         assertTrue(optimisticAsserter.settleAndGetAssertionResult(assertionId));
 
-        // Asserter should get double the bond without paying Oracle fees.
-        _defaultCheckBalancesAfterSettle(true, true, false);
+        // Asserter should get double the bond less Oracle fees.
+        _defaultCheckBalancesAfterSettle(true, true, true);
     }
 
     function test_ResolveAssertionNotTruthfulViaEscalationManager() public {
@@ -80,7 +80,7 @@ contract FullPolicyEscalationManagerArbitrateTest is FullPolicyEscalationManager
         _defaultSaveBalancesBeforeSettle();
         assertFalse(optimisticAsserter.settleAndGetAssertionResult(assertionId));
 
-        // Disputer should get double the bond without paying Oracle fees.
-        _defaultCheckBalancesAfterSettle(true, false, false);
+        // Disputer should get double the bond less Oracle fees.
+        _defaultCheckBalancesAfterSettle(true, false, true);
     }
 }


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
While the existing design allows the DVM to collect a fee for providing oracle services, it does not allow an escalation manager to collect any fee to cover its potential cost for providing the same service.
```

With this PR the oracle fee is always paid to UMA Store, even when dispute is arbitrated via the escalation manager.
Note that this does not follow suggestion in the audit report because switching to arbitrate via the escalation manager is designed only as a fallback mechanism when there are risks of DVM corruption.

Also the prior mechanism to not pay oracle fees when arbitrating via the escalation manager could potentially pose escalation manager to spam attacks, thus dispute should always have the oracle fee.