### PR TITLE
feat: [Proposal] Change PAT -> SPAT

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
@@ -33,9 +33,8 @@ library ResultComputationV2 {
     ) internal {
         data.totalVotes += numberTokens;
         data.voteFrequency[votePrice] += numberTokens;
-        if (votePrice != data.currentMode && data.voteFrequency[votePrice] > data.voteFrequency[data.currentMode]) {
+        if (votePrice != data.currentMode && data.voteFrequency[votePrice] > data.voteFrequency[data.currentMode])
             data.currentMode = votePrice;
-        }
     }
 
     /****************************************

--- a/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
@@ -33,8 +33,9 @@ library ResultComputationV2 {
     ) internal {
         data.totalVotes += numberTokens;
         data.voteFrequency[votePrice] += numberTokens;
-        if (votePrice != data.currentMode && data.voteFrequency[votePrice] > data.voteFrequency[data.currentMode])
+        if (votePrice != data.currentMode && data.voteFrequency[votePrice] > data.voteFrequency[data.currentMode]) {
             data.currentMode = votePrice;
+        }
     }
 
     /****************************************

--- a/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
@@ -45,22 +45,19 @@ library ResultComputationV2 {
      * @notice Returns whether the result is resolved, and if so, what value it resolved to.
      * @dev `price` should be ignored if `isResolved` is false.
      * @param data contains information against which the `minVoteThreshold` is applied.
-     * @param minVoteThreshold min (exclusive) number of tokens that must have voted (in any direction) for the result
+     * @param minTotalVotes min (exclusive) number of tokens that must have voted (in any direction) for the result
      * to be valid. Used to enforce a minimum voter participation rate, regardless of how the votes are distributed.
+     * @param minModalVotes min (exclusive) number of tokens that must have voted for the modal outcome for it to result
+     * in a resolution. This is used to avoid cases where the mode is a very small plurality.
      * @return isResolved indicates if the price has been resolved correctly.
      * @return price the price that the dvm resolved to.
      */
