### PR TITLE
feat(monitor-v2): add ui links in og and oov3 monitors

### DIFF
--- a/packages/monitor-v2/src/monitor-og/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-og/MonitorLogger.ts
@@ -1,6 +1,6 @@
 import { createEtherscanLinkMarkdown } from "@uma/common";
 import { BigNumber } from "ethers";
-import { Logger, tryHexToUtf8String } from "./common";
+import { generateOOv3UILink, Logger, tryHexToUtf8String } from "./common";
 
 import type { MonitoringParams } from "./common";
 
@@ -15,6 +15,7 @@ export async function logTransactions(
     rules: string;
     challengeWindowEnds: BigNumber;
     tx: string;
+    ooEventIndex: number;
   },
   params: MonitoringParams
 ): Promise<void> {
@@ -36,7 +37,10 @@ export async function logTransactions(
       ". Explanation: " +
       tryHexToUtf8String(transaction.explanation) +
       ". The proposal can be disputed till " +
-      new Date(Number(transaction.challengeWindowEnds.toString()) * 1000).toUTCString(),
+      new Date(Number(transaction.challengeWindowEnds.toString()) * 1000).toUTCString() +
+      ": " +
+      generateOOv3UILink(transaction.tx, transaction.ooEventIndex, params.chainId) +
+      ".",
     notificationPath: "optimistic-governor",
   });
 }

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -3,13 +3,14 @@ import { ERC20Ethers } from "@uma/contracts-node";
 import { delay } from "@uma/financial-templates-lib";
 import { utils } from "ethers";
 import { getContractInstanceWithProvider } from "../utils/contracts";
-import { OptimisticGovernorEthers } from "./common";
+import { OptimisticGovernorEthers, OptimisticOracleV3Ethers } from "./common";
 
 import type { Provider } from "@ethersproject/abstract-provider";
 
-export { OptimisticGovernorEthers } from "@uma/contracts-node";
+export { OptimisticGovernorEthers, OptimisticOracleV3Ethers } from "@uma/contracts-node";
 export { Logger } from "@uma/financial-templates-lib";
 export { getContractInstanceWithProvider } from "../utils/contracts";
+export { generateOOv3UILink } from "../utils/logger";
 
 export interface BotModes {
   transactionsProposedEnabled: boolean;
@@ -135,7 +136,7 @@ export const getCurrencySymbol = async (provider: Provider, currencyAddress: str
 };
 
 export const runQueryFilter = async (
-  contract: OptimisticGovernorEthers,
+  contract: OptimisticGovernorEthers | OptimisticOracleV3Ethers,
   filter: any,
   blockRange: BlockRange
 ): Promise<any> => {
@@ -148,4 +149,8 @@ export const getOg = async (params: MonitoringParams): Promise<OptimisticGoverno
     params.provider,
     params.ogAddress
   );
+};
+
+export const getOo = async (params: MonitoringParams): Promise<OptimisticOracleV3Ethers> => {
+  return await getContractInstanceWithProvider<OptimisticOracleV3Ethers>("OptimisticOracleV3", params.provider);
 };

