### PR TITLE
feat(monitor-v2): add disable tx option on osnap automation

### DIFF
--- a/packages/monitor-v2/src/monitor-og/README.md
+++ b/packages/monitor-v2/src/monitor-og/README.md
@@ -62,6 +62,10 @@ All the configuration should be provided with following environment variables:
   `MNEMONIC` for signing execution transactions.
 - `SUPPORTED_BONDS` is a mapping of supported bond tokens and bond values. This is required when running in automated
   support mode. Only oSnap modules with exact match of bond token and bond value will be supported.
+- `SUBMIT_AUTOMATION` is boolean enabling/disabling transaction submission in any of automated support modes (`true` by
+  default). If this is set to `false`, the bot will only simulate transaction submission and log the results. Note that
+  bond approval transactions would be still submitted as they are required for the subsequent proposal/dispute
+  simulation.
 - `SNAPSHOT_ENDPOINT` is the Snapshot endpoint used to verify Snapshot proposals. If not provided, this defaults to
   `https://snapshot.org`.
 - `GRAPHQL_ENDPOINT` is the GraphQL endpoint used to verify Snapshot proposals. If not provided, this defaults to

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -65,6 +65,7 @@ export interface MonitoringParams {
   ipfsEndpoint: string;
   approvalChoices: string[];
   supportedBonds?: SupportedBonds; // Optional. Only used in automated support mode.
+  submitAutomation: boolean; // Defaults to true, but only used in automated support mode.
   useTenderly: boolean;
   botModes: BotModes;
   retryOptions: RetryOptions;
@@ -205,6 +206,10 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     signer = await getSigner(env, provider);
   }
 
+  // By default, submit automation mode transactions (propose/dispute/execute) unless explicitly disabled. This does not
+  // apply to bond approvals as these are always submitted on chain.
+  const submitAutomation = env.SUBMIT_AUTOMATION === "false" ? false : true;
+
   // Mastercopy and module proxy factory addresses are required when monitoring proxy deployments or when not
   // explicitly providing OG_ADDRESS to monitor in other modes.
   if (
@@ -237,6 +242,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     ipfsEndpoint,
     approvalChoices,
     supportedBonds,
+    submitAutomation,
     useTenderly,
     botModes,
     retryOptions,

--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -405,8 +405,8 @@ const submitProposals = async (
     });
     const explanation = ethersUtils.toUtf8Bytes(proposal.ipfs);
 
-    // Create potential error log for simulating/proposing.
-    const proposalErrorLog = {
+    // Create potential log for simulating/proposing.
+    const proposalAttemptLog = {
       at: "oSnapAutomation",
       mrkdwn:
         "Trying to submit proposal for " +
@@ -426,7 +426,7 @@ const submitProposals = async (
       // TODO: We should separately handle the duplicate proposals error. This can occur if there are multiple proposals
       // with the same transactions (e.g. funding in same amount tranches split across multiple proposals). We should
       // only warn when first encountering the blocking proposal and then ignore it in any future runs.
-      logger.error({ ...proposalErrorLog, message: "Proposal submission would fail!", error });
+      logger.error({ ...proposalAttemptLog, message: "Proposal submission would fail!", error });
       continue;
     }
 
@@ -437,7 +437,7 @@ const submitProposals = async (
       receipt = await tx.wait();
     } catch (error) {
       // Log error and proceed with the next proposal.
-      logger.error({ ...proposalErrorLog, message: "Proposal submission failed!", error });
+      logger.error({ ...proposalAttemptLog, message: "Proposal submission failed!", error });
       continue;
     }
 
@@ -475,8 +475,8 @@ const submitDisputes = async (logger: typeof Logger, proposals: DisputablePropos
       oo.address
     );
 
-    // Create potential error log for simulating/disputing.
-    const disputeErrorLog = {
+    // Create potential log for simulating/disputing.
+    const disputeAttemptLog = {
       at: "oSnapAutomation",
       mrkdwn:
         "Trying to submit dispute on assertionId " +
@@ -497,7 +497,7 @@ const submitDisputes = async (logger: typeof Logger, proposals: DisputablePropos
       });
     } catch (error) {
       // Log error and proceed with the next dispute.
-      logger.error({ ...disputeErrorLog, message: "Dispute submission would fail!", error });
+      logger.error({ ...disputeAttemptLog, message: "Dispute submission would fail!", error });
       continue;
     }
 
@@ -508,7 +508,7 @@ const submitDisputes = async (logger: typeof Logger, proposals: DisputablePropos
       receipt = await tx.wait();
     } catch (error) {
       // Log error and proceed with the next dispute.
-      logger.error({ ...disputeErrorLog, message: "Dispute submission failed!", error });
+      logger.error({ ...disputeAttemptLog, message: "Dispute submission failed!", error });
       continue;
     }
 
@@ -526,8 +526,8 @@ const submitExecutions = async (logger: typeof Logger, proposals: SupportedPropo
   for (const proposal of proposals) {
     const og = await getOgByAddress(params, proposal.event.address);
 
-    // Create potential error log for simulating/executing.
-    const executionErrorLog = {
+    // Create potential log for simulating/executing.
+    const executionAttemptLog = {
       at: "oSnapAutomation",
       mrkdwn:
         "Trying to execute proposal with proposalHash " +
@@ -546,7 +546,7 @@ const submitExecutions = async (logger: typeof Logger, proposals: SupportedPropo
       // The execution might revert for various reasons (e.g. insufficient funds in safe, transaction guard blocking or
       // the module has been unplugged). In most of these cases there is nothing the on-call can do, thus log this at
       // warn level and proceed with the next execution.
-      logger.info({ ...executionErrorLog, message: "Proposal execution would fail!", error });
+      logger.info({ ...executionAttemptLog, message: "Proposal execution would fail!", error });
       continue;
     }
 
@@ -557,7 +557,7 @@ const submitExecutions = async (logger: typeof Logger, proposals: SupportedPropo
       receipt = await tx.wait();
     } catch (error) {
       // Log error and proceed with the next execution.
-      logger.error({ ...executionErrorLog, message: "Proposal execution failed!", error });
+      logger.error({ ...executionAttemptLog, message: "Proposal execution failed!", error });
       continue;
     }
 

--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -430,6 +430,12 @@ const submitProposals = async (
       continue;
     }
 
+    // If submitting transactions is disabled, log the proposal attempt and proceed with the next proposal.
+    if (!params.submitAutomation) {
+      logger.info({ ...proposalAttemptLog, message: "Proposal transaction would succeed" });
+      continue;
+    }
+
     // Submit proposal and get receipt.
     let receipt: ContractReceipt;
     try {
@@ -501,6 +507,12 @@ const submitDisputes = async (logger: typeof Logger, proposals: DisputablePropos
       continue;
     }
 
+    // If submitting transactions is disabled, log the dispute attempt and proceed with the next dispute.
+    if (!params.submitAutomation) {
+      logger.info({ ...disputeAttemptLog, message: "Dispute transaction would succeed" });
+      continue;
+    }
+
     // Submit dispute and get receipt.
     let receipt: ContractReceipt;
     try {
@@ -547,6 +559,12 @@ const submitExecutions = async (logger: typeof Logger, proposals: SupportedPropo
       // the module has been unplugged). In most of these cases there is nothing the on-call can do, thus log this at
       // warn level and proceed with the next execution.
       logger.info({ ...executionAttemptLog, message: "Proposal execution would fail!", error });
+      continue;
+    }
+
+    // If submitting transactions is disabled, log the execution attempt and proceed with the next execution.
+    if (!params.submitAutomation) {
+      logger.info({ ...executionAttemptLog, message: "Execution transaction would succeed" });
       continue;
     }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Before oSnap automation bots are deployed in production it would benefit testing them in real environment without actually submitting transactions on-chain.

**Summary**

Adds SUBMIT_AUTOMATION environment that allows disabling tx submission when set to false.

**Details**

When SUBMIT_AUTOMATION is set to false, the bot only logs the attempted transaction without submitting it on-chain. This does not apply to bond approvals as they are still required for subsequent static calls to proposal/dispute.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1661/osnap-bot-should-have-option-not-to-submit-tx-while-testing
