### PR TITLE
fix: increment nonce after static call

### DIFF
--- a/packages/common/test/SolidityTestUtils.js
+++ b/packages/common/test/SolidityTestUtils.js
@@ -19,6 +19,6 @@ describe("SolidityTestUtils.js", function () {
     const transaction = erc20Contract.methods.transferFrom(accounts[0], accounts[1], "1").send({ from: accounts[1] });
 
     // This should fail because the owner has not approved the transfer.
-    assert.isTrue(await didContractRevertWith(transaction, "ERC20: transfer amount exceeds allowance"));
+    assert.isTrue(await didContractRevertWith(transaction, "ERC20: insufficient allowance"));
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

fx-tunnel-relayer bot was failing due to nonce management issue in TransactionUtils.

**Summary**

Fixes TransactionUtils by incrementing nonce only after static call succeeds.

**Details**

runTransaction from TransactionUtils modifies web3 object by adding nonces, but it was done before performing simulation with static call. This caused issues for fx-tunnel-relayer that attempted to run multiple relay transactions: after the first transaction reverted on call stage the next message had its nonce incremented causing it to hang in send phase.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

TransactionUtils skip nonce management in test mode due to reasons discussed [here](https://github.com/UMAprotocol/protocol/pull/3609#discussion_r758106701), hence, this change would not be detected in tests.

Instead, the changed code was verified to work in production by relaying Polygon [message](https://etherscan.io/tx/0xe12f0786be795accda3674328f371153ad0df21c264f397d78c62ec148fdf0ee) that was previously causing issues in fx-tunnel-relayer bot.

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-1910/issue-with-fx-tunnel-relayer-transactions
