### PR TITLE
fix(dvm2.0): N-09 - Remove unused import

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/DesignatedVotingV2.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.16;
 import "../../common/implementation/MultiCaller.sol";
 import "../../common/implementation/Stakeable.sol";
 import "../interfaces/FinderInterface.sol";
-import "../interfaces/VotingV2Interface.sol";
 import "./Constants.sol";
 
 /**


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
In the DesignatedVotingV2 contract the import VotingV2Interface.sol is unused and could be removed.
```

This PR addresses this issue by removing the unused import.