### PR TITLE
improve: Update blockfinder to be faster for chains with new average time estimates: {10, 288, 42161}

### DIFF
--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -19,9 +19,9 @@ export async function averageBlockTimeSeconds(chainId?: number): Promise<number>
   switch (chainId) {
     // Source: https://polygonscan.com/chart/blocktime
     case 10:
-      return 0.5; // 2 TPS, an underestimate
+      return 0.5; 
     case 42161:
-      return 0.5; // 2 TPS, an underestimate
+      return 0.5;
     case 288:
       return 30;
     case 137:

--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -11,22 +11,21 @@ export async function averageBlockTimeSeconds(chainId?: number): Promise<number>
   // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
   // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
   // since April 2016, although this value seems to spike periodically for a relatively short period of time.
-  const defaultBlockTimeSeconds = 13.5;
+  const defaultBlockTimeSeconds = 12;
   if (!defaultBlockTimeSeconds) {
     throw "Missing default block time value";
   }
 
   switch (chainId) {
-    // Block time is irrelevant on Arbitrum since one transaction ~= 1 block, so this time value is based on empirical
-    // observation as of January 4 2022 of Arbitrum block propogation.
-    case 42161:
-      return 2.2;
-    // Source: https://blockexplorer.boba.network/
-    case 288:
-      return 3.8;
     // Source: https://polygonscan.com/chart/blocktime
+    case 10:
+      return 0.5; // 2 TPS, an underestimate
+    case 42161:
+      return 0.5; // 2 TPS, an underestimate
+    case 288:
+      return 30;
     case 137:
-      return 2.2;
+      return 2.5;
     case 1:
       return defaultBlockTimeSeconds;
     default:
@@ -44,15 +43,4 @@ export async function getFromBlock(web3: Web3): Promise<number> {
   } else {
     return 0;
   }
-}
-
-/**
- * @notice Estimates the blocks elapsed over a certain number of seconds.
- * @param seconds the number of seconds.
- * @param cushionPercentage the percentage to add to the number as a cushion.
- */
-export async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0): Promise<number> {
-  const cushionMultiplier = cushionPercentage + 1.0;
-  const averageBlockTime = await averageBlockTimeSeconds();
-  return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
 }

