### PR TITLE
feat(common): match exact reverts with didContractRevertWith

### DIFF
--- a/packages/common/src/SolidityTestUtils.ts
+++ b/packages/common/src/SolidityTestUtils.ts
@@ -13,6 +13,18 @@ export async function didContractThrow<T>(promise: Promise<T>): Promise<boolean>
   return false;
 }
 
+// Attempts to execute a promise and returns false if no error is thrown,
+// or the error message does not match the expected revert message
+export async function didContractRevertWith<T>(promise: Promise<T>, revertMessage: string): Promise<boolean> {
+  try {
+    await promise;
+  } catch (error) {
+    const expectedErrorMessage = `VM Exception while processing transaction: reverted with reason string '${revertMessage}'`;
+    return (error as Error).message === expectedErrorMessage;
+  }
+  return false;
+}
+
 type Web3Provider =
   | InstanceType<typeof Web3.providers.HttpProvider>
   | InstanceType<typeof Web3.providers.WebsocketProvider>;

--- a/packages/common/test/SolidityTestUtils.js
+++ b/packages/common/test/SolidityTestUtils.js
@@ -1,0 +1,24 @@
+const { web3, getContract } = require("hardhat");
+const { assert } = require("chai");
+const { didContractRevertWith } = require("../dist/SolidityTestUtils");
+
+const ExpandedERC20 = getContract("ExpandedERC20");
+
+describe("SolidityTestUtils.js", function () {
+  let accounts;
+  before(async function () {
+    accounts = await web3.eth.getAccounts();
+  });
+  it("didContractRevertWith", async function () {
+    const erc20Contract = await ExpandedERC20.new("Test", "TEST", 18).send({ from: accounts[0] });
+
+    // Mint 1 wei to owner.
+    await erc20Contract.methods.addMinter(accounts[0]).send({ from: accounts[0] });
+    await erc20Contract.methods.mint(accounts[0], "1").send({ from: accounts[0] });
+
+    const transaction = erc20Contract.methods.transferFrom(accounts[0], accounts[1], "1").send({ from: accounts[1] });
+
+    // This should fail because the owner has not approved the transfer.
+    assert.isTrue(await didContractRevertWith(transaction, "ERC20: transfer amount exceeds allowance"));
+  });
+});


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

When testing it might be important to check for specific revert message to make sure error is happening in the expected path.


**Summary**

Implements didContractRevertWith that accepts promise for contract call and expected revert message.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

