### PR TITLE
fix(financial-templates-lib): remove anchor text from pd links

### DIFF
--- a/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
+++ b/packages/financial-templates-lib/src/logger/PagerDutyV2Transport.ts
@@ -3,6 +3,7 @@ import Transport from "winston-transport";
 import { event } from "@pagerduty/pdjs";
 import * as ss from "superstruct";
 
+import { removeAnchorTextFromLinks } from "./Formatters";
 import { TransportError } from "./TransportError";
 
 type TransportOptions = ConstructorParameters<typeof Transport>[0];
@@ -52,6 +53,8 @@ export class PagerDutyV2Transport extends Transport {
     try {
       // we route to different pd services using the integration key (routing_key), or multiple services with the custom services object
       const routing_key = this.customServices[info.notificationPath] ?? this.integrationKey;
+      // PagerDuty does not support anchor text in links, so we remove it from markdown if it exists.
+      if (typeof info.mrkdwn === "string") info.mrkdwn = removeAnchorTextFromLinks(info.mrkdwn);
       await event({
         data: {
           routing_key,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

When bot sends link in Markdown formatted as <URL|TEXT> the PagerDuty does not resolve URL correctly as |TEXT is added to URL.

**Summary**

Removes anchor text from links in PagerDuty transports.

**Details**

This uses removeAnchorTextFromLinks that was created for DiscordTicketTransport.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1633/fix-markdown-links-for-pagerduty
