### PR TITLE
feat: update getGckmsSigner to be used in hardhat scripts

### DIFF
--- a/packages/common/src/EthersSignerUtils.ts
+++ b/packages/common/src/EthersSignerUtils.ts
@@ -19,7 +19,7 @@ function getPrivateKeySigner() {
 export async function getGckmsSigner(): Promise<Wallet> {
   if (!args.keys && !process.env.GCKMS_WALLET)
     throw new Error(
-      `Wallet GCKSM selected but no keys parameter set or environment variable GCKMS_WALLET! Set any of them first`
+      `Wallet GCKSM selected but no keys parameter or environment variable GCKMS_WALLET set! Set any of them first`
     );
   const privateKeys = await retrieveGckmsKeys(getGckmsConfig([args.keys ?? process.env.GCKMS_WALLET]));
   return new Wallet(privateKeys[0]); // GCKMS retrieveGckmsKeys returns multiple keys. For now we only support 1.

--- a/packages/common/src/EthersSignerUtils.ts
+++ b/packages/common/src/EthersSignerUtils.ts
@@ -16,9 +16,10 @@ function getPrivateKeySigner() {
   return new Wallet(process.env.PRIVATE_KEY);
 }
 
-export async function getGckmsSigner() {
-  if (!args.keys) throw new Error(`Wallet GCKSM selected but no keys parameter set! Set GCKMS key to use`);
-  const privateKeys = await retrieveGckmsKeys(getGckmsConfig([args.keys]));
+export async function getGckmsSigner(selectedWallet?: string): Promise<Wallet> {
+  if (!args.keys && !selectedWallet)
+    throw new Error(`Wallet GCKSM selected but no keys parameter set or selectedWallet! Set any of them first`);
+  const privateKeys = await retrieveGckmsKeys(getGckmsConfig([args.keys ?? selectedWallet]));
   return new Wallet(privateKeys[0]); // GCKMS retrieveGckmsKeys returns multiple keys. For now we only support 1.
 }
 

--- a/packages/common/src/EthersSignerUtils.ts
+++ b/packages/common/src/EthersSignerUtils.ts
@@ -16,10 +16,12 @@ function getPrivateKeySigner() {
   return new Wallet(process.env.PRIVATE_KEY);
 }
 
-export async function getGckmsSigner(selectedWallet?: string): Promise<Wallet> {
-  if (!args.keys && !selectedWallet)
-    throw new Error(`Wallet GCKSM selected but no keys parameter set or selectedWallet! Set any of them first`);
-  const privateKeys = await retrieveGckmsKeys(getGckmsConfig([args.keys ?? selectedWallet]));
+export async function getGckmsSigner(): Promise<Wallet> {
+  if (!args.keys && !process.env.GCKMS_WALLET)
+    throw new Error(
+      `Wallet GCKSM selected but no keys parameter set or environment variable GCKMS_WALLET! Set any of them first`
+    );
+  const privateKeys = await retrieveGckmsKeys(getGckmsConfig([args.keys ?? process.env.GCKMS_WALLET]));
   return new Wallet(privateKeys[0]); // GCKMS retrieveGckmsKeys returns multiple keys. For now we only support 1.
 }
 

--- a/packages/scripts/src/upgrade-tests/register-new-contract/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/register-new-contract/1_Propose.ts
@@ -46,9 +46,8 @@ async function main() {
   let proposerSigner: Signer;
 
   if (process.env.GCKMS_WALLET) {
-    const wallet: Wallet = await getGckmsSigner(process.env.GCKMS_WALLET);
-    proposerSigner = wallet.connect(hre.ethers.provider as Provider);
-    if (proposerWallet.toLowerCase() != wallet.address.toLowerCase())
+    proposerSigner = ((await getGckmsSigner()) as Wallet).connect(hre.ethers.provider as Provider);
+    if (proposerWallet.toLowerCase() != (await proposerSigner.getAddress()).toLowerCase())
       throw new Error("GCKMS wallet does not match proposer wallet");
   } else {
     proposerSigner = (await hre.ethers.getSigner(proposerWallet)) as Signer;

--- a/packages/scripts/src/upgrade-tests/register-new-contract/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/register-new-contract/1_Propose.ts
@@ -31,6 +31,9 @@ import {
   RegistryRolesEnum,
   relayGovernanceMessages,
   Signer,
+  Wallet,
+  getGckmsSigner,
+  Provider,
 } from "./common";
 
 // PARAMETERS
@@ -40,7 +43,16 @@ const proposerWallet = "0x2bAaA41d155ad8a4126184950B31F50A1513cE25";
 const NODE_URL_ENV = "NODE_URL_";
 
 async function main() {
-  const proposerSigner = (await hre.ethers.getSigner(proposerWallet)) as Signer;
+  let proposerSigner: Signer;
+
+  if (process.env.GCKMS_WALLET) {
+    const wallet: Wallet = await getGckmsSigner(process.env.GCKMS_WALLET);
+    proposerSigner = wallet.connect(hre.ethers.provider as Provider);
+    if (proposerWallet.toLowerCase() != wallet.address.toLowerCase())
+      throw new Error("GCKMS wallet does not match proposer wallet");
+  } else {
+    proposerSigner = (await hre.ethers.getSigner(proposerWallet)) as Signer;
+  }
 
   const newContractAddressMainnet = await getAddress(newContractName, 1);
 

--- a/packages/scripts/src/upgrade-tests/register-new-contract/common.ts
+++ b/packages/scripts/src/upgrade-tests/register-new-contract/common.ts
@@ -1,11 +1,14 @@
 import "@nomiclabs/hardhat-ethers";
 import hre from "hardhat";
 
+import { Provider } from "@ethersproject/abstract-provider";
+
 import { BigNumberish } from "@ethersproject/bignumber";
 import { BytesLike } from "@ethersproject/bytes";
 
 import {
   FinderEthers,
+  getAddress as _getAddress,
   GovernorChildTunnelEthers,
   GovernorEthers,
   GovernorHubEthers,
@@ -15,20 +18,19 @@ import {
   ParentMessengerBaseEthers,
   ProposerEthers,
   RegistryEthers,
-  getAddress as _getAddress,
 } from "@uma/contracts-node";
-import { BaseContract, PopulatedTransaction, Signer } from "ethers";
+import { BaseContract, PopulatedTransaction, Signer, Wallet } from "ethers";
 import { getContractInstance, getContractInstanceByUrl } from "../../utils/contracts";
 import {
-  fundArbitrumParentMessengerForRelays,
-  relayGovernanceMessages,
   decodeData,
   decodeRelayMessages,
+  fundArbitrumParentMessengerForRelays,
   ProposedTransaction,
+  relayGovernanceMessages,
   RelayTransaction,
 } from "../../utils/relay";
 
-import { interfaceName, RegistryRolesEnum } from "@uma/common";
+import { getGckmsSigner, interfaceName, RegistryRolesEnum } from "@uma/common";
 
 import { strict as assert } from "assert";
 
@@ -74,4 +76,7 @@ export {
   OptimisticOracleV3Ethers,
   forkNetwork,
   ParamType,
+  Provider,
+  getGckmsSigner,
+  Wallet,
 };


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Before this update we couldn't use `getGckmsSigner` in a hardhat script run with `yarn hardhat run ./pathToScript --network localhost` because `yarn hardhat run` doens't allow arbitrary positional arguments as required in `getGckmsSigner` previously.

With this change we can now use `getGckmsSigner` by passing the name of the wallet we want to instantiate.
