### PR TITLE
feat: impose gas usage limit for automated osnap execution

### DIFF
--- a/packages/monitor-v2/src/monitor-og/README.md
+++ b/packages/monitor-v2/src/monitor-og/README.md
@@ -72,6 +72,9 @@ All the configuration should be provided with following environment variables:
   default). If this is set to `false`, the bot will only simulate transaction submission and log the results. Note that
   bond approval transactions would be still submitted as they are required for the subsequent proposal/dispute
   simulation.
+- `AUTOMATIC_EXECUTION_GAS_LIMIT` is the gas limit imposed on automated transaction execution. Transactions requiring
+  more gas will not be submitted. This is used only in conjunction with `AUTOMATIC_EXECUTIONS_ENABLED` set to `true`. If
+  not provided, this defaults to `500000`.
 - `SNAPSHOT_ENDPOINT` is the Snapshot endpoint used to verify Snapshot proposals. If not provided, this defaults to
   `https://snapshot.org`.
 - `GRAPHQL_ENDPOINT` is the GraphQL endpoint used to verify Snapshot proposals. If not provided, this defaults to

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -69,6 +69,7 @@ export interface MonitoringParams {
   approvalChoices: string[];
   supportedBonds?: SupportedBonds; // Optional. Only used in automated support mode.
   submitAutomation: boolean; // Defaults to true, but only used in automated support mode.
+  automaticExecutionGasLimit: BigNumber; // Defaults to 500k, but only used in automated support mode.
   disputeIpfsServerErrors: boolean; // Defaults to false, but only used in automated support mode.
   assertionBlacklist: string[]; // Defaults to empty array. Only used in automated support mode.
   useTenderly: boolean;
@@ -222,6 +223,11 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
   // apply to bond approvals as these are always submitted on chain.
   const submitAutomation = env.SUBMIT_AUTOMATION === "false" ? false : true;
 
+  // By default, set automatic execution gas limit to 500k unless explicitly set.
+  const automaticExecutionGasLimit = env.AUTOMATIC_EXECUTION_GAS_LIMIT
+    ? BigNumber.from(env.AUTOMATIC_EXECUTION_GAS_LIMIT)
+    : BigNumber.from(500000);
+
   // By default, do not dispute on IPFS server errors unless explicitly enabled.
   const disputeIpfsServerErrors = env.DISPUTE_IPFS_SERVER_ERRORS === "true" ? true : false;
 
@@ -267,6 +273,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     approvalChoices,
     supportedBonds,
     submitAutomation,
+    automaticExecutionGasLimit,
     disputeIpfsServerErrors,
     assertionBlacklist,
     useTenderly,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Manage gas consumption of oSnap execution bot.

**Summary**

Impose upper limit to gas usage (per proposal) when automatically executing oSnap proposals (defaults to 500k).




**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-2094/add-gas-limit-to-osnap-transactions-that-we-execute
