### PR TITLE
fix: use oo monitors in serverless tests

### DIFF
--- a/packages/serverless-orchestration/test/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/test/ServerlessSpoke.js
@@ -1,7 +1,6 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
 const { web3, getContract } = hre;
-const { toWei, utf8ToHex, padRight } = web3.utils;
 
 // Enables testing http requests to an express spoke.
 const request = require("supertest");
@@ -9,30 +8,17 @@ const request = require("supertest");
 // Script to test
 const spoke = require("../src/ServerlessSpoke");
 
-// Contracts and helpers
-const ExpiringMultiParty = getContract("ExpiringMultiParty");
-const Finder = getContract("Finder");
-const IdentifierWhitelist = getContract("IdentifierWhitelist");
-const TokenFactory = getContract("TokenFactory");
-const Token = getContract("ExpandedERC20");
-const Timer = getContract("Timer");
-const UniswapV2Mock = getContract("UniswapV2Mock");
-const SyntheticToken = getContract("SyntheticToken");
+// Contract to monitor
+const OptimisticOracleV2 = getContract("OptimisticOracleV2");
 
 // Custom winston transport module to monitor winston log outputs
 const winston = require("winston");
 const sinon = require("sinon");
 const { SpyTransport, lastSpyLogIncludes } = require("@uma/financial-templates-lib");
