### PR TITLE
feat: add post update functions

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -600,12 +600,12 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     /**
      * @notice Returns the number of current pending price requests to be voted and the number of resolved price
        requests over all time.
-     * @return numPendingPriceRequests the total number of pending prices requests.
-     * @return numResolvedPriceRequests the total number of prices resolved over all time.
+     * @return numberPendingPriceRequests the total number of pending prices requests.
+     * @return numberResolvedPriceRequests the total number of prices resolved over all time.
      */
     function getNumberOfPriceRequests()
         public
-        returns (uint256 numPendingPriceRequests, uint256 numResolvedPriceRequests)
+        returns (uint256 numberPendingPriceRequests, uint256 numberResolvedPriceRequests)
     {
         return (pendingPriceRequestsIds.length, resolvedPriceRequestIds.length);
     }
@@ -613,12 +613,12 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     /**
      * @notice Returns the number of current pending price requests to be voted and the number of resolved price
        requests over all time after processing any resolvable price requests.
-     * @return numPendingPriceRequests the total number of pending prices requests.
-     * @return numResolvedPriceRequests the total number of prices resolved over all time.
+     * @return numberPendingPriceRequests the total number of pending prices requests.
+     * @return numberResolvedPriceRequests the total number of prices resolved over all time.
      */
     function getNumberOfPriceRequestsPostUpdate()
         external
