### PR TITLE
fix(dvm2.0): N-07 Ensure all external functions are marked as such

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -101,7 +101,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @notice Pulls tokens from the sender's wallet and stakes them on his behalf.
      * @param amount the amount of tokens to stake.
      */
-    function stake(uint128 amount) public {
+    function stake(uint128 amount) external {
         _stakeTo(msg.sender, msg.sender, amount);
     }
 
@@ -110,7 +110,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @param recipient the recipient address.
      * @param amount the amount of tokens to stake.
      */
-    function stakeTo(address recipient, uint128 amount) public {
+    function stakeTo(address recipient, uint128 amount) external {
         _stakeTo(msg.sender, recipient, amount);
     }
 
@@ -189,7 +189,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      * @notice Send accumulated rewards to the voter. Note that these rewards do not include slashing balance changes.
      * @return uint128 the amount of tokens sent to the voter.
      */
-    function withdrawRewards() public returns (uint128) {
+    function withdrawRewards() external returns (uint128) {
         return _withdrawRewards(msg.sender, msg.sender);
     }
 

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -346,7 +346,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
      * @param time unix timestamp of the price request.
      * @return bool if the DVM has resolved to a price for the given identifier and timestamp.
      */
-    function hasPrice(bytes32 identifier, uint256 time) public view override returns (bool) {
+    function hasPrice(bytes32 identifier, uint256 time) external view override returns (bool) {
         return hasPrice(identifier, time, "");
     }
 
@@ -898,7 +898,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
         address voter,
         uint256 roundId,
         MinimumVotingAncillaryInterface.PendingRequestAncillary[] memory toRetrieve
-    ) public returns (uint256) {
+    ) external returns (uint256) {
         uint256 rewards =
             MinimumVotingAncillaryInterface(address(previousVotingContract))
                 .retrieveRewards(voter, roundId, toRetrieve)

--- a/packages/core/contracts/data-verification-mechanism/interfaces/OracleInterface.sol
+++ b/packages/core/contracts/data-verification-mechanism/interfaces/OracleInterface.sol
@@ -21,7 +21,7 @@ abstract contract OracleInterface {
      * @param time unix timestamp for the price request.
      * @return bool if the DVM has resolved to a price for the given identifier and timestamp.
      */
-    function hasPrice(bytes32 identifier, uint256 time) public view virtual returns (bool);
+    function hasPrice(bytes32 identifier, uint256 time) external view virtual returns (bool);
 
     /**
      * @notice Gets the price for `identifier` and `time` if it has already been requested and resolved.

--- a/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
+++ b/packages/core/contracts/data-verification-mechanism/interfaces/VotingV2Interface.sol
@@ -108,7 +108,7 @@ abstract contract VotingV2Interface {
         bytes memory ancillaryData,
         bytes32 hash,
         bytes memory encryptedVote
-    ) public virtual;
+    ) external virtual;
 
     /**
      * @notice Reveal a previously committed vote for `identifier` at `time`.


### PR DESCRIPTION


**Motivation**

OZ identified:
```
N-07 public functions that should have
external visibility
The following public functions should be external :
The stake function in the Staker contract
The stakeTo function in the Staker contract
The withdrawRewards function in the Staker contract
The hasPrice(bytes32, uint256) function in the VotingV2 contract (except the
version with the bytes memory ancillaryData argument, which should indeed be
public )
The getPriceRequestStatuses function in the VotingV2 contract
The revealVote function in the VotingV2 contract
The commitAndEmitEncryptedVote function in the VotingV2 contract
The retrieveRewardsOnMigratedVotingContract function in the VotingV2
contract
Consider changing the visibility of these functions to external in order to clarify that these
functions will only ever be called by external contracts.
```

This PR partially implements the changes requested. in some cases the changes were not made. In particular when it made testing some of the functions more difficult.