-const { ZERO_ADDRESS, runDefaultFixture } = require("@uma/common");
+const { runDefaultFixture } = require("@uma/common");
 
 describe("ServerlessSpoke.js", function () {
-  let contractDeployer, accounts;
-
-  let collateralToken;
-  let syntheticToken;
-  let emp;
-  let uniswap;
-  let defaultPricefeedConfig;
+  let optimisticOracleV2Address;
 
   let spy;
   let spyLogger;
@@ -44,15 +30,7 @@ describe("ServerlessSpoke.js", function () {
   };
 
   before(async function () {
-    accounts = await web3.eth.getAccounts();
-    [contractDeployer] = accounts;
     await runDefaultFixture(hre);
-    collateralToken = await Token.new("Wrapped Ether", "WETH", 18).send({ from: contractDeployer });
-    syntheticToken = await SyntheticToken.new("Test Synthetic Token", "SYNTH", 18).send({ from: contractDeployer });
-
-    // Create identifier whitelist and register the price tracking ticker with it.
-    const identifierWhitelist = await IdentifierWhitelist.deployed();
-    await identifierWhitelist.methods.addSupportedIdentifier(utf8ToHex("ETH/BTC")).send({ from: contractDeployer });
   });
 
   beforeEach(async function () {
@@ -66,34 +44,8 @@ describe("ServerlessSpoke.js", function () {
     // Start the Serverless spoke instance with the spy logger injected.
     spokeInstance = await spoke.Poll(spyLogger, testPort);
 
-    const constructorParams = {
-      expirationTimestamp: "12345678900",
-      withdrawalLiveness: "1000",
-      collateralAddress: collateralToken.options.address,
-      finderAddress: (await Finder.deployed()).options.address,
-      tokenFactoryAddress: (await TokenFactory.deployed()).options.address,
-      priceFeedIdentifier: padRight(utf8ToHex("ETH/BTC"), 64), // Note: an identifier which is part of the default config is required for this test.
-      tokenAddress: syntheticToken.options.address,
-      liquidationLiveness: "1000",
-      collateralRequirement: { rawValue: toWei("1.2") },
-      disputeBondPercentage: { rawValue: toWei("0.1") },
-      sponsorDisputeRewardPercentage: { rawValue: toWei("0.1") },
-      disputerDisputeRewardPercentage: { rawValue: toWei("0.1") },
-      minSponsorTokens: { rawValue: toWei("1") },
-      timerAddress: (await Timer.deployed()).options.address,
-      financialProductLibraryAddress: ZERO_ADDRESS,
-    };
-
-    // Deploy a new expiring multi party
-    emp = await ExpiringMultiParty.new(constructorParams).send({ from: contractDeployer });
-
-    uniswap = await UniswapV2Mock.new().send({ from: contractDeployer });
-
-    defaultPricefeedConfig = { type: "test", currentPrice: "1", historicalPrice: "1" };
-
-    // Set two uniswap prices to give it a little history.
-    await uniswap.methods.setPrice(toWei("1"), toWei("1")).send({ from: contractDeployer });
-    await uniswap.methods.setPrice(toWei("1"), toWei("1")).send({ from: contractDeployer });
+    // Get deployed OptimisticOracleV2 address to monitor.
+    optimisticOracleV2Address = (await OptimisticOracleV2.deployed()).options.address;
   });
   afterEach(async function () {
     spokeInstance.close();
@@ -125,9 +77,8 @@ describe("ServerlessSpoke.js", function () {
       environmentVariables: {
         CUSTOM_NODE_URL: web3.currentProvider.host, // ensures that script runs correctly in tests & CI.
         POLLING_DELAY: 0,
-        EMP_ADDRESS: emp.options.address,
-        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
-        MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
+        OPTIMISTIC_ORACLE_ADDRESS: optimisticOracleV2Address,
+        OPTIMISTIC_ORACLE_TYPE: "OptimisticOracleV2",
       },
     };
 
@@ -145,8 +96,8 @@ describe("ServerlessSpoke.js", function () {
       environmentVariables: {
         CUSTOM_NODE_URL: web3.currentProvider.host,
         POLLING_DELAY: 0,
-        EMP_ADDRESS: emp.options.address,
-        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig, // invalid config that should generate an error
+        OPTIMISTIC_ORACLE_ADDRESS: optimisticOracleV2Address,
+        OPTIMISTIC_ORACLE_TYPE: "OptimisticOracleV2",
       },
     };
 
@@ -164,9 +115,7 @@ describe("ServerlessSpoke.js", function () {
       environmentVariables: {
         CUSTOM_NODE_URL: web3.currentProvider.host,
         POLLING_DELAY: 0,
-        // missing EMP_ADDRESS. Should error before entering main while loop.
-        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig, // invalid config that should generate an error
-        MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
+        // missing OPTIMISTIC_ORACLE_ADDRESS. Should error before entering main while loop.
       },
     };
 
@@ -186,24 +135,22 @@ describe("ServerlessSpoke.js", function () {
     ); // Check the process logger contained the error.
     assert.isTrue(lastSpyLogIncludes(spy, "Process exited with error")); // Check the process logger contains exit error.
   });
-  it("Serverless Spoke can correctly returns errors over http calls(invalid emp)", async function () {
-    // Invalid EMP address should error out when trying to retrieve on-chain data.
-    const invalidEMPAddressBody = {
+  it("Serverless Spoke can correctly returns errors over http calls(invalid oo)", async function () {
+    // Invalid OPTIMISTIC_ORACLE_ADDRESS address should error out when trying to retrieve on-chain data.
+    const invalidOOAddressBody = {
       serverlessCommand: "yarn --silent monitors --network test",
       environmentVariables: {
         CUSTOM_NODE_URL: web3.currentProvider.host,
         POLLING_DELAY: 0,
-        EMP_ADDRESS: "0x0000000000000000000000000000000000000000", // Invalid address that should generate an error
-        TOKEN_PRICE_FEED_CONFIG: defaultPricefeedConfig,
-        MONITOR_CONFIG: { contractVersion: "2.0.1", contractType: "ExpiringMultiParty" },
+        OPTIMISTIC_ORACLE_ADDRESS: "0x0000000000000000000000000000000000000000", // Invalid address that should generate an error
       },
     };
 
-    const invalidEMPAddressResponse = await sendRequest(invalidEMPAddressBody);
-    assert.equal(invalidEMPAddressResponse.res.statusCode, 500); // error code
-    // Expected error text from loading in an EMP from an invalid address
-    assert.isTrue(invalidEMPAddressResponse.res.text.includes("Contract code hash is null")); // error text
-    assert.isTrue(lastSpyLogIncludes(spy, "Contract code hash is null")); // Check the process logger contained the error.
+    const invalidOOAddressResponse = await sendRequest(invalidOOAddressBody);
+    assert.equal(invalidOOAddressResponse.res.statusCode, 500); // error code
+    // Expected error text from loading in an OO from an invalid address
+    assert.isTrue(invalidOOAddressResponse.res.text.includes("Returned values aren't valid")); // error text
+    assert.isTrue(lastSpyLogIncludes(spy, "Returned values aren't valid")); // Check the process logger contained the error.
     assert.isTrue(lastSpyLogIncludes(spy, "Process exited with error")); // Check the process logger contains exit error.
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Kraken has shut down cryptowat.ch api causing some of serverless package tests using EMP monitors to fail and block new PRs.


**Summary**

Replaces EMP monitors with OO monitors in serverless package tests.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1876/cryptowatch-api-no-longer-works-causing-ci-to-fail
