### PR TITLE
fix(dvm2.0): M-01 - Inaccurate function results

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -592,6 +592,9 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     /**
      * @notice Returns the number of current pending price requests to be voted and the number of resolved price
        requests over all time.
+     * @dev This method might return stale values if the state of the contract has changed since the last time
+       `processResolvablePriceRequests()` was called. To get the most up-to-date values, call
+       `getNumberOfPriceRequestsPostUpdate()` instead.
      * @return numberPendingPriceRequests the total number of pending prices requests.
      * @return numberResolvedPriceRequests the total number of prices resolved over all time.
      */

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -293,6 +293,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         bytes memory ancillaryData,
         bool isGovernance
     ) internal {
+        // Process any resolvable price requests
+        processResolvablePriceRequests();
         require(time <= getCurrentTime(), "Can only request in past");
         require(isGovernance || _getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(ancillaryData.length <= ANCILLARY_BYTES_LIMIT, "Invalid ancillary data");

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -1055,7 +1055,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         nextPendingIndexToProcess = requestIndex; // Store the index traversed up to for this round.
     }
 
-    // Returns a price request status. A request is either: NotRequested, Active, Resolved or Future.
+    // Returns a price request status. A request is either: NotRequested, Active, Resolved, Future or ToDelete.
     function _getRequestStatus(PriceRequest storage priceRequest, uint32 currentRoundId)
         private
         view
@@ -1119,7 +1119,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         require(registry.isContractRegistered(msg.sender) || msg.sender == migratedAddress, "Caller not registered");
     }
 
-    // Checks if a request should be deleted. A request should be deleted if it has been rolled more than the maxRolls
+    // Checks if a request should be deleted. A non-gevernance request should be deleted if it has been rolled more than
+    // the maxRolls.
     function _shouldDeleteRequest(uint256 rollCount, bool isGovernance) private view returns (bool) {
         return rollCount > maxRolls && !isGovernance;
     }

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -65,6 +65,12 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         uint32 lastVotingRound; // The last round that this request was voted on (when it resolved).
     }
 
