### PR TITLE
fix!: time based lookback in oov3-bot

### DIFF
--- a/packages/monitor-v2/package.json
+++ b/packages/monitor-v2/package.json
@@ -15,6 +15,7 @@
     "@uma/common": "^2.34.1",
     "@uma/contracts-node": "^0.4.19",
     "@uma/financial-templates-lib": "^2.35.0",
+    "@uma/sdk": "^0.34.4",
     "async-retry": "^1.3.3",
     "ethers": "^5.4.2",
     "graphql-request": "^5.2.0",

--- a/packages/monitor-v2/src/bot-oo-v3/README.md
+++ b/packages/monitor-v2/src/bot-oo-v3/README.md
@@ -23,7 +23,7 @@ All the configuration should be provided with following environment variables:
 - `SETTLEMENTS_ENABLED` is boolean enabling/disabling settlement of assertions (`false` by default).
 - `BOT_IDENTIFIER` identifies the application name in the logs.
 - `SLACK_CONFIG` is a JSON object containing `defaultWebHookUrl` for the default Slack webhook URL.
-- `BLOCK_LOOKBACK`(Optional) is the number of blocks to look back from the current block to look for past events.
-  See default values in blockDefaults in index.ts
-- `MAX_BLOCK_LOOKBACK`(Optional) is the maximum number of blocks to look back per query.
+- `TIME_LOOKBACK` (Optional) is the number of seconds to look back from the current block to look for past events.
+  Defaults to 72h if not provided.
+- `MAX_BLOCK_LOOKBACK` (Optional) is the maximum number of blocks to look back per query.
   See default values in blockDefaults in index.ts

