### PR TITLE
fix: add event index to oo contract monitor

### DIFF
--- a/packages/financial-templates-lib/src/clients/OptimisticOracleEventClient.ts
+++ b/packages/financial-templates-lib/src/clients/OptimisticOracleEventClient.ts
@@ -12,6 +12,7 @@ import { OptimisticOracleContract, OptimisticOracleType } from "./OptimisticOrac
 interface TransactionMetadata {
   transactionHash: string;
   blockNumber: number;
+  logIndex: number;
 }
 
 type EventExport<T extends { returnValues: any }> = T["returnValues"] & TransactionMetadata;
@@ -187,6 +188,7 @@ export class OptimisticOracleEventClient {
           ...(event as SkinnyOptimisticOracleWeb3Events.RequestPrice).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
         });
@@ -195,6 +197,7 @@ export class OptimisticOracleEventClient {
           ...(event as OptimisticOracleWeb3Events.RequestPrice).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
         });
@@ -208,6 +211,7 @@ export class OptimisticOracleEventClient {
           ...(event as SkinnyOptimisticOracleWeb3Events.ProposePrice).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
         });
@@ -216,6 +220,7 @@ export class OptimisticOracleEventClient {
           ...(event as OptimisticOracleWeb3Events.ProposePrice).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
         });
@@ -229,6 +234,7 @@ export class OptimisticOracleEventClient {
           ...(event as SkinnyOptimisticOracleWeb3Events.DisputePrice).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
         });
@@ -245,6 +251,7 @@ export class OptimisticOracleEventClient {
           ...(event as OptimisticOracleWeb3Events.DisputePrice).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
           currency: requestData.currency,
@@ -259,6 +266,7 @@ export class OptimisticOracleEventClient {
           ...(event as SkinnyOptimisticOracleWeb3Events.Settle).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
           // Note: The only param not included in the Skinny version of this event that is included in the normal
@@ -278,6 +286,7 @@ export class OptimisticOracleEventClient {
           ...(event as OptimisticOracleWeb3Events.Settle).returnValues,
           transactionHash: event.transactionHash,
           blockNumber: event.blockNumber,
+          logIndex: event.logIndex,
           identifier: this.hexToUtf8(event.returnValues.identifier),
           ancillaryData: event.returnValues.ancillaryData ? event.returnValues.ancillaryData : "0x",
           currency: requestData.currency,

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -54,7 +54,7 @@ class OptimisticOracleContractMonitor {
       },
       optimisticOracleUIBaseUrl: {
         // Base URL for the Optimistic Oracle UI.
-        value: "https://oracle.umaproject.org",
+        value: "https://oracle.uma.xyz",
         isValid: (x) => typeof x === "string",
       },
     };
@@ -120,7 +120,7 @@ class OptimisticOracleContractMonitor {
         )}. tx: ${createEtherscanLinkMarkdown(
           event.transactionHash,
           this.contractProps.networkId
-        )}. ${this._generateUILink(event.transactionHash, this.contractProps.networkId)}.`;
+        )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -173,6 +173,7 @@ class OptimisticOracleContractMonitor {
         )}. ` +
         `tx ${createEtherscanLinkMarkdown(event.transactionHash, this.contractProps.networkId)}. ${this._generateUILink(
           event.transactionHash,
+          event.logIndex,
           this.contractProps.networkId
         )}.`;
 
@@ -222,7 +223,7 @@ class OptimisticOracleContractMonitor {
         `. tx: ${createEtherscanLinkMarkdown(
           event.transactionHash,
           this.contractProps.networkId
-        )}. ${this._generateUILink(event.transactionHash, this.contractProps.networkId)}.`;
+        )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
       this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
@@ -286,7 +287,7 @@ class OptimisticOracleContractMonitor {
         `. tx: ${createEtherscanLinkMarkdown(
           event.transactionHash,
           this.contractProps.networkId
-        )}. ${this._generateUILink(event.transactionHash, this.contractProps.networkId)}.`;
+        )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -336,20 +337,20 @@ class OptimisticOracleContractMonitor {
     }
   }
 
-  _generateUILink(transactionHash, chainId) {
+  _generateUILink(transactionHash, eventIndex, chainId) {
     let oracleType;
     switch (this.oracleType) {
       case OptimisticOracleType.OptimisticOracle:
-        oracleType = "Optimistic";
+        oracleType = "Optimistic+Oracle+V1";
         break;
       case OptimisticOracleType.OptimisticOracleV2:
-        oracleType = "OptimisticV2";
+        oracleType = "Optimistic+Oracle+V2";
         break;
       case OptimisticOracleType.SkinnyOptimisticOracle:
-        oracleType = "Skinny";
+        oracleType = "Skinny+Optimistic+Oracle";
         break;
     }
-    return `<${this.optimisticOracleUIBaseUrl}/request?transactionHash=${transactionHash}&chainId=${chainId}&oracleType=${oracleType}|View in UI>`;
+    return `<${this.optimisticOracleUIBaseUrl}/?transactionHash=${transactionHash}&eventIndex=${eventIndex}&chainId=${chainId}&oracleType=${oracleType}|View in UI>`;
   }
 }
 

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -708,6 +708,12 @@ describe("OptimisticOracleContractMonitor.js", function () {
       // Should contain etherscan addresses for the transaction
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${skinnySettlementTxn.transactionHash}`));
 
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/?transactionHash=${skinnySettlementTxn.transactionHash}&eventIndex=${skinnySettlementLogIndex}&chainId=${contractProps.chainId}&oracleType=Skinny+Optimistic+Oracle`
+        )
+      );
       // should contain the correct settlement information.
       assert.isTrue(lastSpyLogIncludes(spy, requester)); // Requester
       assert.isTrue(lastSpyLogIncludes(spy, skinnyProposer)); // Proposer
@@ -915,6 +921,13 @@ describe("OptimisticOracleContractMonitor.js", function () {
 
       // Should contain etherscan addresses for the transaction
       assert.isTrue(lastSpyLogIncludes(spy, `https://etherscan.io/tx/${settlementV2Txn.transactionHash}`));
+
+      assert.isTrue(
+        lastSpyLogIncludes(
+          spy,
+          `${sampleBaseUIUrl}/?transactionHash=${settlementV2Txn.transactionHash}&eventIndex=${settlementV2LogIndex}&chainId=${contractProps.chainId}&oracleType=Optimistic+Oracle+V2`
+        )
+      );
 
       // should contain the correct settlement information.
       assert.isTrue(lastSpyLogIncludes(spy, optimisticRequesterV2.options.address)); // Requester


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Monitor bots handling OOv1/OOv2/SkinnyOO do not add eventIndex query parameter to Oracle URL as this was introduced after original monitor bots were built. We should add this parameter similar how we do in OOv3 monitor bots so that Oracle links in bot logs resolve correctly.

**Summary**

Updates oracle link generation in monitors package to be compatible with the current Oracle dApp.

**Details**

Also adds event log index to OptimisticOracleEventClient so that this can be easily added link generation in consuming monitor bots.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1700/add-eventindex-parameter-to-oracle-url-in-monitor-bots
