### PR TITLE
fix: correctly store block numbers in serverless hub

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -150,9 +150,6 @@ hub.post("/", async (req, res) => {
       // Cache the chain id for this node url.
       nodeUrlToChainIdCache[spokeCustomNodeUrl] = chainId;
 
-      // If we've seen this chain ID already we can skip it.
-      if (blockNumbersForChain[chainId]) continue;
-
       // If STORE_MULTI_CHAIN_BLOCK_NUMBERS is set then this bot requires to know a number of last seen blocks across
       // a set of chainIds. Construct a batch promise to evaluate the latest block number for each chainId.
       if (configObject[botName]?.environmentVariables?.STORE_MULTI_CHAIN_BLOCK_NUMBERS) {
@@ -169,11 +166,14 @@ hub.post("/", async (req, res) => {
           if (index % 2 !== 0) return;
           const chainId = multiChainIds[Math.floor(index / 2)];
           blockNumbersForChain[chainId] = {
-            lastQueriedBlockNumber: results[index + 1],
-            latestBlockNumber: results[index],
+            lastQueriedBlockNumber: results[index],
+            latestBlockNumber: results[index + 1],
           };
         });
       }
+
+      // If we've seen this chain ID already we can skip it.
+      if (blockNumbersForChain[chainId]) continue;
 
       // Fetch last seen block for this chain and get the head block for the chosen chain, which we'll use to override the last queried block number
       // stored in GCP at the end of this hub execution.

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -63,7 +63,7 @@ describe("ServerlessHub.js", function () {
       ganacheServer.close();
       ganacheServers.pop();
     }
-  }
+  };
 
   const sendHubRequest = (body, port = hubTestPort) => {
     return request(`http://localhost:${port}`).post("/").send(body).set("Accept", "application/json");


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Serverless hub does not correctly handle block ranges when dealing with multi-network bots.

**Summary**

Fixes 2 bugs in Serverless hub to correctly store network block ranges for multi-network bot instances.

**Details**

We have not encountered this in prod as block ranges get also saved from single-network bot instances, but this could become an issue when adding new bots that have multiple networks not covered by other bots in the same spoke call.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-2373/fix-serverless-hub-block-numbers-for-multiple-network-bots
