### PR TITLE
fix: fix core ci due to hardhat upgrade

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "@awaitjs/express": "^0.3.0",
     "@eth-optimism/contracts": "^0.5.7",
     "@eth-optimism/message-relayer": "^0.1.8",
-    "@eth-optimism/smock": "^1.1.9",
+    "@defi-wonderland/smock": "^2.3.4",
     "@ethersproject/abi": "^5.4.0",
     "@ethersproject/abstract-provider": "^5.4.0",
     "@ethersproject/contracts": "^5.4.0",

--- a/packages/core/test/hardhat/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.js
+++ b/packages/core/test/hardhat/cross-chain-oracle/chain-adapters/Polygon_ChildMessenger.js
@@ -2,7 +2,7 @@ const hre = require("hardhat");
 const { web3, assertEventEmitted } = hre;
 const { getContract } = hre;
 const { utf8ToHex } = web3.utils;
-const { assert } = require("chai");
+const { assert, expect } = require("chai");
 
 const { didContractThrow, interfaceName } = require("@uma/common");
 
@@ -86,8 +86,7 @@ describe("Polygon_ChildMessenger", function () {
     const txn = await messenger.methods.processMessageFromRoot(fxRootTunnelAddress, data).send({ from: deployer });
 
     // Check that oracle spoke is called as expected
-    const processMessageFromParentCall = oracleSpokeSmocked.smocked.processMessageFromParent.calls[0];
-    assert.equal(processMessageFromParentCall.data, dataToSendToTarget);
+    expect(oracleSpokeSmocked.processMessageFromParent.getCall(0).args.data).is.equal(dataToSendToTarget);
 
     // Check events are emitted
     await assertEventEmitted(txn, messenger, "MessageReceivedFromParent", (ev) => {

--- a/packages/core/test/hardhat/cross-chain-oracle/chain-adapters/Polygon_ParentMessenger.js
+++ b/packages/core/test/hardhat/cross-chain-oracle/chain-adapters/Polygon_ParentMessenger.js
@@ -1,7 +1,6 @@
 const hre = require("hardhat");
-const { web3, assertEventEmitted } = hre;
-const { getContract } = hre;
-const { assert } = require("chai");
+const { web3, assertEventEmitted, getContract } = hre;
+const { assert, expect } = require("chai");
 
 const { didContractThrow } = require("@uma/common");
 
@@ -81,9 +80,8 @@ describe("Polygon_ParentMessenger", function () {
     });
 
     // Check that FxRoot function is called with correct params
-    let sendMessageToChildCall = fxRoot.smocked.sendMessageToChild.calls[0];
-    assert.equal(sendMessageToChildCall._receiver, fxChildAddress);
-    assert.equal(sendMessageToChildCall._data, expectedMessageSentData);
+    expect(fxRoot.sendMessageToChild.getCall(0).args._receiver).to.equal(fxChildAddress);
+    expect(fxRoot.sendMessageToChild.getCall(0).args._data).to.equal(expectedMessageSentData);
 
     // Called by GovernorHub sends data to GovernorSpoke
     txn = await sendMessage.send({ from: governorHubAddress });
@@ -101,9 +99,8 @@ describe("Polygon_ParentMessenger", function () {
     });
 
     // Check that FxRoot function is called with correct params
-    sendMessageToChildCall = fxRoot.smocked.sendMessageToChild.calls[0];
-    assert.equal(sendMessageToChildCall._receiver, fxChildAddress);
-    assert.equal(sendMessageToChildCall._data, expectedMessageSentData);
+    expect(fxRoot.sendMessageToChild.getCall(1).args._receiver).to.equal(fxChildAddress);
+    expect(fxRoot.sendMessageToChild.getCall(1).args._data).to.equal(expectedMessageSentData);
   });
   it("_processMessageFromChild", async function () {
     // Data to pass into this method includes: (1) the data to send to the target and (2) the target contract
@@ -118,9 +115,8 @@ describe("Polygon_ParentMessenger", function () {
     const txn = await messenger.methods.processMessageFromChild(data).send({ from: deployer });
 
     // Check that oracle hub is called as expected
-    const processMessageFromChildCall = oracleHubSmocked.smocked.processMessageFromChild.calls[0];
-    assert.equal(processMessageFromChildCall.chainId, childChainId);
-    assert.equal(processMessageFromChildCall.data, dataToSendToTarget);
+    expect(oracleHubSmocked.processMessageFromChild.getCall(0).args.chainId.toString()).to.equal(childChainId);
+    expect(oracleHubSmocked.processMessageFromChild.getCall(0).args.data).to.equal(dataToSendToTarget);
 
     // Check events are emitted
     await assertEventEmitted(txn, messenger, "MessageReceivedFromChild", (ev) => {

--- a/packages/core/test/hardhat/helpers/SmockitHelper.js
+++ b/packages/core/test/hardhat/helpers/SmockitHelper.js
@@ -1,16 +1,16 @@
 // Note: smockit is designed to run on the local hardhat network and not the optimism network.
 const { getContractDefinition } = require("@eth-optimism/contracts");
-const { smockit } = require("@eth-optimism/smock");
-
-const hre = require("hardhat");
+const { smock } = require("@defi-wonderland/smock");
+const chai = require("chai");
+chai.use(smock.matchers);
 
 // TODO: this function is now somewhat janky. if an artifact is provided then it ignores the optimism getContractDefinition
 // and uses the provided artifact. else, it looks for an optimism contract matching to `name`. Refactor this to be clear
 // of the optimism dependency. Left for a later PR as this will introduce a meaningful amount of churn.
 async function deployContractMock(name, opts, artifact = null) {
   if (!artifact) artifact = getContractDefinition(name);
-  const factory = new hre.ethers.ContractFactory(artifact.abi, artifact.bytecode);
-  let mock = await smockit(factory, opts);
+  // const factory = new hre.ethers.ContractFactory(artifact.abi, artifact.bytecode);
+  const mock = await smock.fake(artifact.abi, opts);
   // Create an options prop and put the address within it. This is done to match hardhat's web3 syntax for consistency
   // within unit tests that use this mock.
   mock.options = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,6 +1123,20 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@defi-wonderland/smock@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/smock/-/smock-2.3.4.tgz#2bfe7e19052140634b25db344d77de9b0ac7a96b"
+  integrity sha512-VYJbsoCOdFRyGkAwvaQhQRrU6V8AjK3five8xdbo41DEE9n3qXzUNBUxyD9HhXB/dWWPFWT21IGw5Ztl6Qw3Ew==
+  dependencies:
+    "@nomicfoundation/ethereumjs-evm" "^1.0.0-rc.3"
+    "@nomicfoundation/ethereumjs-util" "^8.0.0-rc.3"
+    "@nomicfoundation/ethereumjs-vm" "^6.0.0-rc.3"
+    diff "^5.0.0"
+    lodash.isequal "^4.5.0"
+    lodash.isequalwith "^4.4.0"
+    rxjs "^7.2.0"
+    semver "^7.3.5"
+
 "@ensdomains/address-encoder@^0.1.7":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@ensdomains/address-encoder/-/address-encoder-0.1.9.tgz#f948c485443d9ef7ed2c0c4790e931c33334d02d"
@@ -1278,14 +1292,6 @@
     ethers "^5.1.0"
     merkletreejs "^0.2.18"
     rlp "^2.2.6"
-
-"@eth-optimism/smock@^1.1.9":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/smock/-/smock-1.1.10.tgz#98a6eefc994ccf707f52ab06849468f3cc57bdb7"
-  integrity sha512-XPx1x9odF/noTBHzIhRgL9ihhr769WgUhf9dOm6X7bjSWRAVsII3IqbdB4ssPycaoSuNSmv8HG1xTLgfgcyOYw==
-  dependencies:
-    "@eth-optimism/core-utils" "^0.5.1"
-    bn.js "^5.2.0"
 
 "@ethereum-waffle/chai@^3.4.0":
   version "3.4.0"
@@ -4559,7 +4565,7 @@
     bigint-crypto-utils "^3.0.23"
     ethereum-cryptography "0.1.3"
 
-"@nomicfoundation/ethereumjs-evm@^1.0.0":
+"@nomicfoundation/ethereumjs-evm@^1.0.0", "@nomicfoundation/ethereumjs-evm@^1.0.0-rc.3":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz#99cd173c03b59107c156a69c5e215409098a370b"
   integrity sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==
@@ -4611,7 +4617,7 @@
     "@nomicfoundation/ethereumjs-util" "^8.0.0"
     ethereum-cryptography "0.1.3"
 
-"@nomicfoundation/ethereumjs-util@^8.0.0":
+"@nomicfoundation/ethereumjs-util@^8.0.0", "@nomicfoundation/ethereumjs-util@^8.0.0-rc.3":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz#deb2b15d2c308a731e82977aefc4e61ca0ece6c5"
   integrity sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==
@@ -4619,7 +4625,7 @@
     "@nomicfoundation/ethereumjs-rlp" "^4.0.0-beta.2"
     ethereum-cryptography "0.1.3"
 
-"@nomicfoundation/ethereumjs-vm@^6.0.0":
+"@nomicfoundation/ethereumjs-vm@^6.0.0", "@nomicfoundation/ethereumjs-vm@^6.0.0-rc.3":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz#2bb50d332bf41790b01a3767ffec3987585d1de6"
   integrity sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==
@@ -8585,7 +8591,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3, bn.js@^5.2.0:
+bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
@@ -17539,6 +17545,11 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
+lodash.isequalwith@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
+  integrity sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ==
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -22374,6 +22385,13 @@ rxjs@6, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.2.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
+  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
+  dependencies:
+    tslib "^2.1.0"
+
 sade@^1.4.2:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/sade/-/sade-1.7.4.tgz#ea681e0c65d248d2095c90578c03ca0bb1b54691"
@@ -24620,6 +24638,11 @@ tslib@^2.0.3, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsort@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
**Motivation**

https://github.com/UMAprotocol/protocol/pull/4397 broke ci silently by upgrading the hardhat version. Because ci _only_ runs on packages that have been directly modified, this PR did not trigger a ci run on core, but because it modified the hardhat version, it did ultimately have an impact.

The hardhat change broke compatibility with Smock v1 (the optimism package), which we use in some of our tests in core. To keep compatibility, we needed to upgrade to Smock v2, which has a different syntax. This is what this PR does.

Note: In the future, we should tweak the ci system to rerun everything when yarn.lock or package.json changes to ensure that packages don't silently break. However, that is out of scope for this PR.


**Summary**

This upgrades the core package to Smock v2.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