+    enum VoteParticipation {
+        DidNotVote, // Voter did not vote.
+        WrongVote, // Voter voted against the resolved price.
+        CorrectVote // Voter voted with the resolved price.
+    }
+
     // Represents the status a price request has.
     enum RequestStatus {
         NotRequested, // Was never requested.
@@ -72,12 +78,6 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         Resolved, // Was resolved in a previous round.
         Future, // Is scheduled to be voted on in a future round.
         ToDelete // Is scheduled to be deleted.
-    }
-
-    enum VoteParticipation {
-        DidNotVote, // Voter did not vote.
-        WrongVote, // Voter voted against the resolved price.
-        CorrectVote // Voter voted with the resolved price.
     }
 
     // Only used as a return value in view methods -- never stored in the contract.

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -530,7 +530,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
         for (uint256 i = 0; i < pendingPriceRequestsIds.length; i = unsafe_inc(i)) {
             PriceRequest storage priceRequest = priceRequests[pendingPriceRequestsIds[i]];
-            if (_getRequestStatus(priceRequest, getCurrentRoundId()) == RequestStatus.Active) {
+            if (_getRequestStatus(priceRequest, currentRoundId) == RequestStatus.Active) {
                 unresolved[numUnresolved] = PendingRequestAncillaryAugmented({
                     lastVotingRound: priceRequest.lastVotingRound,
                     isGovernance: priceRequest.isGovernance,

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -1061,9 +1061,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         view
         returns (RequestStatus)
     {
-        if (priceRequest.lastVotingRound == 0) {
-            return RequestStatus.NotRequested;
-        }
+        if (priceRequest.lastVotingRound == 0) return RequestStatus.NotRequested;
         if (priceRequest.lastVotingRound < currentRoundId) {
             // Check if the request has already been resolved
             VoteInstance storage voteInstance = priceRequest.voteInstances[priceRequest.lastVotingRound];
@@ -1073,9 +1071,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
                 return RequestStatus.ToDelete;
             return RequestStatus.Active;
         }
-        if (priceRequest.lastVotingRound == currentRoundId) {
-            return RequestStatus.Active;
-        }
+        if (priceRequest.lastVotingRound == currentRoundId) return RequestStatus.Active;
+
         return RequestStatus.Future; // Means than priceRequest.lastVotingRound > currentRoundId
     }
 

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -70,7 +70,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         NotRequested, // Was never requested.
         Active, // Is being voted on in the current round.
         Resolved, // Was resolved in a previous round.
-        Future // Is scheduled to be voted on in a future round.
+        Future, // Is scheduled to be voted on in a future round.
+        ToDelete // Is scheduled to be deleted.
     }
 
     enum VoteParticipation {
@@ -932,6 +933,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         }
 
         if (requestStatus == RequestStatus.Future) return (false, 0, "Price is still to be voted on");
+        if (requestStatus == RequestStatus.ToDelete) return (false, 0, "Price will be deleted");
         (bool previouslyResolved, int256 previousPrice) =
             _getPriceFromPreviousVotingContract(identifier, time, ancillaryData);
         if (previouslyResolved) return (true, previousPrice, "");
@@ -1065,7 +1067,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
             (bool isResolved, ) = _getResolvedPrice(voteInstance, priceRequest.lastVotingRound);
             if (isResolved) return RequestStatus.Resolved;
             if (_shouldDeleteRequest(_getActualRollCount(priceRequest, currentRoundId), priceRequest.isGovernance))
-                return RequestStatus.NotRequested;
+                return RequestStatus.ToDelete;
             return RequestStatus.Active;
         }
         if (priceRequest.lastVotingRound == currentRoundId) {

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -590,7 +590,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     /**
      * @notice Returns the number of current pending price requests to be voted and the number of resolved price
-       requests over all time  after processing any resolvable price requests.
+       requests over all time.
      * @return numberPendingPriceRequests the total number of pending prices requests.
      * @return numberResolvedPriceRequests the total number of prices resolved over all time.
      */
@@ -598,8 +598,21 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         public
         returns (uint256 numberPendingPriceRequests, uint256 numberResolvedPriceRequests)
     {
-        processResolvablePriceRequests();
         return (pendingPriceRequestsIds.length, resolvedPriceRequestIds.length);
+    }
+
+    /**
+     * @notice Returns the number of current pending price requests to be voted and the number of resolved price
+       requests over all time after processing any resolvable price requests.
+     * @return numberPendingPriceRequests the total number of pending prices requests.
+     * @return numberResolvedPriceRequests the total number of prices resolved over all time.
+     */
+    function getNumberOfPriceRequestsPostUpdate()
+        external
+        returns (uint256 numberPendingPriceRequests, uint256 numberResolvedPriceRequests)
+    {
+        processResolvablePriceRequests();
+        return getNumberOfPriceRequests();
     }
 
     /**

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -293,8 +293,6 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         bytes memory ancillaryData,
         bool isGovernance
     ) internal {
-        // Process any resolvable price requests
-        processResolvablePriceRequests();
         require(time <= getCurrentTime(), "Can only request in past");
         require(isGovernance || _getIdentifierWhitelist().isIdentifierSupported(identifier), "Unsupported identifier");
         require(ancillaryData.length <= ANCILLARY_BYTES_LIMIT, "Invalid ancillary data");

--- a/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
+++ b/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
@@ -135,12 +135,6 @@ abstract contract VotingV2Interface {
     function getPendingRequests() external virtual returns (PendingRequestAncillaryAugmented[] memory);
 
     /**
-     * @notice Gets the requests that are being voted on this round after processing any resolvable price requests.
-     * @return pendingRequests array containing identifiers of type PendingRequestAncillaryAugmented.
-     */
-    function getPendingRequestsPostUpdate() external virtual returns (PendingRequestAncillaryAugmented[] memory);
-
-    /**
      * @notice Returns the current voting phase, as a function of the current time.
      * @return Phase to indicate the current phase. Either { Commit, Reveal, NUM_PHASES }.
      */

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -4425,20 +4425,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
 
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
-
-    // await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
-
-    // await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
-
-    // await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
-    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
   });
   it("Can successfully remove large amounts of spam piecewise", async function () {
     // Request so many requests in one go that we cant resolve them all in one transaction. Rather, we need to update

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -4262,6 +4262,67 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
     assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
   });
+  it("Request to be deleted can be re-requested only after processing resolvable price requests", async function () {
+    // Verify that if a request rolls enough times (to hit maxRolls) it is automatically removed from the
+    // pending requests array and becomes unresolvable.
+    const identifier = padRight(utf8ToHex("test"), 64);
+    const time = "1000";
+    // Verify that the order of requests is respected as they move between the pending and settled arrays.
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
+
+    await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
+
+    // Within the first active commit the roll counter should be 0.
+    await moveToNextRound(voting, accounts[0]);
+    await moveToNextRound(voting, accounts[0]);
+    await moveToNextRound(voting, accounts[0]);
+
+    assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 2);
+
+    assert.equal((await voting.methods.getPriceRequestStatuses([{ identifier, time }]).call())[0].status, "1");
+
+    await moveToNextRound(voting, accounts[0]);
+
+    assert.equal((await voting.methods.getPendingRequests().call()).length, 0);
+    assert.equal((await voting.methods.getPriceRequestStatuses([{ identifier, time }]).call())[0].status, "4");
+
+    assert(
+      await didContractThrow(
+        voting.methods.getPrice(identifier, time).send({ from: account1 }),
+        "Price will be deleted"
+      )
+    );
+
+    let result = await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
+    await assertEventNotEmitted(result, voting, "RequestAdded");
+
+    await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
+
+    const currentRoundId = await voting.methods.getCurrentRoundId().call();
+    result = await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
+    await assertEventEmitted(result, voting, "RequestAdded", (ev) => {
+      return (
+        // The vote is added to the next round, so we have to add 1 to the current round id.
+        ev.roundId.toString() == toBN(currentRoundId).addn(1).toString() &&
+        web3.utils.hexToUtf8(ev.identifier) == web3.utils.hexToUtf8(identifier) &&
+        ev.time.toString() == time.toString()
+      );
+    });
+
+    await moveToNextRound(voting, accounts[0]);
+
+    assert.equal((await voting.methods.getPendingRequests().call()).length, 1);
+    assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 0);
+
+    assert(
+      await didContractThrow(
+        voting.methods.getPrice(identifier, time).send({ from: account1 }),
+        "Current voting round not ended"
+      )
+    );
+  });
   it("Handles calling settle during reveal", async function () {
     // In the event that someone calls processResolvablePriceRequests() during the reveal phase, after a vote has reached
     // the gat but before the end of the round.

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -1732,11 +1732,8 @@ describe("VotingV2", function () {
     // Pending requests should be empty after the voting round ends and the price is resolved.
     await moveToNextRound(votingTest, accounts[0]);
 
-    // Check that getPendingRequestsPostUpdate already returns the correct number of elements.
-    assert.equal(
-      (await VotingV2.at(votingTest.options.address).methods.getPendingRequestsPostUpdate().call()).length,
-      0
-    );
+    // Check that getPendingRequests already returns the correct number of elements.
+    assert.equal((await VotingV2.at(votingTest.options.address).methods.getPendingRequests().call()).length, 0);
     assert.equal((await votingTest.methods.getPendingPriceRequestsArray().call()).length, 1);
 
     // Updating the account tracker should remove the request from the pending array as it is now resolved.
@@ -1784,25 +1781,19 @@ describe("VotingV2", function () {
       price.toString()
     );
 
-    // Check that getNumberOfPriceRequestsPostUpdate return the correct number of price requests.
-    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numberPendingPriceRequests, 1);
-    assert.equal((await voting.methods.getNumberOfPriceRequestsPostUpdate().call()).numberResolvedPriceRequests, 1);
+    // Check that getNumberOfPriceRequests return the correct number of price requests.
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 1);
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
 
-    // Check that getPendingRequests returns the pending price requests without updating.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
-
-    // Check that getPendingRequestsPostUpdate returns the pending price requests updated.
-    assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 0);
-    assert.equal((await voting.methods.getPendingRequestsPostUpdate().call())[0].rollCount, 1);
+    // Check that getPendingRequests returns the pending price requests updated.
+    assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 1);
 
     // Roll two more rounds to delete the price request.
     await moveToNextRound(voting, accounts[0]);
     await moveToNextRound(voting, accounts[0]);
 
-    // Check that getPendingRequestsPostUpdate already returns the correct number of elements.
-    assert.equal((await voting.methods.getPendingRequestsPostUpdate().call()).length, 0);
-    assert.equal((await voting.methods.getPendingRequests().call()).length, 1);
+    // Check that getPendingRequests already returns the correct number of elements.
+    assert.equal((await voting.methods.getPendingRequests().call()).length, 0);
   });
   it("Votes can correctly handle arbitrary ancillary data", async function () {
     const identifier1 = padRight(utf8ToHex("request-retrieval"), 64);
@@ -3124,8 +3115,8 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]); // Move into the reveal phase
 
