### PR TITLE
fix[DVM2.0-audit-L02]: Emergency proposal execution can be front-run by proposer

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
@@ -149,7 +149,7 @@ contract EmergencyProposer is Ownable, Lockable {
     function removeProposal(uint256 id) external nonReentrant() {
         EmergencyProposal storage proposal = emergencyProposals[id];
         require(proposal.expiryTime <= getCurrentTime(), "must be expired to remove");
-        require(msg.sender == proposal.sender || msg.sender == executor, "proposer or executor");
+        require(msg.sender == owner() || msg.sender == executor, "proposer or executor");
         require(proposal.lockedTokens != 0, "invalid proposal");
         token.safeTransfer(proposal.sender, proposal.lockedTokens);
         emit EmergencyProposalRemoved(

--- a/packages/core/test/hardhat/data-verification-mechanism/EmergencyProposer.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/EmergencyProposer.js
@@ -285,7 +285,6 @@ describe("EmergencyProposer", function () {
 
     // Cannot remove proposal before expiry.
     assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: executor })));
-    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: submitter })));
 
     // Wait through expiry.
     const currentTime = await proposer.methods.getCurrentTime().call();
@@ -295,12 +294,11 @@ describe("EmergencyProposer", function () {
 
     // Only certain addresses can remove proposals.
     assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: rando })));
-    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: owner })));
     await proposer.methods.removeProposal(id).call({ from: executor });
-    const receipt = await proposer.methods.removeProposal(id).send({ from: submitter });
+    const receipt = await proposer.methods.removeProposal(id).send({ from: executor });
 
     // Cannot remove again.
-    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: submitter })));
+    assert(await didContractThrow(proposer.methods.removeProposal(id).send({ from: executor })));
 
     // Check that the event resolved as expected for a true value and the bond was repaid to the submitter.
     assert.equal(await votingToken.methods.balanceOf(submitter).call(), quorum);
@@ -309,7 +307,7 @@ describe("EmergencyProposer", function () {
       proposer,
       "EmergencyProposalRemoved",
       (event) =>
-        event.id === id && event.caller === submitter && event.sender === submitter && event.lockedTokens == quorum
+        event.id === id && event.caller === executor && event.sender === submitter && event.lockedTokens == quorum
     );
 
     // Clean up votingToken balance.


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
In the EmergencyProposer contract, after a proposal has expired, slashing or executing a
proposal can be front-run by the proposer (or executor) by calling removeProposal . Since
an emergency proposal can be created by anyone so long as they have the required bond, this
could allow a malicious actor to create a necessary emergency proposal only to front-run
execution of the proposal by removing it. A new proposal would then need to be created and
would not be able to be executed until minimumWaitTime has passed.
Consider only allowing the owner or executor to remove proposals after they have expired
to prevent such an attack.
```
This PR addresses this by implementing the recomended change.