--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -19,7 +19,7 @@ export async function averageBlockTimeSeconds(chainId?: number): Promise<number>
   switch (chainId) {
     // Source: https://polygonscan.com/chart/blocktime
     case 10:
-      return 0.5; 
+      return 0.5;
     case 42161:
       return 0.5;
     case 288:

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
@@ -678,7 +678,7 @@ describe("OptimisticOracleClient.js", function () {
         web3,
         optimisticOracle.options.address,
         mockOracle.options.address,
-        13,
+        11,
         OptimisticOracleType.SkinnyOptimisticOracle
       );
 
@@ -1015,7 +1015,7 @@ describe("OptimisticOracleClient.js", function () {
         web3,
         optimisticOracle.options.address,
         mockOracle.options.address,
-        13
+        11
       );
 
       // Request a price and check that the longer lookback client currently sees it

--- a/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
+++ b/packages/financial-templates-lib/test/clients/OptimisticOracleClient.js
@@ -427,7 +427,7 @@ describe("OptimisticOracleClient.js", function () {
         web3,
         optimisticOracle.options.address,
         mockOracle.options.address,
-        13
+        11
       );
 
       // Request a price and check that the longer lookback client currently sees it

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -8,7 +8,8 @@ export type WithoutStringTimestamp<T extends { timestamp: number | string }> = T
 export default class BlockFinder<T extends { number: number; timestamp: number | string }> {
   constructor(
     private readonly requestBlock: (requestedBlock: string | number) => Promise<T>,
-    private readonly blocks: T[] = []
+    private readonly blocks: T[] = [],
+    private readonly networkId: number = 1
   ) {
     assert(requestBlock, "requestBlock function must be provided");
   }
@@ -31,7 +32,10 @@ export default class BlockFinder<T extends { number: number; timestamp: number |
       const initialBlock = this.blocks[0] as WithoutStringTimestamp<T>;
       const cushion = 1.1;
       // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
-      const incrementDistance = Math.max(await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion), 1);
+      const incrementDistance = Math.max(
+        await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion, this.networkId),
+        1
+      );
 
       // Search backwards by a constant increment until we find a block before the timestamp or hit block 0.
       for (let multiplier = 1; ; multiplier++) {

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -34,7 +34,7 @@ export default class BlockFinder<T extends { number: number; timestamp: number |
       // that the first block we find sets a floor for the target timestamp. The loop converges on the correct block
       // slower than the following incremental search performed by `findBlock`, so we want to minimize the number of
       // loop iterations in favor of searching more blocks over the `findBlock` search.
-      const cushion = 2;
+      const cushion = 1;
       const incrementDistance = Math.max(
         // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
         await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion, this.chainId),

--- a/packages/sdk/src/blockFinder.ts
+++ b/packages/sdk/src/blockFinder.ts
@@ -30,14 +30,14 @@ export default class BlockFinder<T extends { number: number; timestamp: number |
     // Check the first block. If it's grater than our timestamp, we need to find an earlier block.
     if (this.blocks[0].timestamp > timestamp) {
       const initialBlock = this.blocks[0] as WithoutStringTimestamp<T>;
-      const cushion = 1.1;
-      // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
-      // We double this distance to reduce the number of iterations in the following loop and increase the chance
+      // We use a 2x cushion to reduce the number of iterations in the following loop and increase the chance
       // that the first block we find sets a floor for the target timestamp. The loop converges on the correct block
       // slower than the following incremental search performed by `findBlock`, so we want to minimize the number of
       // loop iterations in favor of searching more blocks over the `findBlock` search.
+      const cushion = 2;
       const incrementDistance = Math.max(
-        (await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion, this.chainId)) * 2,
+        // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
+        await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion, this.chainId),
         1
       );
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { BigNumber, Contract } from "ethers";
+import { averageBlockTimeSeconds } from "@uma/common";
 import type Multicall2 from "./multicall2";
 import zip from "lodash/zip";
 
@@ -96,32 +97,12 @@ export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contra
   );
 };
 
-/**
- * @notice Return average block-time for a period.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function averageBlockTimeSeconds(lookbackSeconds?: number, networkId?: number): Promise<number> {
-  // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
-  // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
-  // since April 2016, although this value seems to spike periodically for a relatively short period of time.
-  const defaultBlockTimeSeconds = 13.5;
-  if (!defaultBlockTimeSeconds) {
-    throw "Missing default block time value";
-  }
-
-  switch (networkId) {
-    // Source: https://polygonscan.com/chart/blocktime
-    case 137:
-      return 2.5;
-    case 1:
-      return defaultBlockTimeSeconds;
-    default:
-      return defaultBlockTimeSeconds;
-  }
-}
-
-export async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0): Promise<number> {
+export async function estimateBlocksElapsed(
+  seconds: number,
+  cushionPercentage = 0.0,
+  networkId?: number
+): Promise<number> {
   const cushionMultiplier = cushionPercentage + 1.0;
-  const averageBlockTime = await averageBlockTimeSeconds();
+  const averageBlockTime = await averageBlockTimeSeconds(networkId);
   return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
 }

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -100,9 +100,9 @@ export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contra
 export async function estimateBlocksElapsed(
   seconds: number,
   cushionPercentage = 0.0,
-  networkId?: number
+  chainId?: number
 ): Promise<number> {
   const cushionMultiplier = cushionPercentage + 1.0;
-  const averageBlockTime = await averageBlockTimeSeconds(networkId);
+  const averageBlockTime = await averageBlockTimeSeconds(chainId);
   return Math.floor((seconds * cushionMultiplier) / averageBlockTime);
 }


### PR DESCRIPTION
The `BlockFinder` is faster if there is an approximate average time estimate for a chain, and these chains were missing.