### PR TITLE
fix(oa): Add missing interface function for Optimistic Asseter

### DIFF
--- a/packages/core/contracts/common/implementation/MultiCaller.sol
+++ b/packages/core/contracts/common/implementation/MultiCaller.sol
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
 // This contract is taken from Uniswap's multi call implementation (https://github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/base/Multicall.sol)
 // and was modified to be solidity 0.8 compatible. Additionally, the method was restricted to only work with msg.value
 // set to 0 to avoid any nasty attack vectors on function calls that use value sent with deposits.
-pragma solidity ^0.8.0;
 
 /// @title MultiCaller
 /// @notice Enables calling multiple methods in a single call to the contract

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -100,6 +100,32 @@ interface OptimisticAsserterInterface {
     ) external returns (bytes32);
 
     /**
+     * @notice Fetches information about a specific identifier & currency from the UMA contracts and stores a local copy
+     * of the information within this contract. This is used to save gas when making assertions as we can avoid an
+     * external call to the UMA contracts to fetch this.
+     * @param identifier identifier to fetch information for and store locally.
+     * @param currency currency to fetch information for and store locally.
+     */
+    function syncUmaParams(bytes32 identifier, address currency) public;
+
+    /**
+     * @notice Resolves an assertion. If the assertion has not been disputed, the assertion is resolved as true and the
+     * asserter receives the bond. If the assertion has been disputed, the assertion is resolved depending on the oracle
+     * result. Based on the result, the asserter or disputer receives the bond. If the assertion was disputed then an
+     * amount of the bond is sent to the UMA Store as an oracle fee based on the burnedBondPercentage. The remainder of
+     * the bond is returned to the asserter or disputer.
+     * @param assertionId unique identifier for the assertion to resolve.
+     */
+    function settleAssertion(bytes32 assertionId) public;
+
+    /**
+     * @notice Settles an assertion and returns the resolution.
+     * @param assertionId unique identifier for the assertion to resolve and return the resolution for.
+     * @return resolution of the assertion.
+     */
+    function settleAndGetAssertionResult(bytes32 assertionId) external returns (bool);
+
+    /**
      * @notice Fetches the resolution of a specific assertion and returns it. If the assertion has not been settled then
      * this will revert. If the assertion was disputed and configured to discard the oracle resolution return false.
      * @param assertionId unique identifier for the assertion to fetch the resolution for.

--- a/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
+++ b/packages/core/contracts/optimistic-asserter/interfaces/OptimisticAsserterInterface.sol
@@ -106,7 +106,7 @@ interface OptimisticAsserterInterface {
      * @param identifier identifier to fetch information for and store locally.
      * @param currency currency to fetch information for and store locally.
      */
-    function syncUmaParams(bytes32 identifier, address currency) public;
+    function syncUmaParams(bytes32 identifier, address currency) external;
 
     /**
      * @notice Resolves an assertion. If the assertion has not been disputed, the assertion is resolved as true and the
@@ -116,7 +116,7 @@ interface OptimisticAsserterInterface {
      * the bond is returned to the asserter or disputer.
      * @param assertionId unique identifier for the assertion to resolve.
      */
-    function settleAssertion(bytes32 assertionId) public;
+    function settleAssertion(bytes32 assertionId) external;
 
     /**
      * @notice Settles an assertion and returns the resolution.


### PR DESCRIPTION
**Motivation**

When working on a sample OA intergration contract I realized we are missing some key functions within the OA interface. This PR addresses this.

**Summary**

Adds OA interfaces that were missing.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [X]  Untested
