### PR TITLE
fix(dvm2.0): N-06 - Address misleading documentation

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
@@ -140,7 +140,7 @@ contract EmergencyProposer is Ownable, Lockable {
     }
 
     /**
-     * @notice After the proposal is executable, the executor or proposer can use this function to remove the proposal
+     * @notice After the proposal is executable, the executor or owner can use this function to remove the proposal
      * without slashing.
      * @dev This means that the DVM didn't explicitly reject the proposal. Allowing the executor to slash the quorum
      * would give the executor too much power. So the only control either party has is to remove the proposal,
@@ -151,7 +151,7 @@ contract EmergencyProposer is Ownable, Lockable {
     function removeProposal(uint256 id) external nonReentrant() {
         EmergencyProposal storage proposal = emergencyProposals[id];
         require(proposal.expiryTime <= getCurrentTime(), "must be expired to remove");
-        require(msg.sender == owner() || msg.sender == executor, "proposer or executor");
+        require(msg.sender == owner() || msg.sender == executor, "owner or executor");
         require(proposal.lockedTokens != 0, "invalid proposal");
         token.safeTransfer(proposal.sender, proposal.lockedTokens);
         emit EmergencyProposalRemoved(

--- a/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/GovernorV2.sol
@@ -197,7 +197,7 @@ contract GovernorV2 is MultiRole, Lockable {
 
     /**
      * @notice Gets the proposal data for a particular id.
-     * @dev after a proposal is executed, its data will be zeroed out, except for the request time.
+     * @dev after a proposal is executed, its data will be zeroed out, except for the request time and ancillary data.
      * @param id uniquely identify the identity of the proposal.
      * @return proposal struct containing transactions[] and requestTime.
      */

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -210,7 +210,6 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
     /**
      * @notice Stake accumulated rewards. This is merely a convenience mechanism that combines the voter's withdrawal
      * and stake in the same transaction if requested by a delegate or the voter.
-     * @dev This method requires that the msg.sender (voter or delegate) has approved this contract.
      * @dev The rewarded tokens simply pass through this contract before being staked on the voter's behalf.
      *  The balance of the delegate remains unchanged.
      * @return uint128 the amount of tokens that the voter is staking.
@@ -248,7 +247,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
      ****************************************/
 
     /**
-     * @notice  Set the token's emission rate, the number of voting tokens that are emitted per second per staked token.
+     * @notice  Set the token's emission rate, the number of voting tokens that are emitted per second.
      * @param newEmissionRate the new amount of voting tokens that are emitted per second, split pro rata to stakers.
      */
     function setEmissionRate(uint128 newEmissionRate) external onlyOwner {

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -383,7 +383,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     }
 
     /**
-     * @notice Gets the status of a list of price requests, identified by their identifier and time.
+     * @notice Gets the status of a list of price requests, identified by their identifier, time and ancillary data.
      * @dev If the status for a particular request is NotRequested, the lastVotingRound will always be 0.
      * @param requests array of pending requests which includes identifier, timestamp & ancillary data for the requests.
      * @return requestStates a list, in the same order as the input list, giving the status of the specified requests.
@@ -708,7 +708,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     }
 
     /**
-     * @notice Resets the GAT number and PAT percentage. GAT is the minimum number of tokens that must participate in a
+     * @notice Resets the GAT number and SPAT percentage. GAT is the minimum number of tokens that must participate in a
      * vote for it to resolve (quorum number). SPAT is the minimum percentage of tokens that must agree on a result
      * for it to resolve (percentage of staked tokens) This change only applies to subsequent rounds.
      * @param newGat sets the next round's GAT and going forward.


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
The following instances of misleading documentation have been identified:
- The docstring for the withdrawAndRestake function in the Staker contract states that "This method requires
that the msg.sender (voter or delegate) has approved this contract." but approval is not required as the
voting token is never transferred from the voter or delegate's wallet.
- The docstring for the setEmissionRate function in the Staker contract states the emission rate as "...per
second per staked token", but the emission rate is per second.
- The docstring for the removeProposal function in the EmergencyProposer contract states that "...the executor
or proposer can use this function" when only the owner and executor can call the function. The proposer is
unable to remove their own proposal.
- The docstring for the getProposal function in the GovernorV2 contract states that "...data will be zeroed
out, except for the request time", however, the ancillaryData will also not be zeroed out.
- The docstring for the getPriceRequestStatuses function in the VotingV2 contract states that price requests
are "...identified by their identifier and time". It should also include that the ancillaryData is required
for identification.
- The docstring for the setGatAndSpat function in the VotingV2 contract states that it "resets the GAT number
and PAT percentage", however the PAT has since been replaced with the SPAT.
```

This PR addresses this issue by resolving these instances of misleading documentation.