### PR TITLE
improve(common): Change Boba average block time

### DIFF
--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -23,7 +23,7 @@ export async function averageBlockTimeSeconds(chainId?: number): Promise<number>
     case 42161:
       return 0.5;
     case 288:
-      return 30;
+      return 150;
     case 137:
       return 2.5;
     case 1:


### PR DESCRIPTION
Boba averaging 600 blocks a day and trending down [source](https://bobascan.com/chart/tx).

This is roughly 150 seconds per block

I'd like to release a new `npm` package with this change to make across bots more efficient