### PR TITLE
fix(dvm2.0): L-04: Add ability to change delegate during voting round

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -475,9 +475,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         // Check that the hash that was committed matches to the one that was revealed. Note that if the voter had
         // then they must reveal with the same account they had committed with.
         require(
-            keccak256(
-                abi.encodePacked(price, salt, voter, time, ancillaryData, uint256(currentRoundId), identifier)
-            ) == voteSubmission.commit,
+            keccak256(abi.encodePacked(price, salt, voter, time, ancillaryData, uint256(currentRoundId), identifier)) ==
+                voteSubmission.commit,
             "Revealed data != commit hash"
         );
 

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -476,7 +476,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         // then they must reveal with the same account they had committed with.
         require(
             keccak256(
-                abi.encodePacked(price, salt, msg.sender, time, ancillaryData, uint256(currentRoundId), identifier)
+                abi.encodePacked(price, salt, voter, time, ancillaryData, uint256(currentRoundId), identifier)
             ) == voteSubmission.commit,
             "Revealed data != commit hash"
         );

--- a/packages/core/test/hardhat/data-verification-mechanism/DesignatedVotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/DesignatedVotingV2.js
@@ -151,12 +151,10 @@ describe("DesignatedVotingV2", function () {
 
     const price = 420;
     const salt = getRandomSignedInt();
-    // Note: the "voter" address for this vote must be the designated voting contract since its the one that will ultimately
-    // "reveal" the vote. Only the voter can call reveal through the designated voting contract.
     const hash = computeVoteHashAncillary({
       price,
       salt,
-      account: voter,
+      account: designatedVoting.options.address,
       time,
       ancillaryData: ancillaryData,
       roundId,
@@ -217,7 +215,7 @@ describe("DesignatedVotingV2", function () {
     const hash1 = computeVoteHashAncillary({
       price: price1,
       salt: salt1,
-      account: voter,
+      account: designatedVoting.options.address,
       time: time1,
       ancillaryData: ancillaryData1,
       roundId,
@@ -230,7 +228,7 @@ describe("DesignatedVotingV2", function () {
     const hash2 = computeVoteHashAncillary({
       price: price2,
       salt: salt2,
-      account: voter,
+      account: designatedVoting.options.address,
       time: time2,
       ancillaryData: ancillaryData2,
       roundId,

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -2767,18 +2767,98 @@ describe("VotingV2", function () {
 
     await moveToNextRound(voting, accounts[0]);
     const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
-
     const price = 1;
-
     const salt = getRandomSignedInt(); // use the same salt for all votes. bad practice but wont impact anything.
 
-    // construct the vote hash. Note the account is the delegate.
-    const hash = computeVoteHash({ salt, roundId, identifier, price, account: rand, time });
+    // construct the vote hash. Note the account remains the account that staked, not the delegate.
+    const hash = computeVoteHash({ salt, roundId, identifier, price, account: account1, time });
 
     // Commit the votes.
     await voting.methods.commitVote(identifier, time, hash).send({ from: rand });
     await moveToNextPhase(voting, accounts[0]); // Reveal the votes.
     await voting.methods.revealVote(identifier, time, price, salt).send({ from: rand });
+    await moveToNextRound(voting, accounts[0]); // Move to the next round.
+
+    // The price should have settled as per usual and be recoverable. The original staker should have gained the positive
+    // slashing from being the oly correct voter. The total slashing should be 68mm * 0.0016 = 108800.
+    assert.equal(await voting.methods.getPrice(identifier, time).call({ from: registeredContract }), price);
+    await voting.methods.updateTrackers(account1).send({ from: account1 });
+    assert.equal((await voting.methods.voterStakes(account1).call()).stake, toWei("32000000").add(toWei("108800")));
+  });
+  it("Can change delegate during active voting round and still correctly reveal", async function () {
+    // Delegate from account1 to rand.
+    await voting.methods.setDelegate(rand).send({ from: account1 });
+    await voting.methods.setDelegator(account1).send({ from: rand });
+
+    // State variables should be set correctly.
+    assert.equal((await voting.methods.voterStakes(account1).call()).delegate, rand);
+    assert.equal(await voting.methods.delegateToStaker(rand).call(), account1);
+
+    // Request a price and see that we can vote on it on behalf of the account1 from the delegate.
+    const identifier = padRight(utf8ToHex("delegated-voting"), 64); // Use the same identifier for both.
+    const time = "420";
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
+    await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
+
+    await moveToNextRound(voting, accounts[0]);
+    const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
+    const price = 1;
+    const salt = getRandomSignedInt(); // use the same salt for all votes. bad practice but wont impact anything.
+    // construct the vote hash. Note the account remains the account that staked, not the delegate.
+    const hash = computeVoteHash({ salt, roundId, identifier, price, account: account1, time });
+
+    // Commit the votes.
+    await voting.methods.commitVote(identifier, time, hash).send({ from: rand });
+    await moveToNextPhase(voting, accounts[0]); // Reveal the votes.
+
+    // Now, before we reveal change the delegate to a now address and reveal from that account. This should not impact
+    // the reveal flow at all.
+    await voting.methods.setDelegate(unregisteredContract).send({ from: account1 });
+    await voting.methods.setDelegator(account1).send({ from: unregisteredContract });
+
+    // State variables should be set correctly.
+    assert.equal((await voting.methods.voterStakes(account1).call()).delegate, unregisteredContract);
+    assert.equal(await voting.methods.delegateToStaker(unregisteredContract).call(), account1);
+
+    // Now, should be able to reveal without any issue.
+    await voting.methods.revealVote(identifier, time, price, salt).send({ from: unregisteredContract });
+    await moveToNextRound(voting, accounts[0]); // Move to the next round.
+
+    // The price should have settled as per usual and be recoverable. The original staker should have gained the positive
+    // slashing from being the oly correct voter. The total slashing should be 68mm * 0.0016 = 108800.
+    assert.equal(await voting.methods.getPrice(identifier, time).call({ from: registeredContract }), price);
+    await voting.methods.updateTrackers(account1).send({ from: account1 });
+    assert.equal((await voting.methods.voterStakes(account1).call()).stake, toWei("32000000").add(toWei("108800")));
+  });
+
+  it("Can commit from delegate and reveal from delegator", async function () {
+    // Delegate from account1 to rand.
+    await voting.methods.setDelegate(rand).send({ from: account1 });
+    await voting.methods.setDelegator(account1).send({ from: rand });
+
+    // State variables should be set correctly.
+    assert.equal((await voting.methods.voterStakes(account1).call()).delegate, rand);
+    assert.equal(await voting.methods.delegateToStaker(rand).call(), account1);
+
+    // Request a price and see that we can vote on it on behalf of the account1 from the delegate.
+    const identifier = padRight(utf8ToHex("delegated-voting"), 64); // Use the same identifier for both.
+    const time = "420";
+    await supportedIdentifiers.methods.addSupportedIdentifier(identifier).send({ from: accounts[0] });
+    await voting.methods.requestPrice(identifier, time).send({ from: registeredContract });
+
+    await moveToNextRound(voting, accounts[0]);
+    const roundId = (await voting.methods.getCurrentRoundId().call()).toString();
+    const price = 1;
+    const salt = getRandomSignedInt(); // use the same salt for all votes. bad practice but wont impact anything.
+
+    // construct the vote hash. Note the account remains the account that staked, not the delegate.
+    const hash = computeVoteHash({ salt, roundId, identifier, price, account: account1, time });
+
+    // Commit the votes.
+    await voting.methods.commitVote(identifier, time, hash).send({ from: rand });
+    await moveToNextPhase(voting, accounts[0]); // Reveal the votes.
+    // Now, reveal from the delegator, not the delegate who did the commit. Should work as expected.
+    await voting.methods.revealVote(identifier, time, price, salt).send({ from: account1 });
     await moveToNextRound(voting, accounts[0]); // Move to the next round.
 
     // The price should have settled as per usual and be recoverable. The original staker should have gained the positive


### PR DESCRIPTION

**Motivation**
OZ identified the following issue:
```
The hashed price that is committed during the commit phase is calculated by using the
msg.sender address as is verified by the revealVote function in the VotingV2 contract.
If a voter has delegated their voting to another address, the delegate address will be used for
calculating the hash. Since the delegate can change at anytime, it is possible that a voter will
be unable to reveal their vote if they have changed their delegate or if they have revoked
delegation which will result in their staked balance being slashed.
Consider using the voter address in the hashed price to ensure a voter will always be able to
reveal their vote.
```

This PR changes the voting contracts by using the `voter` address in all cases when computing the hash. This means that you can: a) commit with the delegate and reveal with the delegator b) commit with the delegator and reveal with the delegate c) change the delegate/delegator relationship during a vote (new delegate) and preform a and b (swapping which you commit/reveal with).
