### PR TITLE
fix(dvm2.0): H-02 - Address intra-round changes of the Slashing library

### DIFF
--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -5188,6 +5188,65 @@ describe("VotingV2", function () {
       if (toBN(slashedTokens).isNeg()) assert(startingAccountBalances[voter].gte(toBN(slashedTokens).abs()));
     }
   });
+  it.only("Can change address of slashing library between rounds and voters are slashed appropriately", async function () {
+    // consider the slashing library being changed between. A voter should be slashed based on the slashing library that
+    // was set at the round the vote resolved. For example consider there being two rounds with requests in each. In
+    // round 1 the standard slashing library is used. In round 2 the slashing library changes to slashing amounts by 2x.
+    // If a voter was staked but did not interact with the contracts between these rounds they should be slashed according
+    // to the library set on each round.
+
+    const identifier = padRight(utf8ToHex("test"), 64);
+    const time = "1000";
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
+    await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
+    await moveToNextRound(voting, accounts[0]);
+
+    const price = 123;
+    const salt = getRandomSignedInt(); // use the same salt for all votes. bad practice but wont impact anything.
+    let roundId = (await voting.methods.getCurrentRoundId().call()).toString();
+    let baseRequest = { salt, roundId, identifier };
+    let hash1 = computeVoteHash({ ...baseRequest, price: price, account: account1, time: time });
+    await voting.methods.commitVote(identifier, time, hash1).send({ from: account1 });
+
+    // move to the next phase, reveal and change the slashing library and request another price to vote on in the next round.
+
+    await moveToNextPhase(voting, accounts[0]);
+    await voting.methods.revealVote(identifier, time, price, salt).send({ from: account1 });
+    const newSlashingLib = await SlashingLibrary.new(toWei("0.0032", "ether"), "0").send({ from: accounts[0] });
+    console.log("newSlashingLib", newSlashingLib.options.address);
+    await voting.methods.setSlashingLibrary(newSlashingLib.options.address).send({ from: accounts[0] });
+    const time2 = time + 1;
+    await voting.methods.requestPrice(identifier, time2).send({ from: registeredContract });
+    await moveToNextRound(voting, accounts[0]);
+
+    // commit and reveal a vote on the second price request.
+    roundId = (await voting.methods.getCurrentRoundId().call()).toString();
+    baseRequest = { salt, roundId, identifier };
+    hash1 = computeVoteHash({ ...baseRequest, price: price, account: account1, time: time2 });
+    await voting.methods.commitVote(identifier, time2, hash1).send({ from: account1 });
+
+    await moveToNextPhase(voting, accounts[0]);
+    await voting.methods.revealVote(identifier, time2, price, salt).send({ from: account1 });
+
+    // We should also be able to check that the round this request was voted on correctly had the new slashing lib frozen.
+    assert.equal((await voting.methods.rounds(roundId).call()).slashingLibrary, newSlashingLib.options.address);
+
+    // Move to next round, update all account slashing trackers and verify the slashing is applied as expected.
+    await moveToNextRound(voting, accounts[0]);
+    for (const account of [account1, account2, account3, account4])
+      await voting.methods.updateTrackers(account).send({ from: account1 });
+
+    // Cumulative slash on first round should be 0.0016 * (100mm-32mm) = 108800. Cumulative slash on second round should
+    // be 0.0032 * (100mm-32mm-108800) = 217,251.84. We should therefore expect the balance of the account1 who
+    // voted in both rounds to be 32mm + 108800 + 217,251.84 = 32326051.84
+    assert.equal(await voting.methods.getVoterStakePostUpdate(account1).call(), toWei("32326051.84"));
+
+    // Equally, we should see the stakers who did not participate slashed at the expected rates. Consider account2. They
+    // did not vote in either request and should habve been slashed at 0.0016 for the first request as 32mm * 0.0016 = 51200
+    // and for the second request at 0.0032 * (32mm-51200) = 102236.16. They should therefore have a balance of 
+    // 32mm - 51200 - 102236.16 = 31846563.84
+    assert.equal(await voting.methods.getVoterStakePostUpdate(account2).call(), toWei("31846563.84"));
+  });
 
   const addNonSlashingVote = async () => {
     // There is a known issue with the contract wherein you roll the first request multiple times which results in this


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
The slashingLibrary state variable in the VotingV2 contract points to an external smart
contract which will be used to determine slashing values for different voting actions. The
address within the state variable can be changed via the setSlashingLibrary function,
which can be used to add new slashing logic or simply update the slashing values. However,
changing the slashingLibrary can retroactively affect the calculations of stakers who still
need to process their slashing trackers.
Each staker is responsible for updating their own slashing trackers via updateTrackers and
updateTrackersRange . updateTrackersRange allows a staker to process only a
portion of the price request indices in resolvedPriceRequestIds . Therefore, each staker
has a nextIndexToProcess to keep track of the next price request index to process in the
resolvedPriceRequestIds array. As a result, a staker can be at any price request index in
resolvedPriceRequestsIds , which means that there is no guarantee that all stakers are
up to date on slashing.
Consequently, updating the slashingLibrary can cause stakers to process their slashing
trackers for the same price request with different slashing values. This breaks an important
system property of the VotingV2 contract, which is that the total sum of positive and
negative slash that is calculated for a price request should be zero. Having an imbalance in the
total applied slash to all stakers in the contract can lead to an integer underflow in
requestSlashingTrackers if it turns out that the contract has given out more stake than
actually exists and all stakers participate in a future vote.

Consider adding an address variable to the Round struct, then freezing the
slashingLibrary address per-round as part of _freezeRoundVariables , and then
using the address stored in the Round struct to call calcSlashing on. Additionally, future
versions of the slashingLibrary should not include conditional logic that could potentially
apply different slashing values for different stakers in the same round, as this could also cause
a similar issue. Finally, the slashingLibrary should not internally update the rate at which
slashing is applied, as this would cause an equivalent issue to deploying a new
slashingLibrary with new parameters.
```

This PR addresses this issue by implementing the recomended solution. Unit test included as well to show fix.
