### PR TITLE
fix(dvm2.0): L06 Address duplicate governance action during migration by adding proposal ID to the proposal ancillary data

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.16;
 
+import "./Constants.sol";
+import "./AdminIdentifierLib.sol";
+
 import "../../common/implementation/Lockable.sol";
 import "../../common/implementation/MultiRole.sol";
+import "../../common/implementation/AncillaryData.sol";
+
 import "../interfaces/FinderInterface.sol";
 import "../interfaces/IdentifierWhitelistInterface.sol";
 import "../interfaces/OracleGovernanceInterface.sol";
-import "./Constants.sol";
-import "./AdminIdentifierLib.sol";
 
 import "@openzeppelin/contracts/utils/Address.sol";
 
@@ -101,6 +104,9 @@ contract GovernorV2 is MultiRole, Lockable {
 
         // Add a zero-initialized element to the proposals array.
         proposals.push();
+
+        // Append the id to the ancillary data. This ensures that the price request to the DVM is unique.
+        ancillaryData = AncillaryData.appendKeyValueUint(ancillaryData, "GovernanceProposalId", id);
 
         // Initialize the new proposal.
         Proposal storage proposal = proposals[id];


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:
```
When the VotingV2 contract is migrated, all active governance price requests will be rolled
indefinitely as no one will be able to reveal votes. A potential sandwich attack could involve
proposing two governance requests, one before and one after the migration occurs within the
same block. The first of these requests would be to the original voting contract, and the
second would be in the new voting contract. These governance requests could be equivalent
as they could have the same identifier , requestTime , and ancillaryData . Only one
of these requests (the latter) would need to resolve for both requests to be able to be executed
by the GovernorV2 contract. If the request resolves to a zero price, both accounts that paid
their bond will lose their bond and the request will never be executed.
Consider checking the previous voting contract when a price request is created in the new
voting contract to ensure that the request is not a duplicate.
```

This issue was addressed in a different way to what OZ recommended by simply adding the proposal ID to the GovernorV2's ancillary data. This forces the proposals to be unique and indirectly address the problem.
