### PR TITLE
fix: dvm-v2 contract comments

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/FixedSlashSlashingLibrary.sol
@@ -10,8 +10,8 @@ import "../interfaces/SlashingLibraryInterface.sol";
  */
 
 contract FixedSlashSlashingLibrary is SlashingLibraryInterface {
-    uint256 public immutable baseSlashAmount;
-    uint256 public immutable governanceSlashAmount;
+    uint256 public immutable baseSlashAmount; // Slash amount per token for missed votes and wrong non-governance votes.
+    uint256 public immutable governanceSlashAmount; // Slash amount per token for wrong governance votes.
 
     /**
      * @notice Construct the FixedSlashSlashingLibrary contract.

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -322,6 +322,7 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     /**
      * @notice Gets the round ID that a request should be voted on.
+     * @param targetRoundId round ID to start searching for a round to vote on.
      * @return uint32 round ID that a request should be voted on.
      */
     function getRoundIdToVoteOnRequest(uint32 targetRoundId) public view returns (uint32) {

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -929,6 +929,8 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     // Returns the price for a given identifier. Three params are returns: bool if there was an error, int to represent
     // the resolved price and a string which is filled with an error message, if there was an error or "".
+    // This method considers actual request status that might be ahead of the stored contract state that gets updated
+    // only after processResolvablePriceRequests() is called.
     function _getPriceOrError(
         bytes32 identifier,
         uint256 time,

--- a/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
+++ b/packages/core/contracts/data-verification-mechanism/implementation/VotingV2.sol
@@ -526,6 +526,9 @@ contract VotingV2 is Staker, OracleInterface, OracleAncillaryInterface, OracleGo
 
     /**
      * @notice Gets the requests that are being voted on this round.
+     * @dev This view method returns requests with Active status that may be ahead of the stored contract state as this
+     * also filters out requests that would be resolvable or deleted if the resolvable requests were processed with the
+     * processResolvablePriceRequests() method.
      * @return pendingRequests array containing identifiers of type PendingRequestAncillaryAugmented.
      */
     function getPendingRequests() public view override returns (PendingRequestAncillaryAugmented[] memory) {


### PR DESCRIPTION
**Motivation**

Final audit report included notes on issues that were partially resolved:

```
- M-01: getPendingRequests and _getPriceOrError can still return results that indicate price
requests have been resolved even though they have not been processed yet, and this behavior
has not been clearly documented in either function.
- L-09: The targetRoundId argument to the getRoundIdToVoteOnRequest function in
the VotingV2 contract is undocumented. The baseSlashAmount and governanceSlashAmount state variables in the
FixedSlashSlashingLibrary contract are undocumented.
```

This PR addresses these unresolved issues with additional documentation. No contract logic is changed.
