### PR TITLE
fix: avoid empty blocks in slack transport

### DIFF
--- a/packages/financial-templates-lib/src/logger/SlackTransport.ts
+++ b/packages/financial-templates-lib/src/logger/SlackTransport.ts
@@ -250,17 +250,21 @@ export function splitByNewLine(block: Block): Block[] {
   }
 
   const lines = block.text.text.split("\n");
-  const smallerBlocks = [createSectionBlock("")];
+  const smallerBlocks: SectionBlock[] = [];
   for (let line of lines) {
     // Skip empty lines.
     if (line.length == 0) continue;
 
     // Add a new block if the previous block's content + current line exceed the char limit.
     line += "\n";
-    const newBlock = createSectionBlock(smallerBlocks[smallerBlocks.length - 1].text.text + line);
+    const newBlock =
+      smallerBlocks.length === 0
+        ? createSectionBlock(line)
+        : createSectionBlock(smallerBlocks[smallerBlocks.length - 1].text.text + line);
     if (JSON.stringify(newBlock).length + line.length > SLACK_MAX_CHAR_LIMIT) {
       smallerBlocks.push(createSectionBlock(line));
     } else {
+      if (smallerBlocks.length === 0) smallerBlocks.push(createSectionBlock(""));
       smallerBlocks[smallerBlocks.length - 1].text.text += line;
     }
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Currently Slack transport can error under certain conditions when splitting lines.

**Summary**

Fixes Slack transport to avoid sending empty blocks.

**Details**

Slack webhook treats empty text blocks as invalid. This could have happened in splitByNewLine if the first line already exceeds Slack character limit. The fix avoids this by not starting the smallerBlocks array with createSectionBlock("").

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
