### PR TITLE
fix(og): L-03 - Add contract address check in setEscalationManager

### DIFF
--- a/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
+++ b/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
@@ -209,7 +209,7 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
      * whitelisting of proposers and disputers since Optimistic Governor is deleting disputed proposals.
      */
     function setEscalationManager(address _escalationManager) external onlyOwner {
-        require(_escalationManager == address(0) || _isContract(_escalationManager), "EM is not a contract");
+        require(_isContract(_escalationManager) || _escalationManager == address(0), "EM is not a contract");
         escalationManager = _escalationManager;
         emit SetEscalationManager(_escalationManager);
     }

--- a/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
+++ b/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
@@ -209,6 +209,7 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
      * whitelisting of proposers and disputers since Optimistic Governor is deleting disputed proposals.
      */
     function setEscalationManager(address _escalationManager) external onlyOwner {
+        require(_escalationManager == address(0) || _isContract(_escalationManager), "EM is not a contract");
         escalationManager = _escalationManager;
         emit SetEscalationManager(_escalationManager);
     }

--- a/packages/core/test/hardhat/optimistic-governor/OptimisticGovernor.js
+++ b/packages/core/test/hardhat/optimistic-governor/OptimisticGovernor.js
@@ -851,22 +851,24 @@ describe("OptimisticGovernor", () => {
       (event) => event.identifier == newIdentifier
     );
 
-    // Set new Escalation Manager.
-    const newEscalationManager = executor;
+    // Deploy Full Policy Escalation Manager and set it as new Escalation Manager.
+    const newEscalationManager = await FullPolicyEscalationManager.new(optimisticOracleV3.options.address).send({
+      from: owner,
+    });
     const setEscalationManagerData = optimisticOracleModule.methods
-      .setEscalationManager(newEscalationManager)
+      .setEscalationManager(newEscalationManager.options.address)
       .encodeABI();
     let escalationManagerReceipt = await avatar.methods
       .exec(optimisticOracleModule.options.address, "0", setEscalationManagerData)
       .send({ from: owner });
 
     // Check that the new Escalation Manager is set.
-    assert.equal(await optimisticOracleModule.methods.escalationManager().call(), newEscalationManager);
+    assert.equal(await optimisticOracleModule.methods.escalationManager().call(), newEscalationManager.options.address);
     await assertEventEmitted(
       escalationManagerReceipt,
       optimisticOracleModule,
       "SetEscalationManager",
-      (event) => event.escalationManager == newEscalationManager
+      (event) => event.escalationManager == newEscalationManager.options.address
     );
   });
 
@@ -896,11 +898,13 @@ describe("OptimisticGovernor", () => {
     await identifierWhitelist.methods.addSupportedIdentifier(newIdentifier).send({ from: owner });
     assert(await didContractThrow(optimisticOracleModule.methods.setIdentifier(newIdentifier).send({ from: rando })));
 
-    // Try set new Escalation Manager from a non-owner.
-    const newEscalationManager = executor;
+    // Deploy Full Policy Escalation Manager and try setting it as new Escalation Manager from a non-owner.
+    const newEscalationManager = await FullPolicyEscalationManager.new(optimisticOracleV3.options.address).send({
+      from: owner,
+    });
     assert(
       await didContractThrow(
-        optimisticOracleModule.methods.setEscalationManager(newEscalationManager).send({ from: rando })
+        optimisticOracleModule.methods.setEscalationManager(newEscalationManager.options.address).send({ from: rando })
       )
     );
   });
@@ -1205,5 +1209,40 @@ describe("OptimisticGovernor", () => {
     // Check that the proposal bond now is set to the floor driven by the final fee.
     const proposalBond = toBN(finalFee).mul(toBN(toWei("1")).div(toBN(burnedBondPercentage)));
     assert.equal(await optimisticOracleModule.methods.getProposalBond().call(), proposalBond.toString());
+  });
+
+  it("Cannot set EOA as Escalation Manager", async function () {
+    // Set EOA as escalation manager.
+    const newEscalationManager = executor;
+    const setEscalationManagerData = optimisticOracleModule.methods
+      .setEscalationManager(newEscalationManager)
+      .encodeABI();
+    assert(
+      await didContractThrow(
+        avatar.methods.exec(optimisticOracleModule.options.address, "0", setEscalationManagerData).send({ from: owner })
+      )
+    );
+  });
+
+  it("Can reset Escalation Manager to zero address", async function () {
+    // Deploy Full Policy Escalation Manager and set it as new Escalation Manager.
+    const newEscalationManager = await FullPolicyEscalationManager.new(optimisticOracleV3.options.address).send({
+      from: owner,
+    });
+    const setEscalationManagerData = optimisticOracleModule.methods
+      .setEscalationManager(newEscalationManager.options.address)
+      .encodeABI();
+    await avatar.methods
+      .exec(optimisticOracleModule.options.address, "0", setEscalationManagerData)
+      .send({ from: owner });
+
+    // Reset Escalation Manager to zero address.
+    const resetEscalationManagerData = optimisticOracleModule.methods.setEscalationManager(ZERO_ADDRESS).encodeABI();
+    await avatar.methods
+      .exec(optimisticOracleModule.options.address, "0", resetEscalationManagerData)
+      .send({ from: owner });
+
+    // Check that Escalation Manager is set to zero address.
+    assert.equal(await optimisticOracleModule.methods.escalationManager().call(), ZERO_ADDRESS);
   });
 });


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
The setEscalationManager administrative function in OptimisticGovernor does not
perform any checks to validate that the _escalationManager address is a contract.
Specifying an address where no contract code is deployed could result in unexpected behavior
since the OptimisticOracleV3 contract expects that all escalation managers implement
EscalationManagerInterface .
```

**Summary**

This PR addresses this issue by using the existing _isContract function to validate the _escalationManager argument unless it is zero address when disabling the Escalation Manager.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

