### PR TITLE
fix: add preexisting unstaking step to simulation script

### DIFF
--- a/packages/scripts/src/monitoring-dvm2.0/slashingEvents.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/slashingEvents.ts
@@ -13,7 +13,7 @@ import {
   getUniqueVoters,
   getVotingContracts,
   updateTrackers,
-} from "./common";
+} from "../utils/votingv2-utils";
 
 async function main() {
   const { votingV2 } = await getVotingContracts();

--- a/packages/scripts/src/monitoring-dvm2.0/unstake.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/unstake.ts
@@ -14,7 +14,7 @@ import {
   unstakeFromStakedAccount,
   updateTrackers,
   votingV2VotingBalanceWithoutExternalTransfers,
-} from "./common";
+} from "../utils/votingv2-utils";
 
 async function main() {
   const { votingV2, votingToken } = await getVotingContracts();

--- a/packages/scripts/src/monitoring-dvm2.0/voterStakes.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/voterStakes.ts
@@ -14,7 +14,7 @@ import {
   getVotingContracts,
   updateTrackers,
   votingV2VotingBalanceWithoutExternalTransfers,
-} from "./common";
+} from "../utils/votingv2-utils";
 const { ethers } = hre;
 
 async function main() {

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -261,7 +261,7 @@ async function main() {
   const unstakeCoolDown = await votingV2.unstakeCoolDown();
   const finalFee = (await store.computeFinalFee(votingToken.address)).rawValue;
 
-  console.log(" 1. Unstake from all preexisting voters...");
+  console.log(" 0. Unstake from all preexisting voters...");
   const uniqueVoters = await getUniqueVoters(votingV2);
 
   for (const address of uniqueVoters) {

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -253,6 +253,7 @@ async function main() {
   if (!(await isVotingV2Instance(votingV2Address))) throw new Error("Oracle is not VotingV2 instance!");
 
   const votingV2 = await getContractInstance<VotingV2Ethers>("VotingV2", votingV2Address);
+  const governorV2Address = await votingV2.owner();
 
   const emissionRate = await votingV2.emissionRate();
   const gat = await votingV2.gat();
@@ -260,12 +261,12 @@ async function main() {
   const finalFee = (await store.computeFinalFee(votingToken.address)).rawValue;
 
   console.log(" 1. Unstake from all preexisting voters...");
-  await hre.network.provider.request({ method: "hardhat_impersonateAccount", params: [await votingV2.owner()] });
+  await hre.network.provider.request({ method: "hardhat_impersonateAccount", params: [governorV2Address] });
   await hre.network.provider.send("hardhat_setBalance", [
-    await votingV2.owner(),
+    governorV2Address,
     hre.ethers.utils.parseEther("10.0").toHexString(),
   ]);
-  const govSigner = (await hre.ethers.getSigner(await votingV2.owner())) as Signer;
+  const govSigner = (await hre.ethers.getSigner(governorV2Address)) as Signer;
 
   const initialCooldDownPeriod = await votingV2.unstakeCoolDown();
 
@@ -714,7 +715,6 @@ async function main() {
   );
 
   const oldVotingAddress = await votingV2.previousVotingContract();
-  const governorV2Address = await votingV2.owner();
   const governorV2 = await getContractInstance<GovernorV2Ethers>("GovernorV2", governorV2Address);
   const proposerV2Address = await governorV2.getMember(1);
   const emergencyProposerAddress = await governorV2.getMember(2);

--- a/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
+++ b/packages/scripts/src/upgrade-tests/voting2/3_SimulateVoting.ts
@@ -41,6 +41,7 @@ import {
   isVotingV2Instance,
   TEST_DOWNGRADE,
 } from "./migrationUtils";
+import { getUniqueVoters, unstakeFromStakedAccount } from "../../utils/votingv2-utils";
 
 interface VotingPriceRequest {
   identifier: BytesLike;
@@ -261,40 +262,11 @@ async function main() {
   const finalFee = (await store.computeFinalFee(votingToken.address)).rawValue;
 
   console.log(" 1. Unstake from all preexisting voters...");
-  await hre.network.provider.request({ method: "hardhat_impersonateAccount", params: [governorV2Address] });
-  await hre.network.provider.send("hardhat_setBalance", [
-    governorV2Address,
-    hre.ethers.utils.parseEther("10.0").toHexString(),
-  ]);
-  const govSigner = (await hre.ethers.getSigner(governorV2Address)) as Signer;
+  const uniqueVoters = await getUniqueVoters(votingV2);
 
-  const initialCooldDownPeriod = await votingV2.unstakeCoolDown();
-
-  // Set the cool down period to 0 so that we can unstake immediately.
-  await (await votingV2.connect(govSigner).setUnstakeCoolDown(0)).wait();
-
-  // Get all Staked events from the VotingV2 contract
-  const stakedEvents = await votingV2.queryFilter(votingV2.filters.Staked(null, null));
-
-  const uniqueAddresses = new Set<string>();
-  stakedEvents.forEach((event) => {
-    uniqueAddresses.add(event.args?.voter);
-  });
-
-  for (const address of uniqueAddresses) {
-    await hre.network.provider.request({ method: "hardhat_impersonateAccount", params: [address] });
-    const signer = (await hre.ethers.getSigner(address)) as Signer;
-    await hre.network.provider.send("hardhat_setBalance", [address, hre.ethers.utils.parseEther("10.0").toHexString()]);
-    const stake = await votingV2.callStatic.getVoterStakePostUpdate(address);
-    if (stake.isZero()) continue;
-    await (
-      await votingV2.connect(signer).requestUnstake(await votingV2.callStatic.getVoterStakePostUpdate(address))
-    ).wait();
-    await (await votingV2.connect(signer).executeUnstake()).wait();
+  for (const address of uniqueVoters) {
+    await unstakeFromStakedAccount(votingV2, address);
   }
-
-  // Reset the cool down period to its original value.
-  await (await votingV2.connect(govSigner).setUnstakeCoolDown(initialCooldDownPeriod)).wait();
 
   console.log("All voters have been unstaked!");
 

--- a/packages/scripts/src/utils/votingv2-utils.ts
+++ b/packages/scripts/src/utils/votingv2-utils.ts
@@ -1,8 +1,8 @@
 import { VotingTokenEthers, VotingV2Ethers } from "@uma/contracts-node";
 import { TypedEventFilter } from "@uma/contracts-node/dist/packages/contracts-node/typechain/core/ethers/commons";
 import { BigNumber } from "ethers";
-import { getContractInstance } from "../utils/contracts";
-import { forkNetwork, getForkChainId, increaseEvmTime } from "../utils/utils";
+import { getContractInstance } from "./contracts";
+import { forkNetwork, getForkChainId, increaseEvmTime } from "./utils";
 
 const hre = require("hardhat");
 const { ethers } = hre;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

In order to do accurate calculations in the VotingV2 upgrade simulation script we need to first unstake all preexisting voter.

**Summary**

Add unstake of all voters at the beginning of the script
