### PR TITLE
feat(api): add boilerplate for osnap tenderly sim

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@google-cloud/datastore": "^8.2.1",
+    "@tenderly/sdk": "^0.2.1",
     "@types/express": "^4.17.11",
     "@uma/financial-templates-lib": "^2.35.0",
     "@uma/sdk": "^0.34.4",

--- a/packages/api/src/apps/serverless_read/app.ts
+++ b/packages/api/src/apps/serverless_read/app.ts
@@ -17,6 +17,7 @@ import {
 } from "../../tables";
 
 import type { AppState, ProcessEnv, Channels } from "../../types";
+import * as libs from "../../libs";
 
 export default async (env: ProcessEnv) => {
   assert(env.EXPRESS_PORT, "requires EXPRESS_PORT");
@@ -107,7 +108,21 @@ export default async (env: ProcessEnv) => {
     // TODO: switch this to root path once frontend is ready to transition
     ["global", Actions.Global(undefined, appState)],
   ];
+  // it looks like we want to enable tenderly simulations, so we are goign to validate env and enable osnap route
+  if (env.TENDERLY_ACCOUNT_NAME || env.TENDERLY_PROJECT_NAME || env.TENDERLY_ACCESS_KEY) {
+    assert(env.TENDERLY_ACCOUNT_NAME, `Osnap requires TENDERLY_ACCOUNT_NAME`);
+    assert(env.TENDERLY_PROJECT_NAME, `Osnap requires TENDERLY_PROJECT_NAME`);
+    assert(env.TENDERLY_ACCESS_KEY, `Osnap requires TENDERLY_ACCESS_KEY`);
+    const tenderlyConfig = {
+      accountName: env.TENDERLY_ACCOUNT_NAME,
+      projectName: env.TENDERLY_PROJECT_NAME,
+      accessKey: env.TENDERLY_ACCESS_KEY,
+    };
+    const tenderlies = new libs.osnap.MultiChainTenderly(tenderlyConfig);
+    channels.push(["osnap", Actions.Osnap({ tenderlies })]);
+    console.log("Enabled Tenderly Simulations for Osnap");
+  }
 
   await Express({ port: Number(env.EXPRESS_PORT), debug }, channels)();
-  console.log("Started Express Server, API accessible");
+  console.log("Started Express Server, API accessible on port", env.EXPRESS_PORT);
 };

--- a/packages/api/src/libs/index.ts
+++ b/packages/api/src/libs/index.ts
@@ -2,3 +2,4 @@ export * as zrx from "./zrx";
 export * as synthPrices from "./synthPrices";
 export * as utils from "./utils";
 export * as queries from "./queries";
+export * as osnap from "./osnap";

--- a/packages/api/src/libs/osnap.ts
+++ b/packages/api/src/libs/osnap.ts
@@ -1,0 +1,33 @@
+import assert from "assert";
+import { Tenderly, Network } from "@tenderly/sdk";
+
+// a list of chains osnap is enabled on. must be updated manually as we add more
+export const ChainsEnabled: Network[] = [
+  Network.MAINNET,
+  Network.GOERLI,
+  Network.SEPOLIA,
+  Network.POLYGON,
+  Network.OPTIMISTIC,
+  Network.ARBITRUM_ONE,
+];
+type BasicTenderlyConfig = Omit<ConstructorParameters<typeof Tenderly>[0], "network">;
+
+// tenderly instances per chain
+export class MultiChainTenderly {
+  public tenderlies: Record<string, Tenderly>;
+  constructor(public config: BasicTenderlyConfig, public chainsEnabled: Network[] = ChainsEnabled) {
+    this.tenderlies = Object.fromEntries(
+      chainsEnabled.map((network) => [network, new Tenderly({ ...config, network })])
+    );
+  }
+  get = (chain: string | number): Tenderly => {
+    const tenderly = this.tenderlies[chain.toString()];
+    assert(tenderly, `No tenderly instance for chain ${chain}`);
+    return tenderly;
+  };
+}
+
+// TODO: add simulation function
+// export function simulateOsnapTx(tenderly: Tenderly) {
+//   return [];
+// }

--- a/packages/api/src/services/actions/index.ts
+++ b/packages/api/src/services/actions/index.ts
@@ -2,3 +2,4 @@ export { default as Emp } from "./emp";
 export { default as Lsp } from "./lsp";
 export { default as Global } from "./global";
 export { default as Scheduler } from "./scheduler";
+export { default as Osnap } from "./osnap";

--- a/packages/api/src/services/actions/osnap.ts
+++ b/packages/api/src/services/actions/osnap.ts
@@ -1,0 +1,36 @@
+import assert from "assert";
+import { Actions, Json, ActionCall } from "../../types";
+import { MultiChainTenderly } from "../../libs/osnap";
+
+type Config = {
+  tenderlies: MultiChainTenderly;
+};
+
+export function Handlers(config: Config): Actions {
+  const { tenderlies } = config;
+
+  const actions: Actions = {
+    async ping() {
+      return "pong";
+    },
+    async chainsEnabled() {
+      return tenderlies.chainsEnabled;
+    },
+    // TODO: fill out simulation fn
+    // async simulate(){
+    // }
+  };
+
+  // list all available actions
+  const keys = Object.keys(actions);
+  actions.actions = () => keys;
+
+  return actions;
+}
+export default (config: Config): ActionCall => {
+  const actions = Handlers(config);
+  return async (action: string, ...args: Json[]): Promise<Json> => {
+    assert(actions[action], `Invalid action: ${action}`);
+    return actions[action](...args);
+  };
+};

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -36,6 +36,7 @@ export type Json = null | undefined | void | boolean | number | string | Json[] 
 // Represents an function where inputs and outputs can serialize to/from json
 export type Action = (...args: any[]) => Json | Promise<Json>;
 export type Actions = { [key: string]: Action };
+export type ActionCall = (action: string, ...args: Json[]) => Promise<Json>;
 
 // this represents valid currencies to check prices against on coingecko
 // see: https://www.coingecko.com/api/documentations/v3#/asset_platforms/get_asset_platforms

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,6 +4685,13 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
+"@tenderly/sdk@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tenderly/sdk/-/sdk-0.2.1.tgz#e4c683986639137fd8440975ccf2ba94d265d255"
+  integrity sha512-VudQOLkvKlQsGXUwITylS6viZ+od0nc2xcoJeHph405EPegcGc5MOgx9J1PYDs+Z46mXE9aXSg+SaTeAJR8o7A==
+  dependencies:
+    axios "^1.3.4"
+
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
@@ -6775,6 +6782,15 @@ axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^1.3.4:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.3.tgz#7f50f23b3aa246eff43c54834272346c396613f4"
+  integrity sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axios@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**
We want to add a serverless function for tenderly simulation with osnap proposals. this feature will be broken up into mutliple prs. first we need to make a space to put this function.


**Summary**

The path of least resistance is to put this in the exisitng API server. this is already running on gcp serverless infrastructure and its set up to add arbitrary new functions.  We add an optional route for tenderly simulations which are enabled with 3 optional environment variables: TENDERLY_ACCOUNT_NAME, TENDERLY_PROJECT_NAME, TENDERLY_ACCESS_KEY. Once set, a `osnap` route will be enabled.  Here is where we will ultimately put simulation logic in future PR. 

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

