### PR TITLE
fix(dvm2.0): L-08 - Address missing emmitted props when setting unstake cooldown and emission rate in construction

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -88,8 +88,8 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
         uint64 _unstakeCoolDown,
         address _votingToken
     ) {
-        emissionRate = _emissionRate;
-        unstakeCoolDown = _unstakeCoolDown;
+        setEmissionRate(_emissionRate);
+        setUnstakeCoolDown(_unstakeCoolDown);
         votingToken = ExpandedIERC20(_votingToken);
     }
 
@@ -251,7 +251,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @notice  Set the token's emission rate, the number of voting tokens that are emitted per second per staked token.
      * @param newEmissionRate the new amount of voting tokens that are emitted per second, split pro rata to stakers.
      */
-    function setEmissionRate(uint128 newEmissionRate) external onlyOwner {
+    function setEmissionRate(uint128 newEmissionRate) public onlyOwner {
         _updateReward(address(0));
         emissionRate = newEmissionRate;
         emit SetNewEmissionRate(newEmissionRate);
@@ -261,7 +261,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @notice  Set the amount of time a voter must wait to unstake after submitting a request to do so.
      * @param newUnstakeCoolDown the new duration of the cool down period in seconds.
      */
-    function setUnstakeCoolDown(uint64 newUnstakeCoolDown) external onlyOwner {
+    function setUnstakeCoolDown(uint64 newUnstakeCoolDown) public onlyOwner {
         unstakeCoolDown = newUnstakeCoolDown;
         emit SetNewUnstakeCoolDown(newUnstakeCoolDown);
     }


### PR DESCRIPTION

**Motivation**

OZ identified the following issue:
```
Consider emitting events for the following state changes:
When emissionRate is set in the constructor of the Staker contract.
When unstakeCoolDown is set in the constructor of the Staker contract.
Emitting events provides a convenient way for external entities to observe and react to
changes in the contract's state.
```
This PR fixes this by using the setters (with events) to the constructor.
