### PR TITLE
fix: add ethers types to contracts-node and contracts-frontend

### DIFF
--- a/packages/common/src/hardhat/tasks/artifacts.ts
+++ b/packages/common/src/hardhat/tasks/artifacts.ts
@@ -225,11 +225,16 @@ task("generate-contracts-node", "Generate typescipt for the contracts-node packa
       if (
         fs.existsSync(`typechain/${packageName}/ethers/${contractName}.d.ts`) ||
         fs.existsSync(`typechain/${packageName}/ethers/${contractName}.ts`)
-      )
+      ) {
+        fs.appendFileSync(
+          out,
+          `export * as ${contractName}EthersTypes from "../typechain/${packageName}/ethers/${contractName}";\n`
+        );
         fs.appendFileSync(
           out,
           `export type { ${contractName} as ${contractName}Ethers } from "../typechain/${packageName}/ethers";\n`
         );
+      }
     });
 
     artifacts.forEach(({ contractName, packageName }) => {


### PR DESCRIPTION
**Motivation**

Importing ethers event types from contracts-node doesn't work.

**Summary**

You can now import ethers event types by doing the following:
```
import { MyContractEthersTypes } from "@uma/contracts-node";

const myVar: MyContractEthersTypes.SomeEvent = ...
```


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
