### PR TITLE
fix: fix foundry scripts in ci

### DIFF
--- a/packages/core/scripts/SetUpFoundryWithHardhat.sh
+++ b/packages/core/scripts/SetUpFoundryWithHardhat.sh
@@ -14,8 +14,9 @@ fi
 # https://book.getfoundry.sh/config/hardhat#use-foundry-in-an-existing-hardhat-project without wanting to commit the
 # foundry lib & standard lib to the repo.
 
-if [ ! -d "./lib" ]; then
+if [ ! -d "./lib" ] || [ -z "$(ls -A ./lib)" ] || [ -z "$(ls -A ./lib/forge-std)" ]; then
     echo "Configuring UMA core to work with foundry std-lib"
+    rm -rf ./lib
     mv .gitignore .gitignore.tmp
     mkdir temp
     cd temp


### PR DESCRIPTION
**Motivation**

The foundry scripts are failing in ci.


**Summary**

This patches the foundry script to detect if the forge-std folder is empty and deletes it if so.

In ci, the caching and/or installation process breaks in such a way where the lib folder exists, but the actual files are not present. This detects that situation and removes the entire thing before reinstalling.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
