### PR TITLE
fix(dvm2.0): N-08 - Address typographical errors

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2.sol
@@ -27,9 +27,9 @@ contract DesignatedVotingV2 is Stakeable, MultiCaller {
     FinderInterface private finder;
 
     /**
-     * @notice Construct the DesignatedVoting contract.
+     * @notice Construct the DesignatedVotingV2 contract.
      * @param finderAddress keeps track of all contracts within the system based on their interfaceName.
-     * @param ownerAddress address of the owner of the DesignatedVoting contract.
+     * @param ownerAddress address of the owner of the DesignatedVotingV2 contract.
      * @param voterAddress address to which the owner has delegated their voting power.
      */
     constructor(

--- a/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/EmergencyProposer.sol
@@ -44,7 +44,7 @@ contract EmergencyProposer is Ownable, Lockable {
     // The number of tokens needed to propose an emergency action.
     uint256 public quorum;
 
-    // The minimum time that must elapsed between from when a proposal is created to when it can be executed.
+    // The minimum time that must elapse between from when a proposal is created to when it can be executed.
     uint64 public minimumWaitTime;
 
     // The only address that can execute an emergency proposal. Will be set to a multisig. Acts to guardrail the
@@ -240,7 +240,7 @@ contract EmergencyProposer is Ownable, Lockable {
 
     /**
      * @notice Admin method to set the minimum wait time for a proposal to be executed.
-     * @dev Admin is intended to be the governance system. The minumum wait time is added to the current time at the
+     * @dev Admin is intended to be the governance system. The minimum wait time is added to the current time at the
      * time of the proposal to determine when the proposal will be executable. Any changes to this value after that
      * point will have no impact on the proposal.
      * @param newMinimumWaitTime the new minimum wait time.

--- a/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/ResultComputationV2.sol
@@ -44,7 +44,7 @@ library ResultComputationV2 {
     /**
      * @notice Returns whether the result is resolved, and if so, what value it resolved to.
      * @dev `price` should be ignored if `isResolved` is false.
-     * @param data contains information against which the `minVoteThreshold` is applied.
+     * @param data contains information against which the `minTotalVotes` and `minModalVotes` thresholds are applied.
      * @param minTotalVotes min (exclusive) number of tokens that must have voted (in any direction) for the result
      * to be valid. Used to enforce a minimum voter participation rate, regardless of how the votes are distributed.
      * @param minModalVotes min (exclusive) number of tokens that must have voted for the modal outcome for it to result
@@ -58,7 +58,7 @@ library ResultComputationV2 {
         uint128 minModalVotes
     ) internal view returns (bool isResolved, int256 price) {
         if (data.totalVotes > minTotalVotes && data.voteFrequency[data.currentMode] > minModalVotes) {
-            isResolved = true; // modeThreshold and minVoteThreshold are exceeded, so the resolved price is the mode.
+            isResolved = true; // minTotalVotes and minModalVotes are exceeded, so the resolved price is the mode.
             price = data.currentMode;
         } else isResolved = false;
     }
@@ -78,7 +78,7 @@ library ResultComputationV2 {
      * @notice Gets the total number of tokens whose votes are considered correct.
      * @dev Should only be called after a vote is resolved, i.e., via `getResolvedPrice`.
      * @param data contains all votes against which the correctly voted tokens are counted.
-     * @return FixedPoint.Unsigned which indicates the frequency of the correctly voted tokens.
+     * @return uint128 which indicates the frequency of the correctly voted tokens.
      */
     function getTotalCorrectlyVotedTokens(Data storage data) internal view returns (uint128) {
         return data.voteFrequency[data.currentMode];

--- a/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/Staker.sol
@@ -124,7 +124,7 @@ abstract contract Staker is StakerInterface, Ownable, Lockable, MultiCaller {
     ) internal {
         VoterStake storage voterStake = voterStakes[recipient];
 
-        // If the staker has a cumulative staked balance of 0 then we can shortcut their lastRequestIndexConsidered to
+        // If the staker has a cumulative staked balance of 0 then we can shortcut their nextIndexToProcess to
         // the most recent index. This means we don't need to traverse requests where the staker was not staked.
         // _getStartingIndexForStaker returns the appropriate index to start at.
         if (voterStake.stake == 0) voterStake.nextIndexToProcess = _getStartingIndexForStaker();

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -584,7 +584,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     /**
      * @notice Returns the current round ID, as a function of the current time.
-     * @return uint256 the unique round ID.
+     * @return uint32 the unique round ID.
      */
     function getCurrentRoundId() public view override returns (uint32) {
         return uint32(voteTiming.computeCurrentRoundId(getCurrentTime()));
@@ -593,7 +593,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
     /**
      * @notice Returns the round end time, as a function of the round number.
      * @param roundId representing the unique round ID.
-     * @return uint256 representing the unique round ID.
+     * @return uint256 representing the round end time.
      */
     function getRoundEndTime(uint256 roundId) external view returns (uint256) {
         return voteTiming.computeRoundEndTime(roundId);


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
Consider addressing the following typographical errors:
- On line 127 in the Staker contract, "lastRequestIndexConsidered" should be "nextIndexToProcess".
- On line 47 in the EmergencyProposer contract, "elapsed" should be "elapse".
- On line 47 in the ResultComputationV2 library, "minVoteThreshold" should be "minTotalVotes and
minModalVotes".
- On line 61 in the ResultComputationV2 library, "modeThreshold and minVoteThreshold" should be
"minTotalVotes and minModalVotes".
- On line 81 in the ResultComputationV2 library, "FixedPoint.Unsigned" should be "uint128".
- On line 30 and line 32 in the DesignatedVotingV2 contract, "DesignatedVoting" should be
"DesignatedVotingV2".
- On line 585 in the VotingV2 contract, "uint256" should be "uint32".
- On line 594 in the VotingV2 contract, "...round ID" should be "round end time".
- On line 243 of the EmergencyProposer contract, "minumum" should be "minimum".
```

This PR addresses this issue by fixing above errors.