### PR TITLE
fix(monitor-v2): og monitor log levels

### DIFF
--- a/packages/monitor-v2/src/monitor-og/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-og/MonitorLogger.ts
@@ -18,7 +18,7 @@ export async function logTransactions(
   },
   params: MonitoringParams
 ): Promise<void> {
-  logger.warn({
+  logger.error({
     at: "OptimisticGovernorMonitor",
     message: "Transactions Proposed 📝",
     mrkdwn:
@@ -86,7 +86,7 @@ export async function logProposalDeleted(
   transaction: { assertionId: string; proposalHash: string; tx: string },
   params: MonitoringParams
 ): Promise<void> {
-  logger.warn({
+  logger.error({
     at: "OptimisticGovernorMonitor",
     message: "Proposal Deleted 🗑️",
     mrkdwn:

--- a/packages/monitor-v2/test/OptimisticGovernorMonitor.ts
+++ b/packages/monitor-v2/test/OptimisticGovernorMonitor.ts
@@ -124,7 +124,7 @@ describe("OptimisticGovernorMonitor", function () {
     // When calling monitoring module directly there should be only one log (index 0) with the proposal caught by spy.
     assert.equal(spy.getCall(0).lastArg.at, "OptimisticGovernorMonitor");
     assert.equal(spy.getCall(0).lastArg.message, "Transactions Proposed 📝");
-    assert.equal(spyLogLevel(spy, 0), "warn");
+    assert.equal(spyLogLevel(spy, 0), "error");
     assert.isTrue(spyLogIncludes(spy, 0, transactionProposedEvent.args.assertionId));
     assert.isTrue(spyLogIncludes(spy, 0, transactionProposedEvent.args.proposer));
     assert.isTrue(spyLogIncludes(spy, 0, transactionProposedEvent.args.rules));
@@ -233,7 +233,7 @@ describe("OptimisticGovernorMonitor", function () {
 
     assert.equal(spy.getCall(0).lastArg.at, "OptimisticGovernorMonitor");
     assert.equal(spy.getCall(0).lastArg.message, "Proposal Deleted 🗑️");
-    assert.equal(spyLogLevel(spy, 0), "warn");
+    assert.equal(spyLogLevel(spy, 0), "error");
     assert.isTrue(spyLogIncludes(spy, 0, transactionProposedEvent.args.assertionId));
     assert.isTrue(spyLogIncludes(spy, 0, transactionProposedEvent.args.proposalHash));
     assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-governor");


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Optimistic Governor users might want to get paged on transaction proposals and disputes.

**Summary**

Changes log level to error for transaction proposals and deletion (that occurs on disputes).



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


