### PR TITLE
fix: monitor-v2 block range in serverless

### DIFF
--- a/packages/monitor-v2/src/monitor-dvm/common.ts
+++ b/packages/monitor-v2/src/monitor-dvm/common.ts
@@ -55,7 +55,8 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
   const latestBlockNumber: number = await provider.getBlockNumber();
   const startingBlock = env[STARTING_BLOCK_KEY] ? Number(env[STARTING_BLOCK_KEY]) : latestBlockNumber;
   const endingBlock = env[ENDING_BLOCK_KEY] ? Number(env[ENDING_BLOCK_KEY]) : latestBlockNumber;
-  if (startingBlock > endingBlock) {
+  // In serverless it is possible for start block to be larger than end block if no new blocks were mined since last run.
+  if (startingBlock > endingBlock && pollingDelay !== 0) {
     throw new Error(`${STARTING_BLOCK_KEY} must be less than or equal to ${ENDING_BLOCK_KEY}`);
   }
 

--- a/packages/monitor-v2/src/monitor-dvm/index.ts
+++ b/packages/monitor-v2/src/monitor-dvm/index.ts
@@ -33,6 +33,11 @@ async function main() {
     // to be greater than the ending block if there were no new blocks in the last polling delay. In this case we should
     // wait for the next block range before running the commands.
     if (params.blockRange.start > params.blockRange.end) {
+      // In serverless it is possible for start block to be larger than end block if no new blocks were mined since last run.
+      if (params.pollingDelay === 0) {
+        await delay(5); // Set a delay to let the transports flush fully.
+        break;
+      }
       params.blockRange = await waitNextBlockRange(params);
       continue;
     }

--- a/packages/monitor-v2/src/monitor-oo-v3/common.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/common.ts
@@ -50,7 +50,8 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
   const latestBlockNumber: number = await provider.getBlockNumber();
   const startingBlock = env[STARTING_BLOCK_KEY] ? Number(env[STARTING_BLOCK_KEY]) : latestBlockNumber;
   const endingBlock = env[ENDING_BLOCK_KEY] ? Number(env[ENDING_BLOCK_KEY]) : latestBlockNumber;
-  if (startingBlock > endingBlock) {
+  // In serverless it is possible for start block to be larger than end block if no new blocks were mined since last run.
+  if (startingBlock > endingBlock && pollingDelay !== 0) {
     throw new Error(`${STARTING_BLOCK_KEY} must be less than or equal to ${ENDING_BLOCK_KEY}`);
   }
 

--- a/packages/monitor-v2/src/monitor-oo-v3/index.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/index.ts
@@ -26,6 +26,11 @@ async function main() {
     // to be greater than the ending block if there were no new blocks in the last polling delay. In this case we should
     // wait for the next block range before running the commands.
     if (params.blockRange.start > params.blockRange.end) {
+      // In serverless it is possible for start block to be larger than end block if no new blocks were mined since last run.
+      if (params.pollingDelay === 0) {
+        await delay(5); // Set a delay to let the transports flush fully.
+        break;
+      }
       params.blockRange = await waitNextBlockRange(params);
       continue;
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

If no new blocks were mined between serverless runs monitoring bots would fail.

**Summary**

Allows starting block higher than ending block in serverless for monitor-v2 bots.

**Details**

Serverless hub might inject starting block value higher than end block if there were no new blocks mined between runs. This fix skips block range check in serverless and exits loop.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested

