### PR TITLE
fix(dvm2.0): M-02 - Enable commit/reveal post migration to still enable requests to be settled if voted on during a migration

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -428,7 +428,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         uint256 time,
         bytes memory ancillaryData,
         bytes32 hash
-    ) public override nonReentrant onlyIfNotMigrated {
+    ) public override nonReentrant {
         uint32 currentRoundId = getCurrentRoundId();
         address voter = getVoterFromDelegate(msg.sender);
         _updateTrackers(voter);
@@ -459,7 +459,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         int256 price,
         bytes memory ancillaryData,
         int256 salt
-    ) public override nonReentrant onlyIfNotMigrated {
+    ) public override nonReentrant {
         uint32 currentRoundId = getCurrentRoundId();
         _freezeRoundVariables(currentRoundId);
         VoteInstance storage voteInstance =

--- a/packages/core/contracts/data-verification-mechanism/implementation/test/VotingV2Test.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/test/VotingV2Test.sol
@@ -44,7 +44,7 @@ contract VotingV2ControllableTiming is VotingV2, Testable {
         bytes32 identifier,
         uint256 time,
         bytes32 hash
-    ) external virtual onlyIfNotMigrated() {
+    ) external virtual {
         commitVote(identifier, time, "", hash);
     }
 

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -5228,6 +5228,11 @@ describe("VotingV2", function () {
       (await voting.methods.getPrice(identifier, time).call({ from: registeredContract })).toString(),
       price.toString()
     );
+
+    // However, cant request another price as migrated.
+    assert(
+      await didContractThrow(voting.methods.requestPrice(identifier, time + 1).send({ from: registeredContract }))
+    );
   });
 
   const addNonSlashingVote = async () => {

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -1529,7 +1529,6 @@ describe("VotingV2", function () {
     const hash = computeVoteHash({ price, salt, account: account1, time: time1, roundId, identifier });
     await newVoting.methods.commitVote(identifier, time1, hash).send({ from: account1 });
     await moveToNextPhase(newVoting, accounts[0]);
-    // await newVoting.methods.snapshotCurrentRound(signature).send({ from: accounts[0] });
     await newVoting.methods.revealVote(identifier, time1, price, salt).send({ from: account1 });
     await moveToNextRound(newVoting, accounts[0]);
 
@@ -1544,12 +1543,6 @@ describe("VotingV2", function () {
     // Now newVoting and registered contracts can call methods.
     assert(await newVoting.methods.hasPrice(identifier, time1).send({ from: migratedVoting }));
     assert(await newVoting.methods.hasPrice(identifier, time1).send({ from: registeredContract }));
-
-    // commit/reveal are completely disabled, regardless if called by newVoting.
-    assert(
-      await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: migratedVoting }))
-    );
-    assert(await didContractThrow(newVoting.methods.commitVote(identifier, time2, hash).send({ from: account1 })));
 
     // Requesting prices is completely disabled after migration, regardless if called by newVoting.
     assert(await didContractThrow(newVoting.methods.requestPrice(identifier, time3).send({ from: migratedVoting })));


### PR DESCRIPTION
OZ identified the following issue:
```
M-02 onlyIfNotMigrated modifier can prevent
price requests from being resolved
As part of migrating to a new voting contract, the onlyIfNotMigrated modifier is used to
restrict access to the following functions in the VotingV2 contract:
requestPrice
requestGovernanceAction
commitVote
revealVote
However, when a migration does occur, the onlyIfNotMigrated modifier prevents stakers
from being able to commit and reveal votes. The consequence of this is twofold: stakers who
did not reveal their vote before the migration could be unintentionally slashed if any price
requests were to resolve, and price requests that did not resolve this round would be
permanently unresolvable. Regular price requests would eventually be deleted from the system
when they reach the maxRolls limit, but governance price requests are not allowed to be
deleted. Consequently, the bond of any unresolved governance price request due to a
migration would be stuck in the ProposerV2 contract.
Consider removing the onlyIfNotMigrated modifier from the commitVote and
revealVote functions. This would allow stakers to vote on and resolve any pending price
requests in the migrated voting contract, but prevents new price requests from being added.
Note that stakers would need to remain staked and participate in the migrated voting contract
until all pending governance price requests are resolved.
```

The solution in this PR is to remove this modifier from commit and reveal, but leave it on the other functions. this way we can still resolve requests if during an active migration, but you cant request subsequent prices.