### PR TITLE
fix(dvm2.0): L-09 - Add missing docstrings

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2Factory.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2Factory.sol
@@ -8,7 +8,10 @@ import "./DesignatedVotingV2.sol";
  * @dev Allows off-chain infrastructure to look up a hot wallet's deployed DesignatedVoting contract.
  */
 contract DesignatedVotingV2Factory {
+    // Finder contract that stores addresses of UMA system contracts.
     address private finder;
+
+    // Mapping of hot wallet addresses to their designated voting contracts.
     mapping(address => DesignatedVotingV2) public designatedVotingContracts;
 
     event NewDesignatedVoting(address indexed designatedVoter, address indexed designatedVoting);

--- a/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
@@ -13,9 +13,14 @@ contract FixedSlashSlashingLibrary is SlashingLibraryInterface {
     uint256 public immutable baseSlashAmount;
     uint256 public immutable governanceSlashAmount;
 
+    /**
+     * @notice Construct the FixedSlashSlashingLibrary contract.
+     * @param _baseSlashAmount Slash amount per token for missed votes and wrong non-governance votes.
+     * @param _governanceSlashAmount Slash amount per token for wrong governance votes.
+     */
     constructor(uint256 _baseSlashAmount, uint256 _governanceSlashAmount) {
-        baseSlashAmount = _baseSlashAmount;
-        governanceSlashAmount = _governanceSlashAmount;
+        baseSlashAmount = _baseSlashAmount; // Slash amount per token for missed votes and wrong non-governance votes.
+        governanceSlashAmount = _governanceSlashAmount; // Slash amount per token for wrong governance votes.
     }
 
     /**

--- a/packages/core/contracts/data-verification-mechanism/implementation/ProposerV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ProposerV2.sol
@@ -16,10 +16,10 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
  */
 contract ProposerV2 is Ownable, Lockable {
     using SafeERC20 for IERC20;
-    IERC20 public immutable token;
-    uint256 public bond;
-    GovernorV2 public immutable governor;
-    Finder public immutable finder;
+    IERC20 public immutable token; // The ERC20 token that the bond is paid in.
+    uint256 public bond; // The bond amount for making a proposal.
+    GovernorV2 public immutable governor; // The governor contract that this contract makes proposals to.
+    Finder public immutable finder; // Finder contract that stores addresses of UMA system contracts.
 
     struct BondedProposal {
         address sender;

--- a/packages/core/contracts/data-verification-mechanism/implementation/VoteTiming.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VoteTiming.sol
@@ -16,6 +16,8 @@ library VoteTiming {
 
     /**
      * @notice Initializes the data object. Sets the phase length based on the input.
+     * @param data reference to the this library's data object.
+     * @param phaseLength length of voting phase in seconds.
      */
     function init(Data storage data, uint256 phaseLength) internal {
         // This should have a require message but this results in an internal Solidity error.

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -318,6 +318,10 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         }
     }
 
+    /**
+     * @notice Gets the round ID that a request should be voted on.
+     * @return uint32 round ID that a request should be voted on.
+     */
     function getRoundIdToVoteOnRequest(uint32 targetRoundId) public view returns (uint32) {
         while (rounds[targetRoundId].numberOfRequestsToVote >= maxRequestsPerRound) ++targetRoundId;
         return targetRoundId;


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
Several functions in the codebase lack complete documentation:
- The getRoundIdToVoteOnRequest function in the VotingV2 contract
- All input arguments to the init function in the VotingTiming library
- The baseSlashAmount and governanceSlashAmount state variables in the FixedSlashSlashingLibrary contract
- The constructor in the FixedSlashSlashingLibrary contract
- The finder and designatedVotingContracts state variables in the DesignatedVotingV2Factory contract
- All state variables in the ProposerV2 contract
```

This PR addresses this issue by adding missing docstrings.