### PR TITLE
fix: unstake health check tolerance

### DIFF
--- a/packages/scripts/src/monitoring-dvm2.0/unstake.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/unstake.ts
@@ -51,7 +51,10 @@ async function main() {
   // VotingV2 cumulativeStake should be 0 with a tolerance of numberSlashedEvents, as every slash can result in 1 WEI of
   // imprecision due to rounding.
   const cumulativeStake = await votingV2.cumulativeStake();
-  if (cumulativeStake.gt(numberSlashedEvents)) throw new Error("VotingV2 cumulativeStake is not 0");
+  if (cumulativeStake.gt(numberSlashedEvents))
+    throw new Error(
+      `VotingV2 cumulativeStake should be between 0 and ${numberSlashedEvents} but is ${cumulativeStake}`
+    );
 
   console.log("Unstake health check passed! All voters have been unstaked successfully");
 }

--- a/packages/scripts/src/monitoring-dvm2.0/unstake.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/unstake.ts
@@ -48,9 +48,10 @@ async function main() {
       `VotingV2 balance should be between 0 and ${numberSlashedEvents} but is ${votingV2BalanceWithoutExternalTransfers}`
     );
 
-  // VotingV2 cumulativeStake should be 0
+  // VotingV2 cumulativeStake should be 0 with a tolerance of numberSlashedEvents, as every slash can result in 1 WEI of
+  // imprecision due to rounding.
   const cumulativeStake = await votingV2.cumulativeStake();
-  if (cumulativeStake.toString() != "0") throw new Error("VotingV2 cumulativeStake is not 0");
+  if (cumulativeStake.gt(numberSlashedEvents)) throw new Error("VotingV2 cumulativeStake is not 0");
 
   console.log("Unstake health check passed! All voters have been unstaked successfully");
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Fixes the unstake health check of DVM2.0 by adding the same tolerance used in other parts of this scripts.

Every voter slashed, represented by a `VoterSlashed` event, can result in 1 WEI drift in favour of the VotingV2 contract.

**Summary**
- Add rounding tolerance to `cumulativeStake` check after all users exiting.



