### PR TITLE
fix: update nodejs version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   checkout_and_install:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - checkout
@@ -28,7 +28,7 @@ jobs:
             - ~/.ssh
   build:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     resource_class: large
     steps:
@@ -50,7 +50,7 @@ jobs:
             - ~/.ssh
   lint:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -73,7 +73,7 @@ jobs:
           configuration_path: /home/circleci/protocol/.circleci/lerna_config.yml
   coverage:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - checkout
@@ -86,7 +86,7 @@ jobs:
           path: packages/core/coverage
   publish:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - add_ssh_keys:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # that are not in the protocol repo, such as the Across v2 relayer. To access these set a command 
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:16
+FROM node:20
 
 # All source code and execution happens from the protocol directory.
 WORKDIR /protocol

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For detailed information on how to initialize and interact with our smart contra
 
 ### Install dependencies 👷‍♂️
 
-You'll need to install the long-term support version of nodejs, currently nodejs v14. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
+You'll need to install the long-term support version of nodejs, currently nodejs v20. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
 
 ```
 yarn


### PR DESCRIPTION
**Motivation**

Nodejs 16 is EOL and it's important to continue to get security updates from nodejs.


**Summary**

Updated all references to nodejs 16.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
