### PR TITLE
fix(monitor-v2): add oov3 bot discord channels

### DIFF
--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
@@ -39,6 +39,7 @@ export async function logAssertion(
       ". The assertion can be disputed till " +
       new Date(Number(assertion.assertionData.expirationTime) * 1000).toUTCString(),
     notificationPath: "optimistic-oracle",
+    discordPaths: ["oo-fact-checking", "oo-events"],
   });
 }
 
@@ -66,6 +67,7 @@ export async function logDispute(
       ". Identifier: " +
       utils.parseBytes32String(dispute.assertionData.identifier),
     notificationPath: "optimistic-oracle",
+    discordPaths: ["oo-fact-checking", "oo-events"],
   });
 }
 
@@ -94,5 +96,6 @@ export async function logSettlement(
       ". Result: assertion was " +
       (settlement.assertionData.settlementResolution ? "true" : "false"),
     notificationPath: "optimistic-oracle",
+    discordPaths: ["oo-fact-checking", "oo-events"],
   });
 }

--- a/packages/monitor-v2/test/OptimisticOracleV3Monitor.ts
+++ b/packages/monitor-v2/test/OptimisticOracleV3Monitor.ts
@@ -99,6 +99,10 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, assertionTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
     assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
+    assert.equal(
+      JSON.stringify(spy.getCall(0).lastArg.discordPaths),
+      JSON.stringify(["oo-fact-checking", "oo-events"])
+    );
   });
   it("Monitor truthful settlement", async function () {
     // Make assertion.
@@ -126,6 +130,10 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
     assert.isTrue(spyLogIncludes(spy, 0, "Result: assertion was true"));
     assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
+    assert.equal(
+      JSON.stringify(spy.getCall(0).lastArg.discordPaths),
+      JSON.stringify(["oo-fact-checking", "oo-events"])
+    );
   });
   it("Monitor dispute", async function () {
     // Make assertion.
@@ -153,6 +161,10 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, disputeTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
     assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
+    assert.equal(
+      JSON.stringify(spy.getCall(0).lastArg.discordPaths),
+      JSON.stringify(["oo-fact-checking", "oo-events"])
+    );
   });
   it("Monitor settlement of false assertion", async function () {
     // Make assertion.
@@ -194,5 +206,9 @@ describe("OptimisticOracleV3Monitor", function () {
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
     assert.isTrue(spyLogIncludes(spy, 0, "Result: assertion was false"));
     assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
+    assert.equal(
+      JSON.stringify(spy.getCall(0).lastArg.discordPaths),
+      JSON.stringify(["oo-fact-checking", "oo-events"])
+    );
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Optimistic Oracle V3 notifications should go to two separate Discord channels, similarly as it is done for Optimistic Oracle V2.

**Summary**

Adds discord specific channels to Optimistic Oracle V3 monitor bot.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

