### PR TITLE
fix(dvm2.0): N-01 Address interface inconsistancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bootstrap": "yarn",
     "lint": "yarn eslint && yarn prettier --list-different",
     "lint-fix": "yarn eslint --fix && yarn prettier --write",
-    "eslint": "eslint './**/*.js' './**/*.ts'",
+    "eslint": "eslint --quiet './**/*.js' './**/*.ts'",
     "prettier": "prettier './**/*.js' './**/*.sol' './**/*.md' './**/*.ts'",
     "test": "NODE_OPTIONS=--max-old-space-size=4096 lerna run --stream --concurrency=4 test",
     "test-concurrent": "NODE_OPTIONS=--max-old-space-size=4096 lerna run --stream --concurrency=4 test --ignore @uma/serverless-orchestration --ignore @uma/affiliates && lerna run --stream --concurrency=1 test --scope @uma/serverless-orchestration --scope @uma/affiliates",

--- a/packages/core/contracts/data-verification-mechanism/interfaces/StakerInterface.sol
+++ b/packages/core/contracts/data-verification-mechanism/interfaces/StakerInterface.sol
@@ -17,9 +17,9 @@ interface StakerInterface {
 
     function withdrawAndRestake() external returns (uint128);
 
-    function setEmissionRate(uint128 emissionRate) external;
+    function setEmissionRate(uint128 newEmissionRate) external;
 
-    function setUnstakeCoolDown(uint64 unstakeCoolDown) external;
+    function setUnstakeCoolDown(uint64 newUnstakeCoolDown) external;
 
     /**
      * @notice Sets the delegate of a voter. This delegate can vote on behalf of the staker. The staker will still own

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -144,12 +144,12 @@ hub.post("/", async (req, res) => {
     for (const botName in configObject) {
       // Check if bot is running on a non-default chain, and fetch last block number seen on this or the default chain.
       const [botWeb3, spokeCustomNodeUrl] = _getWeb3AndUrlForBot(configObject[botName]);
-      
+
       const chainId = await _getChainId(botWeb3);
-      
+
       // Cache the chain id for this node url.
       nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
-      
+
       // If we've seen this chain ID already we can skip it.
       if (blockNumbersForChain[chainId]) continue;
 


### PR DESCRIPTION


**Motivation**
OZ identified:
```
The following instances of mismatched argument names between contracts and interfaces are
present:
The setEmissionRate function in the Staker interface has an argument named
emissionRate , but it is named newEmissionRate in the Staker contract.
The setUnstakeCoolDown function in the Staker interface has an argument named
emissionRate , but it is named newUnstakeCoolDown in the Staker contract.
For clarity, consider renaming one of the arguments so the interface matches the
implementation.
```
This PR fixes it.

**Summary**

Briefly summarize what changes were made to accomplish the motivation above.


**Details**

This may be unnecessary for some PRs. Catch-all for detailed explanations about the implementation decisions and implications of the change.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
