### PR TITLE
fix: transfer voting v2 owner to governor in testnet task

### DIFF
--- a/packages/common/src/hardhat/tasks/dvmv2Testnet.ts
+++ b/packages/common/src/hardhat/tasks/dvmv2Testnet.ts
@@ -127,10 +127,26 @@ task("setup-dvmv2-testnet", "Configures DVMv2 on L1 testnet")
     }
 
     /** ***********************************
+     * Transferring VotingV2 ownership to GovernorV2
+     *************************************/
+
+    const votingV2 = new web3.eth.Contract(VotingV2.abi, VotingV2.address);
+    console.log(`Using VotingV2 @ ${votingV2.options.address}`);
+
+    const GovernorV2 = await deployments.get("GovernorV2");
+
+    const currentOwner = await votingV2.methods.owner().call();
+    if (currentOwner !== GovernorV2.address) {
+      const txn = await votingV2.methods.transferOwnership(GovernorV2.address).send({ from: deployer });
+      console.log(`Set VotingV2 owner to GovernorV2 @ ${GovernorV2.address}, tx: ${txn.transactionHash}`);
+    } else {
+      console.log(`VotingV2 @ ${VotingV2.address} already owned by GovernorV2`);
+    }
+
+    /** ***********************************
      * Setting up roles for GovernorV2
      *************************************/
 
-    const GovernorV2 = await deployments.get("GovernorV2");
     const governorV2 = new web3.eth.Contract(GovernorV2.abi, GovernorV2.address);
     console.log(`Using GovernorV2 @ ${governorV2.options.address}`);
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

DVMv2 testnet setup tasks was missing transfer of VotingV2 owner to GovernorV2. This is required so we can submit governance proposals on testnet.

**Summary**

Transfers VotingV2 owner to GovernorV2 in DVMv2 setup task for testnets.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
