### PR TITLE
feat: blast contract deployments

### DIFF
--- a/packages/common/src/HardhatConfig.ts
+++ b/packages/common/src/HardhatConfig.ts
@@ -107,7 +107,14 @@ export function getHardhatConfig(
         chainId: 1,
         url: getNodeUrl("mainnet", true, 1),
         accounts: { mnemonic },
-        companionNetworks: { arbitrum: "arbitrum", optimism: "optimism", boba: "boba", xdai: "xdai", base: "base" },
+        companionNetworks: {
+          arbitrum: "arbitrum",
+          optimism: "optimism",
+          boba: "boba",
+          xdai: "xdai",
+          base: "base",
+          blast: "blast",
+        },
       },
       rinkeby: { chainId: 4, url: getNodeUrl("rinkeby", true, 4), accounts: { mnemonic } },
       goerli: { chainId: 5, url: getNodeUrl("goerli", true, 5), accounts: { mnemonic } },
@@ -202,6 +209,12 @@ export function getHardhatConfig(
         accounts: { mnemonic },
         companionNetworks: { mainnet: "mainnet" },
       },
+      blast: {
+        chainId: 81457,
+        url: getNodeUrl("blast", true, 81457),
+        accounts: { mnemonic },
+        companionNetworks: { mainnet: "mainnet" },
+      },
     },
     mocha: { timeout: 1800000 },
     etherscan: {
@@ -263,6 +276,14 @@ export function getHardhatConfig(
           urls: {
             apiURL: "https://www.oklink.com/api/explorer/v1/contract/verify/async/api/polygonAmoy",
             browserURL: "https://www.oklink.com/amoy",
+          },
+        },
+        {
+          network: "blast",
+          chainId: 81457,
+          urls: {
+            apiURL: "https://api.blastscan.io/api",
+            browserURL: "https://blastscan.io/",
           },
         },
       ],

