### PR TITLE
feat(core): reference requests by hash in mock oracle

### DIFF
--- a/packages/core/contracts/data-verification-mechanism/test/MockOracleAncillary.sol
+++ b/packages/core/contracts/data-verification-mechanism/test/MockOracleAncillary.sol
@@ -111,8 +111,8 @@ contract MockOracleAncillary is OracleAncillaryInterface, Testable {
 
     // Wrapper function to push the verified price by request ID.
     function pushPriceByRequestId(bytes32 requestId, int256 price) external {
-        (bytes32 identifier, uint256 time, bytes memory ancillaryData) = getRequestParameters(requestId);
-        pushPrice(identifier, time, ancillaryData, price);
+        QueryPoint memory queryPoint = getRequestParameters(requestId);
+        pushPrice(queryPoint.identifier, queryPoint.time, queryPoint.ancillaryData, price);
     }
 
     // Checks whether a price has been resolved.
@@ -142,19 +142,10 @@ contract MockOracleAncillary is OracleAncillaryInterface, Testable {
     }
 
     // Gets the request parameters by request ID.
-    function getRequestParameters(bytes32 requestId)
-        public
-        view
-        returns (
-            bytes32,
-            uint256,
-            bytes memory
-        )
-    {
+    function getRequestParameters(bytes32 requestId) public view returns (QueryPoint memory) {
         QueryIndex storage queryIndex = queryIndices[requestId];
         require(queryIndex.isValid, "Request ID not found");
-        QueryPoint storage queryPoint = requestedPrices[queryIndex.index];
-        return (queryPoint.identifier, queryPoint.time, queryPoint.ancillaryData);
+        return requestedPrices[queryIndex.index];
     }
 
     function _getIdentifierWhitelist() internal view returns (IdentifierWhitelistInterface supportedIdentifiers) {

--- a/packages/core/contracts/data-verification-mechanism/test/MockOracleGovernance.sol
+++ b/packages/core/contracts/data-verification-mechanism/test/MockOracleGovernance.sol
@@ -24,13 +24,14 @@ contract MockOracleGovernance is MockOracleAncillary {
         bool isGovernance
     ) internal {
         require(isGovernance || _getIdentifierWhitelist().isIdentifierSupported(identifier));
-        Price storage lookup = verifiedPrices[identifier][time][ancillaryData];
-        if (!lookup.isAvailable && !queryIndices[identifier][time][ancillaryData].isValid) {
+        bytes32 requestId = _encodePriceRequest(identifier, time, ancillaryData);
+        Price storage lookup = verifiedPrices[requestId];
+        if (!lookup.isAvailable && !queryIndices[requestId].isValid) {
             // New query, enqueue it for review.
-            queryIndices[identifier][time][ancillaryData] = QueryIndex(true, requestedPrices.length);
+            queryIndices[requestId] = QueryIndex(true, requestedPrices.length);
             QueryPoint memory queryPoint = QueryPoint(identifier, time, ancillaryData);
             requestedPrices.push(queryPoint);
-            emit PriceRequestAdded(msg.sender, identifier, time, ancillaryData);
+            emit PriceRequestAdded(msg.sender, identifier, time, ancillaryData, requestId);
         }
     }
 }

--- a/packages/core/test/foundry/optimistic-oracle-v3/CommonOptimisticOracleV3Test.sol
+++ b/packages/core/test/foundry/optimistic-oracle-v3/CommonOptimisticOracleV3Test.sol
@@ -61,7 +61,13 @@ contract CommonOptimisticOracleV3Test is CommonTestBase {
     );
     event AssertionDisputed(bytes32 indexed assertionId, address indexed caller, address indexed disputer);
 
-    event PriceRequestAdded(address indexed requester, bytes32 indexed identifier, uint256 time, bytes ancillaryData);
+    event PriceRequestAdded(
+        address indexed requester,
+        bytes32 indexed identifier,
+        uint256 time,
+        bytes ancillaryData,
+        bytes32 indexed requestId
+    );
 
     event AssertionSettled(
         bytes32 indexed assertionId,

--- a/packages/core/test/foundry/optimistic-oracle-v3/OptimisticOracleV3.Events.t.sol
+++ b/packages/core/test/foundry/optimistic-oracle-v3/OptimisticOracleV3.Events.t.sol
@@ -51,12 +51,15 @@ contract OptimisticOracleV3Events is CommonOptimisticOracleV3Test {
         vm.stopPrank();
 
         // Dispute should emit logs on Optimistic Oracle V3 and Oracle.
+        uint64 assertionTime = optimisticOracleV3.getAssertion(assertionId).assertionTime;
+        bytes memory ancillaryData = optimisticOracleV3.stampAssertion(assertionId);
         vm.expectEmit(true, true, true, true);
         emit PriceRequestAdded(
             address(optimisticOracleV3),
-            optimisticOracleV3.defaultIdentifier(),
-            optimisticOracleV3.getAssertion(assertionId).assertionTime,
-            optimisticOracleV3.stampAssertion(assertionId)
+            defaultIdentifier,
+            assertionTime,
+            ancillaryData,
+            keccak256(abi.encode(defaultIdentifier, assertionTime, ancillaryData))
         );
         vm.expectEmit(true, true, true, true);
         emit AssertionDisputed(assertionId, TestAddress.account2, TestAddress.account2);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Make it easier to interact with mocked oracle when testing Optimistic Oracle dispute flow. It is especially useful for testing in Foundry that currently does not have convenient way to parse unindexed event parameters.

**Summary**

Stores and retrieves all mocked oracle requests by their hashed request identifier. Adds wrapper method pushPriceByRequestId to resolve request identified by its hash instead of its individual parameters.

**Details**

When initiating and resolving requests this change also emits the hashed request identifier.

This PR also deletes relevant requestedPrices array element when resolving requests so that getPendingQueries would return correct state of pending requests.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


