### PR TITLE
feat: add logIndexes to request data and searching

### DIFF
--- a/packages/sdk/src/clients/optimisticOracle/client.ts
+++ b/packages/sdk/src/clients/optimisticOracle/client.ts
@@ -64,6 +64,10 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
   }>;
 
 export interface EventState {
@@ -96,6 +100,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Requested,
         requestTx: event.transactionHash,
         requestBlockNumber: event.blockNumber,
+        requestLogIndex: event.logIndex,
       };
       break;
     }
@@ -128,6 +133,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,
+        proposeLogIndex: event.logIndex,
       };
       break;
     }
@@ -150,6 +156,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Disputed,
         disputeTx: event.transactionHash,
         disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
       };
       break;
     }
@@ -174,6 +181,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Settled,
         settleTx: event.transactionHash,
         settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
       };
       break;
     }

--- a/packages/sdk/src/clients/optimisticOracleV2/client.ts
+++ b/packages/sdk/src/clients/optimisticOracleV2/client.ts
@@ -71,6 +71,10 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
     requestSettings: RequestSettings;
   }>;
 
@@ -104,6 +108,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Requested,
         requestTx: event.transactionHash,
         requestBlockNumber: event.blockNumber,
+        requestLogIndex: event.logIndex,
       };
       break;
     }
@@ -136,6 +141,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,
+        proposeLogIndex: event.logIndex,
       };
       break;
     }
@@ -158,6 +164,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Disputed,
         disputeTx: event.transactionHash,
         disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
       };
       break;
     }
@@ -182,6 +189,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Settled,
         settleTx: event.transactionHash,
         settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
       };
       break;
     }

--- a/packages/sdk/src/clients/skinnyOptimisticOracle/client.ts
+++ b/packages/sdk/src/clients/skinnyOptimisticOracle/client.ts
@@ -66,6 +66,10 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
   }>;
 
 export interface EventState {
@@ -94,6 +98,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Requested,
         requestTx: event.transactionHash,
         requestBlockNumber: event.blockNumber,
+        requestLogIndex: event.logIndex,
       };
       break;
     }
@@ -112,6 +117,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,
+        proposeLogIndex: event.logIndex,
       };
       break;
     }
@@ -130,6 +136,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Disputed,
         disputeTx: event.transactionHash,
         disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
       };
       break;
     }
@@ -148,6 +155,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Settled,
         settleTx: event.transactionHash,
         settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
       };
       break;
     }

