### PR TITLE
fix: request timing in dvm2 monitor tests

### DIFF
--- a/packages/monitor-v2/test/DVM2Monitor.ts
+++ b/packages/monitor-v2/test/DVM2Monitor.ts
@@ -244,7 +244,7 @@ describe("DVMMonitor", function () {
   });
   it("Monitor deleted request", async function () {
     const identifier = formatBytes32String("TEST_IDENTIFIER");
-    const time = Math.floor(Date.now() / 1000);
+    const time = await votingV2.getCurrentTime();
     const ancillaryData = toUtf8Bytes("Test ancillary data");
 
     // Register requester and approve price identifier.
@@ -279,7 +279,7 @@ describe("DVMMonitor", function () {
   });
   it("Monitor rolled request", async function () {
     const identifier = formatBytes32String("TEST_IDENTIFIER");
-    const time = Math.floor(Date.now() / 1000);
+    const time = await votingV2.getCurrentTime();
     const ancillaryData = toUtf8Bytes("Test ancillary data");
 
     // Register requester and approve price identifier.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

In some instances monitor bot tests failed due to out-of sync hardhat EVM timing.

**Summary**

Uses timestamp from contract state when submitting requests in DVM2 monitor bot testing.


**Details**


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested
