### PR TITLE
fix(monitor-v2): use sets for osnap bots

### DIFF
--- a/packages/monitor-v2/src/monitor-og/SnapshotVerification.ts
+++ b/packages/monitor-v2/src/monitor-og/SnapshotVerification.ts
@@ -446,13 +446,15 @@ const hasBeenExecuted = async (
   );
 
   // Return true if any of the matching proposals have been executed.
-  const executedAssertionIds = (
-    await runQueryFilter<ProposalExecutedEvent>(og, og.filters.ProposalExecuted(), {
-      start: 0,
-      end: currentProposal.blockNumber,
-    })
-  ).map((executedProposal) => executedProposal.args.assertionId);
-  return matchingProposals.some((matchingProposal) => executedAssertionIds.includes(matchingProposal.args.assertionId));
+  const executedAssertionIds = new Set(
+    (
+      await runQueryFilter<ProposalExecutedEvent>(og, og.filters.ProposalExecuted(), {
+        start: 0,
+        end: currentProposal.blockNumber,
+      })
+    ).map((executedProposal) => executedProposal.args.assertionId)
+  );
+  return matchingProposals.some((matchingProposal) => executedAssertionIds.has(matchingProposal.args.assertionId));
 };
 
 export const verifyProposal = async (

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -253,15 +253,16 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     start: 0,
     end: initialParams.blockRange.end,
   });
+  const deployedProxyAddressesSet = new Set(deployedProxyAddresses);
   const ogWhitelist: string[] = env.OG_WHITELIST ? JSON.parse(env.OG_WHITELIST) : [];
   const ogBlacklist: string[] = env.OG_BLACKLIST ? JSON.parse(env.OG_BLACKLIST) : [];
   ogWhitelist.forEach((address) => {
-    if (!deployedProxyAddresses.includes(utils.getAddress(address))) {
+    if (!deployedProxyAddressesSet.has(utils.getAddress(address))) {
       throw new Error(`OG_WHITELIST contains address ${address} that is not a deployed proxy`);
     }
   });
   ogBlacklist.forEach((address) => {
-    if (!deployedProxyAddresses.includes(utils.getAddress(address))) {
+    if (!deployedProxyAddressesSet.has(utils.getAddress(address))) {
       throw new Error(`OG_BLACKLIST contains address ${address} that is not a deployed proxy`);
     }
   });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Improve oSnap bot efficiency as pointed out in [this comment](https://github.com/UMAprotocol/protocol/pull/4591#discussion_r1262823869).

**Summary**

Uses Sets with `has` instead of Arrays with `includes` when matching elements in dynamic range addresses/events.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1651/optimize-osnap-bot-event-matching-with-set
