### PR TITLE
feat: make polymarket notifier serverless

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -52,20 +52,7 @@ export async function monitorTransactionsProposedOrderBook(
   const marketsWithAncillary = await getMarketsAncillary(params, markets);
   // Filter out markets that do not have a proposal event.
   const marketsWithEventData: PolymarketWithEventData[] = marketsWithAncillary
-    .filter((market) => {
-      const found = proposalEvents.find((event) => event.ancillaryData === market.ancillaryData);
-      if (!found && market.umaResolutionStatus == "proposed") {
-        // Log a warning if the market has a proposal event but no ancillary data was found.
-        // This would mean that getMarketsAncillary is not working properly.
-        logger.warn({
-          at: "PolymarketNotifier",
-          message: "Market has a proposal event but no ancillary data was found",
-          mrkdwn: `Market: ${market.questionID} | Question: ${market.question} | Market Status: ${market.endDate}`,
-          notificationPath: "polymarket-notifier",
-        });
-      }
-      return found;
-    })
+    .filter((market) => proposalEvents.find((event) => event.ancillaryData === market.ancillaryData))
     .map((market) => {
       const event = proposalEvents.find((event) => event.ancillaryData === market.ancillaryData);
       if (!event) throw new Error("Could not find event for market");

--- a/packages/monitor-v2/src/monitor-polymarket/README.md
+++ b/packages/monitor-v2/src/monitor-polymarket/README.md
@@ -14,15 +14,12 @@ All the configuration should be provided with following environment variables:
 
 - `CHAIN_ID` is network number.
 - `NODE_URLS_X` is an array of RPC node URLs replacing `X` in variable name with network number from `CHAIN_ID`.
-- `NODE_URL_X` is a single RPC node URL replacing `X` in variable name with network number from `CHAIN_ID`. This is
+- `NODE_URL_X` is a single RPC node URL replacing `X` in variable name with network number from `CHAIN_ID`.
   considered only if matching `NODE_URLS_X` is not provided.
 - `NODE_RETRIES` is the number of retries to make when a node request fails (defaults to `2`).
 - `NODE_RETRY_DELAY` is the delay in seconds between retries (defaults to `1`).
 - `NODE_TIMEOUT` is the timeout in seconds for node requests (defaults to `60`).
-- `POLLING_DELAY` is value in seconds for delay between consecutive runs, defaults to 1 minute. If set to 0 then running
+- `POLLING_DELAY` is value in seconds for delay between consecutive runs, defaults to 1 minute. If set to 0 then running in serverless mode will exit after the loop.
   in serverless mode will exit after the loop.
-- `STARTING_BLOCK_NUMBER` and `ENDING_BLOCK_NUMBER` defines block range to look for events on the `CHAIN_ID` network.
-  These are mandatory when `POLLING_DELAY=0`.
-- `TRANSACTIONS_PROPOSED_ENABLED` is boolean enabling/disabling monitoring transactions proposed (`false` by default).
 - `THRESHOLD_ASKS` Price threshold for winner outcome asks in the orderbook that triggers a notification (defaults to `1`).
 - `THRESHOLD_BIDS` Price threshold for loser outcome bids in the orderbook that triggers a notification (defaults to `0`).

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -167,7 +167,9 @@ export const getPolymarketMarkets = async (params: MonitoringParams): Promise<Po
   const now = Math.floor(Date.now() / 1000);
   const oneWeek = 60 * 60 * 24 * 7;
   const filtered = polymarketContracts.filter((contract: { [k: string]: any }) => {
-    const endDate = new Date(contract.endDate).getTime() / 1000;
+    const parsedDateTime = new Date(contract.endDate).getTime();
+    if (isNaN(parsedDateTime)) return true; // If endDate is not a valid date we keep the market.
+    const endDate = parsedDateTime / 1000;
     return endDate > now - oneWeek;
   });
 

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -38,6 +38,7 @@ export interface MonitoringParams {
   apiEndpoint: string;
   provider: Provider;
   chainId: number;
+  pollingDelay: number;
 }
 
 interface PolymarketMarket {
@@ -396,6 +397,9 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
   // Creating provider will check for other chainId specific env variables.
   const provider = getRetryProvider(chainId) as Provider;
 
+  // Default to 1 minute polling delay.
+  const pollingDelay = env.POLLING_DELAY ? Number(env.POLLING_DELAY) : 60;
+
   const maxBlockLookBack = env.MAX_BLOCK_LOOK_BACK ? Number(env.MAX_BLOCK_LOOK_BACK) : 3499;
 
   return {
@@ -407,6 +411,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
     apiEndpoint,
     provider,
     chainId,
+    pollingDelay,
   };
 };
 

--- a/packages/monitor-v2/src/monitor-polymarket/index.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/index.ts
@@ -1,50 +1,19 @@
 import { delay } from "@uma/financial-templates-lib";
-import { BotModes, initMonitoringParams, Logger, startupLogLevel, waitNextBlockRange } from "./common";
+import { initMonitoringParams, Logger } from "./common";
 import { monitorTransactionsProposedOrderBook } from "./MonitorProposalsOrderBook";
 
 const logger = Logger;
 
 async function main() {
   const params = await initMonitoringParams(process.env);
-  const cache = { ancillaryData: new Map<string, string>() };
 
-  logger[startupLogLevel(params)]({
+  logger.debug({
     at: "PolymarketMonitor",
     message: "Polymarket Monitor started 🔭",
-    botModes: params.botModes,
   });
 
-  const cmds = {
-    transactionsProposedEnabled: monitorTransactionsProposedOrderBook,
-  };
-
-  for (;;) {
-    // In case of non-zero polling delay waitNextBlockRange at the end of the loop could have returned the starting block
-    // to be greater than the ending block if there were no new blocks in the last polling delay. In this case we should
-    // wait for the next block range before running the commands.
-    if (params.blockRange.start > params.blockRange.end) {
-      // In serverless it is possible for start block to be larger than end block if no new blocks were mined since last run.
-      if (params.pollingDelay === 0) {
-        await delay(5); // Set a delay to let the transports flush fully.
-        break;
-      }
-      params.blockRange = await waitNextBlockRange(params);
-      continue;
-    }
-
-    const runCmds = Object.entries(cmds)
-      .filter(([mode]) => params.botModes[mode as keyof BotModes])
-      .map(([, cmd]) => cmd(logger, params, cache));
-
-    await Promise.all(runCmds);
-
-    // If polling delay is 0 then we are running in serverless mode and should exit after one iteration.
-    if (params.pollingDelay === 0) {
-      await delay(5); // Set a delay to let the transports flush fully.
-      break;
-    }
-    params.blockRange = await waitNextBlockRange(params);
-  }
+  await monitorTransactionsProposedOrderBook(logger, params);
+  await delay(5);
 }
 
 main().then(
@@ -53,8 +22,8 @@ main().then(
   },
   async (error) => {
     logger.error({
-      at: "OOv3Monitor",
-      message: "Optimistic Oracle V3 Monitor execution error🚨",
+      at: "PolymarketNotifier",
+      message: "Polymarket Notifier execution error 🚨",
       error,
     });
     await delay(5); // Wait 5 seconds to allow logger to flush.

--- a/packages/monitor-v2/src/monitor-polymarket/index.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/index.ts
@@ -12,8 +12,17 @@ async function main() {
     message: "Polymarket Monitor started 🔭",
   });
 
-  await monitorTransactionsProposedOrderBook(logger, params);
-  await delay(5);
+  for (;;) {
+    await monitorTransactionsProposedOrderBook(logger, params);
+
+    // If polling delay is 0 then we are running in serverless mode and should exit after one iteration.
+    if (params.pollingDelay === 0) {
+      await delay(5); // Set a delay to let the transports flush fully.
+      break;
+    }
+
+    await delay(params.pollingDelay);
+  }
 }
 
 main().then(

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -68,6 +68,7 @@ describe("PolymarketNotifier", function () {
       apiEndpoint,
       provider: ethers.provider as Provider,
       chainId: (await ethers.provider.getNetwork()).chainId,
+      pollingDelay: 0,
     };
   };
 

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -10,7 +10,7 @@ import { createNewLogger, spyLogIncludes, spyLogLevel, SpyTransport } from "@uma
 import { assert } from "chai";
 import sinon from "sinon";
 import * as commonModule from "../src/monitor-polymarket/common";
-import { BotModes, MonitoringParams, TradeInformation } from "../src/monitor-polymarket/common";
+import { MonitoringParams, TradeInformation } from "../src/monitor-polymarket/common";
 import { monitorTransactionsProposedOrderBook } from "../src/monitor-polymarket/MonitorProposalsOrderBook";
 import { umaEcosystemFixture } from "./fixtures/UmaEcosystem.Fixture";
 import { formatBytes32String, getContractFactory, hre, Provider, Signer } from "./utils";
@@ -20,7 +20,6 @@ const ethers = hre.ethers;
 describe("PolymarketNotifier", function () {
   let oov2: OptimisticOracleV2Ethers;
   let deployer: Signer;
-  const cache = { ancillaryData: new Map<string, string>() };
   const indentifier = formatBytes32String("TEST_IDENTIFIER");
 
   const mockData: any[] = [
@@ -54,11 +53,6 @@ describe("PolymarketNotifier", function () {
 
   // Create monitoring params for single block to pass to monitor modules.
   const createMonitoringParams = async (): Promise<MonitoringParams> => {
-    // Bot modes are not used as we are calling monitor modules directly.
-    const botModes: BotModes = {
-      transactionsProposedEnabled: true,
-    };
-
     const binaryAdapterAddress = "dummy";
     const ctfAdapterAddress = "dummy";
     const ctfExchangeAddress = "dummy";
@@ -74,9 +68,6 @@ describe("PolymarketNotifier", function () {
       apiEndpoint,
       provider: ethers.provider as Provider,
       chainId: (await ethers.provider.getNetwork()).chainId,
-      blockRange: { start: 0, end: 0 },
-      pollingDelay: 0,
-      botModes,
     };
   };
 
@@ -152,7 +143,7 @@ describe("PolymarketNotifier", function () {
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();
     const spyLogger = createNewLogger([new SpyTransport({}, { spy: spy })]);
-    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams(), cache);
+    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams());
 
     // The spy should have been called as the order book is not empty.
     assert.equal(spy.callCount, 1);
@@ -187,7 +178,7 @@ describe("PolymarketNotifier", function () {
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();
     const spyLogger = createNewLogger([new SpyTransport({}, { spy: spy })]);
-    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams(), cache);
+    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams());
 
     // The spy should not have been called as the order book is empty.
     assert.equal(spy.callCount, 0);
@@ -226,7 +217,7 @@ describe("PolymarketNotifier", function () {
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();
     const spyLogger = createNewLogger([new SpyTransport({}, { spy: spy })]);
-    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams(), cache);
+    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams());
 
     // The spy should have been called as the order book is not empty.
     assert.equal(spy.callCount, 1);
@@ -279,7 +270,7 @@ describe("PolymarketNotifier", function () {
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();
     const spyLogger = createNewLogger([new SpyTransport({}, { spy: spy })]);
-    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams(), cache);
+    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams());
 
     // The spy should have been called as the order book is not empty.
     assert.equal(spy.callCount, 1);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The previous design wasn't compatible with serverless bots configs as this bot was running in a continuous process.

**Summary**

- Filter ended markets from markets query
- Parallelise ancillary on-chain requests
- Simplify bot structure

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
Fixes #XXXX
