### PR TITLE
fix(dvm2.0): L-05 - Add input validation

### DIFF
--- a/packages/common/src/SolidityTestUtils.ts
+++ b/packages/common/src/SolidityTestUtils.ts
@@ -13,6 +13,18 @@ export async function didContractThrow<T>(promise: Promise<T>): Promise<boolean>
   return false;
 }
 
+// Attempts to execute a promise and returns false if no error is thrown,
+// or the error message does not match the expected revert message
+export async function didContractRevertWith<T>(promise: Promise<T>, revertMessage: string): Promise<boolean> {
+  try {
+    await promise;
+  } catch (error) {
+    const expectedErrorMessage = `VM Exception while processing transaction: reverted with reason string '${revertMessage}'`;
+    return (error as Error).message === expectedErrorMessage;
+  }
+  return false;
+}
+
 type Web3Provider =
   | InstanceType<typeof Web3.providers.HttpProvider>
   | InstanceType<typeof Web3.providers.WebsocketProvider>;

--- a/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
@@ -14,6 +14,8 @@ contract FixedSlashSlashingLibrary is SlashingLibraryInterface {
     uint256 public immutable governanceSlashAmount;
 
     constructor(uint256 _baseSlashAmount, uint256 _governanceSlashAmount) {
+        require(_baseSlashAmount < 1e18, "Invalid base slash amount");
+        require(_governanceSlashAmount < 1e18, "Invalid governance slash amount");
         baseSlashAmount = _baseSlashAmount;
         governanceSlashAmount = _governanceSlashAmount;
     }

--- a/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
@@ -93,6 +93,7 @@ contract GovernorV2 is MultiRole, Lockable {
         nonReentrant()
         onlyRoleHolder(uint256(Roles.Proposer))
     {
+        require(transactions.length > 0, "Empty transactions array");
         uint256 id = proposals.length;
         uint256 time = getCurrentTime();
 

--- a/packages/core/contracts/data-verification-mechanism/implementation/ProposerV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ProposerV2.sol
@@ -84,6 +84,7 @@ contract ProposerV2 is Ownable, Lockable {
      */
     function resolveProposal(uint256 id) external nonReentrant() {
         BondedProposal memory bondedProposal = bondedProposals[id];
+        require(bondedProposal.sender != address(0), "Invalid proposal id");
         OracleAncillaryInterface voting =
             OracleAncillaryInterface(finder.getImplementationAddress(OracleInterfaces.Oracle));
         bytes32 adminIdentifier = AdminIdentifierLib._constructIdentifier(id);

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -122,6 +122,8 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
         address recipient,
         uint128 amount
     ) internal {
+        require(amount > 0, "Cannot stake 0");
+
         VoterStake storage voterStake = voterStakes[recipient];
 
         // If the staker has a cumulative staked balance of 0 then we can shortcut their lastRequestIndexConsidered to

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -153,6 +153,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      */
     function requestUnstake(uint128 amount) external override nonReentrant() {
         require(!_inActiveReveal(), "In an active reveal phase");
+        require(amount > 0, "Cannot unstake 0");
         _updateTrackers(msg.sender);
         VoterStake storage voterStake = voterStakes[msg.sender];
 

--- a/packages/core/test/hardhat/data-verification-mechanism/FixedSlashSlashingLibrary.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/FixedSlashSlashingLibrary.js
@@ -1,0 +1,31 @@
+const { assert } = require("chai");
+const hre = require("hardhat");
+const { didContractThrow } = require("@uma/common");
+
+const { getContract, web3 } = hre;
+const { toWei } = web3.utils;
+
+const SlashingLibrary = getContract("FixedSlashSlashingLibrary");
+
+const baseSlashAmount = toWei("0.0016");
+const governanceSlashAmount = toWei("0");
+
+describe("FixedSlashSlashingLibrary", function () {
+  let accounts, owner;
+  beforeEach(async function () {
+    accounts = await web3.eth.getAccounts();
+    [owner] = accounts;
+  });
+  it("Validate baseSlashAmount", async function () {
+    const invalidBaseSlashAmount = toWei("1");
+    assert(
+      await didContractThrow(SlashingLibrary.new(invalidBaseSlashAmount, governanceSlashAmount).send({ from: owner }))
+    );
+  });
+  it("Validate governanceSlashAmount", async function () {
+    const invalidGovernanceSlashAmount = toWei("1");
+    assert(
+      await didContractThrow(SlashingLibrary.new(baseSlashAmount, invalidGovernanceSlashAmount).send({ from: owner }))
+    );
+  });
+});

--- a/packages/core/test/hardhat/data-verification-mechanism/FixedSlashSlashingLibrary.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/FixedSlashSlashingLibrary.js
@@ -1,6 +1,6 @@
 const { assert } = require("chai");
 const hre = require("hardhat");
-const { didContractThrow } = require("@uma/common");
+const { didContractRevertWith } = require("@uma/common");
 
 const { getContract, web3 } = hre;
 const { toWei } = web3.utils;
@@ -19,13 +19,19 @@ describe("FixedSlashSlashingLibrary", function () {
   it("Validate baseSlashAmount", async function () {
     const invalidBaseSlashAmount = toWei("1");
     assert(
-      await didContractThrow(SlashingLibrary.new(invalidBaseSlashAmount, governanceSlashAmount).send({ from: owner }))
+      await didContractRevertWith(
+        SlashingLibrary.new(invalidBaseSlashAmount, governanceSlashAmount).send({ from: owner }),
+        "Invalid base slash amount"
+      )
     );
   });
   it("Validate governanceSlashAmount", async function () {
     const invalidGovernanceSlashAmount = toWei("1");
     assert(
-      await didContractThrow(SlashingLibrary.new(baseSlashAmount, invalidGovernanceSlashAmount).send({ from: owner }))
+      await didContractRevertWith(
+        SlashingLibrary.new(baseSlashAmount, invalidGovernanceSlashAmount).send({ from: owner }),
+        "Invalid governance slash amount"
+      )
     );
   });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/GovernorV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/GovernorV2.js
@@ -1,7 +1,13 @@
 const hre = require("hardhat");
 const { runVotingV2Fixture, ZERO_ADDRESS } = require("@uma/common");
 const { getContract, assertEventEmitted } = hre;
-const { RegistryRolesEnum, didContractThrow, getRandomSignedInt, computeVoteHashAncillary } = require("@uma/common");
+const {
+  RegistryRolesEnum,
+  didContractRevertWith,
+  didContractThrow,
+  getRandomSignedInt,
+  computeVoteHashAncillary,
+} = require("@uma/common");
 const { moveToNextRound, moveToNextPhase } = require("../utils/Voting.js");
 const { interfaceName } = require("@uma/common");
 const { assert } = require("chai");
@@ -1050,6 +1056,11 @@ describe("GovernorV2", function () {
   });
 
   it("Cannot propose empty transactions array", async function () {
-    assert(await didContractThrow(governorV2.methods.propose([], defaultAncillaryData).send({ from: accounts[0] })));
+    assert(
+      await didContractRevertWith(
+        governorV2.methods.propose([], defaultAncillaryData).send({ from: accounts[0] }),
+        "Empty transactions array"
+      )
+    );
   });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/GovernorV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/GovernorV2.js
@@ -1048,4 +1048,8 @@ describe("GovernorV2", function () {
 
     assert.equal(hexToUtf8(identifier), `Admin ${expectedOutputIdValue}`);
   });
+
+  it("Cannot propose empty transactions array", async function () {
+    assert(await didContractThrow(governorV2.methods.propose([], defaultAncillaryData).send({ from: accounts[0] })));
+  });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/ProposerV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/ProposerV2.js
@@ -1,6 +1,6 @@
 const hre = require("hardhat");
 const { getContract, assertEventEmitted, web3 } = hre;
-const { runVotingV2Fixture, interfaceName, didContractThrow } = require("@uma/common");
+const { runVotingV2Fixture, interfaceName, didContractRevertWith, didContractThrow } = require("@uma/common");
 const { assert } = require("chai");
 
 const MockOracleGovernance = getContract("MockOracleGovernance");
@@ -234,6 +234,11 @@ describe("ProposerV2", function () {
 
   it("Validate proposal id", async function () {
     const invalidId = "100";
-    assert(await didContractThrow(proposer.methods.resolveProposal(invalidId).send({ from: rando })));
+    assert(
+      await didContractRevertWith(
+        proposer.methods.resolveProposal(invalidId).send({ from: rando }),
+        "Invalid proposal id"
+      )
+    );
   });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/ProposerV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/ProposerV2.js
@@ -92,7 +92,13 @@ describe("ProposerV2", function () {
   });
 
   it("Bond must be paid", async function () {
-    const txn = proposer.methods.propose([], defaultAncillaryData);
+    // Build a no-op txn for the governor to execute.
+    const noOpTxnBytes = votingToken.methods.approve(submitter, "0").encodeABI();
+
+    const txn = proposer.methods.propose(
+      [{ to: votingToken.options.address, value: 0, data: noOpTxnBytes }],
+      defaultAncillaryData
+    );
 
     // No balance and bond isn't approved.
     assert(await didContractThrow(txn.send({ from: submitter })));

--- a/packages/core/test/hardhat/data-verification-mechanism/ProposerV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/ProposerV2.js
@@ -231,4 +231,9 @@ describe("ProposerV2", function () {
     await votingToken.methods.transfer(proposer.options.address, bond).send({ from: submitter });
     assert(await didContractThrow(proposer.methods.resolveProposal(id).send({ from: submitter })));
   });
+
+  it("Validate proposal id", async function () {
+    const invalidId = "100";
+    assert(await didContractThrow(proposer.methods.resolveProposal(invalidId).send({ from: rando })));
+  });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/Staker.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/Staker.js
@@ -354,5 +354,11 @@ describe("Staker", function () {
     it("Cannot stake 0 UMA", async function () {
       assert(await didContractThrow(staker.methods.stake("0").send({ from: account1 })));
     });
+
+    it("Cannot unstake 0 UMA", async function () {
+      await staker.methods.stake(amountToStake).send({ from: account1 });
+
+      assert(await didContractThrow(staker.methods.requestUnstake("0").send({ from: account1 })));
+    });
   });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/Staker.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/Staker.js
@@ -1,6 +1,6 @@
 const hre = require("hardhat");
 const { web3, assertEventEmitted } = hre;
-const { runDefaultFixture, didContractThrow } = require("@uma/common");
+const { runDefaultFixture, didContractRevertWith, didContractThrow } = require("@uma/common");
 const { getContract } = hre;
 
 const { assert } = require("chai");
@@ -352,13 +352,15 @@ describe("Staker", function () {
   });
   describe("Staker: input validation", function () {
     it("Cannot stake 0 UMA", async function () {
-      assert(await didContractThrow(staker.methods.stake("0").send({ from: account1 })));
+      assert(await didContractRevertWith(staker.methods.stake("0").send({ from: account1 }), "Cannot stake 0"));
     });
 
     it("Cannot unstake 0 UMA", async function () {
       await staker.methods.stake(amountToStake).send({ from: account1 });
 
-      assert(await didContractThrow(staker.methods.requestUnstake("0").send({ from: account1 })));
+      assert(
+        await didContractRevertWith(staker.methods.requestUnstake("0").send({ from: account1 }), "Cannot unstake 0")
+      );
     });
   });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/Staker.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/Staker.js
@@ -350,4 +350,9 @@ describe("Staker", function () {
       await assertEventEmitted(result, staker, "ExecutedUnstake");
     });
   });
+  describe("Staker: input validation", function () {
+    it("Cannot stake 0 UMA", async function () {
+      assert(await didContractThrow(staker.methods.stake("0").send({ from: account1 })));
+    });
+  });
 });

--- a/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/VotingV2.js
@@ -126,8 +126,11 @@ describe("VotingV2", function () {
     for (const ac of [account1, account2, account3, account4, rand]) {
       if ((await voting.methods.voterStakes(ac).call()).pendingUnstake != 0)
         await voting.methods.executeUnstake().send({ from: ac });
-      await voting.methods.requestUnstake(await voting.methods.getVoterStakePostUpdate(ac).call()).send({ from: ac });
-      await voting.methods.executeUnstake().send({ from: ac });
+      const stake = await voting.methods.getVoterStakePostUpdate(ac).call();
+      if (stake !== "0") {
+        await voting.methods.requestUnstake(stake).send({ from: ac });
+        await voting.methods.executeUnstake().send({ from: ac });
+      }
     }
 
     const votingBalance = await votingToken.methods.balanceOf(voting.options.address).call();
@@ -4063,13 +4066,11 @@ describe("VotingV2", function () {
     await voting.methods
       .requestUnstake((await voting.methods.voterStakes(account4).call()).stake)
       .send({ from: account4 });
-    await voting.methods.requestUnstake((await voting.methods.voterStakes(rand).call()).stake).send({ from: rand });
 
     await voting.methods.executeUnstake().send({ from: account1 });
     await voting.methods.executeUnstake().send({ from: account2 });
     await voting.methods.executeUnstake().send({ from: account3 });
     await voting.methods.executeUnstake().send({ from: account4 });
-    await voting.methods.executeUnstake().send({ from: rand });
 
     const finalContractBalance = await votingToken.methods.balanceOf(voting.options.address).call();
     assert.equal(finalContractBalance, "0");
@@ -4620,13 +4621,11 @@ describe("VotingV2", function () {
     await voting.methods
       .requestUnstake((await voting.methods.voterStakes(account4).call()).stake)
       .send({ from: account4 });
-    await voting.methods.requestUnstake((await voting.methods.voterStakes(rand).call()).stake).send({ from: rand });
 
     await voting.methods.executeUnstake().send({ from: account1 });
     await voting.methods.executeUnstake().send({ from: account2 });
     await voting.methods.executeUnstake().send({ from: account3 });
     await voting.methods.executeUnstake().send({ from: account4 });
-    await voting.methods.executeUnstake().send({ from: rand });
 
     const finalContractBalance = await votingToken.methods.balanceOf(voting.options.address).call();
     assert.equal(finalContractBalance, "0");


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
The following inputs lack the appropriate validation:
- The amount argument to the _stakeTo function in the Staker contract should be validated to ensure it is
non-zero.
- The amount argument to the requestUnstake function in the Staker contract should be validated to ensure it
is non-zero.
- The _baseSlashAmount and _governanceSlashAmount arguments to the constructor of the
FixedSlashSlashingLibrary contract should both be strictly less than 1e18 to prevent slashing more than 100%
of a voter's staked balance.
- In the propose function in the GovernorV2 contract, a lack of input validation allows for proposals that
contain no transactions to be created. Consider adding a check that ensures the length of the transactions
input array is not zero.
- In the resolveProposal function in the ProposerV2 contract, the id argument is never validated to ensure it
corresponds to a valid proposal. Although the function will revert for an invalid id due to not having a
price, it is recommended that an explicit check of the id is included to avoid relying on the external voting
contract for validation.
```

This PR addresses this issue by implementing the appropriate input validations. Unit test included as well to show the fix.