-    // We should have a total number of priceRequestIds (instances where prices are requested) of 3.
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 3);
+    // We should have a total number of priceRequestIds (instances where prices are requested) of 4.
+    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
 
     // Consider the slashing. There were a total of 4 requests that actually settled. Account2 and account3 were
     // slashed every time as they did not participate in any votes. Account4 only participated in the last vote.
@@ -4434,20 +4425,20 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
 
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 4);
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 0);
 
-    await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
+    // await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 3);
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 1);
 
-    await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
+    // await voting.methods.processResolvablePriceRequestsRange(1).send({ from: accounts[0] });
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 2);
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 2);
 
-    await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
-    assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
+    // await voting.methods.processResolvablePriceRequests().send({ from: accounts[0] });
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberPendingPriceRequests, 0);
+    // assert.equal((await voting.methods.getNumberOfPriceRequests().call()).numberResolvedPriceRequests, 4);
   });
   it("Can successfully remove large amounts of spam piecewise", async function () {
     // Request so many requests in one go that we cant resolve them all in one transaction. Rather, we need to update

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -5,6 +5,7 @@ const { getContract, assertEventEmitted, assertEventNotEmitted } = hre;
 const {
   RegistryRolesEnum,
   VotePhasesEnum,
+  didContractRevertWith,
   didContractThrow,
   getRandomSignedInt,
   decryptMessage,
@@ -4293,8 +4294,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.getPriceRequestStatuses([{ identifier, time }]).call())[0].status, "4");
 
     assert(
-      await didContractThrow(
-        voting.methods.getPrice(identifier, time).send({ from: account1 }),
+      await didContractRevertWith(
+        voting.methods.getPrice(identifier, time).send({ from: registeredContract }),
         "Price will be deleted"
       )
     );
@@ -4321,8 +4322,8 @@ describe("VotingV2", function () {
     assert.equal((await voting.methods.getPendingRequests().call())[0].rollCount, 0);
 
     assert(
-      await didContractThrow(
-        voting.methods.getPrice(identifier, time).send({ from: account1 }),
+      await didContractRevertWith(
+        voting.methods.getPrice(identifier, time).send({ from: registeredContract }),
         "Current voting round not ended"
       )
     );


### PR DESCRIPTION
OZ identified the following issue:

```
M-01 Inaccurate function results

The following functions return information about the state of the VotingV2 contract:
getPendingRequests : returns an array of pending requests to be voted on in the
current round.
currentActiveRequests : returns a boolean to indicate whether there are any active
requests.
_getPriceOrError : returns a boolean to indicate success or failure to retrieve a price
for a price request, a price (if applicable), and a string error (if applicable).
getNumberOfPriceRequests : returns the number of pending price requests and the
number of resolved price requests.
However, these functions can return results that are inconsistent with the true state of the
VotingV2 contract. The functions getPendingRequests , currentActiveRequests ,
and _getPriceOrError use the _getRequestStatus function to determine whether a
request is still active or not. _getRequestStatus may determine that a price request has
been resolved, even if it has not yet been processed via the
_processResolvablePriceRequests function in the contract. Additionally, the
_getRequestStatus function does not take into consideration whether pending price
requests will be deleted. The getNumberOfPriceRequests function simply returns the
length of the pendingPriceRequestsIds and resolvedPriceRequestIds arrays,
which can be outdated if _processResolvablePriceRequests has not yet been called for
the current round.
```

The solution in this PR is to update the [_getRequestStatus()](https://github.com/UMAprotocol/protocol/blob/md0x/dvm-audit-m01/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol#L1041) to consider the case where the price request should be deleted because of too many rolls. This update fixes all the issues allowing us to remove the `...PostUpdate()` functions except for [getNumberOfPriceRequestsPostUpdate()](https://github.com/UMAprotocol/protocol/blob/0a6d6bb34935bd6ec0f435bc622aefbfb22afd9b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol#L610) for which we have kept both versions of it for convenience: `getNumberOfPriceRequestsPostUpdate` and `getNumberOfPriceRequests`. We have documented the latter properly.