### PR TITLE
fix[DVM2.0-audit-N01]: Add input validation to EmergencyProposer

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
@@ -124,6 +124,7 @@ contract EmergencyProposer is Ownable, Lockable {
      */
     function emergencyPropose(GovernorV2.Transaction[] memory transactions) external nonReentrant() returns (uint256) {
         require(msg.sender != address(governor), "Governor can't propose"); // The governor should never be the proposer.
+        require(transactions.length > 0, "No transactions to propose");
         token.safeTransferFrom(msg.sender, address(this), quorum);
         uint256 id = emergencyProposals.length;
         EmergencyProposal storage proposal = emergencyProposals.push();

--- a/packages/core/test/hardhat/data-verification-mechanism/EmergencyProposer.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/EmergencyProposer.js
@@ -171,7 +171,10 @@ describe("EmergencyProposer", function () {
   });
 
   it("Quorum must be paid", async function () {
-    const txn = proposer.methods.emergencyPropose([]);
+    // Build a no-op txn for the governor to execute.
+    const noOpTxnBytes = votingToken.methods.approve(submitter, "0").encodeABI();
+
+    const txn = proposer.methods.emergencyPropose([{ to: votingToken.options.address, value: 0, data: noOpTxnBytes }]);
 
     // No balance and bond isn't approved.
     assert(await didContractThrow(txn.send({ from: submitter })));
@@ -314,5 +317,15 @@ describe("EmergencyProposer", function () {
 
     // Clean up votingToken balance.
     await votingToken.methods.transfer(owner, quorum).send({ from: submitter });
+  });
+  it("Cannot propose empty proposal", async function () {
+    // Move tokens.
+    await votingToken.methods.transfer(submitter, quorum).send({ from: owner });
+    await votingToken.methods.approve(proposer.options.address, quorum).send({ from: submitter });
+
+    // Construct an empty proposal.
+    const txn = proposer.methods.emergencyPropose([]);
+
+    assert(await didContractThrow(txn.send({ from: submitter })));
   });
 });


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
In the emergencyPropose function in the EmergencyProposer contract, a lack of input
validation allows for proposals to be created that contain no transactions.
```

This PR addresses this issue by adding a check that ensures the length of the transactions input array is not zero.
