### PR TITLE
fix[DVM2.0-audit-L03]: Fix erroneous comment

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -1243,7 +1243,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         unchecked { return x + 1; }
     }
 
-    // Gas optimized uint256 decrement.
+    // Gas optimized uint64 increment.
     function unsafe_inc_64(uint64 x) internal pure returns (uint64) {
         unchecked { return x + 1; }
     }


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
In VotingV2.sol, the comment on line 1251 should be "Gas optimized uint64 increment."
```

This PR fixes the issue mentioned.