### PR TITLE
fix(dvm2.0): L-02 - Retroactively unstake cooldown

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -159,7 +159,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
         cumulativeStake -= amount;
         voterStake.pendingUnstake = amount;
         voterStake.stake -= amount;
-        voterStake.unstakeTime = SafeCast.toUint64(getCurrentTime()) + unstakeCoolDown;
+        voterStake.unstakeTime = uint64(getCurrentTime()) + unstakeCoolDown;
 
         emit RequestedUnstake(msg.sender, amount, voterStake.unstakeTime, voterStake.stake);
     }

--- a/packages/core/test/hardhat/data-verification-mechanism/Staker.js
+++ b/packages/core/test/hardhat/data-verification-mechanism/Staker.js
@@ -192,12 +192,35 @@ describe("Staker", function () {
       // The account should have 0 outstanding rewards as they requested to unstake right at the beginning of the test.
       assert.equal(await staker.methods.outstandingRewards(account1).call(), toWei("0"));
     });
+    it("Unstaking time can be shortcut if unstakeCooldown is set to zero", async function () {
+      await staker.methods.stake(amountToStake).send({ from: account1 });
+
+      // Attempting to unstake without requesting.
+      assert(await didContractThrow(staker.methods.executeUnstake().send({ from: account1 })));
+      await staker.methods.requestUnstake(amountToStake).send({ from: account1 });
+      // Not waiting long enough should also revert.
+      assert(await didContractThrow(staker.methods.executeUnstake().send({ from: account1 })));
+      await advanceTime(1000);
+      assert(await didContractThrow(staker.methods.executeUnstake().send({ from: account1 })));
+
+      // Set the unstake cooldown to 0.
+      await staker.methods.setUnstakeCoolDown(0).send({ from: account1 });
+
+      const balanceBefore = await votingToken.methods.balanceOf(account1).call();
+      await staker.methods.executeUnstake().send({ from: account1 });
+      const balanceAfter = await votingToken.methods.balanceOf(account1).call();
+      assert.equal(balanceAfter, amountToStake.add(toBN(balanceBefore))); // Should get back the original amount staked.
+
+      // The account should have 0 outstanding rewards as they requested to unstake right at the beginning of the test.
+      assert.equal(await staker.methods.outstandingRewards(account1).call(), toWei("0"));
+    });
     it("Can not re-request to unstake", async function () {
       await staker.methods.stake(amountToStake).send({ from: account1 });
 
-      const unstakeRequestTime = Number(await staker.methods.getCurrentTime().call());
+      const currentTime = toBN(await staker.methods.getCurrentTime().call());
+      const unstakeTime = currentTime.add(toBN(await staker.methods.unstakeCoolDown().call()));
       await staker.methods.requestUnstake(amountToStake).send({ from: account1 });
-      assert((await staker.methods.voterStakes(account1).call()).unstakeRequestTime, unstakeRequestTime);
+      assert((await staker.methods.voterStakes(account1).call()).unstakeTime, unstakeTime.toString());
       assert((await staker.methods.voterStakes(account1).call()).pendingUnstake, amountToStake);
       assert(await didContractThrow(staker.methods.requestUnstake(420).send({ from: account1 })));
     });

--- a/packages/scripts/src/monitoring-dvm2.0/common.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/common.ts
@@ -93,7 +93,7 @@ export const unstakeFromStakedAccount = async (votingV2: VotingV2Ethers, voter: 
     const voterStake = await votingV2.voterStakes(voter);
     if (voterStake.pendingUnstake.gt(ethers.BigNumber.from(0))) {
       console.log("Staker", voter, "has a pending unstake. Executing then re-unstaking");
-      const unstakeTime = voterStake.unstakeRequestTime.add(await votingV2.unstakeCoolDown());
+      const unstakeTime = voterStake.unstakeTime;
       const currentTime = await votingV2.getCurrentTime();
       const pendingStakeRemainingTime = unstakeTime.gt(currentTime) ? unstakeTime.sub(currentTime) : BigNumber.from(0);
       await increaseEvmTime(pendingStakeRemainingTime.toNumber());


### PR DESCRIPTION
OZ identified the following issue:

```
L-02 Changing the unstake cooldown
retroactively impacts stakers
Increasing the unstake cooldown time in the Staker contract using the
setUnstakeCoolDown function can result in a staker being unable to withdraw their stake at
the anticipated time when they initially requested to unstake. This happens as only the
unstakeRequestTime is cached for a staker, instead of the time at which they will be able
to unstake.
Consider caching the time at which a staker will be able to execute their unstake.
```

The solution in this PR is to store the pre-calculated `unstakeTime` instead of the `requestUnstakeTime`. By doing this we fix the retroactive behaviour of the `setUnstakeCoolDown` function reported by OZ. 
Additionally we allow to shortcut the `unstakeTime` if the global variable `unstakeCoolDown` is set to allow in an emergency scenario to `unstake` without cooldown already requested users as well as unrequested. 