### PR TITLE
fix: temp fix to handle erroring in PM bot

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -342,11 +342,15 @@ export const getPolymarketOrderBooks = async (
       const [marketOne, marketTwo] = market.clobTokenIds;
       const apiUrlOne = params.apiEndpoint + `/book?token_id=${marketOne}`;
       const apiUrlTwo = params.apiEndpoint + `/book?token_id=${marketTwo}`;
-      const { bids: outcome1Bids, asks: outcome1Asks } = (await networker.getJson(apiUrlOne, {
+
+      // TODO: defaulting to [] is a temporary fix to handle the case where the API returns an error.
+      // This means we just assume there are no orders on that side. We don't expect this to happen, but it
+      // does occasionally. We should get to the bottom of this.
+      const { bids: outcome1Bids = [], asks: outcome1Asks = [] } = (await networker.getJson(apiUrlOne, {
         method: "get",
       })) as PolymarketOrderBook;
 
-      const { bids: outcome2Bids, asks: outcome2Asks } = (await networker.getJson(apiUrlTwo, {
+      const { bids: outcome2Bids = [], asks: outcome2Asks = [] } = (await networker.getJson(apiUrlTwo, {
         method: "get",
       })) as PolymarketOrderBook;
 


### PR DESCRIPTION
**Motivation**

The polymarket bot is erroring because some markets don't exist on the clob API.


**Summary**

Until we figure out why, this adds defaulting to allow the bot to continue to run, just ignoring those parts of the book that return errors.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
