### PR TITLE
feat(api): add GET routes that mirror POST routes in express

### DIFF
--- a/packages/api/src/services/express.ts
+++ b/packages/api/src/services/express.ts
@@ -27,7 +27,7 @@ export default async (config: Config, actions: Actions) => {
     return res.send("ok");
   });
 
-  app.post("/:action", (req: Request, res: Response, next: NextFunction) => {
+  function actionHandler(req: Request, res: Response, next: NextFunction) {
     const action = req?.params?.action;
 
     const end = profile(`action: ${action}`);
@@ -35,7 +35,12 @@ export default async (config: Config, actions: Actions) => {
       .then(res.json.bind(res))
       .catch(next)
       .finally(end);
-  });
+  }
+
+  app.post("/:action", actionHandler);
+
+  // duplicate calls on get
+  app.get("/:action", actionHandler);
 
   app.use(cors());
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

we want to add some kind of health check to the bots to make sure our connection to datastore is working. this can be done as long as we have a way to query routes through "GET". currently these actions require a POST.


**Summary**
This does not break any existing functionality, only mirrorss the  POST calls to GET calls using the exact same underlying logic

for health checks, you can now  hit  `GET global/listActive`

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


