### PR TITLE
fix: do not dispute ipfs server errors by default

### DIFF
--- a/packages/monitor-v2/src/monitor-og/README.md
+++ b/packages/monitor-v2/src/monitor-og/README.md
@@ -60,6 +60,8 @@ All the configuration should be provided with following environment variables:
 - `AUTOMATIC_EXECUTIONS_ENABLED` is boolean enabling/disabling automatic execution of supported oSnap proposals (`false`
   by default). This mode requires setting supported bond values in `SUPPORTED_BONDS` and either `GCKMS_WALLET` or
   `MNEMONIC` for signing execution transactions.
+- `DISPUTE_IPFS_SERVER_ERRORS` is boolean enabling/disabling automatic dispute of proposals with IPFS server errors
+  (`false` by default). This is used only in conjunction with `AUTOMATIC_DISPUTES_ENABLED` set to `true`.
 - `SUPPORTED_BONDS` is a mapping of supported bond tokens and bond values. This is required when running in automated
   support mode. Only oSnap modules with exact match of bond token and bond value will be supported.
 - `SUBMIT_AUTOMATION` is boolean enabling/disabling transaction submission in any of automated support modes (`true` by

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -66,6 +66,7 @@ export interface MonitoringParams {
   approvalChoices: string[];
   supportedBonds?: SupportedBonds; // Optional. Only used in automated support mode.
   submitAutomation: boolean; // Defaults to true, but only used in automated support mode.
+  disputeIpfsServerErrors: boolean; // Defaults to false, but only used in automated support mode.
   useTenderly: boolean;
   botModes: BotModes;
   retryOptions: RetryOptions;
@@ -210,6 +211,9 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
   // apply to bond approvals as these are always submitted on chain.
   const submitAutomation = env.SUBMIT_AUTOMATION === "false" ? false : true;
 
+  // By default, do not dispute on IPFS server errors unless explicitly enabled.
+  const disputeIpfsServerErrors = env.DISPUTE_IPFS_SERVER_ERRORS === "true" ? true : false;
+
   // Mastercopy and module proxy factory addresses are required when monitoring proxy deployments or when not
   // explicitly providing OG_ADDRESS to monitor in other modes.
   if (
@@ -243,6 +247,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     approvalChoices,
     supportedBonds,
     submitAutomation,
+    disputeIpfsServerErrors,
     useTenderly,
     botModes,
     retryOptions,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Avoid false oSnap disputes caused by IPFS gateway issues.

**Summary**

Changes default oSnap dispute bot behavior not to trigger dispute caused by invalid IPFS gateway response.

**Details**

New DISPUTE_IPFS_SERVER_ERRORS variable defaults to false, but enabling it allows to return to the old behavior.

Since the returned HTTP response code behavior differs across providers we cannot reliably identify whether the referenced proposal is available on IPFS or not.

This change should not affect behavior of other modules. Particularly, any non-ok IPFS gateway responses would still trigger error alerts as the monitoring module would fail validation, as well as proposal module would abstain from posting the proposal till it can fetch IPFS hosted proposal.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1904/osnap-bot-better-handle-ipfs-errors
