### PR TITLE
fix: polymarket order filled filtering

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -232,7 +232,9 @@ export const getOrderFilledEvents = async (
       const outcomeTokenOne = await Promise.all(
         events
           .filter((event) => {
-            return market.clobTokenIds[0] == event?.args?.takerAssetId.toString();
+            return [event?.args?.takerAssetId.toString(), event?.args?.makerAssetId.toString()].includes(
+              market.clobTokenIds[0]
+            );
           })
           .map((event) => getTradeInfoFromOrderFilledEvent(params.provider, event))
       );
@@ -240,7 +242,9 @@ export const getOrderFilledEvents = async (
       const outcomeTokenTwo = await Promise.all(
         events
           .filter((event) => {
-            return market.clobTokenIds[1] == event?.args?.makerAssetId.toString();
+            return [event?.args?.takerAssetId.toString(), event?.args?.makerAssetId.toString()].includes(
+              market.clobTokenIds[1]
+            );
           })
           .map((event) => getTradeInfoFromOrderFilledEvent(params.provider, event))
       );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

There was a bug in the OrderFilled filtering in the polymarket notifier only considering buys of `outcomeToken0` and sells of `outcomeToken1`


**Summary**

Fix `OrderFilled` filtering

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
