### PR TITLE
fix: allow monitors to flush log transport

### DIFF
--- a/packages/monitor-v2/src/monitor-dvm/index.ts
+++ b/packages/monitor-v2/src/monitor-dvm/index.ts
@@ -44,7 +44,10 @@ async function main() {
     await Promise.all(runCmds);
 
     // If polling delay is 0 then we are running in serverless mode and should exit after one iteration.
-    if (params.pollingDelay === 0) break;
+    if (params.pollingDelay === 0) {
+      await delay(5); // Set a delay to let the transports flush fully.
+      break;
+    }
     params.blockRange = await waitNextBlockRange(params);
   }
 }

--- a/packages/monitor-v2/src/monitor-oo-v3/index.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/index.ts
@@ -37,7 +37,10 @@ async function main() {
     await Promise.all(runCmds);
 
     // If polling delay is 0 then we are running in serverless mode and should exit after one iteration.
-    if (params.pollingDelay === 0) break;
+    if (params.pollingDelay === 0) {
+      await delay(5); // Set a delay to let the transports flush fully.
+      break;
+    }
     params.blockRange = await waitNextBlockRange(params);
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Some of log transports used by monitor-v2 bots require time to flush.

**Summary**

Adds 5 second delay to DVM2.0 and OOv3 monitoring bots before exiting on success.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

