### PR TITLE
feat: polymarket notifier update

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorLogger.ts
@@ -99,3 +99,29 @@ export async function logProposalHighVolume(
     notificationPath: "polymarket-notifier",
   });
 }
+
+export async function logUnknownMarketProposal(
+  logger: typeof Logger,
+  market: {
+    adapterAddress: string;
+    question: string;
+    questionID: string;
+    umaResolutionStatus: string;
+    endDate: string;
+    volumeNum: number;
+  }
+): Promise<void> {
+  logger.error({
+    at: "PolymarketMonitor",
+    message: "Market proposal event not found for proposed market! 🚨",
+    mrkdwn:
+      ` Proposal event not found for market: ${market.question}.` +
+      ` The question ID is ${market.questionID}.` +
+      ` The UMA resolution status is ${market.umaResolutionStatus}.` +
+      ` The end date is ${new Date(market.endDate).toUTCString()}.` +
+      ` The volume is ${market.volumeNum}.` +
+      ` The adapter address is ${market.adapterAddress}.` +
+      " The polymarket-notifier cannot check the market, please verify manually and dispute if necessary.",
+    notificationPath: "polymarket-notifier",
+  });
+}

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorLogger.ts
@@ -50,12 +50,12 @@ export async function logProposalOrderBook(
         ? ` Someone is trying to buy ${market.buyingLoserSide?.size} loser outcome tokens at a price of ${market.buyingLoserSide?.price} on the orderbook.`
         : "") +
       (market.soldWinnerSide.length > 0
-        ? ` Someone has already sold winner outcome tokens at a price below the threshold. These are the trades: ${JSON.stringify(
+        ? ` Someone sold winner outcome tokens at a price below the threshold. These are the trades: ${JSON.stringify(
             market.soldWinnerSide
           )}.`
         : "") +
       (market.boughtLoserSide.length > 0
-        ? ` Someone has already bought loser outcome tokens at a price above the threshold. These are the trades: ${JSON.stringify(
+        ? ` Someone bought loser outcome tokens at a price above the threshold. These are the trades: ${JSON.stringify(
             market.boughtLoserSide
           )}.`
         : "") +
@@ -63,7 +63,39 @@ export async function logProposalOrderBook(
       new Date(market.expirationTimestamp * 1000).toUTCString() +
       ". " +
       generateUILink(market.tx, params.chainId, market.eventIndex) +
-      ". Please check the market proposal and dispute if necessary.",
+      " Please check the market proposal and dispute if necessary.",
+    notificationPath: "polymarket-notifier",
+  });
+}
+
+export async function logProposalHighVolume(
+  logger: typeof Logger,
+  market: {
+    proposedPrice: string;
+    proposalTime: number;
+    proposedOutcome: string;
+    question: string;
+    tx: string;
+    volumeNum: number;
+    outcomes: [string, string];
+    expirationTimestamp: number;
+    eventIndex: number;
+  },
+  params: MonitoringParams
+): Promise<void> {
+  logger.error({
+    at: "PolymarketMonitor",
+    message: "A market with high volume has been proposed and needs to be checked! 🚨",
+    mrkdwn:
+      ` A price of ${market.proposedPrice} corresponding to outcome ${market.proposedOutcome} was proposed at ${market.proposalTime} for the following question:` +
+      ` ${market.question}.` +
+      ` In the following transaction: ` +
+      createEtherscanLinkMarkdown(market.tx, params.chainId) +
+      +" The proposal can be disputed until " +
+      new Date(market.expirationTimestamp * 1000).toUTCString() +
+      ". " +
+      generateUILink(market.tx, params.chainId, market.eventIndex) +
+      " Please check the market proposal and dispute if necessary.",
     notificationPath: "polymarket-notifier",
   });
 }

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -62,17 +62,7 @@ export async function monitorTransactionsProposedOrderBook(
       const events = proposalEvents.filter(
         (event) => event.ancillaryData === market.ancillaryData && event.timestamp === market.requestTimestamp
       );
-      // get last proposal event
-      const event = events.reduce((maxEvent, currentEvent) => {
-        if (currentEvent.eventBlockNumber > maxEvent.eventBlockNumber) {
-          return currentEvent;
-        } else if (currentEvent.eventBlockNumber === maxEvent.eventBlockNumber) {
-          if (currentEvent.eventIndex > maxEvent.eventIndex) {
-            return currentEvent;
-          }
-        }
-        return maxEvent;
-      });
+      const event = events[0];
       if (!event) throw new Error("Could not find event for market");
       return {
         ...market,
@@ -95,7 +85,7 @@ export async function monitorTransactionsProposedOrderBook(
     const complementaryOutcome = proposedOutcome === 0 ? 1 : 0;
     const thresholdAsks = Number(process.env["THRESHOLD_ASKS"]) || 1;
     const thresholdBids = Number(process.env["THRESHOLD_BIDS"]) || 0;
-    const thresholdVolume = Number(process.env["THRESHOLD_VOLUME"]) || 1_000_000;
+    const thresholdVolume = Number(process.env["THRESHOLD_VOLUME"]) || 500000;
 
     const sellingWinnerSide = market.orderBooks[proposedOutcome].asks.find((ask) => ask.price < thresholdAsks);
     const buyingLoserSide = market.orderBooks[complementaryOutcome].bids.find((bid) => bid.price > thresholdBids);

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -57,6 +57,7 @@ export async function monitorTransactionsProposedOrderBook(
     .filter((market) =>
       proposalEvents.find(
         (event) =>
+          [params.binaryAdapterAddress, params.ctfAdapterAddress].includes(event.requester) &&
           event.ancillaryData === market.ancillaryData &&
           event.timestamp === market.requestTimestamp &&
           event.identifier === YES_OR_NO_QUERY
@@ -65,6 +66,7 @@ export async function monitorTransactionsProposedOrderBook(
     .map((market) => {
       const event = proposalEvents.find(
         (event) =>
+          [params.binaryAdapterAddress, params.ctfAdapterAddress].includes(event.requester) &&
           event.ancillaryData === market.ancillaryData &&
           event.timestamp === market.requestTimestamp &&
           event.identifier === YES_OR_NO_QUERY

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -6,6 +6,7 @@ import {
   Logger,
   MonitoringParams,
   PolymarketWithEventData,
+  YES_OR_NO_QUERY,
   formatPriceEvents,
   getContractInstanceWithProvider,
   getMarketKeyToStore,
@@ -55,12 +56,18 @@ export async function monitorTransactionsProposedOrderBook(
   const marketsWithEventData: PolymarketWithEventData[] = marketsWithAncillary
     .filter((market) =>
       proposalEvents.find(
-        (event) => event.ancillaryData === market.ancillaryData && event.timestamp === market.requestTimestamp
+        (event) =>
+          event.ancillaryData === market.ancillaryData &&
+          event.timestamp === market.requestTimestamp &&
+          event.identifier === YES_OR_NO_QUERY
       )
     )
     .map((market) => {
       const event = proposalEvents.find(
-        (event) => event.ancillaryData === market.ancillaryData && event.timestamp === market.requestTimestamp
+        (event) =>
+          event.ancillaryData === market.ancillaryData &&
+          event.timestamp === market.requestTimestamp &&
+          event.identifier === YES_OR_NO_QUERY
       );
       if (!event) throw new Error("Could not find event for market");
       return {

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -16,7 +16,8 @@ import {
   getPolymarketOrderBooks,
   storeNotifiedProposals,
 } from "./common";
-import { logProposalOrderBook } from "./MonitorLogger";
+import { logProposalHighVolume, logProposalOrderBook } from "./MonitorLogger";
+import { Event, ethers } from "ethers";
 
 export async function monitorTransactionsProposedOrderBook(
   logger: typeof Logger,
@@ -39,6 +40,40 @@ export async function monitorTransactionsProposedOrderBook(
     maxBlockLookBack,
   };
 
+  const binaryAdapterAbi = require("./abi/binaryAdapter.json");
+  const ctfAdapterAbi = require("./abi/ctfAdapter.json");
+  const binaryAdapter = new ethers.Contract(params.binaryAdapterAddress, binaryAdapterAbi, params.provider);
+  const ctfAdapter = new ethers.Contract(params.ctfAdapterAddress, ctfAdapterAbi, params.provider);
+  const ctfExchange = new ethers.Contract(
+    params.ctfExchangeAddress,
+    require("./abi/ctfExchange.json"),
+    params.provider
+  );
+
+  const searchConfigCtfAdapter = {
+    fromBlock: 34876144,
+    toBlock: currentBlockNumber,
+    maxBlockLookBack,
+  };
+
+  const searchConfigBinaryAdapter = {
+    fromBlock: 23569780,
+    toBlock: currentBlockNumber,
+    maxBlockLookBack,
+  };
+
+  // const binaryAdapterEvents: Event[] = await paginatedEventQuery(
+  //   binaryAdapter,
+  //   binaryAdapter.filters.QuestionInitialized(),
+  //   searchConfigBinaryAdapter
+  // );
+
+  // const ctfAdapterEvents: Event[] = await paginatedEventQuery(
+  //   ctfAdapter,
+  //   ctfAdapter.filters.QuestionInitialized(),
+  //   searchConfigCtfAdapter
+  // );
+
   const oo = await getContractInstanceWithProvider<OptimisticOracleEthers>("OptimisticOracle", params.provider);
   const oov2 = await getContractInstanceWithProvider<OptimisticOracleV2Ethers>("OptimisticOracleV2", params.provider);
 
@@ -47,33 +82,82 @@ export async function monitorTransactionsProposedOrderBook(
   // Merge the events from both OO versions.
   const proposalEvents = await formatPriceEvents([...eventsOo, ...eventsOov2]);
 
+  const filteredEvents = proposalEvents.filter((event) =>
+    [params.binaryAdapterAddress, params.ctfAdapterAddress].includes(event.requester)
+  );
+
+  // find if there is any event with requester = binaryAdapterAddress
+  const binaryAdapterEvent = filteredEvents.find((event) => event.requester === params.binaryAdapterAddress);
+
+  // find question ids
+  for (const event of filteredEvents) {
+    const ancillaryData = event.ancillaryData;
+    const questionId = ethers.utils.keccak256(ancillaryData);
+    const conditionId = ethers.utils.keccak256(
+      ethers.utils.solidityPack(["address", "bytes32", "uint256"], [params.ctfAdapterAddress, questionId, 2])
+    );
+
+    const tk = await ctfExchange.queryFilter(ctfExchange.filters.TokenRegistered(null, null, conditionId));
+    if (!tk.length) {
+      console.log("no tk");
+    }
+    // get log with biggest logIndex
+    const log = tk.reduce((prev, current) => (prev.logIndex > current.logIndex ? prev : current));
+
+    if (!log || !log.args) throw new Error("no log found");
+    const clobTokenIds = [log.args.token0.toString(), log.args.token1.toString()];
+    // console.log(tk);
+  }
+
   const markets = await getPolymarketMarkets(params);
 
   const marketsWithAncillary = await getMarketsAncillary(params, markets);
-  // Filter out markets that do not have a proposal event.
-  const marketsWithEventData: PolymarketWithEventData[] = marketsWithAncillary
-    .filter((market) => proposalEvents.find((event) => event.ancillaryData === market.ancillaryData))
-    .map((market) => {
-      const events = proposalEvents.filter((event) => event.ancillaryData === market.ancillaryData);
-      // get last proposal event
-      const event = events.reduce((maxEvent, currentEvent) => {
-        if (currentEvent.eventBlockNumber > maxEvent.eventBlockNumber) {
-          return currentEvent;
-        } else if (currentEvent.eventBlockNumber === maxEvent.eventBlockNumber) {
-          if (currentEvent.eventIndex > maxEvent.eventIndex) {
-            return currentEvent;
-          }
-        }
-        return maxEvent;
-      });
-      if (!event) throw new Error("Could not find event for market");
+
+  // 34876144 ctf
+  // 23569780 binary
+
+  // const events: Event[] = await paginatedEventQuery(
+  //   ctfExchange,
+  //   ctfExchange.filters.OrderFilled(null, null, null, null, null, null, null, null),
+  //   searchConfig
+  // );
+
+  // Find corresponding market for each proposal event.
+  const marketsWithEventData: PolymarketWithEventData[] = proposalEvents
+    // .filter((market) => market.expirationTimestamp > Date.now() / 1000)
+    .filter((event) => [params.binaryAdapterAddress, params.ctfAdapterAddress].includes(event.requester))
+    .filter((event) => {
+      const market = marketsWithAncillary.find((market) => event.ancillaryData === market.ancillaryData);
+      if (!market) {
+        // This should never happen but if it does, we want to know about it.
+        logger.error({
+          at: "PolymarketMonitor",
+          message: "Could not find market for proposal event",
+          event,
+        });
+        return false;
+      }
+      // Filter out markets that have already been notified.
+      return !Object.keys(pastNotifiedProposals).includes(
+        getMarketKeyToStore({
+          txHash: event.txHash,
+          question: market.question,
+          proposedPrice: event.proposedPrice,
+          requestTimestamp: event.timestamp,
+        })
+      );
+    })
+    .map((event) => {
+      const market = marketsWithAncillary.find(
+        (market) => event.ancillaryData === market.ancillaryData // && event.timestamp === market.requestTimestamp
+      );
       return {
-        ...market,
+        // disable eslint because we know market is defined here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ...market!,
         ...event,
       };
-    })
-    .filter((market) => market.expirationTimestamp > Date.now() / 1000)
-    .filter((market) => !Object.keys(pastNotifiedProposals).includes(getMarketKeyToStore(market)));
+    });
 
   // Get live order books for markets that have a proposal event.
   const marketsWithOrderBooks = await getPolymarketOrderBooks(params, marketsWithEventData, networker);
@@ -88,6 +172,7 @@ export async function monitorTransactionsProposedOrderBook(
     const complementaryOutcome = proposedOutcome === 0 ? 1 : 0;
     const thresholdAsks = Number(process.env["THRESHOLD_ASKS"]) || 1;
     const thresholdBids = Number(process.env["THRESHOLD_BIDS"]) || 0;
+    const thresholdVolume = Number(process.env["THRESHOLD_VOLUME"]) || 1_000_000;
 
     const sellingWinnerSide = market.orderBooks[proposedOutcome].asks.find((ask) => ask.price < thresholdAsks);
     const buyingLoserSide = market.orderBooks[complementaryOutcome].bids.find((bid) => bid.price > thresholdBids);
@@ -98,6 +183,25 @@ export async function monitorTransactionsProposedOrderBook(
     const boughtLoserSide = market.orderFilledEvents[complementaryOutcome].filter(
       (event) => event.type == "buy" && event.price > thresholdBids
     );
+
+    if (market.volumeNum > thresholdVolume) {
+      await logProposalHighVolume(
+        logger,
+        {
+          proposedPrice: market.proposedPrice,
+          proposedOutcome: market.outcomes[proposedOutcome],
+          proposalTime: market.proposalTimestamp,
+          question: market.question,
+          tx: market.txHash,
+          volumeNum: market.volumeNum,
+          outcomes: market.outcomes,
+          expirationTimestamp: market.expirationTimestamp,
+          eventIndex: market.eventIndex,
+        },
+        params
+      );
+      notifiedProposals.push(market);
+    }
 
     if (sellingWinnerSide || buyingLoserSide || soldWinnerSide.length > 0 || boughtLoserSide.length > 0) {
       await logProposalOrderBook(

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -95,7 +95,7 @@ export async function monitorTransactionsProposedOrderBook(
     const boughtLoserSide = market.orderFilledEvents[complementaryOutcome].filter(
       (event) => event.type == "buy" && event.price > thresholdBids
     );
-
+    let notified = false;
     if (market.volumeNum > thresholdVolume) {
       await logProposalHighVolume(
         logger,
@@ -112,7 +112,10 @@ export async function monitorTransactionsProposedOrderBook(
         },
         params
       );
-      notifiedProposals.push(market);
+      if (!notified) {
+        notified = true;
+        notifiedProposals.push(market);
+      }
     }
 
     if (sellingWinnerSide || buyingLoserSide || soldWinnerSide.length > 0 || boughtLoserSide.length > 0) {
@@ -134,7 +137,10 @@ export async function monitorTransactionsProposedOrderBook(
         },
         params
       );
-      notifiedProposals.push(market);
+      if (!notified) {
+        notified = true;
+        notifiedProposals.push(market);
+      }
     }
   }
   await storeNotifiedProposals(notifiedProposals);

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -73,7 +73,7 @@ export async function monitorTransactionsProposedOrderBook(
         ...event,
       };
     })
-    // .filter((market) => market.expirationTimestamp > Date.now() / 1000)
+    .filter((market) => market.expirationTimestamp > Date.now() / 1000)
     .filter((market) => !Object.keys(pastNotifiedProposals).includes(getMarketKeyToStore(market)));
 
   // Get live order books for markets that have a proposal event.

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -17,7 +17,6 @@ import {
   storeNotifiedProposals,
 } from "./common";
 import { logProposalHighVolume, logProposalOrderBook } from "./MonitorLogger";
-import { Event, ethers } from "ethers";
 
 export async function monitorTransactionsProposedOrderBook(
   logger: typeof Logger,
@@ -40,40 +39,6 @@ export async function monitorTransactionsProposedOrderBook(
     maxBlockLookBack,
   };
 
-  const binaryAdapterAbi = require("./abi/binaryAdapter.json");
-  const ctfAdapterAbi = require("./abi/ctfAdapter.json");
-  const binaryAdapter = new ethers.Contract(params.binaryAdapterAddress, binaryAdapterAbi, params.provider);
-  const ctfAdapter = new ethers.Contract(params.ctfAdapterAddress, ctfAdapterAbi, params.provider);
-  const ctfExchange = new ethers.Contract(
-    params.ctfExchangeAddress,
-    require("./abi/ctfExchange.json"),
-    params.provider
-  );
-
-  const searchConfigCtfAdapter = {
-    fromBlock: 34876144,
-    toBlock: currentBlockNumber,
-    maxBlockLookBack,
-  };
-
-  const searchConfigBinaryAdapter = {
-    fromBlock: 23569780,
-    toBlock: currentBlockNumber,
-    maxBlockLookBack,
-  };
-
-  // const binaryAdapterEvents: Event[] = await paginatedEventQuery(
-  //   binaryAdapter,
-  //   binaryAdapter.filters.QuestionInitialized(),
-  //   searchConfigBinaryAdapter
-  // );
-
-  // const ctfAdapterEvents: Event[] = await paginatedEventQuery(
-  //   ctfAdapter,
-  //   ctfAdapter.filters.QuestionInitialized(),
-  //   searchConfigCtfAdapter
-  // );
-
   const oo = await getContractInstanceWithProvider<OptimisticOracleEthers>("OptimisticOracle", params.provider);
   const oov2 = await getContractInstanceWithProvider<OptimisticOracleV2Ethers>("OptimisticOracleV2", params.provider);
 
@@ -82,82 +47,34 @@ export async function monitorTransactionsProposedOrderBook(
   // Merge the events from both OO versions.
   const proposalEvents = await formatPriceEvents([...eventsOo, ...eventsOov2]);
 
-  const filteredEvents = proposalEvents.filter((event) =>
-    [params.binaryAdapterAddress, params.ctfAdapterAddress].includes(event.requester)
-  );
-
-  // find if there is any event with requester = binaryAdapterAddress
-  const binaryAdapterEvent = filteredEvents.find((event) => event.requester === params.binaryAdapterAddress);
-
-  // find question ids
-  for (const event of filteredEvents) {
-    const ancillaryData = event.ancillaryData;
-    const questionId = ethers.utils.keccak256(ancillaryData);
-    const conditionId = ethers.utils.keccak256(
-      ethers.utils.solidityPack(["address", "bytes32", "uint256"], [params.ctfAdapterAddress, questionId, 2])
-    );
-
-    const tk = await ctfExchange.queryFilter(ctfExchange.filters.TokenRegistered(null, null, conditionId));
-    if (!tk.length) {
-      console.log("no tk");
-    }
-    // get log with biggest logIndex
-    const log = tk.reduce((prev, current) => (prev.logIndex > current.logIndex ? prev : current));
-
-    if (!log || !log.args) throw new Error("no log found");
-    const clobTokenIds = [log.args.token0.toString(), log.args.token1.toString()];
-    // console.log(tk);
-  }
-
   const markets = await getPolymarketMarkets(params);
 
   const marketsWithAncillary = await getMarketsAncillary(params, markets);
 
-  // 34876144 ctf
-  // 23569780 binary
-
-  // const events: Event[] = await paginatedEventQuery(
-  //   ctfExchange,
-  //   ctfExchange.filters.OrderFilled(null, null, null, null, null, null, null, null),
-  //   searchConfig
-  // );
-
-  // Find corresponding market for each proposal event.
-  const marketsWithEventData: PolymarketWithEventData[] = proposalEvents
-    // .filter((market) => market.expirationTimestamp > Date.now() / 1000)
-    .filter((event) => [params.binaryAdapterAddress, params.ctfAdapterAddress].includes(event.requester))
-    .filter((event) => {
-      const market = marketsWithAncillary.find((market) => event.ancillaryData === market.ancillaryData);
-      if (!market) {
-        // This should never happen but if it does, we want to know about it.
-        logger.error({
-          at: "PolymarketMonitor",
-          message: "Could not find market for proposal event",
-          event,
-        });
-        return false;
-      }
-      // Filter out markets that have already been notified.
-      return !Object.keys(pastNotifiedProposals).includes(
-        getMarketKeyToStore({
-          txHash: event.txHash,
-          question: market.question,
-          proposedPrice: event.proposedPrice,
-          requestTimestamp: event.timestamp,
-        })
-      );
-    })
-    .map((event) => {
-      const market = marketsWithAncillary.find(
-        (market) => event.ancillaryData === market.ancillaryData // && event.timestamp === market.requestTimestamp
-      );
+  // Filter out markets that do not have a proposal event.
+  const marketsWithEventData: PolymarketWithEventData[] = marketsWithAncillary
+    .filter((market) => proposalEvents.find((event) => event.ancillaryData === market.ancillaryData))
+    .map((market) => {
+      const events = proposalEvents.filter((event) => event.ancillaryData === market.ancillaryData);
+      // get last proposal event
+      const event = events.reduce((maxEvent, currentEvent) => {
+        if (currentEvent.eventBlockNumber > maxEvent.eventBlockNumber) {
+          return currentEvent;
+        } else if (currentEvent.eventBlockNumber === maxEvent.eventBlockNumber) {
+          if (currentEvent.eventIndex > maxEvent.eventIndex) {
+            return currentEvent;
+          }
+        }
+        return maxEvent;
+      });
+      if (!event) throw new Error("Could not find event for market");
       return {
-        // disable eslint because we know market is defined here.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        ...market!,
+        ...market,
         ...event,
       };
-    });
+    })
+    // .filter((market) => market.expirationTimestamp > Date.now() / 1000)
+    .filter((market) => !Object.keys(pastNotifiedProposals).includes(getMarketKeyToStore(market)));
 
   // Get live order books for markets that have a proposal event.
   const marketsWithOrderBooks = await getPolymarketOrderBooks(params, marketsWithEventData, networker);

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -59,10 +59,9 @@ export async function monitorTransactionsProposedOrderBook(
       )
     )
     .map((market) => {
-      const events = proposalEvents.filter(
+      const event = proposalEvents.find(
         (event) => event.ancillaryData === market.ancillaryData && event.timestamp === market.requestTimestamp
       );
-      const event = events[0];
       if (!event) throw new Error("Could not find event for market");
       return {
         ...market,

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -53,9 +53,15 @@ export async function monitorTransactionsProposedOrderBook(
 
   // Filter out markets that do not have a proposal event.
   const marketsWithEventData: PolymarketWithEventData[] = marketsWithAncillary
-    .filter((market) => proposalEvents.find((event) => event.ancillaryData === market.ancillaryData))
+    .filter((market) =>
+      proposalEvents.find(
+        (event) => event.ancillaryData === market.ancillaryData && event.timestamp === market.requestTimestamp
+      )
+    )
     .map((market) => {
-      const events = proposalEvents.filter((event) => event.ancillaryData === market.ancillaryData);
+      const events = proposalEvents.filter(
+        (event) => event.ancillaryData === market.ancillaryData && event.timestamp === market.requestTimestamp
+      );
       // get last proposal event
       const event = events.reduce((maxEvent, currentEvent) => {
         if (currentEvent.eventBlockNumber > maxEvent.eventBlockNumber) {

--- a/packages/monitor-v2/src/monitor-polymarket/README.md
+++ b/packages/monitor-v2/src/monitor-polymarket/README.md
@@ -23,3 +23,4 @@ All the configuration should be provided with following environment variables:
   in serverless mode will exit after the loop.
 - `THRESHOLD_ASKS` Price threshold for winner outcome asks in the orderbook that triggers a notification (defaults to `1`).
 - `THRESHOLD_BIDS` Price threshold for loser outcome bids in the orderbook that triggers a notification (defaults to `0`).
+- `THRESHOLD_VOLUME` Volume threshold for the market that triggers a notification (defaults to `1000000`).

--- a/packages/monitor-v2/src/monitor-polymarket/README.md
+++ b/packages/monitor-v2/src/monitor-polymarket/README.md
@@ -23,4 +23,4 @@ All the configuration should be provided with following environment variables:
   in serverless mode will exit after the loop.
 - `THRESHOLD_ASKS` Price threshold for winner outcome asks in the orderbook that triggers a notification (defaults to `1`).
 - `THRESHOLD_BIDS` Price threshold for loser outcome bids in the orderbook that triggers a notification (defaults to `0`).
-- `THRESHOLD_VOLUME` Volume threshold for the market that triggers a notification (defaults to `1000000`).
+- `THRESHOLD_VOLUME` Volume threshold for the market that triggers a notification (defaults to `500000`).

--- a/packages/monitor-v2/src/monitor-polymarket/abi/ctfAdapter.json
+++ b/packages/monitor-v2/src/monitor-polymarket/abi/ctfAdapter.json
@@ -1,5 +1,313 @@
 [
   {
+    "inputs": [
+      { "internalType": "address", "name": "_ctf", "type": "address" },
+      { "internalType": "address", "name": "_finder", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "Flagged", "type": "error" },
+  { "inputs": [], "name": "Initialized", "type": "error" },
+  { "inputs": [], "name": "InvalidAncillaryData", "type": "error" },
+  { "inputs": [], "name": "InvalidOOPrice", "type": "error" },
+  { "inputs": [], "name": "InvalidPayouts", "type": "error" },
+  { "inputs": [], "name": "NotAdmin", "type": "error" },
+  { "inputs": [], "name": "NotFlagged", "type": "error" },
+  { "inputs": [], "name": "NotInitialized", "type": "error" },
+  { "inputs": [], "name": "NotOptimisticOracle", "type": "error" },
+  { "inputs": [], "name": "NotReadyToResolve", "type": "error" },
+  { "inputs": [], "name": "Paused", "type": "error" },
+  { "inputs": [], "name": "PriceNotAvailable", "type": "error" },
+  { "inputs": [], "name": "Resolved", "type": "error" },
+  { "inputs": [], "name": "SafetyPeriodNotPassed", "type": "error" },
+  { "inputs": [], "name": "UnsupportedToken", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "update", "type": "bytes" }
+    ],
+    "name": "AncillaryDataUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "admin", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newAdminAddress", "type": "address" }
+    ],
+    "name": "NewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256[]", "name": "payouts", "type": "uint256[]" }
+    ],
+    "name": "QuestionEmergencyResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "QuestionFlagged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "indexed": true, "internalType": "uint256", "name": "requestTimestamp", "type": "uint256" },
+      { "indexed": true, "internalType": "address", "name": "creator", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": false, "internalType": "address", "name": "rewardToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reward", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "proposalBond", "type": "uint256" }
+    ],
+    "name": "QuestionInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "QuestionPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "QuestionReset",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "indexed": true, "internalType": "int256", "name": "settledPrice", "type": "int256" },
+      { "indexed": false, "internalType": "uint256[]", "name": "payouts", "type": "uint256[]" }
+    ],
+    "name": "QuestionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "QuestionUnpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "admin", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "removedAdmin", "type": "address" }
+    ],
+    "name": "RemovedAdmin",
+    "type": "event"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "admin", "type": "address" }],
+    "name": "addAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "admins",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "collateralWhitelist",
+    "outputs": [{ "internalType": "contract IAddressWhitelist", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ctf",
+    "outputs": [{ "internalType": "contract IConditionalTokens", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "internalType": "uint256[]", "name": "payouts", "type": "uint256[]" }
+    ],
+    "name": "emergencyResolve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "emergencySafetyPeriod",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "flag",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "getExpectedPayouts",
+    "outputs": [{ "internalType": "uint256[]", "name": "", "type": "uint256[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "getLatestUpdate",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+          { "internalType": "bytes", "name": "update", "type": "bytes" }
+        ],
+        "internalType": "struct BulletinBoard.AncillaryDataUpdate",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "getQuestion",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "requestTimestamp", "type": "uint256" },
+          { "internalType": "uint256", "name": "reward", "type": "uint256" },
+          { "internalType": "uint256", "name": "proposalBond", "type": "uint256" },
+          { "internalType": "uint256", "name": "emergencyResolutionTimestamp", "type": "uint256" },
+          { "internalType": "bool", "name": "resolved", "type": "bool" },
+          { "internalType": "bool", "name": "paused", "type": "bool" },
+          { "internalType": "bool", "name": "reset", "type": "bool" },
+          { "internalType": "address", "name": "rewardToken", "type": "address" },
+          { "internalType": "address", "name": "creator", "type": "address" },
+          { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+        ],
+        "internalType": "struct QuestionData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "getUpdates",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+          { "internalType": "bytes", "name": "update", "type": "bytes" }
+        ],
+        "internalType": "struct BulletinBoard.AncillaryDataUpdate[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "address", "name": "rewardToken", "type": "address" },
+      { "internalType": "uint256", "name": "reward", "type": "uint256" },
+      { "internalType": "uint256", "name": "proposalBond", "type": "uint256" }
+    ],
+    "name": "initialize",
+    "outputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "addr", "type": "address" }],
+    "name": "isAdmin",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "isFlagged",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "isInitialized",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxAncillaryData",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "optimisticOracle",
+    "outputs": [{ "internalType": "contract IOptimisticOracleV2", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "questionID", "type": "bytes32" },
+      { "internalType": "bytes", "name": "update", "type": "bytes" }
+    ],
+    "name": "postUpdate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "", "type": "bytes32" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "priceDisputed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
     "name": "questions",
     "outputs": [
@@ -14,6 +322,62 @@
       { "internalType": "address", "name": "creator", "type": "address" },
       { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
     ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "ready",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "admin", "type": "address" }],
+    "name": "removeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceAdmin", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "reset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "resolve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "questionID", "type": "bytes32" }],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "", "type": "bytes32" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "updates",
+    "outputs": [
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "update", "type": "bytes" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "yesOrNoIdentifier",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
     "stateMutability": "view",
     "type": "function"
   }

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -31,6 +31,12 @@ export interface TradeInformation {
   timestamp: number;
 }
 
+export interface MarketKeyStoreData {
+  txHash: string;
+  question: string;
+  proposedPrice: string;
+}
+
 export interface MonitoringParams {
   binaryAdapterAddress: string;
   ctfAdapterAddress: string;
@@ -71,7 +77,7 @@ interface PolymarketMarketGraphql {
   umaResolutionStatus: string;
 }
 
-interface PolymarketMarketWithAncillaryData extends PolymarketMarket {
+export interface PolymarketMarketWithAncillaryData extends PolymarketMarket {
   ancillaryData: string;
   requestTimestamp: string;
 }
@@ -481,12 +487,14 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
   };
 };
 
-export const getMarketKeyToStore = (market: {
-  txHash: string;
-  question: string;
-  proposedPrice: string;
-  requestTimestamp?: string;
-}): string => {
+export const getUnknownProposalKeyData = (question: string): MarketKeyStoreData & { requestTimestamp: string } => ({
+  txHash: "unknown",
+  question: question,
+  proposedPrice: "unknown",
+  requestTimestamp: "unknown",
+});
+
+export const getMarketKeyToStore = (market: MarketKeyStoreData & { requestTimestamp?: string }): string => {
   return market.txHash + "_" + market.question + "_" + market.proposedPrice + "_" + (market.requestTimestamp || "");
 };
 

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -10,7 +10,12 @@ import { createNewLogger, spyLogIncludes, spyLogLevel, SpyTransport } from "@uma
 import { assert } from "chai";
 import sinon from "sinon";
 import * as commonModule from "../src/monitor-polymarket/common";
-import { MonitoringParams, TradeInformation } from "../src/monitor-polymarket/common";
+import {
+  MonitoringParams,
+  TradeInformation,
+  getMarketKeyToStore,
+  getUnknownProposalKeyData,
+} from "../src/monitor-polymarket/common";
 import { monitorTransactionsProposedOrderBook } from "../src/monitor-polymarket/MonitorProposalsOrderBook";
 import { umaEcosystemFixture } from "./fixtures/UmaEcosystem.Fixture";
 import { formatBytes32String, getContractFactory, hre, Provider, Signer, toUtf8Bytes } from "./utils";
@@ -18,6 +23,7 @@ import { formatBytes32String, getContractFactory, hre, Provider, Signer, toUtf8B
 const ethers = hre.ethers;
 
 describe("PolymarketNotifier", function () {
+  let sandbox: sinon.SinonSandbox;
   let oov2: OptimisticOracleV2Ethers;
   let deployer: Signer;
   let votingToken: VotingTokenEthers;
@@ -26,8 +32,8 @@ describe("PolymarketNotifier", function () {
 
   const mockData: any[] = [
     {
-      resolvedBy: "",
-      questionID: "",
+      resolvedBy: "0x1234",
+      questionID: "0x123456789",
       createdAt: "2023-01-30 19:06:23.106+00",
       question: "Will NATO expand by June 30?",
       outcomes: ["Yes", "No"],
@@ -50,16 +56,27 @@ describe("PolymarketNotifier", function () {
       proposalTimestamp: 1680615675,
       identifier,
       eventIndex: 366,
+      umaResolutionStatus: "requested",
+      orderBooks: [
+        {
+          bids: [],
+          asks: [],
+        },
+        {
+          bids: [],
+          asks: [],
+        },
+      ],
     },
   ];
 
   // Create monitoring params for single block to pass to monitor modules.
   const createMonitoringParams = async (): Promise<MonitoringParams> => {
-    const binaryAdapterAddress = "dummy";
-    const ctfAdapterAddress = "dummy";
-    const ctfExchangeAddress = "dummy";
-    const graphqlEndpoint = "dummy";
-    const apiEndpoint = "dummy";
+    const binaryAdapterAddress = "0x1234";
+    const ctfAdapterAddress = "0x1234";
+    const ctfExchangeAddress = "0x1234";
+    const graphqlEndpoint = "endpoint";
+    const apiEndpoint = "endpoint";
 
     return {
       binaryAdapterAddress,
@@ -75,6 +92,8 @@ describe("PolymarketNotifier", function () {
   };
 
   beforeEach(async function () {
+    sandbox = sinon.createSandbox();
+
     // Signer from ethers and hardhat-ethers are not version compatible, thus, we cannot use the SignerWithAddress.
     [deployer] = (await ethers.getSigners()) as Signer[];
 
@@ -108,22 +127,23 @@ describe("PolymarketNotifier", function () {
     await (await identifierWhitelist.addSupportedIdentifier(identifier)).wait();
     await (await collateralWhitelist.addToWhitelist(votingToken.address)).wait();
 
-    // clear all mocks
-    sinon.restore();
-
-    const getNotifiedProposalsMock = sinon.stub();
+    const getNotifiedProposalsMock = sandbox.stub();
     getNotifiedProposalsMock.returns({});
-    sinon.stub(commonModule, "getNotifiedProposals").callsFake(getNotifiedProposalsMock);
+    sandbox.stub(commonModule, "getNotifiedProposals").callsFake(getNotifiedProposalsMock);
 
-    const storeNotifiedProposalsMock = sinon.stub();
+    const storeNotifiedProposalsMock = sandbox.stub();
     storeNotifiedProposalsMock.returns({});
-    sinon.stub(commonModule, "storeNotifiedProposals").callsFake(storeNotifiedProposalsMock);
+    sandbox.stub(commonModule, "storeNotifiedProposals").callsFake(storeNotifiedProposalsMock);
 
     // Fund staker and stake tokens.
     const TEN_MILLION = ethers.utils.parseEther("10000000");
     await (await votingToken.addMinter(await deployer.getAddress())).wait();
     await (await votingToken.mint(await deployer.getAddress(), TEN_MILLION)).wait();
     await (await votingToken.connect(deployer).approve(oov2.address, TEN_MILLION)).wait();
+  });
+
+  afterEach(async function () {
+    sandbox.restore();
   });
 
   it("It should notify if there are orders over the threshold", async function () {
@@ -143,12 +163,12 @@ describe("PolymarketNotifier", function () {
       },
     ];
 
-    const mockDataFunction = sinon.stub();
+    const mockDataFunction = sandbox.stub();
     mockDataFunction.returns(mockData);
-    sinon.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
 
     await oov2.requestPrice(identifier, 1, mockData[0].ancillaryData, votingToken.address, 0);
     await oov2.proposePrice(await deployer.getAddress(), identifier, 1, mockData[0].ancillaryData, 1);
@@ -181,12 +201,12 @@ describe("PolymarketNotifier", function () {
       },
     ];
 
-    const mockDataFunction = sinon.stub();
+    const mockDataFunction = sandbox.stub();
     mockDataFunction.returns(mockData);
-    sinon.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
 
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();
@@ -220,12 +240,12 @@ describe("PolymarketNotifier", function () {
       [],
     ];
 
-    const mockDataFunction = sinon.stub();
+    const mockDataFunction = sandbox.stub();
     mockDataFunction.returns(mockData);
-    sinon.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
 
     await oov2.requestPrice(identifier, 1, mockData[0].ancillaryData, votingToken.address, 0);
     await oov2.proposePrice(await deployer.getAddress(), identifier, 1, mockData[0].ancillaryData, 1);
@@ -276,12 +296,12 @@ describe("PolymarketNotifier", function () {
       ] as TradeInformation[],
     ];
 
-    const mockDataFunction = sinon.stub();
+    const mockDataFunction = sandbox.stub();
     mockDataFunction.returns(mockData);
-    sinon.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
 
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();
@@ -305,7 +325,6 @@ describe("PolymarketNotifier", function () {
     ); // price
     assert.equal(spy.getCall(0).lastArg.notificationPath, "polymarket-notifier");
   });
-
   it("It should notify if there are proposals with high volume", async function () {
     mockData[0].proposedPrice = "1.0";
     mockData[0].orderBooks = [
@@ -320,12 +339,12 @@ describe("PolymarketNotifier", function () {
     ];
     mockData[0].orderFilledEvents = [[], [] as TradeInformation[]];
 
-    const mockDataFunction = sinon.stub();
+    const mockDataFunction = sandbox.stub();
     mockDataFunction.returns([{ ...mockData[0], volumeNum: 2_000_000 }]);
-    sinon.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
 
     await oov2.requestPrice(identifier, 1, mockData[0].ancillaryData, votingToken.address, 0);
     await oov2.proposePrice(await deployer.getAddress(), identifier, 1, mockData[0].ancillaryData, 1);
@@ -345,6 +364,54 @@ describe("PolymarketNotifier", function () {
     assert.equal(spyLogLevel(spy, 0), "error");
     assert.isTrue(spy.getCall(0).toString().includes(mockData[0].question));
     assert.equal(spy.getCall(0).lastArg.notificationPath, "polymarket-notifier");
+  });
+  it("It should notify if market adapter is unknown", async function () {
+    const mockDataFunction = sandbox.stub();
+    mockDataFunction.returns([{ ...mockData[0], resolvedBy: "unknown", umaResolutionStatus: "proposed" }]);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+
+    // Call monitorAssertions directly for the block when the assertion was made.
+    const spy = sinon.spy();
+    const spyLogger = createNewLogger([new SpyTransport({}, { spy: spy })]);
+    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams());
+
+    // The spy should have been called as the market adapter is unknown.
+    assert.equal(spy.callCount, 1);
+    assert.equal(spy.getCall(0).lastArg.at, "PolymarketMonitor");
+    assert.equal(spy.getCall(0).lastArg.message, "Market proposal event not found for proposed market! 🚨");
+    assert.equal(spyLogLevel(spy, 0), "error");
+    assert.isTrue(spy.getCall(0).toString().includes(`Proposal event not found for market: ${mockData[0].question}`));
+    assert.equal(spy.getCall(0).lastArg.notificationPath, "polymarket-notifier");
+  });
+  it("It should not notify if unknown market adapter was already notified", async function () {
+    sandbox.restore();
+    const mockDataFunction = sandbox.stub();
+    mockDataFunction.returns([{ ...mockData[0], resolvedBy: "unknown", umaResolutionStatus: "proposed" }]);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+
+    const storeNotifiedProposalsMock = sandbox.stub();
+    storeNotifiedProposalsMock.returns({});
+    sandbox.stub(commonModule, "storeNotifiedProposals").callsFake(storeNotifiedProposalsMock);
+
+    const getNotifiedProposalsMock = sandbox.stub();
+    getNotifiedProposalsMock.returns({
+      [getMarketKeyToStore(getUnknownProposalKeyData(mockData[0].question))]: {},
+    });
+    sandbox.replace(commonModule, "getNotifiedProposals", getNotifiedProposalsMock);
+
+    // Call monitorAssertions directly for the block when the assertion was made.
+    const spy = sinon.spy();
+    const spyLogger = createNewLogger([new SpyTransport({}, { spy: spy })]);
+    await monitorTransactionsProposedOrderBook(spyLogger, await createMonitoringParams());
+
+    // The spy should not have been called as the market adapter is unknown and was already notified.
+    assert.equal(spy.callCount, 0);
   });
 
   it("It should notify two times if there are buy trades over the threshold and it's a high volume market proposal", async function () {
@@ -371,17 +438,17 @@ describe("PolymarketNotifier", function () {
       ] as TradeInformation[],
     ];
 
-    const mockDataFunction = sinon.stub();
+    const mockDataFunction = sandbox.stub();
     mockDataFunction.returns([{ ...mockData[0], volumeNum: 2_000_000 }]);
-    sinon.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
-    sinon.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketMarkets").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getMarketsAncillary").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getPolymarketOrderBooks").callsFake(mockDataFunction);
+    sandbox.stub(commonModule, "getOrderFilledEvents").callsFake(mockDataFunction);
 
     // unwrap the storeNotifiedProposals function to check the arguments
-    const storeNotifiedProposalsMock = sinon.stub();
+    const storeNotifiedProposalsMock = sandbox.stub();
     storeNotifiedProposalsMock.returns({});
-    sinon.replace(commonModule, "storeNotifiedProposals", storeNotifiedProposalsMock);
+    sandbox.replace(commonModule, "storeNotifiedProposals", storeNotifiedProposalsMock);
 
     // Call monitorAssertions directly for the block when the assertion was made.
     const spy = sinon.spy();

--- a/packages/monitor-v2/test/fixtures/UmaEcosystem.Fixture.ts
+++ b/packages/monitor-v2/test/fixtures/UmaEcosystem.Fixture.ts
@@ -58,6 +58,8 @@ export const umaEcosystemFixture = hre.deployments.createFixture(
     await finder.changeImplementationAddress(formatBytes32String("IdentifierWhitelist"), identifierWhitelist.address);
     await finder.changeImplementationAddress(formatBytes32String("Oracle"), mockOracle.address);
 
+    await collateralWhitelist.whitelist(votingToken.address);
+
     await store.setFinalFee(votingToken.address, { rawValue: utils.parseEther("1.0") });
     // Add voting token to global hardhatTestingAddresses.
     addGlobalHardhatTestingAddress("VotingToken", votingToken.address);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

- Notify if proposals are for markets with volume over a certain threshold that can be configured. (default to `500_000`)
- Add pagination to graphql queries: this was just implemented to the polymarket API.
- Filter market proposals with request timestamp and ancillary data to handle situation where 2 polymarket markets have the same ancillary data

Fixes UMA-1525, UMA-1524

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
