### PR TITLE
fix: maxFeePerGas cannot be less than maxPriorityFeePerGas

### DIFF
--- a/packages/financial-templates-lib/src/helpers/GasEstimator.ts
+++ b/packages/financial-templates-lib/src/helpers/GasEstimator.ts
@@ -192,8 +192,12 @@ export class GasEstimator {
     ]);
 
     if (this.type == NetworkType.London) {
-      this.latestMaxFeePerGasGwei = (gasInfo as LondonGasData).maxFeePerGas;
       this.latestMaxPriorityFeePerGasGwei = (gasInfo as LondonGasData).maxPriorityFeePerGas;
+      // If we are using a hardcoded maxPriorityFeePerGas value, ensure that maxFeePerGas is not set below it.
+      this.latestMaxFeePerGasGwei = Math.max(
+        (gasInfo as LondonGasData).maxFeePerGas,
+        this.latestMaxPriorityFeePerGasGwei
+      );
 
       // Extract the base fee from the most recent block. If the block is not available or errored then is set to the
       // latest max fee per gas so we still have some value in the right ballpark to return to the client implementer.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

GasEstimator is using hardcoded maxPriorityFeePerGas for some of networks. This can cause errors if estimated maxFeePerGas gets below this.

**Summary**

Enforce that maxFeePerGas is not set below maxPriorityFeePerGas.

**Details**

We experienced the error recently on Polygon where estimated maxFeePerGas got below hardcoded 50 GWei maxPriorityFeePerGas

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
