### PR TITLE
fix: unstake health check

### DIFF
--- a/packages/scripts/src/utils/votingv2-utils.ts
+++ b/packages/scripts/src/utils/votingv2-utils.ts
@@ -85,6 +85,9 @@ export const votingV2VotingBalanceWithoutExternalTransfers = async (
 };
 
 export const unstakeFromStakedAccount = async (votingV2: VotingV2Ethers, voter: string): Promise<void> => {
+  // Set the balance of the voter to 10 ETH so that they can unstake.
+  await hre.network.provider.send("hardhat_setBalance", [voter, hre.ethers.utils.parseEther("10.0").toHexString()]);
+
   let stakeBalance = await votingV2.callStatic.getVoterStakePostUpdate(voter);
 
   if (stakeBalance.gt(ethers.BigNumber.from(0))) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Unstake DVM2.0 fails because of insufficient eth balance to unstake from voter wallets. We need to increase voter balances to make sure they have enough ETH to unstake.


**Summary**

- Set ETH balance of voter before unstaking

