### PR TITLE
fix(dvm2.0): L-11 - Address duplicate code

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -149,7 +149,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * Note there is no way to cancel an unstake request, you must wait until after unstakeRequestTime and re-stake.
      * @param amount the amount of tokens to request to be unstaked.
      */
-    function requestUnstake(uint128 amount) external override nonReentrant() {
+    function requestUnstake(uint128 amount) external nonReentrant() {
         require(!_inActiveReveal(), "In an active reveal phase");
         _updateTrackers(msg.sender);
         VoterStake storage voterStake = voterStakes[msg.sender];
@@ -168,7 +168,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @notice  Execute a previously requested unstake. Requires the unstake time to have passed.
      * @dev If a staker requested an unstake and time > unstakeRequestTime then send funds to staker.
      */
-    function executeUnstake() external override nonReentrant() {
+    function executeUnstake() external nonReentrant() {
         VoterStake storage voterStake = voterStakes[msg.sender];
         require(
             voterStake.unstakeRequestTime != 0 && getCurrentTime() >= voterStake.unstakeRequestTime + unstakeCoolDown,
@@ -291,10 +291,10 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @return address voter that corresponds to the delegate.
      */
     function getVoterFromDelegate(address caller) public view returns (address) {
-        if (
-            delegateToStaker[caller] != address(0) && // The delegate chose to be a delegate for the staker.
-            voterStakes[delegateToStaker[caller]].delegate == caller // The staker chose the delegate.
-        ) return delegateToStaker[caller];
+        address delegateToStaker = delegateToStaker[caller];
+        // The delegate chose to be a delegate for the staker.
+        if (delegateToStaker != address(0) && voterStakes[delegateToStaker].delegate == caller) return delegateToStaker;
+        // The staker chose the delegate.
         else return caller;
     }
 

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -294,7 +294,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @return address voter that corresponds to the delegate.
      */
     function getVoterFromDelegate(address caller) public view returns (address) {
-        address delegator = delegator[caller];
+        address delegator = delegateToStaker[caller];
         // The delegate chose to be a delegate for the staker.
         if (delegator != address(0) && voterStakes[delegator].delegate == caller) return delegator;
         else return caller; // The staker chose the delegate.

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -294,11 +294,10 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @return address voter that corresponds to the delegate.
      */
     function getVoterFromDelegate(address caller) public view returns (address) {
-        address delegateToStaker = delegateToStaker[caller];
+        address delegator = delegator[caller];
         // The delegate chose to be a delegate for the staker.
-        if (delegateToStaker != address(0) && voterStakes[delegateToStaker].delegate == caller) return delegateToStaker;
-        // The staker chose the delegate.
-        else return caller;
+        if (delegator != address(0) && voterStakes[delegator].delegate == caller) return delegator;
+        else return caller; // The staker chose the delegate.
     }
 
     /**


### PR DESCRIPTION

**Motivation**
OZ identified the following issue:
```
L-11 Redundant Code
The following instances of redundant code have been identified:
The requestUnstake and executeUnstake functions in the Staker contract do
not need to include override .
In the getVoterFromDelegate function in the Staker contract, the
delegateToStaker[caller] value is read from storage up to three times.
The requestPrice function in the VotingV2 contract can only be called if the
contract has not been migrated, as the onlyIfNotMigrated modifier checks that the
migratedAddress is non-zero. The onlyRegisteredContract modifier checks if
msg.sender is the migratedAddress . Since the onlyIfNotMigrated modifier
will cause execution to revert if the contract is migrated, the msg.sender will never be
the migratedAddress in the onlyRegisteredContract modifier.
Consider addressing these instances of redundant code to promote conciseness and clarity of
the codebase.
```
2 of the 3 issues were addressed. the Last one, pertaining to `onlyIfNotMigrated` and `onlyRegisteredContract` was not changed as this would make other parts of the code that use these modifiers a bit more complex and the redundant call is very unlikely of being hit.