-        returns (uint256 numPendingPriceRequests, uint256 numResolvedPriceRequests)
+        returns (uint256 numberPendingPriceRequests, uint256 numberResolvedPriceRequests)
     {
         processResolvablePriceRequests();
         return getNumberOfPriceRequests();

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -517,12 +517,10 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
      ****************************************/
 
     /**
-     * @notice Gets the requests that are being voted on this round after resolving them when possible.
+     * @notice Gets the requests that are being voted on this round.
      * @return pendingRequests array containing identifiers of type PendingRequestAncillaryAugmented.
      */
-    function getPendingRequests() external override returns (PendingRequestAncillaryAugmented[] memory) {
-        // First, resolve any pending requests that can be resolved.
-        processResolvablePriceRequests();
+    function getPendingRequests() public override returns (PendingRequestAncillaryAugmented[] memory) {
         // Solidity memory arrays aren't resizable (and reading storage is expensive). Hence this hackery to filter
         // pendingPriceRequestsIds only to those requests that have an Active RequestStatus.
         PendingRequestAncillaryAugmented[] memory unresolved =
@@ -550,6 +548,15 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         for (uint256 i = 0; i < numUnresolved; i = unsafe_inc(i)) pendingRequests[i] = unresolved[i];
 
         return pendingRequests;
+    }
+
+    /**
+     * @notice Gets the requests that are being voted on this round after processing any resolvable price requests.
+     * @return pendingRequests array containing identifiers of type PendingRequestAncillaryAugmented.
+     */
+    function getPendingRequestsPostUpdate() external override returns (PendingRequestAncillaryAugmented[] memory) {
+        processResolvablePriceRequests();
+        return getPendingRequests();
     }
 
     /**
@@ -591,19 +598,30 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     }
 
     /**
-     * @notice Returns the number of resolved price requests over all time.
-     * @return uint256 the total number of prices resolved over all time.
+     * @notice Returns the number of current pending price requests to be voted and the number of resolved price
+       requests over all time.
+     * @return numPendingPriceRequests the total number of pending prices requests.
+     * @return numResolvedPriceRequests the total number of prices resolved over all time.
      */
-    function getNumberOfResolvedPriceRequests() external view returns (uint256) {
-        return resolvedPriceRequestIds.length;
+    function getNumberOfPriceRequests()
+        public
+        returns (uint256 numPendingPriceRequests, uint256 numResolvedPriceRequests)
+    {
+        return (pendingPriceRequestsIds.length, resolvedPriceRequestIds.length);
     }
 
     /**
-     * @notice Returns the number of current pending price requests to be voted.
-     * @return uint256 the total number of pending prices requests.
+     * @notice Returns the number of current pending price requests to be voted and the number of resolved price
+       requests over all time after processing any resolvable price requests.
+     * @return numPendingPriceRequests the total number of pending prices requests.
+     * @return numResolvedPriceRequests the total number of prices resolved over all time.
      */
-    function getNumberOfPendingPriceRequests() external view returns (uint256) {
-        return pendingPriceRequestsIds.length;
+    function getNumberOfPriceRequestsPostUpdate()
+        external
+        returns (uint256 numPendingPriceRequests, uint256 numResolvedPriceRequests)
+    {
+        processResolvablePriceRequests();
+        return getNumberOfPriceRequests();
     }
 
     /**

--- a/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
+++ b/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
@@ -129,11 +129,16 @@ abstract contract VotingV2Interface {
     ) public virtual;
 
     /**
-     * @notice Gets the queries that are being voted on this round.
-     * @return pendingRequests `PendingRequest` array containing identifiers
-     * and timestamps for all pending requests.
+     * @notice Gets the requests that are being voted on this round.
+     * @return pendingRequests array containing identifiers of type PendingRequestAncillaryAugmented.
      */
     function getPendingRequests() external virtual returns (PendingRequestAncillaryAugmented[] memory);
+
+    /**
+     * @notice Gets the requests that are being voted on this round after processing any resolvable price requests.
+     * @return pendingRequests array containing identifiers of type PendingRequestAncillaryAugmented.
+     */
+    function getPendingRequestsPostUpdate() external virtual returns (PendingRequestAncillaryAugmented[] memory);
 
     /**
      * @notice Returns the current voting phase, as a function of the current time.

--- a/packages/core/test/foundry/data-verification-mechanism/fork-tests/CommonDataVerificationMechanismForkTest.sol
+++ b/packages/core/test/foundry/data-verification-mechanism/fork-tests/CommonDataVerificationMechanismForkTest.sol
@@ -27,7 +27,7 @@ contract CommonDataVerificationMechanismForkTest is CommonTestBase {
         if (!shouldRunForkedTest) return; // Exit early if we are not executing forked tests.
 
         // TODO: look into a way to not have to hard code these addresses. Ok for now as we wont be changing them.
-        address votingAddress = chainId == 1 ? address(0) : 0xF71cdF8A34c56933A8871354A2570a301364e95F;
+        address votingAddress = chainId == 1 ? address(0) : 0xBc3683DEf184ad64f6162024BD401e8D49d0E517;
 
         voting = VotingV2(votingAddress);
 

--- a/packages/core/test/foundry/data-verification-mechanism/fork-tests/FakeLifeCycle.ft.sol
+++ b/packages/core/test/foundry/data-verification-mechanism/fork-tests/FakeLifeCycle.ft.sol
@@ -15,10 +15,11 @@ contract FakeLifeCycle is CommonDataVerificationMechanismForkTest {
         // Ensure we are at the start of a voting round so we can stake and vote without the stake being disabled.
         if (voting.getVotePhase() == VotingV2Interface.Phase.Reveal) moveToNextRound();
 
-        uint256 numberRequestsPreRequest = voting.getNumberOfPendingPriceRequests();
+        (uint256 numberRequestsPreRequest, ) = voting.getNumberOfPriceRequests();
         vm.prank(registeredRequester);
         voting.requestPrice(identifier, requestTime, ancillaryData);
-        assert(voting.getNumberOfPendingPriceRequests() == numberRequestsPreRequest + 1);
+        (uint256 numberRequestsPostRequest, ) = voting.getNumberOfPriceRequests();
+        assert(numberRequestsPostRequest == numberRequestsPreRequest + 1);
 
         // Mint fresh UMA and stake them.
         vm.prank(address(voting));

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -571,7 +571,7 @@ describe("VotingV2", function () {
 
     // Move to next round and roll the first request over.
     await moveToNextRound(voting, accounts[0]);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
 
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
 
@@ -1785,12 +1785,12 @@ describe("VotingV2", function () {
     );
 
     // Check that getNumberOfPriceRequestsPostUpdate return the correct number of price requests.
-    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numPendingPriceRequests, 1);
-    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numberPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numberResolvedPriceRequests, 1);
 
     // Check that getPendingRequests returns the pending price requests without updating.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // Check that getPendingRequestsPostUpdate returns the pending price requests updated.
     assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 0);
@@ -2270,8 +2270,8 @@ describe("VotingV2", function () {
     // Now call updateTrackers to update the slashing metrics. We should see a cumulative slashing amount increment and
     // the slash per wrong vote and slash per no vote set correctly.
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
 
     // The test configuration has a wrong vote and no vote slash per token set to 0.0016. This works out to ~ equal to
     // the emission rate of the contract assuming 10 votes per month over a year. At this rate we should see two groups
@@ -3125,7 +3125,7 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]); // Move into the reveal phase
 
     // We should have a total number of priceRequestIds (instances where prices are requested) of 3.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 3);
 
     // Consider the slashing. There were a total of 4 requests that actually settled. Account2 and account3 were
     // slashed every time as they did not participate in any votes. Account4 only participated in the last vote.
@@ -3226,7 +3226,7 @@ describe("VotingV2", function () {
 
     // As we've updated the trackers all requests should be resolved. Resolution of price requests is independent of
     // slashing tracker updates. there should be 6 requests, 1 before the loop then 5 in the loop.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 6);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 6);
 
     assert.equal((await voting.methods.voterStakes(account1).call()).nextIndexToProcess, 1);
 
@@ -3302,7 +3302,7 @@ describe("VotingV2", function () {
 
     // Now, the number of requests should be 1.
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, "1");
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, "1");
 
     // Now, stake from another account. we are in the reveal phase of an active request and so the starting index should
     // be 1 as this voter should not be susceptible to slashing for this request.
@@ -3320,8 +3320,8 @@ describe("VotingV2", function () {
     // is now 2 with one in the resolved phase and one still in the pending phase. However, if someone was to stake now
     // they can still vote on this request and so their nextIndexToProcess should still be set to 1.
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, "1");
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, "1");
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, "1");
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, "1");
     await voting.methods.stake(toWei("32000000")).send({ from: account3 });
     assert.equal((await voting.methods.voterStakes(account3).call()).nextIndexToProcess, 1);
 
@@ -3419,7 +3419,7 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -3446,8 +3446,8 @@ describe("VotingV2", function () {
     await voting.methods.revealVote(identifier, time + 3, price, salt).send({ from: account4 });
 
     // There should be a total of 4 requests, still.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     await moveToNextRound(voting, accounts[0]); // Move to the next round.
 
@@ -3457,8 +3457,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.voterStakes(account4).call()).stake, toWei("4000000").sub(toWei("6400")));
 
     // There should now show up as being 4 resolved requests and 3 pending requests.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
 
     // Now, re-commit and reveal on 2 of the rolled requests, this time from account1 so they dont roll. Re-commit and
     // reveal on the last vote with an account that does not meet the gat. this should push 3/4 votes to settled.
@@ -3480,8 +3480,8 @@ describe("VotingV2", function () {
     await voting.methods.updateTrackers(account4).send({ from: account1 });
 
     // We should now expect to see 3 settled requests and one remaining pending request.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 3);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
 
     // Account4 should loose two equal slots of (4mm-6400)*0.0016 as they were both within the same voting
     // round and they did not vote on them after the roll.
@@ -3552,7 +3552,7 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -3579,7 +3579,7 @@ describe("VotingV2", function () {
     await voting.methods.revealVote(identifier, time + 3, price, salt).send({ from: account1 });
 
     // There should be a total of 4  pending requests, still.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
 
     await moveToNextRound(voting, accounts[0]); // Move to the next round.
 
@@ -3609,8 +3609,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.voterStakes(account3).call()).unappliedSlash, toWei("0"));
 
     // There are still 2 pending requests and two settled requests after these 2 requests settle.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
   });
 
   it("Duplicate Request Rewards", async function () {
@@ -4142,8 +4142,8 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // Roll request 2 and 3. Settle request 1 and 4. We should see the order respected when settled.
     await moveToNextRound(voting, accounts[0]);
@@ -4169,8 +4169,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
 
     // Check slot 0 in the resolved array is the first request (based on time of the request).
     const resolvedRequest1Id = await voting.methods.resolvedPriceRequestIds(0).call();
@@ -4196,8 +4196,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
   });
   it("Requests are automatically removed after a fixed number of rolls", async function () {
     // Verify that if a request rolls enough times (to hit maxRolls) it is automatically removed from the
@@ -4209,8 +4209,8 @@ describe("VotingV2", function () {
 
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     const request1Id = await voting.methods.pendingPriceRequestsIds(0).call();
     const request2Id = await voting.methods.pendingPriceRequestsIds(1).call();
@@ -4235,8 +4235,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.priceRequests(request1Id).call()).rollCount, 2);
     assert.equal((await voting.methods.priceRequests(request2Id).call()).rollCount, 2);
 
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // On the next roll these requests should be automatically removed from the pending array and become unresolvable.
     await moveToNextRound(voting, accounts[0]);
@@ -4264,8 +4264,8 @@ describe("VotingV2", function () {
     assert.equal(spamRequest2.identifier, padRight(utf8ToHex(""), 64));
     assert.isNull(spamRequest2.ancillaryData);
 
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
   });
   it("Handles calling settle during reveal", async function () {
     // In the event that someone calls processResolvablePriceRequests() during the reveal phase, after a vote has reached
@@ -4276,7 +4276,7 @@ describe("VotingV2", function () {
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
 
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -4290,9 +4290,9 @@ describe("VotingV2", function () {
 
     // We are now in the reveal phase with the vote having met the gat. If someone tries to settle the request now
     // nothing should happen as the round is not over yet, even though the gat has been met.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
   });
   it("Handles multiple rolls with no contract interactions", async function () {
     // Consider the case where a vote rolls for a number of rounds with no voter interaction with the voting contract to
@@ -4302,8 +4302,8 @@ describe("VotingV2", function () {
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     const request1Id = await voting.methods.pendingPriceRequestsIds(0).call();
     const request2Id = await voting.methods.pendingPriceRequestsIds(1).call();
@@ -4365,8 +4365,8 @@ describe("VotingV2", function () {
     const request3Id = await voting.methods.pendingPriceRequestsIds(2).call();
     const request4Id = await voting.methods.pendingPriceRequestsIds(3).call();
 
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // Before doing anything the nextPendingIndexToProcess should be 0.
     assert.equal(await voting.methods.nextPendingIndexToProcess().call(), "0");
@@ -4434,28 +4434,28 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
 
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 3);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
 
     await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
 
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
   });
   it("Can successfully remove large amounts of spam piecewise", async function () {
     // Request so many requests in one go that we cant resolve them all in one transaction. Rather, we need to update
     // them piecewise. The same goes for deleting the requests once we've rolled enough times. This checks that in the
     // event the DVM is spammed we can recover gracefully.
     await submitManyRequests(5, 125); // send 625 requests, split over 5 multicalls of size 125.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 625);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 625);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // Move to the active round and then a following round. This will force these requests to need to be rolled.
     // When resolving we will now need to roll 625 requests in one go.
@@ -4480,7 +4480,7 @@ describe("VotingV2", function () {
     await voting.methods.processResolvablePriceRequestsRange(310).send({ from: account1 });
 
     // verify that we've traversed all the requests and that subsequent calls are very cheap.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 625);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 625);
     const roundId = await voting.methods.getCurrentRoundId().call();
     assert.equal(await voting.methods.lastRoundIdProcessed().call(), roundId);
     assert.equal(await voting.methods.nextPendingIndexToProcess().call(), 625);
@@ -4504,7 +4504,7 @@ describe("VotingV2", function () {
     assert(didRunOutOfGas);
     await voting.methods.processResolvablePriceRequestsRange(315).send({ from: account1 });
     await voting.methods.processResolvablePriceRequestsRange(310).send({ from: account1 });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
     assert.equal((await voting.getPastEvents("RequestDeleted", { fromBlock: 0, toBlock: "latest" })).length, 625);
     const gasUsed2 = (await voting.methods.processResolvablePriceRequests().send({ from: account1 })).gasUsed;
     assert(gasUsed2 < 40000);
@@ -4518,8 +4518,8 @@ describe("VotingV2", function () {
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
     await submitManyRequests(2, 125, 500); // send 250 spam requests.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 501);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 501);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // Move to the active round and then a following round. This will force these requests to need to be rolled.
     // When resolving we will now need to roll 501 requests in one go.
@@ -4540,8 +4540,8 @@ describe("VotingV2", function () {
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
 
     // There should now be 1 resolved request and 500 rolled requests.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 500);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 500);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
     assert.equal(
       (await voting.methods.getPrice(identifier, time).call({ from: registeredContract })).toString(),
       price.toString()
@@ -4552,8 +4552,8 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequestsRange(250).send({ from: account1 });
     await voting.methods.processResolvablePriceRequestsRange(250).send({ from: account1 });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
   });
 
   it("Staking during active reveal is dealt with correctly via pendingStakes", async function () {
@@ -4801,8 +4801,8 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]);
 
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
 
     // Check that the correct amount of tokens were slashed.
     const slashingTracker = await voting.methods.requestSlashingTrackers(0).call();

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -4878,8 +4878,8 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]);
 
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 5);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 5);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     const price = 123;
     const salt = getRandomSignedInt(); // use the same salt for all votes. bad practice but wont impact anything.
@@ -4902,8 +4902,8 @@ describe("VotingV2", function () {
     );
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 3);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
 
     // Now, we should expect none of the requests to have rolled as they were enqued for this round, not the previous
     // round and so should not have rolled. Equally, we should now be able to vote on 3 and 4 but not 5.
@@ -4932,8 +4932,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 1);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
 
     assert.equal((await voting.methods.priceRequests(request3Id).call()).lastVotingRound, requestRoundId + 2);
     assert.equal((await voting.methods.priceRequests(request3Id).call()).rollCount, 0);
@@ -4950,8 +4950,8 @@ describe("VotingV2", function () {
     await voting.methods.revealVote(identifier, time + 4, price, salt).send({ from: account1 });
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 5);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 5);
 
     // All prices are resolved.
     assert.equal(
@@ -4980,8 +4980,8 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 3);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     const requestRoundId = Number(await voting.methods.getCurrentRoundId().call());
 
@@ -4996,8 +4996,8 @@ describe("VotingV2", function () {
     const request3Id = await voting.methods.pendingPriceRequestsIds(2).call();
     assert.equal((await voting.methods.priceRequests(request3Id).call()).lastVotingRound, requestRoundId + 2);
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 3);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     // Now, make the votes roll. To do this we can simply move 2 rounds forward (the next round is the active round and
     // the subsequent round is will cause them to roll. We should see
@@ -5020,8 +5020,8 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 4).send({ from: registeredContract });
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 5);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 5);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
     const request4Id = await voting.methods.pendingPriceRequestsIds(3).call();
     assert.equal((await voting.methods.priceRequests(request4Id).call()).lastVotingRound, requestRoundId + 3);
@@ -5053,8 +5053,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 3);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
 
     // Traverse the next 2 rounds, voting as we go to resolve everything.
     baseRequest.roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -5074,8 +5074,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 1);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
 
     // Resolve final request.
     baseRequest.roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -5085,8 +5085,8 @@ describe("VotingV2", function () {
     await voting.methods.revealVote(identifier, time + 4, price, salt).send({ from: account1 });
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 5);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 5);
 
     // All prices are resolved.
     assert.equal(

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -571,7 +571,7 @@ describe("VotingV2", function () {
 
     // Move to next round and roll the first request over.
     await moveToNextRound(voting, accounts[0]);
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
 
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
 
@@ -1732,15 +1732,77 @@ describe("VotingV2", function () {
     // Pending requests should be empty after the voting round ends and the price is resolved.
     await moveToNextRound(votingTest, accounts[0]);
 
-    // Check that getPendingRequests already returns the correct number of elements.
+    // Check that getPendingRequestsPostUpdate already returns the correct number of elements.
+    assert.equal(
+      (await VotingV2.at(votingTest.options.address).methods.getPendingRequestsPostUpdate().call()).length,
+      0
+    );
     assert.equal((await votingTest.methods.getPendingPriceRequestsArray().call()).length, 1);
-    assert.equal((await VotingV2.at(votingTest.options.address).methods.getPendingRequests().call()).length, 0);
 
     // Updating the account tracker should remove the request from the pending array as it is now resolved.
     await VotingV2.at(votingTest.options.address).methods.updateTrackers(account1).send({ from: account1 });
 
     // After updating the account trackers, the length should be decreased back to 0 since the element added in this test is now deleted.
     assert.equal((await votingTest.methods.getPendingPriceRequestsArray().call()).length, 0);
+  });
+  it("Post update functions return post price request information up to date", async function () {
+    const identifier = padRight(utf8ToHex("request-retrieval"), 64);
+    const time1 = "1001";
+    const time2 = "1002";
+
+    // Make the Oracle support these two identifiers.
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
+
+    // Requests should not be added to the current voting round.
+    await voting.methods.requestPrice(identifier, time1).send({ from: registeredContract });
+    await voting.methods.requestPrice(identifier, time2).send({ from: registeredContract });
+
+    // Move to the next round.
+    await moveToNextRound(voting, accounts[0]);
+    const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
+
+    // Commit votes.
+    const price = 123;
+    const salt = getRandomSignedInt(); // use the same salt for all votes. bad practice but wont impact anything.
+    const baseRequest = { salt, roundId, identifier };
+    const hash1 = computeVoteHash({ ...baseRequest, price, account: accounts[0], time: time1 });
+
+    await voting.methods.commitVote(identifier, time1, hash1).send({ from: accounts[0] });
+
+    // Move to the reveal phase.
+    await moveToNextPhase(voting, accounts[0]);
+
+    // Reveal the vote.
+    await voting.methods.revealVote(identifier, time1, price, salt).send({ from: accounts[0] });
+
+    // Move to the next round.
+    await moveToNextRound(voting, accounts[0]);
+
+    // Check that the price is resolved.
+    assert.equal(
+      (await voting.methods.getPrice(identifier, time1).call({ from: registeredContract })).toString(),
+      price.toString()
+    );
+
+    // Check that getNumberOfPriceRequestsPostUpdate return the correct number of price requests.
+    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numResolvedPriceRequests, 1);
+
+    // Check that getPendingRequests returns the pending price requests without updating.
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
+
+    // Check that getPendingRequestsPostUpdate returns the pending price requests updated.
+    assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 0);
+    assert.equal((await voting.methods.getPendingRequestsPostUpdate().call())[0].rollCount, 1);
+
+    // Roll two more rounds to delete the price request.
+    await moveToNextRound(voting, accounts[0]);
+    await moveToNextRound(voting, accounts[0]);
+
+    // Check that getPendingRequestsPostUpdate already returns the correct number of elements.
+    assert.equal((await voting.methods.getPendingRequestsPostUpdate().call()).length, 0);
+    assert.equal((await voting.methods.getPendingRequests().call()).length, 1);
   });
   it("Votes can correctly handle arbitrary ancillary data", async function () {
     const identifier1 = padRight(utf8ToHex("request-retrieval"), 64);
@@ -2208,8 +2270,8 @@ describe("VotingV2", function () {
     // Now call updateTrackers to update the slashing metrics. We should see a cumulative slashing amount increment and
     // the slash per wrong vote and slash per no vote set correctly.
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
 
     // The test configuration has a wrong vote and no vote slash per token set to 0.0016. This works out to ~ equal to
     // the emission rate of the contract assuming 10 votes per month over a year. At this rate we should see two groups
@@ -3063,7 +3125,7 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]); // Move into the reveal phase
 
     // We should have a total number of priceRequestIds (instances where prices are requested) of 3.
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 3);
 
     // Consider the slashing. There were a total of 4 requests that actually settled. Account2 and account3 were
     // slashed every time as they did not participate in any votes. Account4 only participated in the last vote.
@@ -3164,7 +3226,7 @@ describe("VotingV2", function () {
 
     // As we've updated the trackers all requests should be resolved. Resolution of price requests is independent of
     // slashing tracker updates. there should be 6 requests, 1 before the loop then 5 in the loop.
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 6);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 6);
 
     assert.equal((await voting.methods.voterStakes(account1).call()).nextIndexToProcess, 1);
 
@@ -3240,7 +3302,7 @@ describe("VotingV2", function () {
 
     // Now, the number of requests should be 1.
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), "1");
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, "1");
 
     // Now, stake from another account. we are in the reveal phase of an active request and so the starting index should
     // be 1 as this voter should not be susceptible to slashing for this request.
@@ -3258,8 +3320,8 @@ describe("VotingV2", function () {
     // is now 2 with one in the resolved phase and one still in the pending phase. However, if someone was to stake now
     // they can still vote on this request and so their nextIndexToProcess should still be set to 1.
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), "1");
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), "1");
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, "1");
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, "1");
     await voting.methods.stake(toWei("32000000")).send({ from: account3 });
     assert.equal((await voting.methods.voterStakes(account3).call()).nextIndexToProcess, 1);
 
@@ -3357,7 +3419,7 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -3384,8 +3446,8 @@ describe("VotingV2", function () {
     await voting.methods.revealVote(identifier, time + 3, price, salt).send({ from: account4 });
 
     // There should be a total of 4 requests, still.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     await moveToNextRound(voting, accounts[0]); // Move to the next round.
 
@@ -3395,8 +3457,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.voterStakes(account4).call()).stake, toWei("4000000").sub(toWei("6400")));
 
     // There should now show up as being 4 resolved requests and 3 pending requests.
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 1);
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 3);
 
     // Now, re-commit and reveal on 2 of the rolled requests, this time from account1 so they dont roll. Re-commit and
     // reveal on the last vote with an account that does not meet the gat. this should push 3/4 votes to settled.
@@ -3418,8 +3480,8 @@ describe("VotingV2", function () {
     await voting.methods.updateTrackers(account4).send({ from: account1 });
 
     // We should now expect to see 3 settled requests and one remaining pending request.
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 3);
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
 
     // Account4 should loose two equal slots of (4mm-6400)*0.0016 as they were both within the same voting
     // round and they did not vote on them after the roll.
@@ -3490,7 +3552,7 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -3517,7 +3579,7 @@ describe("VotingV2", function () {
     await voting.methods.revealVote(identifier, time + 3, price, salt).send({ from: account1 });
 
     // There should be a total of 4  pending requests, still.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
 
     await moveToNextRound(voting, accounts[0]); // Move to the next round.
 
@@ -3547,8 +3609,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.voterStakes(account3).call()).unappliedSlash, toWei("0"));
 
     // There are still 2 pending requests and two settled requests after these 2 requests settle.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
   });
 
   it("Duplicate Request Rewards", async function () {
@@ -4080,8 +4142,8 @@ describe("VotingV2", function () {
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 2).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 3).send({ from: registeredContract });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     // Roll request 2 and 3. Settle request 1 and 4. We should see the order respected when settled.
     await moveToNextRound(voting, accounts[0]);
@@ -4107,8 +4169,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
 
     // Check slot 0 in the resolved array is the first request (based on time of the request).
     const resolvedRequest1Id = await voting.methods.resolvedPriceRequestIds(0).call();
@@ -4134,8 +4196,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 4);
   });
   it("Requests are automatically removed after a fixed number of rolls", async function () {
     // Verify that if a request rolls enough times (to hit maxRolls) it is automatically removed from the
@@ -4147,8 +4209,8 @@ describe("VotingV2", function () {
 
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     const request1Id = await voting.methods.pendingPriceRequestsIds(0).call();
     const request2Id = await voting.methods.pendingPriceRequestsIds(1).call();
@@ -4173,8 +4235,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.priceRequests(request1Id).call()).rollCount, 2);
     assert.equal((await voting.methods.priceRequests(request2Id).call()).rollCount, 2);
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     // On the next roll these requests should be automatically removed from the pending array and become unresolvable.
     await moveToNextRound(voting, accounts[0]);
@@ -4202,8 +4264,8 @@ describe("VotingV2", function () {
     assert.equal(spamRequest2.identifier, padRight(utf8ToHex(""), 64));
     assert.isNull(spamRequest2.ancillaryData);
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
   });
   it("Handles calling settle during reveal", async function () {
     // In the event that someone calls processResolvablePriceRequests() during the reveal phase, after a vote has reached
@@ -4214,7 +4276,7 @@ describe("VotingV2", function () {
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
@@ -4228,9 +4290,9 @@ describe("VotingV2", function () {
 
     // We are now in the reveal phase with the vote having met the gat. If someone tries to settle the request now
     // nothing should happen as the round is not over yet, even though the gat has been met.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 1);
   });
   it("Handles multiple rolls with no contract interactions", async function () {
     // Consider the case where a vote rolls for a number of rounds with no voter interaction with the voting contract to
@@ -4240,8 +4302,8 @@ describe("VotingV2", function () {
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
     await voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     const request1Id = await voting.methods.pendingPriceRequestsIds(0).call();
     const request2Id = await voting.methods.pendingPriceRequestsIds(1).call();
@@ -4303,8 +4365,8 @@ describe("VotingV2", function () {
     const request3Id = await voting.methods.pendingPriceRequestsIds(2).call();
     const request4Id = await voting.methods.pendingPriceRequestsIds(3).call();
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     // Before doing anything the nextPendingIndexToProcess should be 0.
     assert.equal(await voting.methods.nextPendingIndexToProcess().call(), "0");
@@ -4372,28 +4434,28 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
 
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 4);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 3);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 3);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
 
     await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 2);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
 
     await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 4);
   });
   it("Can successfully remove large amounts of spam piecewise", async function () {
     // Request so many requests in one go that we cant resolve them all in one transaction. Rather, we need to update
     // them piecewise. The same goes for deleting the requests once we've rolled enough times. This checks that in the
     // event the DVM is spammed we can recover gracefully.
     await submitManyRequests(5, 125); // send 625 requests, split over 5 multicalls of size 125.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 625);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 625);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     // Move to the active round and then a following round. This will force these requests to need to be rolled.
     // When resolving we will now need to roll 625 requests in one go.
@@ -4418,7 +4480,7 @@ describe("VotingV2", function () {
     await voting.methods.processResolvablePriceRequestsRange(310).send({ from: account1 });
 
     // verify that we've traversed all the requests and that subsequent calls are very cheap.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 625);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 625);
     const roundId = await voting.methods.getCurrentRoundId().call();
     assert.equal(await voting.methods.lastRoundIdProcessed().call(), roundId);
     assert.equal(await voting.methods.nextPendingIndexToProcess().call(), 625);
@@ -4442,7 +4504,7 @@ describe("VotingV2", function () {
     assert(didRunOutOfGas);
     await voting.methods.processResolvablePriceRequestsRange(315).send({ from: account1 });
     await voting.methods.processResolvablePriceRequestsRange(310).send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
     assert.equal((await voting.getPastEvents("RequestDeleted", { fromBlock: 0, toBlock: "latest" })).length, 625);
     const gasUsed2 = (await voting.methods.processResolvablePriceRequests().send({ from: account1 })).gasUsed;
     assert(gasUsed2 < 40000);
@@ -4456,8 +4518,8 @@ describe("VotingV2", function () {
     await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
     await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
     await submitManyRequests(2, 125, 500); // send 250 spam requests.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 501);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 501);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 0);
 
     // Move to the active round and then a following round. This will force these requests to need to be rolled.
     // When resolving we will now need to roll 501 requests in one go.
@@ -4478,8 +4540,8 @@ describe("VotingV2", function () {
     await voting.methods.processResolvablePriceRequests().send({ from: account1 });
 
     // There should now be 1 resolved request and 500 rolled requests.
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 500);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 500);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
     assert.equal(
       (await voting.methods.getPrice(identifier, time).call({ from: registeredContract })).toString(),
       price.toString()
@@ -4490,8 +4552,8 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]);
     await voting.methods.processResolvablePriceRequestsRange(250).send({ from: account1 });
     await voting.methods.processResolvablePriceRequestsRange(250).send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 1);
   });
 
   it("Staking during active reveal is dealt with correctly via pendingStakes", async function () {
@@ -4739,8 +4801,8 @@ describe("VotingV2", function () {
     await moveToNextRound(voting, accounts[0]);
 
     await voting.methods.updateTrackers(account1).send({ from: account1 });
-    assert.equal(await voting.methods.getNumberOfPendingPriceRequests().call(), 0);
-    assert.equal(await voting.methods.getNumberOfResolvedPriceRequests().call(), 2);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numResolvedPriceRequests, 2);
 
     // Check that the correct amount of tokens were slashed.
     const slashingTracker = await voting.methods.requestSlashingTrackers(0).call();


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Add "post update" function versions of some view external functions in the VotingV2 contract to simplify the access to the price requests information after [processing resolvable price requests](https://github.com/UMAprotocol/protocol/blob/9c55f013d23dc04780c0222788b2fa347ec29a17/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol#L716).

**Summary**

- Add again the `getPendingRequests` and `getPendingRequestsPostUpdate`
- Group getNumberOfPendingPriceRequests and getNumberOfResolvedPriceRequests into getNumberOfRequests + add the “processed” version getNumberOfRequestsPostUpdate


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

