### PR TITLE
fix(og): N-02 - Remove payable in executeProposal

### DIFF
--- a/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
+++ b/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
@@ -297,7 +297,7 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
      * @notice Executes an approved proposal.
      * @param _transactions the transactions being executed. These must exactly match those that were proposed.
      */
-    function executeProposal(Transaction[] memory _transactions) external payable nonReentrant {
+    function executeProposal(Transaction[] memory _transactions) external nonReentrant {
         // Recreate the proposal hash from the inputs and check that it matches the stored proposal hash.
         bytes32 _proposalHash = keccak256(abi.encode(_transactions));
 


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
The executeProposal function has the payable modifier. However, any ETH sent is not
used in the function and will be locked in the OptimisticGovernor contract.
```

**Summary**

This PR addresses this issue by removing the payable attribute to avoid potentially locking ETH in the OptimisticGovernor contract.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested

