### PR TITLE
fix: fix an issue in the health check

### DIFF
--- a/packages/monitor-v2/src/health-check-runner/index.ts
+++ b/packages/monitor-v2/src/health-check-runner/index.ts
@@ -6,7 +6,7 @@ let logger: AugmentedLogger;
 export async function run(): Promise<void> {
   logger = Logger;
 
-  logger.debug({ at: "HealthCheckRunner", message: "Starting health check runner 🩺" });
+  logger.debug({ at: "HealthCheckRunner", message: "Health check runner started 🩺" });
 
   const healthCheckCommands = process.env.HEALTH_CHECK_COMMANDS ? JSON.parse(process.env.HEALTH_CHECK_COMMANDS) : [];
 


### PR DESCRIPTION
The health check is missing a key word that the hub expects. See log.

<img width="626" alt="2023-02-27 at 16 10 02@2x" src="https://user-images.githubusercontent.com/12886084/221601258-ff64cef4-a55a-47db-b9e9-61826ede2521.png">


This PR fixes this.