--- a/packages/sdk/src/oracle/services/statemachines/setActiveRequestByTransaction.ts
+++ b/packages/sdk/src/oracle/services/statemachines/setActiveRequestByTransaction.ts
@@ -13,6 +13,44 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
     async start(params: Params) {
       const { chainId, transactionHash, eventIndex = 0 } = params;
 
+      // search all known requests first
+      const filteredRequests = store
+        .read()
+        .descendingRequests()
+        .filter((request) => {
+          if (request.chainId.toString() !== chainId.toString()) return false;
+          if (
+            ![
+              request?.requestTx?.toLowerCase(),
+              request?.proposeTx?.toLowerCase(),
+              request?.disputeTx?.toLowerCase(),
+              request?.settleTx?.toLowerCase(),
+            ].includes(transactionHash.toLowerCase())
+          )
+            return false;
+          return [
+            request?.requestLogIndex?.toString(),
+            request?.proposeLogIndex?.toString(),
+            request?.disputeLogIndex?.toString(),
+            request?.settleLogIndex?.toString(),
+          ].includes(eventIndex.toString());
+        });
+
+      // if we found a request from known requests, then set it as our selected request
+      if (filteredRequests.length === 1) {
+        const [found] = filteredRequests;
+        // we can parse out the necessary params to kick off fetching the state of the request
+        const requestInput = {
+          timestamp: found.timestamp,
+          requester: found.requester,
+          ancillaryData: found.ancillaryData,
+          identifier: found.identifier,
+          chainId,
+        };
+        store.write((write) => write.inputs().request(requestInput));
+        return "done";
+      }
+
       // have to do all of this to fetch the identifier, ancData, requester and timestamp from the request
       const provider = store.read().provider(chainId);
       const receipt = await provider.getTransactionReceipt(transactionHash);
@@ -25,7 +63,11 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       const decodedLogs = oracleLogs.map((log) => oracle.parseLog(log));
 
       // this is the event we care about, we index into the appropriate oracle event generated from this tx
-      const log = decodedLogs[eventIndex];
+      // we want to keep backwards compatibility with previous links which were indexed by an array index and not logIndex
+      const log =
+        decodedLogs.find((log) => log?.logIndex?.toString() === eventIndex.toString()) ||
+        decodedLogs[eventIndex] ||
+        decodedLogs[0];
       // we dont actually know the type of the log, so we need to do some validation before continuing
       assert(log, `Unable to find optimistic oracle event at ${transactionHash} eventIndex ${eventIndex}`);
       assert(log.args, `Unable to find optimistic oracle event args at ${transactionHash} eventIndex ${eventIndex}`);

--- a/packages/sdk/src/oracle/types/ethers.ts
+++ b/packages/sdk/src/oracle/types/ethers.ts
@@ -5,6 +5,7 @@ export type { Signer, BigNumber, BigNumberish, Contract } from "ethers";
 export type { Overrides } from "@ethersproject/contracts";
 export { Provider, JsonRpcSigner, JsonRpcProvider, Web3Provider, FallbackProvider } from "@ethersproject/providers";
 export { TransactionRequest, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+export type { Log } from "@ethersproject/abstract-provider";
 export type { Event, Interface };
 
 export type SerializableEvent = Omit<
@@ -13,5 +14,4 @@ export type SerializableEvent = Omit<
 >;
 
 // taken from ethers code https://github.com/ethers-io/ethers.js/blob/master/packages/abi/src.ts/interface.ts#L654
-export type Log = Parameters<Interface["parseLog"]>[0];
 export type ParsedLog = ReturnType<Interface["parseLog"]>;

--- a/packages/sdk/src/oracle/types/interfaces.ts
+++ b/packages/sdk/src/oracle/types/interfaces.ts
@@ -40,6 +40,10 @@ export type Request = RequestKey & {
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
     // oo v2 fields moved here from settings object
     bond: BigNumber;
     customLiveness: BigNumber;
@@ -74,7 +78,7 @@ export interface OracleInterface {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
   getProps: () => Promise<OracleProps>;
   listRequests: () => Requests;
-  parseLog: (log: Log) => ParsedLog;
+  parseLog: (log: Log) => Log & ParsedLog & { event: string; eventSignature: string };
 }
 
 export type ClientTable = {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import { BigNumber, Contract } from "ethers";
-import { averageBlockTimeSeconds } from "@uma/common";
 import type Multicall2 from "./multicall2";
 import zip from "lodash/zip";
 
@@ -96,6 +95,36 @@ export const BatchReadWithErrors = (multicall2: Multicall2) => (contract: Contra
     })
   );
 };
+
+/**
+ * @notice Return average block-time for a period.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function averageBlockTimeSeconds(chainId?: number): Promise<number> {
+  // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
+  // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
+  // since April 2016, although this value seems to spike periodically for a relatively short period of time.
+  const defaultBlockTimeSeconds = 12;
+  if (!defaultBlockTimeSeconds) {
+    throw "Missing default block time value";
+  }
+
+  switch (chainId) {
+    // Source: https://polygonscan.com/chart/blocktime
+    case 10:
+      return 0.5;
+    case 42161:
+      return 0.5;
+    case 288:
+      return 150;
+    case 137:
+      return 2.5;
+    case 1:
+      return defaultBlockTimeSeconds;
+    default:
+      return defaultBlockTimeSeconds;
+  }
+}
 
 export async function estimateBlocksElapsed(
   seconds: number,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
In the oracle dapp, we were not correctly using event log indexes to differentiate between requests generated within the same transaction. optimism frequently does this when reqeusts are disputed, but issuing a new request in the same transaction.

**Summary**
we make sure to add correct log index to requests when parsed from events. these events are also used now to search based on known requests to find a match, in order to set the users currently selected request, or if not in the list, it will query contract events and find a match that way. 

**Testing**
Tested this with the dapp itself by integrateing changes.

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

