### PR TITLE
fix(dvm2.0): N-04 - Address named return consistency

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
@@ -76,8 +76,8 @@ contract FixedSlashSlashingLibrary is SlashingLibraryInterface {
      * @param totalCorrectVotes The total amount of correct votes.
      * @param priceRequestIndex The price request index within the resolvedPriceRequestIds array.
      * @param isGovernance Whether the request is a governance request.
-     * @return wrongVoteSlashPerToken The amount of tokens to slash for voting wrong.
-     * @return noVoteSlashPerToken The amount of tokens to slash for not voting.
+     * @return uint256 The amount of tokens to slash for voting wrong.
+     * @return uint256 The amount of tokens to slash for not voting.
      */
     function calcSlashing(
         uint256 totalStaked,
@@ -85,7 +85,7 @@ contract FixedSlashSlashingLibrary is SlashingLibraryInterface {
         uint256 totalCorrectVotes,
         uint256 priceRequestIndex,
         bool isGovernance
-    ) external view returns (uint256 wrongVoteSlashPerToken, uint256 noVoteSlashPerToken) {
+    ) external view returns (uint256, uint256) {
         return (
             isGovernance
                 ? calcWrongVoteSlashPerTokenGovernance(totalStaked, totalVotes, totalCorrectVotes, priceRequestIndex)

--- a/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
@@ -49,18 +49,18 @@ library ResultComputationV2 {
      * to be valid. Used to enforce a minimum voter participation rate, regardless of how the votes are distributed.
      * @param minModalVotes min (exclusive) number of tokens that must have voted for the modal outcome for it to result
      * in a resolution. This is used to avoid cases where the mode is a very small plurality.
-     * @return isResolved indicates if the price has been resolved correctly.
-     * @return price the price that the dvm resolved to.
+     * @return bool true if the price has been resolved correctly.
+     * @return int256 the price that the dvm resolved to.
      */
     function getResolvedPrice(
         Data storage data,
         uint128 minTotalVotes,
         uint128 minModalVotes
-    ) internal view returns (bool isResolved, int256 price) {
-        if (data.totalVotes > minTotalVotes && data.voteFrequency[data.currentMode] > minModalVotes) {
-            isResolved = true; // modeThreshold and minVoteThreshold are exceeded, so the resolved price is the mode.
-            price = data.currentMode;
-        } else isResolved = false;
+    ) internal view returns (bool, int256) {
+        // If minimum participation is met and the mode has enough votes, then the result is the mode.
+        if (data.totalVotes > minTotalVotes && data.voteFrequency[data.currentMode] > minModalVotes)
+            return (true, data.currentMode);
+        return (false, 0);
     }
 
     /**

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -602,26 +602,20 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     /**
      * @notice Returns the number of current pending price requests to be voted and the number of resolved price
        requests over all time.
-     * @return numberPendingPriceRequests the total number of pending prices requests.
-     * @return numberResolvedPriceRequests the total number of prices resolved over all time.
+     * @return uint256 the total number of pending prices requests.
+     * @return uint256 the total number of prices resolved over all time.
      */
-    function getNumberOfPriceRequests()
-        public
-        returns (uint256 numberPendingPriceRequests, uint256 numberResolvedPriceRequests)
-    {
+    function getNumberOfPriceRequests() public returns (uint256, uint256) {
         return (pendingPriceRequestsIds.length, resolvedPriceRequestIds.length);
     }
 
     /**
      * @notice Returns the number of current pending price requests to be voted and the number of resolved price
        requests over all time after processing any resolvable price requests.
-     * @return numberPendingPriceRequests the total number of pending prices requests.
-     * @return numberResolvedPriceRequests the total number of prices resolved over all time.
+     * @return uint256 the total number of pending prices requests.
+     * @return uint256 the total number of prices resolved over all time.
      */
-    function getNumberOfPriceRequestsPostUpdate()
-        external
-        returns (uint256 numberPendingPriceRequests, uint256 numberResolvedPriceRequests)
-    {
+    function getNumberOfPriceRequestsPostUpdate() external returns (uint256, uint256) {
         processResolvablePriceRequests();
         return getNumberOfPriceRequests();
     }
@@ -1076,10 +1070,11 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         else return RequestStatus.Future; // Means than priceRequest.lastVotingRound > currentRoundId
     }
 
+    // Returns if the price is resolvable and the price.
     function _getResolvedPrice(VoteInstance storage voteInstance, uint256 lastVotingRound)
         internal
         view
-        returns (bool isResolved, int256 price)
+        returns (bool, int256)
     {
         return
             voteInstance.results.getResolvedPrice(


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
The following instances of inconsistent usage of named return values were identified:
- In the FixedSlashSlashingLibrary contract, named returns are used inconsistently. All functions use unnamed
returns except for the calcSlashing function, which uses a named return value.
- In the ResultComputationV2 library, there is inconsistent use of named return values.
- In the VotingV2 contract, most functions do not use named return values with the exception of the
getNumberOfPriceRequests , getNumberOfPriceRequestsPostUpdate , and _getResolvedPrice functions.
```
This PR addresses this issue by removing named returns for the sake of consistency.