### PR TITLE
fix: emit redis errors to console rather than sending a logger error

### DIFF
--- a/packages/logger/src/logger/PersistentTransport.ts
+++ b/packages/logger/src/logger/PersistentTransport.ts
@@ -26,7 +26,9 @@ export abstract class PersistentTransport extends Transport {
     super(winstonOpts);
 
     const url = process.env.REDIS_URL || redisDefaultUrl;
-    this.redis = createClient({ url }).on("error", (err) => this.emit("error", err)); // Pass redis errors to logger.
+    // Pass redis errors to console. We don't want this to emit an error log, since these are normally connection
+    // errors unrelated to a particular request.
+    this.redis = createClient({ url }).on("error", (err) => console.error("Redis error", err));
 
     const botIdentifier = process.env.BOT_IDENTIFIER || noBotId;
     this.logListKey = `uma-persistent-log-queue:${botIdentifier}:${derivedTransport}`;


### PR DESCRIPTION
We've seen quite a few socket related errors being spit out of the redis client, generating pages. Redis emits network errors frequently. I suspect that most are recoverable and unrelated to a particular request, so it's probably not right to page on them.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
