### PR TITLE
fix(scripts): fork at block number passed from serverless

### DIFF
--- a/packages/scripts/src/utils/utils.ts
+++ b/packages/scripts/src/utils/utils.ts
@@ -17,7 +17,7 @@ export const revertToSnapshot = async (snapshotId: string): Promise<void> => {
   await ethers.provider.send("evm_revert", [snapshotId]);
 };
 
-export const forkNetwork = (jsonRpcUrl: string, blockNumber?: string): Promise<void> => {
+export const forkNetwork = (jsonRpcUrl: string, blockNumber?: number): Promise<void> => {
   return hre.network.provider.request({
     method: "hardhat_reset",
     params: [{ forking: { jsonRpcUrl, blockNumber } }],

--- a/packages/scripts/src/utils/votingv2-utils.ts
+++ b/packages/scripts/src/utils/votingv2-utils.ts
@@ -38,7 +38,7 @@ export const getVotingContracts = async (): Promise<{ votingV2: VotingV2Ethers; 
     chainId = (await ethers.provider.getNetwork()).chainId;
   } else {
     if (!process.env.CUSTOM_NODE_URL) throw new Error("CUSTOM_NODE_URL must be defined in env");
-    await forkNetwork(process.env.CUSTOM_NODE_URL);
+    await forkNetwork(process.env.CUSTOM_NODE_URL, process.env.ENDING_BLOCK_NUMBER);
     chainId = await getForkChainId(process.env.CUSTOM_NODE_URL);
   }
 

--- a/packages/scripts/src/utils/votingv2-utils.ts
+++ b/packages/scripts/src/utils/votingv2-utils.ts
@@ -38,7 +38,10 @@ export const getVotingContracts = async (): Promise<{ votingV2: VotingV2Ethers; 
     chainId = (await ethers.provider.getNetwork()).chainId;
   } else {
     if (!process.env.CUSTOM_NODE_URL) throw new Error("CUSTOM_NODE_URL must be defined in env");
-    await forkNetwork(process.env.CUSTOM_NODE_URL, process.env.ENDING_BLOCK_NUMBER);
+    const blockNumber = process.env.ENDING_BLOCK_NUMBER ? parseInt(process.env.ENDING_BLOCK_NUMBER) : undefined;
+    if (blockNumber !== undefined && (isNaN(blockNumber) || blockNumber < 0))
+      throw new Error("ENDING_BLOCK_NUMBER must be non-negative number");
+    await forkNetwork(process.env.CUSTOM_NODE_URL, blockNumber);
     chainId = await getForkChainId(process.env.CUSTOM_NODE_URL);
   }
 

--- a/packages/scripts/src/utils/votingv2-utils.ts
+++ b/packages/scripts/src/utils/votingv2-utils.ts
@@ -38,9 +38,11 @@ export const getVotingContracts = async (): Promise<{ votingV2: VotingV2Ethers; 
     chainId = (await ethers.provider.getNetwork()).chainId;
   } else {
     if (!process.env.CUSTOM_NODE_URL) throw new Error("CUSTOM_NODE_URL must be defined in env");
-    const blockNumber = process.env.ENDING_BLOCK_NUMBER ? parseInt(process.env.ENDING_BLOCK_NUMBER) : undefined;
+    // Forking from block with less than 6 confirmations will affect Hardhat Network's performance, so we subtract 6
+    // blocks if serverless hub injected the latest block number.
+    const blockNumber = process.env.ENDING_BLOCK_NUMBER ? parseInt(process.env.ENDING_BLOCK_NUMBER) - 6 : undefined;
     if (blockNumber !== undefined && (isNaN(blockNumber) || blockNumber < 0))
-      throw new Error("ENDING_BLOCK_NUMBER must be non-negative number");
+      throw new Error("Invalid ENDING_BLOCK_NUMBER");
     await forkNetwork(process.env.CUSTOM_NODE_URL, blockNumber);
     chainId = await getForkChainId(process.env.CUSTOM_NODE_URL);
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

It was hard to debug forking tests as they were using latest block number when forking. By fixing fork at block number passed from serverless hub it might be easier to reproduce the issue.

**Summary**

Uses block number passed in `ENDING_BLOCK_NUMBER` variable when forking in DVM health checks.

**Details**

Also fixes type error in `forkNetwork` as `hardhat_reset` expects number type.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