--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorAssertions.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorAssertions.ts
@@ -8,6 +8,7 @@ export async function monitorAssertions(logger: typeof Logger, params: Monitorin
     await oo.queryFilter(oo.filters.AssertionMade(), params.blockRange.start, params.blockRange.end)
   ).map(async (event) => ({
     tx: event.transactionHash,
+    eventIndex: event.logIndex,
     assertionId: event.args.assertionId,
     claim: event.args.claim,
     assertionData: await oo.getAssertion(event.args.assertionId),

--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorDisputes.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorDisputes.ts
@@ -8,6 +8,7 @@ export async function monitorDisputes(logger: typeof Logger, params: MonitoringP
     await oo.queryFilter(oo.filters.AssertionDisputed(), params.blockRange.start, params.blockRange.end)
   ).map(async (event) => ({
     tx: event.transactionHash,
+    eventIndex: event.logIndex,
     assertionId: event.args.assertionId,
     claim: (await oo.queryFilter(oo.filters.AssertionMade(event.args.assertionId))).map((event) => event.args.claim)[0],
     assertionData: await oo.getAssertion(event.args.assertionId),

--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
@@ -1,6 +1,6 @@
 import { createEtherscanLinkMarkdown, createFormatFunction } from "@uma/common";
 import { utils } from "ethers";
-import { Logger, OptimisticOracleV3Ethers } from "./common";
+import { generateOOv3UILink, Logger, OptimisticOracleV3Ethers } from "./common";
 
 import type { MonitoringParams } from "./common";
 import { getCurrencyDecimals, getCurrencySymbol, tryHexToUtf8String } from "../utils/contracts";
@@ -9,6 +9,7 @@ export async function logAssertion(
   logger: typeof Logger,
   assertion: {
     tx: string;
+    eventIndex: number;
     assertionId: string;
     claim: string;
     assertionData: Awaited<ReturnType<typeof OptimisticOracleV3Ethers.prototype.getAssertion>>;
@@ -37,7 +38,10 @@ export async function logAssertion(
       " " +
       currencySymbol +
       ". The assertion can be disputed till " +
-      new Date(Number(assertion.assertionData.expirationTime) * 1000).toUTCString(),
+      new Date(Number(assertion.assertionData.expirationTime) * 1000).toUTCString() +
+      ": " +
+      generateOOv3UILink(assertion.tx, assertion.eventIndex, params.chainId) +
+      ".",
     notificationPath: "optimistic-oracle",
     discordPaths: ["oo-fact-checking", "oo-events"],
   });
@@ -47,6 +51,7 @@ export async function logDispute(
   logger: typeof Logger,
   dispute: {
     tx: string;
+    eventIndex: number;
     assertionId: string;
     claim: string;
     assertionData: Awaited<ReturnType<typeof OptimisticOracleV3Ethers.prototype.getAssertion>>;
@@ -65,7 +70,10 @@ export async function logDispute(
       ". Claim: " +
       tryHexToUtf8String(dispute.claim) +
       ". Identifier: " +
-      utils.parseBytes32String(dispute.assertionData.identifier),
+      utils.parseBytes32String(dispute.assertionData.identifier) +
+      ". " +
+      generateOOv3UILink(dispute.tx, dispute.eventIndex, params.chainId) +
+      ".",
     notificationPath: "optimistic-oracle",
     discordPaths: ["oo-fact-checking", "oo-events"],
   });
@@ -75,6 +83,7 @@ export async function logSettlement(
   logger: typeof Logger,
   settlement: {
     tx: string;
+    eventIndex: number;
     assertionId: string;
     claim: string;
     assertionData: Awaited<ReturnType<typeof OptimisticOracleV3Ethers.prototype.getAssertion>>;
@@ -94,7 +103,10 @@ export async function logSettlement(
       ". Identifier: " +
       utils.parseBytes32String(settlement.assertionData.identifier) +
       ". Result: assertion was " +
-      (settlement.assertionData.settlementResolution ? "true" : "false"),
+      (settlement.assertionData.settlementResolution ? "true" : "false") +
+      ". " +
+      generateOOv3UILink(settlement.tx, settlement.eventIndex, params.chainId) +
+      ".",
     notificationPath: "optimistic-oracle",
     discordPaths: ["oo-fact-checking", "oo-events"],
   });

--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorSettlements.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorSettlements.ts
@@ -8,6 +8,7 @@ export async function monitorSettlements(logger: typeof Logger, params: Monitori
     await oo.queryFilter(oo.filters.AssertionSettled(), params.blockRange.start, params.blockRange.end)
   ).map(async (event) => ({
     tx: event.transactionHash,
+    eventIndex: event.logIndex,
     assertionId: event.args.assertionId,
     claim: (await oo.queryFilter(oo.filters.AssertionMade(event.args.assertionId))).map((event) => event.args.claim)[0],
     assertionData: await oo.getAssertion(event.args.assertionId),

--- a/packages/monitor-v2/src/monitor-oo-v3/common.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/common.ts
@@ -6,6 +6,7 @@ import type { Provider } from "@ethersproject/abstract-provider";
 export { OptimisticOracleV3Ethers } from "@uma/contracts-node";
 export { Logger } from "@uma/financial-templates-lib";
 export { getContractInstanceWithProvider } from "../utils/contracts";
+export { generateOOv3UILink } from "../utils/logger";
 
 export interface BotModes {
   assertionsEnabled: boolean;

--- a/packages/monitor-v2/src/utils/logger.ts
+++ b/packages/monitor-v2/src/utils/logger.ts
@@ -1,0 +1,9 @@
+const optimisticOracleV2UIBaseUrl = "https://oracle.uma.xyz";
+const testnetOptimisticOracleV2UIBaseUrl = "https://testnet.oracle.uma.xyz";
+
+// monitor-v2 package is only using Optimistic Oracle V3, so currently there is no need to generalize this.
+export const generateOOv3UILink = (transactionHash: string, eventIndex: number, chainId?: number): string => {
+  // Currently testnet UI supports only goerli, so assume any other chain is production.
+  const baseUrl = chainId === 5 ? testnetOptimisticOracleV2UIBaseUrl : optimisticOracleV2UIBaseUrl;
+  return `<${baseUrl}/?transactionHash=${transactionHash}&eventIndex=${eventIndex}|View in UI>`;
+};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

When receiving alerts on Optimistic Governor or Optimistic Oracle V3 transactions, it would be convenient to include Oracle dApp URL similarly as it is already done for other types of oracles.

**Summary**

Adds Oracle dApp URL for Optimistic Governor proposals and all Optimistic Oracle V3 transactions.




**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


