### PR TITLE
feat: skip disputes and execution for blacklisted assertions

### DIFF
--- a/packages/monitor-v2/src/monitor-og/README.md
+++ b/packages/monitor-v2/src/monitor-og/README.md
@@ -62,6 +62,9 @@ All the configuration should be provided with following environment variables:
   `MNEMONIC` for signing execution transactions.
 - `DISPUTE_IPFS_SERVER_ERRORS` is boolean enabling/disabling automatic dispute of proposals with IPFS server errors
   (`false` by default). This is used only in conjunction with `AUTOMATIC_DISPUTES_ENABLED` set to `true`.
+- `ASSERTION_BLACKLIST` is an array of assertion IDs that should be ignored when submitting disputes or trying to
+  execute. This is used only in conjunction with `AUTOMATIC_DISPUTES_ENABLED` or `AUTOMATIC_EXECUTIONS_ENABLED` set to
+  `true`.
 - `SUPPORTED_BONDS` is a mapping of supported bond tokens and bond values. This is required when running in automated
   support mode. Only oSnap modules with exact match of bond token and bond value will be supported.
 - `SUBMIT_AUTOMATION` is boolean enabling/disabling transaction submission in any of automated support modes (`true` by

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -67,6 +67,7 @@ export interface MonitoringParams {
   supportedBonds?: SupportedBonds; // Optional. Only used in automated support mode.
   submitAutomation: boolean; // Defaults to true, but only used in automated support mode.
   disputeIpfsServerErrors: boolean; // Defaults to false, but only used in automated support mode.
+  assertionBlacklist: string[]; // Defaults to empty array. Only used in automated support mode.
   useTenderly: boolean;
   botModes: BotModes;
   retryOptions: RetryOptions;
@@ -214,6 +215,9 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
   // By default, do not dispute on IPFS server errors unless explicitly enabled.
   const disputeIpfsServerErrors = env.DISPUTE_IPFS_SERVER_ERRORS === "true" ? true : false;
 
+  // By default, do not blacklist assertions unless explicitly enabled.
+  const assertionBlacklist: string[] = env.ASSERTION_BLACKLIST ? JSON.parse(env.ASSERTION_BLACKLIST) : [];
+
   // Mastercopy and module proxy factory addresses are required when monitoring proxy deployments or when not
   // explicitly providing OG_ADDRESS to monitor in other modes.
   if (
@@ -248,6 +252,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     supportedBonds,
     submitAutomation,
     disputeIpfsServerErrors,
+    assertionBlacklist,
     useTenderly,
     botModes,
     retryOptions,

--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -366,6 +366,12 @@ const hasChallengePeriodEnded = (proposal: TransactionsProposedEvent, timestamp:
   return timestamp >= proposal.args.challengeWindowEnds.toNumber();
 };
 
+// Filter function to check if the proposal has been blacklisted by its corresponding assertionId.
+const isProposalBlacklisted = (proposal: TransactionsProposedEvent, params: MonitoringParams): boolean => {
+  const assertionBlaclistSet = new Set(params.assertionBlacklist.map((assertionId) => assertionId.toLowerCase()));
+  return assertionBlaclistSet.has(proposal.args.assertionId.toLowerCase());
+};
+
 // Filters supported proposal events and adds their parameters to the result.
 const getSupportedProposals = async (
   proposals: TransactionsProposedEvent[],
@@ -386,7 +392,8 @@ const getSupportedProposals = async (
     )
   ).filter((proposal) => proposal !== null) as SupportedProposal[];
 
-  return supportedProposals;
+  // Filter out all proposals that have been blacklisted.
+  return supportedProposals.filter((proposal) => !isProposalBlacklisted(proposal.event, params));
 };
 
 // Filter proposals that did not pass verification and also retain verification result for logging.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

oSnap execution module is spamming notification channel for proposals that are known to be misconfigured and will be reverting.

**Summary**

Adds ability to selectively blacklist automated proposal dispute/execution.

**Details**

We identify proposals by their assertionId's that are guaranteed to be unique.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-2024/osnap-bot-trying-to-execute-bad-proposal-over-and-over
