### PR TITLE
feat: dedicated channel for oo disputes

### DIFF
--- a/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
+++ b/packages/monitor-v2/src/monitor-oo-v3/MonitorLogger.ts
@@ -59,7 +59,7 @@ export async function logDispute(
   },
   params: MonitoringParams
 ): Promise<void> {
-  logger.error({
+  logger.warn({
     at: "OOv3Monitor",
     message: "Assertion disputed ❌",
     mrkdwn:
@@ -75,7 +75,7 @@ export async function logDispute(
       ". " +
       generateOOv3UILink(dispute.tx, dispute.eventIndex, params.chainId) +
       ".",
-    notificationPath: "optimistic-oracle",
+    notificationPath: "optimistic-oracle-disputes",
     discordPaths: ["oo-fact-checking", "oo-events"],
   });
 }

--- a/packages/monitor-v2/test/OptimisticOracleV3Monitor.ts
+++ b/packages/monitor-v2/test/OptimisticOracleV3Monitor.ts
@@ -156,11 +156,11 @@ describe("OptimisticOracleV3Monitor", function () {
     // When calling monitoring module directly there should be only one log (index 0) with the dispute caught by spy.
     assert.equal(spy.getCall(0).lastArg.at, "OOv3Monitor");
     assert.equal(spy.getCall(0).lastArg.message, "Assertion disputed ❌");
-    assert.equal(spyLogLevel(spy, 0), "error");
+    assert.equal(spyLogLevel(spy, 0), "warn");
     assert.isTrue(spyLogIncludes(spy, 0, assertionId));
     assert.isTrue(spyLogIncludes(spy, 0, disputeTx.hash));
     assert.isTrue(spyLogIncludes(spy, 0, toUtf8String(claim)));
-    assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle");
+    assert.equal(spy.getCall(0).lastArg.notificationPath, "optimistic-oracle-disputes");
     assert.equal(
       JSON.stringify(spy.getCall(0).lastArg.discordPaths),
       JSON.stringify(["oo-fact-checking", "oo-events"])

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -229,7 +229,7 @@ class OptimisticOracleContractMonitor {
         at: "OptimisticOracleContractMonitor",
         message: `${this.oracleType}: Price Dispute Alert ⛔️!`,
         mrkdwn,
-        notificationPath: "optimistic-oracle",
+        notificationPath: "optimistic-oracle-disputes",
       });
     }
     this.lastDisputePriceBlockNumber = this._getLastSeenBlockNumber(latestEvents);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Monitor OO disputes in dedicated channel without raising PD error alerts.

**Summary**

Changes notification path for OO disputes.

**Details**

Log level for OOv3 is changed to warn. For older OO bot this should be changed in MONITOR_CONFIG.logOverrides.disputedPrice in environment.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1774/move-oo-disputes-to-slack-instead-of-pd
