### PR TITLE
feat: redundant rpc in dvm-v2 monitor

### DIFF
--- a/packages/common/src/EthersProviderUtils.ts
+++ b/packages/common/src/EthersProviderUtils.ts
@@ -1,0 +1,106 @@
+import { ethers } from "ethers";
+
+const defaultTimeout = 60 * 1000;
+
+function delay(s: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, Math.round(s * 1000)));
+}
+
+// This provider class is used to retry requests to a list of providers in order.
+// This class is not exported as it is only used internally from getRetryProvider that validates constructor parameters.
+class EthersRetryProvider extends ethers.providers.StaticJsonRpcProvider {
+  readonly providers: ethers.providers.StaticJsonRpcProvider[];
+  constructor(
+    params: ConstructorParameters<typeof ethers.providers.StaticJsonRpcProvider>[],
+    chainId: number,
+    readonly retries: number,
+    readonly delay: number
+  ) {
+    // Initialize the super just with the chainId, which stops it from trying to immediately send out a .send before
+    // this derived class is initialized.
+    super(undefined, chainId);
+
+    // Initialize the providers list with the provided parameters.
+    this.providers = params.map((inputs) => new ethers.providers.StaticJsonRpcProvider(...inputs));
+  }
+
+  async send(method: string, params: Array<any>): Promise<any> {
+    const primaryProvider = this.providers[0];
+    const fallbackProviders = this.providers.slice(1);
+
+    // This function is used to try to send with a provider and if it fails pop an element off the fallback list to try
+    // with that one. Once the fallback provider list is empty, the method throws.
+    const tryWithFallback = async (provider: ethers.providers.StaticJsonRpcProvider): Promise<any> => {
+      try {
+        return await this._trySend(provider, method, params);
+      } catch (err) {
+        // If there are no new fallback providers to use, terminate the recursion by throwing an error.
+        // Otherwise, we can try to call another provider.
+        const nextProvider = fallbackProviders.shift();
+        if (nextProvider === undefined) throw err;
+        return await tryWithFallback(nextProvider);
+      }
+    };
+
+    return await tryWithFallback(primaryProvider);
+  }
+
+  _trySend(provider: ethers.providers.StaticJsonRpcProvider, method: string, params: Array<any>): Promise<any> {
+    let promise = provider.send(method, params);
+    for (let i = 0; i < this.retries; i++) {
+      promise = promise.catch(() => delay(this.delay).then(() => provider.send(method, params)));
+    }
+    return promise;
+  }
+}
+
+function getNodeUrlList(chainId: number): string[] {
+  const retryConfigKey = `NODE_URLS_${chainId}`;
+  const retryConfig = process.env[retryConfigKey];
+  if (retryConfig) {
+    const nodeUrls = JSON.parse(retryConfig) || [];
+    if (nodeUrls?.length === 0)
+      throw new Error(`Provided ${retryConfigKey}, but parsing it as json did not result in an array of urls.`);
+    return nodeUrls;
+  }
+
+  const nodeUrlKey = `NODE_URL_${chainId}`;
+  const nodeUrl = process.env[nodeUrlKey];
+
+  if (nodeUrl) {
+    return [nodeUrl];
+  }
+
+  throw new Error(
+    `Cannot get node url(s) for ${chainId} because neither ${retryConfigKey} or ${nodeUrlKey} were provided.`
+  );
+}
+
+export function getRetryProvider(chainId: number): EthersRetryProvider {
+  const { NODE_RETRIES, NODE_RETRY_DELAY, NODE_TIMEOUT } = process.env;
+
+  const timeout = Number(process.env[`NODE_TIMEOUT_${chainId}`] || NODE_TIMEOUT || defaultTimeout);
+
+  // Default to 2 retries.
+  const retries = Number(process.env[`NODE_RETRIES_${chainId}`] || NODE_RETRIES || "2");
+  if (retries < 0 || !Number.isInteger(retries))
+    throw new Error(`retries cannot be < 0 and must be an integer. Currently set to ${retries}`);
+
+  // Default to a delay of 1 second between retries.
+  const retryDelay = Number(process.env[`NODE_RETRY_DELAY_${chainId}`] || NODE_RETRY_DELAY || "1");
+  if (retryDelay < 0) throw new Error(`delay cannot be < 0. Currently set to ${retryDelay}`);
+
+  // Create a list of constructor arguments for each node url. Each element in the list is a tuple of the constructor
+  // arguments for the StaticJsonRpcProvider. We do not check the length of the list here as getRetryProvider ensures
+  // that at least one node url is provided.
+  const constructorArgumentLists = getNodeUrlList(chainId).map((nodeUrl): [ethers.utils.ConnectionInfo, number] => [
+    {
+      url: nodeUrl,
+      timeout,
+      allowGzip: true,
+    },
+    chainId,
+  ]);
+
+  return new EthersRetryProvider(constructorArgumentLists, chainId, retries, retryDelay);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -10,3 +10,4 @@ export * from "./RetryProvider";
 export * from "./UniswapV3Helpers";
 export * from "./types";
 export * from "./EthersSignerUtils";
+export * from "./EthersProviderUtils";

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -3,11 +3,13 @@
   "version": "1.22.0",
   "description": "UMA Core Peripheral Scripts",
   "dependencies": {
+    "@ethersproject/abstract-provider": "^5.4.0",
     "@ethersproject/units": "^5.0.3",
     "@google-cloud/bigquery": "^5.3.0",
     "@uma/common": "^2.29.1",
     "@uma/financial-templates-lib": "^2.32.4",
     "dotenv": "^6.2.0",
+    "ethers": "^5.4.2",
     "hardhat": "^2.9.0",
     "minimist": "^1.2.0",
     "web3": "^1.6.0",

--- a/packages/scripts/src/monitor-dvm/MonitorDeletion.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorDeletion.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { VotingV2Ethers } from "@uma/contracts-node";
 import { logDeleted } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorDeletion(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const votingV2 = await getContractInstanceByUrl<VotingV2Ethers>("VotingV2", params.jsonRpcUrl);
+  const votingV2 = await getContractInstanceWithProvider<VotingV2Ethers>("VotingV2", params.provider);
 
   const deletedRequests = (
     await votingV2.queryFilter(votingV2.filters.RequestDeleted(), params.blockRange.start, params.blockRange.end)

--- a/packages/scripts/src/monitor-dvm/MonitorEmergency.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorEmergency.ts
@@ -1,13 +1,13 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { EmergencyProposerEthers } from "@uma/contracts-node";
 import { logEmergencyProposal } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorEmergency(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const emergencyProposer = await getContractInstanceByUrl<EmergencyProposerEthers>(
+  const emergencyProposer = await getContractInstanceWithProvider<EmergencyProposerEthers>(
     "EmergencyProposer",
-    params.jsonRpcUrl
+    params.provider
   );
 
   const emergencyProposals = (

--- a/packages/scripts/src/monitor-dvm/MonitorGovernance.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorGovernance.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { GovernorV2Ethers } from "@uma/contracts-node";
 import { logGovernanceProposal } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorGovernance(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const governorV2 = await getContractInstanceByUrl<GovernorV2Ethers>("GovernorV2", params.jsonRpcUrl);
+  const governorV2 = await getContractInstanceWithProvider<GovernorV2Ethers>("GovernorV2", params.provider);
 
   const governanceProposals = (
     await governorV2.queryFilter(governorV2.filters.NewProposal(), params.blockRange.start, params.blockRange.end)

--- a/packages/scripts/src/monitor-dvm/MonitorGovernorTransfers.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorGovernorTransfers.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { VotingTokenEthers, getAddress } from "@uma/contracts-node";
 import { logGovernorTransfer } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorGovernorTransfers(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const votingToken = await getContractInstanceByUrl<VotingTokenEthers>("VotingToken", params.jsonRpcUrl);
+  const votingToken = await getContractInstanceWithProvider<VotingTokenEthers>("VotingToken", params.provider);
   const governorV2Address = await getAddress("GovernorV2", params.chainId);
 
   const largeGovernorTransfers = (

--- a/packages/scripts/src/monitor-dvm/MonitorMints.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorMints.ts
@@ -2,11 +2,11 @@ import { Logger } from "@uma/financial-templates-lib";
 import { ZERO_ADDRESS } from "@uma/common";
 import { VotingTokenEthers } from "@uma/contracts-node";
 import { logMint } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorMints(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const votingToken = await getContractInstanceByUrl<VotingTokenEthers>("VotingToken", params.jsonRpcUrl);
+  const votingToken = await getContractInstanceWithProvider<VotingTokenEthers>("VotingToken", params.provider);
 
   const largeMints = (
     await votingToken.queryFilter(

--- a/packages/scripts/src/monitor-dvm/MonitorRolled.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorRolled.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { VotingV2Ethers } from "@uma/contracts-node";
 import { logRolled } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorRolled(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const votingV2 = await getContractInstanceByUrl<VotingV2Ethers>("VotingV2", params.jsonRpcUrl);
+  const votingV2 = await getContractInstanceWithProvider<VotingV2Ethers>("VotingV2", params.provider);
 
   const rolledRequests = (
     await votingV2.queryFilter(votingV2.filters.RequestRolled(), params.blockRange.start, params.blockRange.end)

--- a/packages/scripts/src/monitor-dvm/MonitorStakes.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorStakes.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { VotingV2Ethers } from "@uma/contracts-node";
 import { logLargeStake } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorStakes(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const votingV2 = await getContractInstanceByUrl<VotingV2Ethers>("VotingV2", params.jsonRpcUrl);
+  const votingV2 = await getContractInstanceWithProvider<VotingV2Ethers>("VotingV2", params.provider);
 
   const largeStakes = (
     await votingV2.queryFilter(votingV2.filters.Staked(), params.blockRange.start, params.blockRange.end)

--- a/packages/scripts/src/monitor-dvm/MonitorUnstakes.ts
+++ b/packages/scripts/src/monitor-dvm/MonitorUnstakes.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@uma/financial-templates-lib";
 import { VotingV2Ethers } from "@uma/contracts-node";
 import { logLargeUnstake } from "./MonitorLogger";
-import { getContractInstanceByUrl } from "../utils/contracts";
+import { getContractInstanceWithProvider } from "../utils/contracts";
 import type { MonitoringParams } from "./common";
 
 export async function monitorUnstakes(logger: typeof Logger, params: MonitoringParams): Promise<void> {
-  const votingV2 = await getContractInstanceByUrl<VotingV2Ethers>("VotingV2", params.jsonRpcUrl);
+  const votingV2 = await getContractInstanceWithProvider<VotingV2Ethers>("VotingV2", params.provider);
 
   const largeUnstakes = (
     await votingV2.queryFilter(votingV2.filters.RequestedUnstake(), params.blockRange.start, params.blockRange.end)

--- a/packages/scripts/src/monitor-dvm/README.md
+++ b/packages/scripts/src/monitor-dvm/README.md
@@ -13,7 +13,7 @@ node ./packages/scripts/dist/monitor-dvm/index.js
 All the configuration should be provided with following environment variables:
 
 - `CHAIN_ID` is L1 network number (`"1"` for Ethereum mainnet or `"5"` for goerli).
-- `NODE_URLS_1` or `NODE_URLS_5` is a comma separated list of L1 node URLs.
+- `NODE_URLS_1` or `NODE_URLS_5` is an array of L1 node URLs.
 - `NODE_URL_1` or `NODE_URL_5` is a single L1 node URL. This is considered only if `NODE_URLS_1` or `NODE_URLS_5` is not provided.
 - `NODE_RETRIES` is the number of retries to make when a node request fails (defaults to `"2"`).
 - `NODE_RETRY_DELAY` is the delay in seconds between retries (defaults to `"1"`).

--- a/packages/scripts/src/monitor-dvm/README.md
+++ b/packages/scripts/src/monitor-dvm/README.md
@@ -12,12 +12,12 @@ node ./packages/scripts/dist/monitor-dvm/index.js
 
 All the configuration should be provided with following environment variables:
 
-- `CHAIN_ID` is L1 network number (`"1"` for Ethereum mainnet or `"5"` for goerli).
+- `CHAIN_ID` is L1 network number (`1` for Ethereum mainnet or `5` for goerli).
 - `NODE_URLS_1` or `NODE_URLS_5` is an array of L1 node URLs.
 - `NODE_URL_1` or `NODE_URL_5` is a single L1 node URL. This is considered only if `NODE_URLS_1` or `NODE_URLS_5` is not provided.
-- `NODE_RETRIES` is the number of retries to make when a node request fails (defaults to `"2"`).
-- `NODE_RETRY_DELAY` is the delay in seconds between retries (defaults to `"1"`).
-- `NODE_TIMEOUT` is the timeout in seconds for node requests (defaults to `"60"`).
+- `NODE_RETRIES` is the number of retries to make when a node request fails (defaults to `2`).
+- `NODE_RETRY_DELAY` is the delay in seconds between retries (defaults to `1`).
+- `NODE_TIMEOUT` is the timeout in seconds for node requests (defaults to `60`).
 - `POLLING_DELAY` is value in seconds for delay between consecutive runs, defaults to 1 minute. If set to 0 then running in serverless mode will exit after the loop.
 - `STARTING_BLOCK_NUMBER` and `ENDING_BLOCK_NUMBER` defines block range to look for events on L1 network. These are mandatory when `POLLING_DELAY=0`.
 - `UNSTAKES_ENABLED` is boolean enabling/disabling monitoring large unstake attempts (disabled by default).

--- a/packages/scripts/src/monitor-dvm/README.md
+++ b/packages/scripts/src/monitor-dvm/README.md
@@ -12,7 +12,12 @@ node ./packages/scripts/dist/monitor-dvm/index.js
 
 All the configuration should be provided with following environment variables:
 
-- `CUSTOM_NODE_URL` is L1 network node endpoint (Ethereum mainnet or goerli).
+- `CHAIN_ID` is L1 network number (`"1"` for Ethereum mainnet or `"5"` for goerli).
+- `NODE_URLS_1` or `NODE_URLS_5` is a comma separated list of L1 node URLs.
+- `NODE_URL_1` or `NODE_URL_5` is a single L1 node URL. This is considered only if `NODE_URLS_1` or `NODE_URLS_5` is not provided.
+- `NODE_RETRIES` is the number of retries to make when a node request fails (defaults to `"2"`).
+- `NODE_RETRY_DELAY` is the delay in seconds between retries (defaults to `"1"`).
+- `NODE_TIMEOUT` is the timeout in seconds for node requests (defaults to `"60"`).
 - `POLLING_DELAY` is value in seconds for delay between consecutive runs, defaults to 1 minute. If set to 0 then running in serverless mode will exit after the loop.
 - `STARTING_BLOCK_NUMBER` and `ENDING_BLOCK_NUMBER` defines block range to look for events on L1 network. These are mandatory when `POLLING_DELAY=0`.
 - `UNSTAKES_ENABLED` is boolean enabling/disabling monitoring large unstake attempts (disabled by default).

--- a/packages/scripts/src/utils/contracts.ts
+++ b/packages/scripts/src/utils/contracts.ts
@@ -1,4 +1,4 @@
-const { getAddress } = require("@uma/contracts-node");
+const { getAbi, getAddress } = require("@uma/contracts-node");
 const hre = require("hardhat");
 import { Contract, ContractFactory } from "ethers";
 import { Provider } from "@ethersproject/abstract-provider";
@@ -24,4 +24,14 @@ export const getContractInstanceByUrl = async <T extends Contract>(
   const factory: ContractFactory = await hre.ethers.getContractFactory(contractName);
   const contractAddress = await getAddress(contractName, Number(networkId));
   return (await factory.attach(contractAddress)).connect(provider) as T;
+};
+
+export const getContractInstanceWithProvider = async <T extends Contract>(
+  contractName: string,
+  provider: Provider
+): Promise<T> => {
+  const networkId = (await provider.getNetwork()).chainId;
+  const contractAddress = await getAddress(contractName, networkId);
+  const contractAbi = getAbi(contractName);
+  return new Contract(contractAddress, contractAbi, provider) as T;
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

DVMv2 monitor bot requires RPC node redundancy.


**Summary**

Uses EthersRetryProvider as redundant RPC provider for DVMv2 monitor bots.


**Details**

This should be merged only after #4389 that implements EthersRetryProvider, thus changes in `common` package should be ignored for this PR.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
