### PR TITLE
fix(og): N-01 - Consistent variable naming

### DIFF
--- a/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
+++ b/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
@@ -223,12 +223,12 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
 
     /**
      * @notice Makes a new proposal for transactions to be executed with an explanation argument.
-     * @param _transactions the transactions being proposed.
-     * @param _explanation Auxillary information that can be referenced to validate the proposal.
+     * @param transactions the transactions being proposed.
+     * @param explanation Auxillary information that can be referenced to validate the proposal.
      * @dev Proposer must grant the contract collateral allowance at least to the bondAmount or result of getMinimumBond
      * from the Optimistic Oracle V3, whichever is greater.
      */
-    function proposeTransactions(Transaction[] memory _transactions, bytes memory _explanation) external nonReentrant {
+    function proposeTransactions(Transaction[] memory transactions, bytes memory explanation) external nonReentrant {
         // note: Optional explanation explains the intent of the transactions to make comprehension easier.
         uint256 time = getCurrentTime();
         address proposer = msg.sender;
@@ -238,20 +238,20 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
         proposal.requestTime = time;
 
         // Add transactions to proposal in memory.
-        for (uint256 i = 0; i < _transactions.length; i++) {
-            require(_transactions[i].to != address(0), "The `to` address cannot be 0x0");
+        for (uint256 i = 0; i < transactions.length; i++) {
+            require(transactions[i].to != address(0), "The `to` address cannot be 0x0");
             // If the transaction has any data with it the recipient must be a contract, not an EOA.
-            if (_transactions[i].data.length > 0) {
-                require(_isContract(_transactions[i].to), "EOA can't accept tx with data");
+            if (transactions[i].data.length > 0) {
+                require(_isContract(transactions[i].to), "EOA can't accept tx with data");
             }
         }
-        proposal.transactions = _transactions;
+        proposal.transactions = transactions;
 
         // Create the proposal hash.
-        bytes32 proposalHash = keccak256(abi.encode(_transactions));
+        bytes32 proposalHash = keccak256(abi.encode(transactions));
 
         // Add the proposal hash, explanation and rules to ancillary data.
-        bytes memory claim = _constructClaim(proposalHash, _explanation);
+        bytes memory claim = _constructClaim(proposalHash, explanation);
 
         // Check that the proposal is not already mapped to an assertionId, i.e., is not a duplicate.
         require(proposalHashes[proposalHash] == bytes32(0), "Duplicate proposals not allowed");
@@ -287,7 +287,7 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
             assertionId,
             proposal,
             proposalHash,
-            _explanation,
+            explanation,
             rules,
             time + liveness
         );
@@ -295,22 +295,22 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
 
     /**
      * @notice Executes an approved proposal.
-     * @param _transactions the transactions being executed. These must exactly match those that were proposed.
+     * @param transactions the transactions being executed. These must exactly match those that were proposed.
      */
-    function executeProposal(Transaction[] memory _transactions) external payable nonReentrant {
+    function executeProposal(Transaction[] memory transactions) external payable nonReentrant {
         // Recreate the proposal hash from the inputs and check that it matches the stored proposal hash.
-        bytes32 _proposalHash = keccak256(abi.encode(_transactions));
+        bytes32 proposalHash = keccak256(abi.encode(transactions));
 
         // This will reject the transaction if the proposal hash generated from the inputs does not match the stored
         // proposal hash. This is possible when a) the transactions have not been proposed, b) transactions have already
         // been executed, c) the proposal was disputed or d) the proposal was deleted after Optimistic Oracle V3 upgrade.
-        require(proposalHashes[_proposalHash] != bytes32(0), "Proposal hash does not exist");
+        require(proposalHashes[proposalHash] != bytes32(0), "Proposal hash does not exist");
 
         // Get the original proposal assertionId.
-        bytes32 assertionId = proposalHashes[_proposalHash];
+        bytes32 assertionId = proposalHashes[proposalHash];
 
         // Remove proposal hash and assertionId so transactions can not be executed again.
-        delete proposalHashes[_proposalHash];
+        delete proposalHashes[proposalHash];
         delete assertionIds[assertionId];
 
         // There is no need to check the assertion result as this point can be reached only for non-disputed assertions.
@@ -318,39 +318,39 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
         optimisticOracleV3.settleAndGetAssertionResult(assertionId);
 
         // Execute the transactions.
-        for (uint256 i = 0; i < _transactions.length; i++) {
-            Transaction memory transaction = _transactions[i];
+        for (uint256 i = 0; i < transactions.length; i++) {
+            Transaction memory transaction = transactions[i];
 
             require(
                 exec(transaction.to, transaction.value, transaction.data, transaction.operation),
                 "Failed to execute transaction"
             );
-            emit TransactionExecuted(_proposalHash, assertionId, i);
+            emit TransactionExecuted(proposalHash, assertionId, i);
         }
 
-        emit ProposalExecuted(_proposalHash, assertionId);
+        emit ProposalExecuted(proposalHash, assertionId);
     }
 
     /**
      * @notice Function to delete a proposal on an Optimistic Oracle V3 upgrade.
-     * @param _proposalHash the hash of the proposal to delete.
+     * @param proposalHash the hash of the proposal to delete.
      * @dev In case of an Optimistic Oracle V3 upgrade, the proposal execution would be blocked as its related
      * assertionId would not be recognized by the new Optimistic Oracle V3. This function allows the proposal to be
      * deleted if detecting an Optimistic Oracle V3 upgrade so that transactions can be re-proposed if needed.
      */
-    function deleteProposalOnUpgrade(bytes32 _proposalHash) public nonReentrant {
-        require(_proposalHash != bytes32(0), "Invalid proposal hash");
-        bytes32 assertionId = proposalHashes[_proposalHash];
+    function deleteProposalOnUpgrade(bytes32 proposalHash) public nonReentrant {
+        require(proposalHash != bytes32(0), "Invalid proposal hash");
+        bytes32 assertionId = proposalHashes[proposalHash];
         require(assertionId != bytes32(0), "Proposal hash does not exist");
 
         // Detect Optimistic Oracle V3 upgrade by checking if it has the matching assertionId.
         require(optimisticOracleV3.getAssertion(assertionId).asserter == address(0), "OOv3 upgrade not detected");
 
         // Remove proposal hash and assertionId so that transactions can be re-proposed if needed.
-        delete proposalHashes[_proposalHash];
+        delete proposalHashes[proposalHash];
         delete assertionIds[assertionId];
 
-        emit ProposalDeleted(_proposalHash, assertionId);
+        emit ProposalDeleted(proposalHash, assertionId);
     }
 
     /**
@@ -429,14 +429,14 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
     }
 
     // Constructs the claim that will be asserted at the Optimistic Oracle V3.
-    function _constructClaim(bytes32 _proposalHash, bytes memory _explanation) internal view returns (bytes memory) {
+    function _constructClaim(bytes32 proposalHash, bytes memory explanation) internal view returns (bytes memory) {
         return
             abi.encodePacked(
-                ClaimData.appendKeyValueBytes32("", PROPOSAL_HASH_KEY, _proposalHash),
+                ClaimData.appendKeyValueBytes32("", PROPOSAL_HASH_KEY, proposalHash),
                 ",",
                 EXPLANATION_KEY,
                 ':"',
-                _explanation,
+                explanation,
                 '",',
                 RULES_KEY,
                 ':"',


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
Some functions in the OptimisticGovernor contract use leading underscores to name
either input parameters or local variables in cases where there is no name collision with the
contract's storage variables:
• proposeTransactions : Input parameters _transactions and _explanation
• executeProposal : Input parameter _transactions and local variable
_proposalHash
• deleteProposalOnUpgrade : Input parameter _proposalHash
• _constructClaim : Input parameters _proposalHash and _explanation
```

**Summary**

This PR addresses this issue by removing the leading underscore from these parameters, and also updating the corresponding docstrings.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested

