### PR TITLE
fix: polymarket notifier to use latest proposal for market

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -54,7 +54,14 @@ export async function monitorTransactionsProposedOrderBook(
   const marketsWithEventData: PolymarketWithEventData[] = marketsWithAncillary
     .filter((market) => proposalEvents.find((event) => event.ancillaryData === market.ancillaryData))
     .map((market) => {
-      const event = proposalEvents.find((event) => event.ancillaryData === market.ancillaryData);
+      const events = proposalEvents.filter((event) => event.ancillaryData === market.ancillaryData);
+      // get last proposal event
+      const event = events.reduce((maxEvent, currentEvent) => {
+        if (currentEvent.proposalTimestamp > maxEvent.proposalTimestamp) {
+          return currentEvent;
+        }
+        return maxEvent;
+      });
       if (!event) throw new Error("Could not find event for market");
       return {
         ...market,

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -57,8 +57,12 @@ export async function monitorTransactionsProposedOrderBook(
       const events = proposalEvents.filter((event) => event.ancillaryData === market.ancillaryData);
       // get last proposal event
       const event = events.reduce((maxEvent, currentEvent) => {
-        if (currentEvent.proposalTimestamp > maxEvent.proposalTimestamp) {
+        if (currentEvent.eventBlockNumber > maxEvent.eventBlockNumber) {
           return currentEvent;
+        } else if (currentEvent.eventBlockNumber === maxEvent.eventBlockNumber) {
+          if (currentEvent.eventIndex > maxEvent.eventIndex) {
+            return currentEvent;
+          }
         }
         return maxEvent;
       });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Previous design was not handling correctly having multiple proposals for the same market

**Summary**

Use the latest price proposal for a market.
