### PR TITLE
fix(og): L-01 - Restrict ProposalDeleted event emission to valid assertionId

### DIFF
--- a/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
+++ b/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
@@ -359,15 +359,16 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
      * @param assertionId the identifier of the disputed assertion.
      */
     function assertionDisputedCallback(bytes32 assertionId) external {
-        // In order to optimize for happy path, the assertionId is validated for potential spoofing only in the
-        // deleteProposalOnUpgrade call. Genuine Optimistic Oracle V3 should always pass a valid assertionId that has a
-        // matching proposalHash in this contract.
         bytes32 proposalHash = assertionIds[assertionId];
 
         // Callback should only be called by the Optimistic Oracle V3. Address would not match in case of contract
         // upgrade, thus try deleting the proposal through deleteProposalOnUpgrade function that should revert if
         // address mismatch was not caused by an Optimistic Oracle V3 upgrade.
         if (msg.sender == address(optimisticOracleV3)) {
+            // Validate the assertionId through existence of non-zero proposalHash. This is the same check as in
+            // deleteProposalOnUpgrade method that is called in the else branch.
+            require(proposalHash != bytes32(0), "Invalid proposal hash");
+
             // Delete the disputed proposal and associated assertionId.
             delete proposalHashes[proposalHash];
             delete assertionIds[assertionId];

--- a/packages/core/test/hardhat/optimistic-governor/OptimisticGovernor.js
+++ b/packages/core/test/hardhat/optimistic-governor/OptimisticGovernor.js
@@ -1206,4 +1206,47 @@ describe("OptimisticGovernor", () => {
     const proposalBond = toBN(finalFee).mul(toBN(toWei("1")).div(toBN(burnedBondPercentage)));
     assert.equal(await optimisticOracleModule.methods.getProposalBond().call(), proposalBond.toString());
   });
+
+  it("Cannot process callback from Optimistic Oracle V3 with invalid assertionId", async function () {
+    // Create assertion directly with Optimistic Oracle V3 and pointing Optimistic Governor as the callback recipient.
+    await bondToken.methods.approve(optimisticOracleV3.options.address, bond).send({ from: proposer });
+    const fakeClaim = utf8ToHex("Fake claim");
+    await optimisticOracleV3.methods
+      .assertTruth(
+        fakeClaim,
+        proposer,
+        optimisticOracleModule.options.address,
+        ZERO_ADDRESS,
+        liveness,
+        bondToken.options.address,
+        bond,
+        identifier,
+        rightPad(0, 64)
+      )
+      .send({ from: proposer });
+    const assertionTimestamp = await optimisticOracleV3.methods.getCurrentTime().call();
+    const assertionId = web3.utils.keccak256(
+      web3.eth.abi.encodeParameters(
+        ["bytes", "uint256", "uint256", "uint64", "address", "address", "address", "bytes32", "address"],
+        [
+          fakeClaim,
+          bond,
+          assertionTimestamp,
+          liveness,
+          bondToken.options.address,
+          optimisticOracleModule.options.address,
+          ZERO_ADDRESS,
+          identifier,
+          proposer,
+        ]
+      )
+    );
+
+    // Disputing the assertion should revert because the assertionId is not known to the Optimistic Governor.
+    assert(
+      await didContractThrow(
+        optimisticOracleV3.methods.disputeAssertion(assertionId, disputer).send({ from: disputer })
+      )
+    );
+  });
 });


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
The OptimisticGovernor contract's assertionDisputedCallback function does not
validate whether its assertionId argument is valid (i.e., whether it is associated with a
proposal). This allows a ProposalDeleted event to be emitted for any assertionId
value, not just values that correspond to actual proposals.
```

**Summary**

This PR addresses this issue by adding a check in the assertionDisputedCallback function that ensures the assertionId value maps to a non-zero proposalHash.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

