### PR TITLE
fix(dvm2.0): N-10 Mark all state variables that can be as immutable

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2.sol
@@ -22,9 +22,8 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
         Voter // Can vote through this contract.
     }
 
-    // Reference to the UMA Finder contract, allowing Voting upgrades to be performed
-    // without requiring any calls to this contract.
-    FinderInterface private finder;
+    // Reference to UMA Finder contract, allowing Voting upgrades to be without requiring any calls to this contract.
+    FinderInterface public immutable finder;
 
     /**
      * @notice Construct the DesignatedVoting contract.

--- a/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2Factory.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2Factory.sol
@@ -8,7 +8,7 @@ import "./DesignatedVotingV2.sol";
  * @dev Allows off-chain infrastructure to look up a hot wallet's deployed DesignatedVoting contract.
  */
 contract DesignatedVotingV2Factory {
-    address private finder;
+    address public immutable finder;
     mapping(address => DesignatedVotingV2) public designatedVotingContracts;
 
     event NewDesignatedVoting(address indexed designatedVoter, address indexed designatedVoting);

--- a/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
@@ -43,7 +43,7 @@ contract GovernorV2 is MultiRole, Lockable {
     }
 
     // Reference to UMA finder, used to find addresses of other UMA ecosystem contracts.
-    FinderInterface private finder;
+    FinderInterface public immutable finder;
 
     // Array of all proposals.
     Proposal[] public proposals;

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -46,7 +46,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
 
     uint64 public lastUpdateTime; // Tracks the last time the reward rate was updated, used in reward allocation.
 
-    ExpandedIERC20 public votingToken; // An instance of the UMA voting token to mint rewards for stakers
+    ExpandedIERC20 public immutable votingToken; // An instance of the UMA voting token to mint rewards for stakers
 
     /****************************************
      *                EVENTS                *

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -95,7 +95,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     uint64 public nextPendingIndexToProcess; // Next pendingPriceRequestsIds index to process in lastRoundIdProcessed.
 
-    FinderInterface private immutable finder; // Reference to the UMA Finder contract, used to find other UMA contracts.
+    FinderInterface public immutable finder; // Reference to the UMA Finder contract, used to find other UMA contracts.
 
     SlashingLibraryInterface public slashingLibrary; // Reference to Slashing Library, used to compute slashing amounts.
 
@@ -121,7 +121,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     uint64 public spat; // SPAT: Minimum percentage of staked tokens that must agree on the answer to resolve a vote.
 
-    uint64 private constant UINT64_MAX = type(uint64).max; // Max value of an unsigned integer.
+    uint64 public constant UINT64_MAX = type(uint64).max; // Max value of an unsigned integer.
 
     uint256 public constant ANCILLARY_BYTES_LIMIT = 8192; // Max length in bytes of ancillary data.
 


### PR DESCRIPTION

**Motivation**

OZ identified the following:
```
The following state variables are only set once within their respective constructors:
The votingToken variable in the Staker contract.
The finder variable in the DesignatedVotingV2 contract.
The finder variable in the DesignatedVotingV2Factory contract.
The finder variable in the GovernorV2 contract.
Consider declaring these state variables as immutable to increase gas efficiency and enhance
the clarity of the codebase.
```

