### PR TITLE
feat: Relax OOv3 Interfaces Solidity Version Requirement to ^0.8.16

### DIFF
--- a/packages/core/contracts/optimistic-oracle-v3/interfaces/EscalationManagerInterface.sol
+++ b/packages/core/contracts/optimistic-oracle-v3/interfaces/EscalationManagerInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 import "./OptimisticOracleV3CallbackRecipientInterface.sol";
 

--- a/packages/core/contracts/optimistic-oracle-v3/interfaces/OptimisticOracleV3CallbackRecipientInterface.sol
+++ b/packages/core/contracts/optimistic-oracle-v3/interfaces/OptimisticOracleV3CallbackRecipientInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 /**
  * @title Optimistic Oracle V3 Callback Recipient Interface

--- a/packages/core/contracts/optimistic-oracle-v3/interfaces/OptimisticOracleV3Interface.sol
+++ b/packages/core/contracts/optimistic-oracle-v3/interfaces/OptimisticOracleV3Interface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 


### PR DESCRIPTION
Changes proposed in this PR:
- Relax OOv3 Interfaces Solidity Version Requirement to ^0.8.16