--- a/packages/monitor-v2/src/bot-oo-v3/SettleAssertions.ts
+++ b/packages/monitor-v2/src/bot-oo-v3/SettleAssertions.ts
@@ -9,12 +9,15 @@ import {
 export async function settleAssertions(logger: typeof Logger, params: MonitoringParams): Promise<void> {
   const oo = await getContractInstanceWithProvider<OptimisticOracleV3Ethers>("OptimisticOracleV3", params.provider);
 
-  const currentBlockNumber = await params.provider.getBlockNumber();
+  const currentBlock = await params.provider.getBlock("latest");
 
-  const loopBack = params.blockLookback;
+  console.log("currentBlock.timestamp", currentBlock.timestamp);
+  console.log("currentBlock.timestamp - params.timeLookback", currentBlock.timestamp - params.timeLookback);
+  const fromBlock = await params.blockFinder.getBlockForTimestamp(currentBlock.timestamp - params.timeLookback);
+
   const searchConfig = {
-    fromBlock: currentBlockNumber - loopBack < 0 ? 0 : currentBlockNumber - loopBack,
-    toBlock: currentBlockNumber,
+    fromBlock: fromBlock.number,
+    toBlock: currentBlock.number,
     maxBlockLookBack: params.maxBlockLookBack,
   };
 

--- a/packages/monitor-v2/src/bot-oo-v3/SettleAssertions.ts
+++ b/packages/monitor-v2/src/bot-oo-v3/SettleAssertions.ts
@@ -11,8 +11,6 @@ export async function settleAssertions(logger: typeof Logger, params: Monitoring
 
   const currentBlock = await params.provider.getBlock("latest");
 
-  console.log("currentBlock.timestamp", currentBlock.timestamp);
-  console.log("currentBlock.timestamp - params.timeLookback", currentBlock.timestamp - params.timeLookback);
   const fromBlock = await params.blockFinder.getBlockForTimestamp(currentBlock.timestamp - params.timeLookback);
 
   const searchConfig = {

--- a/packages/monitor-v2/src/bot-oo-v3/common.ts
+++ b/packages/monitor-v2/src/bot-oo-v3/common.ts
@@ -1,7 +1,8 @@
 import { getGckmsSigner, getMnemonicSigner, getRetryProvider } from "@uma/common";
+import { BlockFinder } from "@uma/sdk";
 import { Signer, Wallet } from "ethers";
 
-import type { Provider } from "@ethersproject/abstract-provider";
+import type { Block, Provider } from "@ethersproject/abstract-provider";
 import { blockDefaults } from "../utils/constants";
 
 export { OptimisticOracleV3Ethers } from "@uma/contracts-node";
@@ -22,8 +23,9 @@ export interface MonitoringParams {
   chainId: number;
   botModes: BotModes;
   signer: Signer;
-  blockLookback: number;
+  timeLookback: number;
   maxBlockLookBack: number;
+  blockFinder: BlockFinder<Block>;
   pollingDelay: number;
 }
 
@@ -49,23 +51,23 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
     settleAssertionsEnabled: env.SETTLEMENTS_ENABLED === "true",
   };
 
-  const blockLookback =
-    Number(env.BLOCK_LOOKBACK) ||
-    blockDefaults[chainId.toString() as keyof typeof blockDefaults]?.oneHour ||
-    blockDefaults.other.oneHour;
+  const timeLookback = Number(env.TIME_LOOKBACK) || 72 * 60 * 60;
 
   const maxBlockLookBack =
     Number(env.MAX_BLOCK_LOOKBACK) ||
     blockDefaults[chainId.toString() as keyof typeof blockDefaults]?.maxBlockLookBack ||
     blockDefaults.other.maxBlockLookBack;
 
+  const blockFinder = new BlockFinder(provider.getBlock, undefined, chainId);
+
   return {
     provider,
     chainId,
     botModes,
     signer,
-    blockLookback,
+    timeLookback,
     maxBlockLookBack,
+    blockFinder,
     pollingDelay,
   };
 };

--- a/packages/monitor-v2/src/bot-oo-v3/common.ts
+++ b/packages/monitor-v2/src/bot-oo-v3/common.ts
@@ -58,7 +58,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
     blockDefaults[chainId.toString() as keyof typeof blockDefaults]?.maxBlockLookBack ||
     blockDefaults.other.maxBlockLookBack;
 
-  const blockFinder = new BlockFinder(provider.getBlock, undefined, chainId);
+  const blockFinder = new BlockFinder(provider.getBlock.bind(provider), undefined, chainId);
 
   return {
     provider,

--- a/packages/monitor-v2/test/OptimisticOracleV3Bot.ts
+++ b/packages/monitor-v2/test/OptimisticOracleV3Bot.ts
@@ -1,6 +1,7 @@
 import type { Provider } from "@ethersproject/abstract-provider";
 import { ExpandedERC20Ethers, MockOracleAncillaryEthers, OptimisticOracleV3Ethers } from "@uma/contracts-node";
 import { createNewLogger, spyLogIncludes, spyLogLevel, SpyTransport } from "@uma/financial-templates-lib";
+import { BlockFinder } from "@uma/sdk";
 import { assert } from "chai";
 import sinon from "sinon";
 import { BotModes, MonitoringParams } from "../src/bot-oo-v3/common";
@@ -25,8 +26,11 @@ const createMonitoringParams = async (): Promise<MonitoringParams> => {
     chainId: (await ethers.provider.getNetwork()).chainId,
     botModes,
     signer,
-    blockLookback: 2000,
+    timeLookback: 72 * 60 * 60,
     maxBlockLookBack: 1000,
+    blockFinder: new BlockFinder(() => {
+      return { number: 0, timestamp: 0 };
+    }),
     pollingDelay: 0,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,7 +3609,7 @@
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
-"@napi-rs/triples@^1.1.0":
+"@napi-rs/triples@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.2.0.tgz#bcd9c936acb93890e7015818e0181f3db421aafa"
   integrity sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==
@@ -3630,51 +3630,51 @@
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@node-rs/crc32-android-arm64@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.7.2.tgz#40bbbb54289fe47abf67558d22d87abace78d7d3"
-  integrity sha512-SMEd6cN+034LTv9kFmCGMZjBNTf39xXIcgqq05JM9A55ywUvXdoXnFOttrQ9x/iZgqANNU6Ms5uZCAJbNA2dZA==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.9.1.tgz#f34e71cad679bc48a3ab8f8aa3542f8d361043e9"
+  integrity sha512-glJx4YstOlfF1jmtVBpmhwNsuE+qV0GnNUDQWQ134uGa+XWOpK/I/nSH+peGlmUEmy0YGeboe7h3M/ecBchcBA==
 
 "@node-rs/crc32-darwin-arm64@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.7.2.tgz#3fa11b1176a1d463accf95deb046896487e0d374"
-  integrity sha512-sPJisK5pyZ+iBs9KuGsvu0Z+Qshw4GvOgaHjPktQ+suz0p00Yts3zl5D6PpGaaW4EAKTo8zCUIlVEArV0vglvw==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.9.1.tgz#41b89028c7d65c2ea19dd2cb957ef2101474e2b8"
+  integrity sha512-IG5G4r5lZekKfw/lY4pzeSpZC3d4M46T6lOlG5084OGWUmMawAI1VgWFVWN5VsztdbN9vClDqixIH0txWY4KBg==
 
 "@node-rs/crc32-darwin-x64@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.7.2.tgz#bf5b1b3e471da1c84e5af19c8a4f667cb0e31540"
-  integrity sha512-+/lgHYJaZdXU+7fhGYTnXvGkeSqZE3UwPyKAUO5YSL0nIpFHMybZMnvqjcoxrfx0QfMFOwVEbd7vfVh+1GpwhA==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.9.1.tgz#10fbdcb20924b5595a26dfec31732db20d93b259"
+  integrity sha512-Dr7Fqqw4FDb9Ui0dG/SO0ivnzkYqIdFxrn3ykz3cOfBMNpn2/m2nvxban0cgICbjl3M4lg0FOrCkoulym34uyg==
 
 "@node-rs/crc32-linux-arm-gnueabihf@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.7.2.tgz#b26c60564a85cd92de5961050aaa9b5e62dda97c"
-  integrity sha512-hTY83MQML8WrMnD3dmzjrcCn0Sqgw0w2wRc1Ji2dCaE0fDqra47W5KBQXx4hKZYFwNr5KreTqdvD3Ejf/mKzEA==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.9.1.tgz#c724a1709208233e95a284e5d79694c8df77b77e"
+  integrity sha512-XDXu30DH9sRpf6arLOi+0CGokKL/BEAZeWZ6/s8WVF7ft7EpyXKTAVQimrq0wKUuk/GisQRFgxrdfMYLDAIovg==
 
 "@node-rs/crc32-linux-arm64-gnu@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.7.2.tgz#076e43f3592496a1cbea69e0e8fb3031d7711569"
-  integrity sha512-4p6DZ9YT+CBSi+72OclzI5hBin15brqrbLLHFePPl4AhAazg6+ReTv3C4DnyJqyL0ZHZamiA9zDtOlvHo0nk0Q==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.9.1.tgz#b557154d5264fc5ccec6a931a29177afd065d817"
+  integrity sha512-988Oq0/J0METxGui6DdDGeoMNVfoZoJ2krgXpY5/ZrLo9BL05gseWcEQvHH1AlzzRGAMgba+JBxCAX+XjiWsXA==
 
 "@node-rs/crc32-linux-x64-gnu@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.7.2.tgz#f17f2d570823ae9195296960af2045d9f76108eb"
-  integrity sha512-rzoqXqPLjx5sx8jzEg/xRAdBDkjnaM+D3Nrm9xJckHWzeeUB0FC0E4QGrdtqFo15lQ1GDVV/q6n93mLSK5vCkQ==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.9.1.tgz#ba2afccc2c5537e946f9aee80b3d57f0a792153d"
+  integrity sha512-D0tJRYa2Bg8EeD6iDe/SgQg81W2+75cGrl+0hK65qSCVLUHPVeIXVFzSheeL7XxMsKHLhv1rZpt+YmxP5GGHrw==
 
 "@node-rs/crc32-linux-x64-musl@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.7.2.tgz#3a3406486db63ffcdb6e4c08681d91dba8585640"
-  integrity sha512-Hwim1Wc8LoNqG53qX8Dm3VY32ClbKWpdi9pkbJU4/aG5RFUfd3k/x9WSeATlBx+K36Tc1XsrWvbsf1eWwryEYA==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.9.1.tgz#ddbd5745001f50a2da80272709860ce140bcdaba"
+  integrity sha512-WD0GHcQCNNMXwtb5NI7Y6WjXWBd8LEBUpo2XrMZstL8fEAWC0qGO7RsIaDclAAN2T/B7L74tud5yYVLm/c5XMw==
 
 "@node-rs/crc32-win32-x64-msvc@^1.0.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.7.2.tgz#7e509ea3969a0190324beb8c829f7845c547e4cf"
-  integrity sha512-DnluAFM6X8qsYVI1VaFQtI6ukigIQ2P4eVcEuNQ3d1lF5fs0RYAKY7Ajqrdk298TSGZ2joMiqfJksTHBsQoxtA==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.9.1.tgz#e44e392b5a66270efcb31772fa734c4cc2d4be42"
+  integrity sha512-HEg0560fHGUJJohxEHQYQeg/ITqaW9033PURG8M1S0rFmJpl2a7aeWouQRBDCfWJXSA2N1QIjRa3csMyULTKvg==
 
 "@node-rs/helper@^1.0.0":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@node-rs/helper/-/helper-1.3.3.tgz#2b1953846ddba31bfb7ecf4ba57e7b1359fcdedc"
-  integrity sha512-p4OdfQObGN9YFy5WZaGwlPYICQSe7xZYyXB0sxREmvj1HzGKp5bPg2PlfgfMZEfnjIA882B9ZrnagYzZihIwjA==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/helper/-/helper-1.5.0.tgz#7ca665286e90a6c46d572084759a052247c03dbb"
+  integrity sha512-4E1laLlg532nkrvUohZzl/wFos3bsHExSDw/guaoLekMcTKtD3ZsH6Vc4/qIRzOzAhQv5LLRnTE+vOeJ6C9Z8w==
   dependencies:
-    "@napi-rs/triples" "^1.1.0"
+    "@napi-rs/triples" "^1.2.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

OOv3 bot looks for assertions that can be settled using block range based lookback. Sometimes this is not sufficient and we cannot guarantee that even standard 2h challenge window assertions get detected. This is particularly an issue for chains that don't have fixed block times (e.g. Arbitrum).

**Summary**

Use `BlockFinder` for time based lookback and set the default to use 72h that should cover most use cases.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

Since BlockFinder does not work in local test network, this was tested in production:
- Made test assertion [here](https://arbiscan.io/tx/0x6ab738456f1403fe88335c2f9cda5704c43753ab2fe446a61d965b249d1382ef)
- Bot picked it up 2h later (after challenge window) after 27k blocks had passed:
  ```
  2024-01-12 20:33:51 [warn]: {
    "at": "OOv3Bot",
    "message": "Assertion Settled ✅",
    "mrkdwn": "Assertion with ID 0xd7f821a847dbf4f76c10bcd3631d430328fddb6ba036f8cc41604e1079f64b33 settled in transaction <https://arbiscan.io/tx/0xbb738e58a7cdd9b8e3cdba9d5c2d6f9ce1f29849e1b811204a39fdacfcf822d7|0xbb7...f822d7>. Claim: test assertion: 1+1=2. Settlement Resolution: true. Identifier: ASSERT_TRUTH. Bond: 500.00 USDC.",
    "notificationPath": "optimistic-oracle",
    "bot-identifier": "NO_BOT_ID"
  }
  ```

**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-2236/fix-oov3-settlement-bot-lookback