-    function getResolvedPrice(Data storage data, uint256 minVoteThreshold)
-        internal
-        view
-        returns (bool isResolved, int256 price)
-    {
-        uint256 modeThreshold = 5e17 + 1;
-
-        if (
-            data.totalVotes > minVoteThreshold &&
-            (data.voteFrequency[data.currentMode] * 1e18) / data.totalVotes > modeThreshold
-        ) {
+    function getResolvedPrice(
+        Data storage data,
+        uint256 minTotalVotes,
+        uint256 minModalVotes
+    ) internal view returns (bool isResolved, int256 price) {
+        if (data.totalVotes > minTotalVotes && data.voteFrequency[data.currentMode] > minModalVotes) {
             isResolved = true; // modeThreshold and minVoteThreshold are exceeded, so the resolved price is the mode.
             price = data.currentMode;
         } else isResolved = false;

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -863,11 +863,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         if (requestStatus == RequestStatus.Active) return (false, 0, "Current voting round not ended");
         if (requestStatus == RequestStatus.Resolved) {
             VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
-            (, int256 resolvedPrice) =
-                voteInstance.results.getResolvedPrice(
-                    rounds[priceRequest.lastVotingRound].minParticipationRequirement,
-                    rounds[priceRequest.lastVotingRound].minAgreementRequirement
-                );
+            (, int256 resolvedPrice) = _getResolvedPrice(voteInstance, priceRequest.lastVotingRound);
             return (true, resolvedPrice, "");
         }
 
@@ -951,10 +947,6 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             // Else, we are dealing with a request that can either be: a) deleted, b) rolled or c) resolved.
             VoteInstance storage voteInstance = request.voteInstances[request.lastVotingRound];
             (bool isResolvable, int256 resolvedPrice) = _getResolvedPrice(voteInstance, request.lastVotingRound);
-            // voteInstance.results.getResolvedPrice(
-            //     rounds[request.lastVotingRound].minParticipationRequirement,
-            //     rounds[request.lastVotingRound].minAgreementRequirement
-            // );
 
             if (isResolvable) {
                 // If resolvable, resolve. This involves a) moving the requestId from pendingPriceRequestsIds array to

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -52,7 +52,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     struct Round {
         uint256 minParticipationRequirement; // Minimum staked tokens that must vote to resolve a price in this round.
-        uint256 minAgreementRequirment; // Minimum staked tokens that must agree on an outcome to resolve a price in this round.
+        uint256 minAgreementRequirement; // Minimum staked tokens that must agree on an outcome to resolve a price in this round.
         uint256 cumulativeStakeAtRound; // Total staked tokens at the start of the round.
         uint64 resolvedIndex; // Index of pendingPriceRequestsIds that has been traversed this round.
     }
@@ -865,7 +865,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             (, int256 resolvedPrice) =
                 voteInstance.results.getResolvedPrice(
                     rounds[priceRequest.lastVotingRound].minParticipationRequirement,
-                    rounds[priceRequest.lastVotingRound].minAgreementRequirment
+                    rounds[priceRequest.lastVotingRound].minAgreementRequirement
                 );
             return (true, resolvedPrice, "");
         }
@@ -920,7 +920,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
             // The minimum votes on the modal outcome for the vote to settle within this round is the SPAT (percentage).
             uint256 effectiveSpat = (spat * cumulativeStake) / 1e18;
-            rounds[roundId].minAgreementRequirment = effectiveSpat;
+            rounds[roundId].minAgreementRequirement = effectiveSpat;
             rounds[roundId].cumulativeStakeAtRound = cumulativeStake; // Store the cumulativeStake to work slashing.
         }
     }
@@ -954,7 +954,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             (bool isResolvable, int256 resolvedPrice) =
                 voteInstance.results.getResolvedPrice(
                     rounds[request.lastVotingRound].minParticipationRequirement,
-                    rounds[request.lastVotingRound].minAgreementRequirment
+                    rounds[request.lastVotingRound].minAgreementRequirement
                 );
 
             if (isResolvable) {
@@ -1006,7 +1006,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             (bool isResolved, ) =
                 voteInstance.results.getResolvedPrice(
                     rounds[priceRequest.lastVotingRound].minParticipationRequirement,
-                    rounds[priceRequest.lastVotingRound].minAgreementRequirment
+                    rounds[priceRequest.lastVotingRound].minAgreementRequirement
                 );
 
             return isResolved ? RequestStatus.Resolved : RequestStatus.Active;

--- a/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
+++ b/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
@@ -161,14 +161,14 @@ abstract contract VotingV2Interface {
     function setMaxRolls(uint32 newMaxRolls) external virtual;
 
     /**
-     * @notice Resets the GAT number and PAT percentage. The GAT is the minimum number of tokens that must participate
-     * in a vote for it to resolve (quorum number). The PAT is is the minimum percentage of tokens that must participate
-     * in a vote  for it to resolve (quorum percentage of staked tokens) Note: this change only applies to rounds that
+     * @notice Resets the GAT number and SPAT percentage. The GAT is the minimum number of tokens that must participate
+     * in a vote for it to resolve (quorum number). The SPAT is is the minimum percentage of tokens that must agree
+     * in a vote for it to resolve (percentage of staked tokens) Note: this change only applies to rounds that
      * have not yet begun.
      * @param newGat sets the next round's GAT and going forward.
-     * @param newPat sets the next round's PAT and going forward.
+     * @param newSpat sets the next round's SPAT and going forward.
      */
-    function setGatAndPat(uint256 newGat, uint256 newPat) external virtual;
+    function setGatAndSpat(uint256 newGat, uint256 newSpat) external virtual;
 
     /**
      * @notice Changes the slashing library used by this contract.

--- a/packages/core/deploy/052_deploy_votingV2.js
+++ b/packages/core/deploy/052_deploy_votingV2.js
@@ -14,8 +14,8 @@ const func = async function (hre) {
   // Set the GAT to 5.5 million tokens. This is the number of tokens that must participate to resolve a vote.
   const gat = web3.utils.toBN(web3.utils.toWei("5500000", "ether"));
 
-  // Set the PAT to 25%. This is the percentage of staked tokens that must participate to resolve a vote.
-  const pat = web3.utils.toBN(web3.utils.toWei("0.25", "ether"));
+  // Set the SPAT to 25%. This is the percentage of staked tokens that must participate to resolve a vote.
+  const spat = web3.utils.toBN(web3.utils.toWei("0.25", "ether"));
 
   const emissionRate = "640000000000000000"; // 0.64 UMA per second.
 
@@ -43,7 +43,7 @@ const func = async function (hre) {
         phaseLength,
         maxRolls,
         gat.toString(),
-        pat.toString(),
+        spat.toString(),
         VotingToken.address,
         Finder.address,
         SlashingLibrary.address,
@@ -61,7 +61,7 @@ const func = async function (hre) {
         phaseLength,
         maxRolls,
         gat.toString(),
-        pat.toString(),
+        spat.toString(),
         VotingToken.address,
         Finder.address,
         SlashingLibrary.address,


### PR DESCRIPTION
**Motivation**

The PAT, which was recently introduced, makes the incentives far better for those who want to intentionally roll/delete a vote in the case of spam or to prolong the voting period/gather more information.

However, a small caveat of the PAT is that it creates a two-tiered resolution system, where a certain quorum of voters need to agree to resolve a vote, but if many voters sit out because they intend to roll the vote, the threshold for _agreeing_ on an outcome becomes as small as half of that quorum. The intention of this PR is to make a slight modification to the PAT to make the incentives simpler and stronger in cases of high controversy over rolls/spam.

The SPAT (Schelling Point Activation Threshold) is simply a percentage of staked tokens that _must_ agree on the outcome for the vote to resolve. It rolls more in every case that the PAT (with the same value) does since to satisfy the SPAT, voters must participate _and_ agree on the outcome.

Now that there is a staker community that has signaled their intent to vote, the modal threshold (SPAT) doesn't have to use the number of _active voters_ as the baseline. Note: previously, there was a hardcoded modal threshold of 50% of _participating votes_. Instead, it can use the entire staked balance as the baseline for determining agreement. Those who choose not to vote will be considered to be voting for abstention/rolling.

**Summary**

This PR adds the SPAT as described above.


**Details**

I have not updated tests, but can do if we decide that these incentives are preferable.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A
