### PR TITLE
fix: fix unstake health check by avoiding Promise.all

### DIFF
--- a/packages/scripts/src/monitoring-dvm2.0/unstake.ts
+++ b/packages/scripts/src/monitoring-dvm2.0/unstake.ts
@@ -25,7 +25,11 @@ async function main() {
   await updateTrackers(votingV2, uniqueVoters);
 
   console.log("Unstaking from all voters");
-  await Promise.all(uniqueVoters.map((voter) => unstakeFromStakedAccount(votingV2, voter)));
+
+  // We must process these in series since these functions have concurrency issues due to changing the block time.
+  for (const voter of uniqueVoters) {
+    await unstakeFromStakedAccount(votingV2, voter);
+  }
 
   const numberSlashedEvents = await getNumberSlashedEvents(votingV2);
   const votingV2BalanceWithoutExternalTransfers = await votingV2VotingBalanceWithoutExternalTransfers(


### PR DESCRIPTION
**Motivation**

This health check was consistently erroring.

**Summary**

Running the calls concurrently causes the timing to change in unpredictable ways, causing some calls to error. This was changed to a for loop to avoid the concurrency/timing issues.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
