### PR TITLE
feat: add notification path for oov3 monitor

### DIFF
--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
@@ -37,6 +37,7 @@ export async function logAssertion(
       currencySymbol +
       ". The assertion can be disputed till " +
       new Date(Number(assertion.assertionData.expirationTime) * 1000).toUTCString(),
+    notificationPath: "optimistic-oracle",
   });
 }
 
@@ -63,6 +64,7 @@ export async function logDispute(
       tryHexToUtf8String(dispute.claim) +
       ". Identifier: " +
       utils.parseBytes32String(dispute.assertionData.identifier),
+    notificationPath: "optimistic-oracle",
   });
 }
 
@@ -90,5 +92,6 @@ export async function logSettlement(
       utils.parseBytes32String(settlement.assertionData.identifier) +
       ". Result: assertion was " +
       (settlement.assertionData.settlementResolution ? "true" : "false"),
+    notificationPath: "optimistic-oracle",
   });
 }

--- a/packages/monitor-v2/test/OptimisticOracleV3Monitor.ts
+++ b/packages/monitor-v2/test/OptimisticOracleV3Monitor.ts
@@ -98,6 +98,7 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, assertionId));
     assert.isTrue(spyLogIncludes(spy, 0, assertionTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
+    assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
   });
   it("Monitor truthful settlement", async function () {
     // Make assertion.
@@ -124,6 +125,7 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, settlementTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
     assert.isTrue(spyLogIncludes(spy, 0, "Result: assertion was true"));
+    assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
   });
   it("Monitor dispute", async function () {
     // Make assertion.
@@ -150,6 +152,7 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, assertionId));
     assert.isTrue(spyLogIncludes(spy, 0, disputeTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
+    assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
   });
   it("Monitor settlement of false assertion", async function () {
     // Make assertion.
@@ -190,5 +193,6 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, settlementTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
     assert.isTrue(spyLogIncludes(spy, 0, "Result: assertion was false"));
+    assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Simplify bot configuration.

**Summary**

Adds optimistic-oracle notificationPath to OOv3 monitor bot.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


