### PR TITLE
test: retroactive rewards

### DIFF
--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -5260,6 +5260,9 @@ describe("VotingV2", function () {
     const outstandingRewardsAccount2 = await voting.methods.outstandingRewards(account2).call();
 
     // Outstanding rewards should be equal, regardless of when the user called updateTracker.
+    // At this point this test fails because account1 is getting rewards for 1 round at 32M tokends and 1 round at 32M
+    // + positive slash, whereas account2 is getting rewards for 2 round at 32M tokens + positive slash. This is because
+    // they way we calculate Staker rewards in voting.updateTrackers makes them behave retroactively.
     assert.equal(outstandingRewardsAccount1.toString(), outstandingRewardsAccount2.toString());
   });
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OZ has detected a bug in VotingV2 and Staker, which causes user rewards to be retroactive in certain circumstances. If 2 users have exactly the same voting activity and stakes, they may not receive the same constant emission rewards depending on when they update trackers.

This can cause a user to receive more or less rewards than they should depending on when they interact with the contract, triggering an updateTrackers.

**Summary**




**Details**



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

