### PR TITLE
feat: update downgrade upgrader

### DIFF
--- a/packages/scripts/src/admin-proposals/simulateVoteV2.ts
+++ b/packages/scripts/src/admin-proposals/simulateVoteV2.ts
@@ -19,6 +19,7 @@ const assert = require("assert").strict;
 // NODE_URL_1=http://localhost:9545 node ./packages/scripts/src/admin-proposals/simulateVoteV2.ts --network localhost
 // VOTING_V2_ADDRESS=<VOTING-V2-ADDRESS> \
 // GOVERNOR_V2_ADDRESS=<GOVERNOR-V2-ADDRESS> \
+// EXECUTOR_ADDRESS=<EXECUTOR-ADDRESS> \  Optional. If not provided, the first signer will be used.
 // NODE_URL_1=http://127.0.0.1:9545/ \
 // yarn hardhat run ./src/admin-proposals/simulateVoteV2.ts --network localhost
 
@@ -27,7 +28,7 @@ async function simulateVoteV2() {
 
   const governorV2Address = process.env["GOVERNOR_V2_ADDRESS"];
   const votingV2Address = process.env["VOTING_V2_ADDRESS"];
-  const executor = process.env["EXECUTOR"];
+  const executor = process.env["EXECUTOR_ADDRESS"];
   let executorSigner;
   if (executor) {
     await hre.network.provider.request({ method: "hardhat_impersonateAccount", params: [executor] });

--- a/packages/scripts/src/admin-proposals/simulateVoteV2.ts
+++ b/packages/scripts/src/admin-proposals/simulateVoteV2.ts
@@ -13,17 +13,28 @@ require("dotenv").config();
 const assert = require("assert").strict;
 
 // Run:
-// - Check out README.md in this folder for setup instructions and simulating votes between the Propose and Verify
-//   steps.
 // - This script should be run after any Admin proposal UMIP script against a local Mainnet fork. It allows the tester
 //   to simulate what would happen if the proposal were to pass and to verify that contract state changes as expected.
-// - Vote Simulate: NODE_URL_1=http://localhost:9545 node ./packages/scripts/src/admin-proposals/simulateVoteV2.ts --network localhost
+// - Vote Simulate:
+// NODE_URL_1=http://localhost:9545 node ./packages/scripts/src/admin-proposals/simulateVoteV2.ts --network localhost
+// VOTING_V2_ADDRESS=<VOTING-V2-ADDRESS> \
+// GOVERNOR_V2_ADDRESS=<GOVERNOR-V2-ADDRESS> \
+// NODE_URL_1=http://127.0.0.1:9545/ \
+// yarn hardhat run ./src/admin-proposals/simulateVoteV2.ts --network localhost
 
 async function simulateVoteV2() {
   const foundationSigner = await ethers.getSigner(FOUNDATION_WALLET);
 
   const governorV2Address = process.env["GOVERNOR_V2_ADDRESS"];
   const votingV2Address = process.env["VOTING_V2_ADDRESS"];
+  const executor = process.env["EXECUTOR"];
+  let executorSigner;
+  if (executor) {
+    await hre.network.provider.request({ method: "hardhat_impersonateAccount", params: [executor] });
+    executorSigner = (await hre.ethers.getSigner(executor)) as Signer;
+  } else {
+    executorSigner = (await hre.ethers.getSigners())[0];
+  }
 
   const governorV2 = await getContractInstance<GovernorV2Ethers>("GovernorV2", governorV2Address);
   const votingV2 = await getContractInstance<VotingV2Ethers>("VotingV2", votingV2Address);
@@ -184,7 +195,7 @@ async function simulateVoteV2() {
     for (let j = 0; j < proposal.transactions.length; j++) {
       console.log(`- Submitting transaction #${j + 1} from proposal #${proposalId}`);
       try {
-        const txn = await governorV2.executeProposal(proposalId.toString(), j.toString());
+        const txn = await governorV2.connect(executorSigner).executeProposal(proposalId.toString(), j.toString());
         console.log(`    - Success, receipt: ${txn.hash}`);
       } catch (err) {
         console.error("    - Failure: Txn was likely executed previously, skipping to next one");

--- a/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
@@ -99,7 +99,7 @@ async function main() {
   if (process.env[TEST_DOWNGRADE]) {
     if (!process.env[EMERGENCY_EXECUTOR]) throw new Error("Must provide EMERGENCY_EXECUTOR");
     votingUpgrader = await deployVotingUpgraderAndRunDowngradeOptionalTx(
-      process.env[EMERGENCY_EXECUTOR],
+      String(process.env[EMERGENCY_EXECUTOR]),
       adminProposalTransactions,
       governor,
       governorV2,

--- a/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
@@ -319,7 +319,7 @@ async function main() {
     ${NEW_CONTRACTS.voting}=${oldVoting.address} \\
     ${NEW_CONTRACTS.governor}=${governor.address} \\
     ${NEW_CONTRACTS.proposer}=${proposer.address} \\
-    EXECUTOR=${await votingUpgrader.upgrader()} \\
+    EXECUTOR_ADDRESS=${await votingUpgrader.upgrader()} \\
     NODE_URL_1=http://127.0.0.1:9545/ \\
     yarn hardhat run ./src/admin-proposals/simulateVoteV2.ts --network localhost`)
     );

--- a/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
@@ -96,9 +96,10 @@ async function main() {
 
   let votingUpgrader;
 
-  if (process.env[TEST_DOWNGRADE])
+  if (process.env[TEST_DOWNGRADE]) {
+    if (!process.env[EMERGENCY_EXECUTOR]) throw new Error("Must provide EMERGENCY_EXECUTOR");
     votingUpgrader = await deployVotingUpgraderAndRunDowngradeOptionalTx(
-      process.env[EMERGENCY_EXECUTOR] || "",
+      process.env[EMERGENCY_EXECUTOR],
       adminProposalTransactions,
       governor,
       governorV2,
@@ -110,7 +111,7 @@ async function main() {
       ownableContractsToMigrate,
       multicallContractsToMigrate
     );
-  else {
+  } else {
     const votingUpgraderAddress = process.env[VOTING_UPGRADER_ADDRESS];
     if (!votingUpgraderAddress) throw new Error("Must provide VOTING_UPGRADER_ADDRESS");
     votingUpgrader = await getContractInstance<VotingUpgraderV2Ethers>("VotingUpgraderV2", votingUpgraderAddress);

--- a/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
@@ -98,7 +98,7 @@ async function main() {
 
   if (process.env[TEST_DOWNGRADE])
     votingUpgrader = await deployVotingUpgraderAndRunDowngradeOptionalTx(
-      (await hre.ethers.getSigners())[0].address,
+      process.env[EMERGENCY_EXECUTOR] || "",
       adminProposalTransactions,
       governor,
       governorV2,

--- a/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/1_Propose.ts
@@ -319,6 +319,7 @@ async function main() {
     ${NEW_CONTRACTS.voting}=${oldVoting.address} \\
     ${NEW_CONTRACTS.governor}=${governor.address} \\
     ${NEW_CONTRACTS.proposer}=${proposer.address} \\
+    EXECUTOR=${await votingUpgrader.upgrader()} \\
     NODE_URL_1=http://127.0.0.1:9545/ \\
     yarn hardhat run ./src/admin-proposals/simulateVoteV2.ts --network localhost`)
     );

--- a/packages/scripts/src/upgrade-tests/voting2/readme.md
+++ b/packages/scripts/src/upgrade-tests/voting2/readme.md
@@ -36,6 +36,7 @@ From this point the scripts will log the next step to be executed. But below is 
 ```
 GCKMS_WALLET=<OPTIONAL-GCKMS-WALLET> \ # If not provided, the script will use the first account in the node
 VOTING_V2_ADDRESS=<VOTING-V2-ADDRESS> \
+VOTING_UPGRADER_ADDRESS=<VOTING-UPGRADER-ADDRESS> \
 GOVERNOR_V2_ADDRESS=<GOVERNOR-V2-ADDRESS> \
 PROPOSER_V2_ADDRESS=<PROPOSER-V2-ADDRESS> \
 EMERGENCY_PROPOSER_ADDRESS=<EMERGENCY-PROPOSER-ADDRESS> \
@@ -66,6 +67,7 @@ or if during the test of the downgrade and voting with voting v2 with:
 VOTING_V2_ADDRESS=<VOTING-V2-ADDRESS> \
 GOVERNOR_V2_ADDRESS=<GOVERNOR-V2-ADDRESS> \
 PROPOSER_V2_ADDRESS=<PROPOSER-V2-ADDRESS> \
+EXECUTOR_ADDRESS=<VOTING-UPGRADER-V2-UPGRADER-ADDRESS> \
 NODE_URL_1=http://127.0.0.1:9545/ \
 yarn hardhat run ./src/admin-proposals/simulateVoteV2.ts --network localhost
 ```


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

When downgrading the `VotingUpgraderV2.upgrader` needs to be the `EmergencyProposer.executor`

Previously, when doing a downgrade we deployed a new VotingUpgraderV2 that used the account[0] as the upgrader, account[0] was also the `EmergencyProposer.executor` so this change wasn't required.

When testing against the mainnet deployments, during the downgrade, the new VotingUpgraderV2.upgrader has to 
be the EmergencyProposer.executor which is a multisig different than account[0]. For these scripts to work, we need to update this argument.


Note that with this change, the full upgrade workflow (Deploy, Propose, Verify, Downgrade, ...) still works identically as before given that account[0] is used as the `VotingUpgraderV2.upgrader` and `EmergencyProposer.executor`
