### PR TITLE
feat: deploy optimistic asserter on production networks

### DIFF
--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -156,5 +156,9 @@
   {
     "contractName": "Proposer",
     "address": "0x226726Ac52e6e948D1B7eA9168F9Ff2E27DbcbB5"
+  },
+  {
+    "contractName": "OptimisticAsserter",
+    "address": "0xFEc7C6AA64fDD17f456028e0B411f5c3877ADa5e"
   }
 ]

--- a/packages/core/networks/10.json
+++ b/packages/core/networks/10.json
@@ -62,5 +62,9 @@
   {
     "contractName": "LinearLongShortPairFinancialProductLibrary",
     "address": "0x168144503BFDA917657A6CcD079d1B7d2e6BF0E2"
+  },
+  {
+    "contractName": "OptimisticAsserter",
+    "address": "0xCd5FE81278FEbf3a9323eFC9F68AEcCAeAE8BE2C"
   }
 ]

--- a/packages/core/networks/137.json
+++ b/packages/core/networks/137.json
@@ -86,5 +86,9 @@
   {
     "contractName": "CappedYieldDollarLongShortPairFinancialProductLibrary",
     "address": "0x821B8aF8f616bd5C2B3ccF4392F5635CcA545307"
+  },
+  {
+    "contractName": "OptimisticAsserter",
+    "address": "0x1a3cF7c0f99256431Fd6e8163FF8748A4aE50b6F"
   }
 ]

--- a/packages/core/networks/288.json
+++ b/packages/core/networks/288.json
@@ -63,5 +63,9 @@
   {
     "contractName": "LinearLongShortPairFinancialProductLibrary",
     "address": "0x01eb880B005D7a3690A42246B5A8b7F384b45136"
+  },
+  {
+    "contractName": "OptimisticAsserter",
+    "address": "0x17d02b5CDb6fe2c681A447B119e9f6F5AB4E3018"
   }
 ]

--- a/packages/core/networks/42161.json
+++ b/packages/core/networks/42161.json
@@ -62,5 +62,9 @@
   {
     "contractName": "LinearLongShortPairFinancialProductLibrary",
     "address": "0x85F46e5aCf6309345D0d6cfe22fbBAF7c349fF84"
+  },
+  {
+    "contractName": "OptimisticAsserter",
+    "address": "0x211AD7adEf4d4348408B43da49D99bA117ADD8D1"
   }
 ]


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Optimistic Asserter should be available on production networks.

**Summary**

Adds Optimistic Asserter deployments on Ethereum mainnet, Polygon, Optimism, Arbitrum and Boba.


- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
