### PR TITLE
fix(og): N-04 - Eliminate redundant code

### DIFF
--- a/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
+++ b/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol
@@ -260,7 +260,7 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
         // This will fail if the proposer has not granted the Optimistic Governor contract an allowance
         // of the collateral token equal to or greater than the totalBond.
         uint256 totalBond = getProposalBond();
-        collateral.safeTransferFrom(msg.sender, address(this), totalBond);
+        collateral.safeTransferFrom(proposer, address(this), totalBond);
         collateral.safeIncreaseAllowance(address(optimisticOracleV3), totalBond);
 
         // Assert that the proposal is correct at the Optimistic Oracle V3.
@@ -301,13 +301,14 @@ contract OptimisticGovernor is OptimisticOracleV3CallbackRecipientInterface, Mod
         // Recreate the proposal hash from the inputs and check that it matches the stored proposal hash.
         bytes32 _proposalHash = keccak256(abi.encode(_transactions));
 
-        // This will reject the transaction if the proposal hash generated from the inputs does not match the stored
-        // proposal hash. This is possible when a) the transactions have not been proposed, b) transactions have already
-        // been executed, c) the proposal was disputed or d) the proposal was deleted after Optimistic Oracle V3 upgrade.
-        require(proposalHashes[_proposalHash] != bytes32(0), "Proposal hash does not exist");
-
         // Get the original proposal assertionId.
         bytes32 assertionId = proposalHashes[_proposalHash];
+
+        // This will reject the transaction if the proposal hash generated from the inputs does not have the associated
+        // assertionId stored. This is possible when a) the transactions have not been proposed, b) transactions have
+        // already been executed, c) the proposal was disputed or d) the proposal was deleted after Optimistic Oracle V3
+        // upgrade.
+        require(assertionId != bytes32(0), "Proposal hash does not exist");
 
         // Remove proposal hash and assertionId so transactions can not be executed again.
         delete proposalHashes[_proposalHash];


### PR DESCRIPTION
**Motivation**

OZ identified the following issue:

```
Consider making the following changes to eliminate redundant code:
• In OptimisticGovernor.sol , msg.sender is used on line 263 to transfer tokens
from the proposer to the Optimistic Governor contract, but proposer has already been
defined as msg.sender on line 234, so proposer can be used here.
• In OptimisticGovernor.sol , line 310 computes the assertionId , but this value
was already computed on line 307 inside a require statement. Lines 310 and 307 can
be swapped, and proposalHashes[_proposalhash] inside the require
statement can be replaced with assertionId .
```

**Summary**

This PR addresses this issue by implementing suggested fixes above.




**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