--- a/packages/common/src/ProviderUtils.ts
+++ b/packages/common/src/ProviderUtils.ts
@@ -53,6 +53,7 @@ export function getNodeUrl(networkName: string, useHttps = false, chainId: numbe
     if (name === "core") return overrideUrl || "https://rpc.coredao.org/";
     if (name === "base-goerli") return overrideUrl || "https://goerli.base.org";
     if (name === "base") return overrideUrl || "https://mainnet.base.org";
+    if (name === "blast") return overrideUrl || "https://rpc.blast.io/";
     return (
       overrideUrl ||
       (useHttps ? `https://${name}.infura.io/v3/${infuraApiKey}` : `wss://${name}.infura.io/ws/v3/${infuraApiKey}`)

--- a/packages/common/src/PublicNetworks.ts
+++ b/packages/common/src/PublicNetworks.ts
@@ -93,6 +93,7 @@ export const PublicNetworks: PublicNetworksType = {
   42161: { name: "arbitrum", nativeToken: "ETH", etherscan: "https://arbiscan.io/" },
   43114: { name: "avalanche", nativeToken: "AVAX", etherscan: "https://snowtrace.io/" },
   8453: { name: "base", nativeToken: "ETH", etherscan: "https://basescan.org/" },
+  81457: { name: "blast", nativeToken: "ETH", etherscan: "https://blastscan.io/" },
   84531: { name: "base-goerli", nativeToken: "ETH", etherscan: "https://goerli.basescan.org/" },
   421611: { name: "arbitrum-rinkeby", nativeToken: "ETH", etherscan: "https://testnet.arbiscan.io/" },
   421613: { name: "arbitrum-goerli", nativeToken: "ETH", etherscan: "https://goerli.arbiscan.io/" },

--- a/packages/common/src/TimeUtils.ts
+++ b/packages/common/src/TimeUtils.ts
@@ -32,6 +32,8 @@ export async function averageBlockTimeSeconds(chainId?: number): Promise<number>
       return 3;
     case 8453:
       return 2;
+    case 81457:
+      return 2;
     case 1:
       return defaultBlockTimeSeconds;
     default:

--- a/packages/core/deploy/038_deploy_oracle_spoke.js
+++ b/packages/core/deploy/038_deploy_oracle_spoke.js
@@ -17,5 +17,6 @@ func.tags = [
   "l2-optimism-xchain",
   "l2-admin-xchain",
   "l2-base-xchain",
+  "l2-blast-xchain",
 ];
 func.dependencies = ["Finder"];

--- a/packages/core/deploy/039_deploy_oracle_hub.js
+++ b/packages/core/deploy/039_deploy_oracle_hub.js
@@ -21,5 +21,12 @@ const func = async function (hre) {
   });
 };
 module.exports = func;
-func.tags = ["OracleHub", "l1-arbitrum-xchain", "l1-boba-xchain", "l1-optimism-xchain", "l1-base-xchain"];
+func.tags = [
+  "OracleHub",
+  "l1-arbitrum-xchain",
+  "l1-boba-xchain",
+  "l1-optimism-xchain",
+  "l1-base-xchain",
+  "l1-blast-xchain",
+];
 func.dependencies = ["Finder", "VotingToken"];

--- a/packages/core/deploy/040_deploy_governor_spoke.js
+++ b/packages/core/deploy/040_deploy_governor_spoke.js
@@ -17,5 +17,6 @@ func.tags = [
   "l2-optimism-xchain",
   "l2-admin-xchain",
   "l2-base-xchain",
+  "l2-blast-xchain",
 ];
 func.dependencies = ["Finder"];

--- a/packages/core/deploy/041_deploy_governor_hub.js
+++ b/packages/core/deploy/041_deploy_governor_hub.js
@@ -7,4 +7,11 @@ const func = async function (hre) {
   await deploy("GovernorHub", { from: deployer, args: [], log: true, skipIfAlreadyDeployed: true });
 };
 module.exports = func;
-func.tags = ["GovernorHub", "l1-arbitrum-xchain", "l1-boba-xchain", "l1-optimism-xchain", "l1-base-xchain"];
+func.tags = [
+  "GovernorHub",
+  "l1-arbitrum-xchain",
+  "l1-boba-xchain",
+  "l1-optimism-xchain",
+  "l1-base-xchain",
+  "l1-blast-xchain",
+];

--- a/packages/core/deploy/057_deploy_optimistic_oracle_V3.js
+++ b/packages/core/deploy/057_deploy_optimistic_oracle_V3.js
@@ -16,6 +16,7 @@ const ADDRESSES_FOR_NETWORK = {
   43114: { defaultCurrency: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E" },
   80001: { defaultCurrency: "0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747" },
   80002: { defaultCurrency: "0x9b4A302A548c7e313c2b74C461db7b84d3074A84" },
+  81457: { defaultCurrency: "0x4300000000000000000000000000000000000003" },
   11155111: { defaultCurrency: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238" },
 };
 const func = async function (hre) {

--- a/packages/core/deploy/064_deploy_blast_parent_messenger.js
+++ b/packages/core/deploy/064_deploy_blast_parent_messenger.js
@@ -1,0 +1,19 @@
+const func = async function (hre) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+
+  await deploy("Blast_ParentMessenger", {
+    contract: "Optimism_ParentMessenger",
+    from: deployer,
+    args: [
+      "0x5D4472f31Bd9385709ec61305AFc749F0fA8e9d0", // Blast's OVM L1 Cross Domain Messenger
+      81457, // Child network ID
+    ],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
+};
+module.exports = func;
+func.tags = ["Blast_ParentMessenger", "l1-blast-xchain"];

--- a/packages/core/deploy/065_deploy_blast_child_messenger.js
+++ b/packages/core/deploy/065_deploy_blast_child_messenger.js
@@ -1,0 +1,25 @@
+const func = async function (hre) {
+  const { deployments, getNamedAccounts, companionNetworks } = hre;
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  // Grab parent messenger address:
+  // Default to pulling from this chain if the companion network doesn't exist.
+  if (!companionNetworks["mainnet"])
+    console.error(
+      "WARNING: attempting to use same chain for mainnet and blast contracts because mainnet companion network doesn't exist."
+    );
+  const { deployments: l1Deployments } = companionNetworks["mainnet"] || hre;
+  const parentMessenger = await l1Deployments.get("Blast_ParentMessenger");
+  console.log(`Using l1 parent messenger @ ${parentMessenger.address}`);
+
+  await deploy("Blast_ChildMessenger", {
+    contract: "Optimism_ChildMessenger",
+    from: deployer,
+    args: [parentMessenger.address],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  });
+};
+module.exports = func;
+func.tags = ["Blast_ChildMessenger", "l2-blast-xchain"];

--- a/packages/core/networks/1.json
+++ b/packages/core/networks/1.json
@@ -163,6 +163,11 @@
     "address": "0x721bA6f9A0a44657f008f3d68C6dBdDeDBDE831A"
   },
   {
+    "contractName": "Optimism_ParentMessenger",
+    "deploymentName": "Blast_ParentMessenger",
+    "address": "0xe3C52FB4c395165b13f8184644D60357e7D3b995"
+  },
+  {
     "contractName": "Proposer",
     "address": "0x226726Ac52e6e948D1B7eA9168F9Ff2E27DbcbB5"
   },

--- a/packages/core/networks/81457.json
+++ b/packages/core/networks/81457.json
@@ -1,0 +1,47 @@
+[
+  {
+    "contractName": "Registry",
+    "address": "0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75"
+  },
+  {
+    "contractName": "Finder",
+    "address": "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96"
+  },
+  {
+    "contractName": "OracleSpoke",
+    "address": "0x38fAc33bD20D4c4Cce085C0f347153C06CbA2968"
+  },
+  {
+    "contractName": "GovernorSpoke",
+    "address": "0x9b4A302A548c7e313c2b74C461db7b84d3074A84"
+  },
+  {
+    "contractName": "Optimism_ChildMessenger",
+    "deploymentName": "Blast_ChildMessenger",
+    "address": "0x3Db06DA8F0a24A525f314eeC954fC5c6a973d40E"
+  },
+  {
+    "contractName": "IdentifierWhitelist",
+    "address": "0xd2ecb3afe598b746F8123CaE365a598DA831A449"
+  },
+  {
+    "contractName": "Store",
+    "address": "0x6999526e507Cc3b03b180BbE05E1Ff938259A874"
+  },
+  {
+    "contractName": "AddressWhitelist",
+    "address": "0xd85630E361cEbBC4c7f13e6eEd3587050fB81B86"
+  },
+  {
+    "contractName": "OptimisticOracle",
+    "address": "0x3CA11702f7c0F28e0b4e03C31F7492969862C569"
+  },
+  {
+    "contractName": "OptimisticOracleV2",
+    "address": "0x4e8E101924eDE233C13e2D8622DC8aED2872d505"
+  },
+  {
+    "contractName": "OptimisticOracleV3",
+    "address": "0xE8FF2a3d5Cc19DDcBd93328371E1Dd8995e7AfAA"
+  }
+]

--- a/packages/financial-templates-lib/src/helpers/GasEstimator.ts
+++ b/packages/financial-templates-lib/src/helpers/GasEstimator.ts
@@ -71,6 +71,7 @@ export const MAPPING_BY_NETWORK: GasEstimatorMapping = {
     defaultMaxPriorityFeePerGasGwei: 1,
     type: NetworkType.London,
   },
+  81457: { type: NetworkType.London },
 };
 
 const DEFAULT_NETWORK_ID = 1; // Ethereum Mainnet.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Potential UMA integrations would need to use Optimistic Oracle on Blast network.

**Summary**

Adds Optimistic Oracle contract deployments for Blast network.

**Details**

Changes proposed in this PR:
- Add Blast network as a supported network
- Deploy Blast contracts and L1 Parent Messenger
- Verify contracts
- Run all the required L1 and L2 configurations
- Update configuration and verification scripts (including new default gas limit of 500k in parent messenger)
- Update readme

This requires governance action set Blast parent messenger on L1 (see verification script below):

```
$ yarn hardhat verify-xchain --network mainnet --l2 blast

🌕 Verifying L1 contract state 🌕
  GovernorHub
    - Owner set to Governor: ✅
    - Messenger for chain ID 81457 set to ParentMessenger: ❌ ==> Requires governance action
  OracleHub
    - Owner set to Governor: ✅
    - Messenger for chain ID 81457 set to ParentMessenger: ❌ ==> Requires governance action
  Blast_ParentMessenger
    - Owner set to Governor: ✅
    - Child chain ID set to 81457: ✅
    - Set childMessenger address: ✅
    - Set oracleHub address: ✅
    - Set governorHub address: ✅
    - Set oracleSpoke address: ✅
    - Set governorSpoke address: ✅
  Registry
    - OracleHub registered: ✅

🌚 Verifying L2 contract state 🌚
  Registry
    - OptimisticOracle registered: ✅
    - OptimisticOracleV2 registered: ✅
    - OptimisticOracleV3 registered: ✅
    - Owned by GovernorSpoke: ✅
  Store
    - Owned by GovernorSpoke: ✅
  IdentifierWhitelist
    - Owned by GovernorSpoke: ✅
  OptimisticOracleV3
    - Owned by GovernorSpoke: ✅
  AddressWhitelist
    - Owned by GovernorSpoke: ✅
  Blast_ChildMessenger
    - Set oracleSpoke: ✅
    - Set parentMessenger: ✅
  Finder
    - Owned by GovernorSpoke: ✅
    - Set "Store" in Finder: ✅
    - Set "IdentifierWhitelist": ✅
    - Set "CollateralWhitelist" in Finder: ✅
    - Set "Oracle" in Finder (to OracleSpoke): ✅
    - Set "OptimisticOracle" in Finder: ✅
    - Set "OptimisticOracleV2" in Finder: ✅
    - Set "OptimisticOracleV3" in Finder: ✅
    - Set "ChildMessenger" in Finder: ✅
```

Following collateral currencies have been pre-approved on Blast:

- WETH at [0x4300000000000000000000000000000000000004]([0x4300000000000000000000000000000000000004](https://blastscan.io/address/0x4300000000000000000000000000000000000004)) with 0.135 final fee. This is rebasing token that captures yield from staking ETH on L1 bridge.
- USDB at [0x4300000000000000000000000000000000000003](https://blastscan.io/address/0x4300000000000000000000000000000000000003) with 250 final fee. Users who bridge stablecoins receive USDB, Blast’s auto-rebasing stablecoin. The yield for USDB comes from MakerDAO’s on-chain T-Bill protocol. USDB can be redeemed for DAI when bridging back to Ethereum.
- WBTC at [0xF7bc58b8D8f97ADC129cfC4c9f45Ce3C0E1D2692](https://blastscan.io/address/0xF7bc58b8D8f97ADC129cfC4c9f45Ce3C0E1D2692) with 0.025 final fee.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes https://linear.app/uma/issue/UMA-2515/blast-contract-deployments
