### PR TITLE
fix: reorder lines to ensure the node url chain id mapping gets cached

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -144,11 +144,14 @@ hub.post("/", async (req, res) => {
     for (const botName in configObject) {
       // Check if bot is running on a non-default chain, and fetch last block number seen on this or the default chain.
       const [botWeb3, spokeCustomNodeUrl] = _getWeb3AndUrlForBot(configObject[botName]);
+      
       const chainId = await _getChainId(botWeb3);
+      
+      // Cache the chain id for this node url.
+      nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
+      
       // If we've seen this chain ID already we can skip it.
       if (blockNumbersForChain[chainId]) continue;
-
-      nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
 
       // If STORE_MULTI_CHAIN_BLOCK_NUMBERS is set then this bot requires to know a number of last seen blocks across
       // a set of chainIds. Construct a batch promise to evaluate the latest block number for each chainId.


### PR DESCRIPTION
**Motivation**

When there are different node providers for different bots in the same config, the cache step can get skipped. This caching, however, is required in the subsequent loop.


**Summary**

Simple swapping of the order should mean this cache always gets populated.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

N/A