### PR TITLE
fix: pause persistent log queue after flush timeout

### DIFF
--- a/packages/logger/src/logger/PersistentTransport.ts
+++ b/packages/logger/src/logger/PersistentTransport.ts
@@ -33,7 +33,7 @@ export abstract class PersistentTransport extends Transport {
     const botIdentifier = process.env.BOT_IDENTIFIER || noBotId;
     this.logListKey = `uma-persistent-log-queue:${botIdentifier}:${derivedTransport}`;
 
-    this.on("processed", () => this.isQueueBeingExecuted = false); // Unlock queue execution when current run processed.
+    this.on("processed", () => (this.isQueueBeingExecuted = false)); // Unlock queue execution when current run processed.
   }
 
   // Getter for checking if the transport is flushed.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Discord verification team reported that Optimistic Oracle bots are rate limited to 1 ticket per every serverless run cycle of 5 minutes. This is a bug that should be fixed.

**Summary**

Fixes Discord Ticket logger bug to allow submit max tickets as permitted by intended rate limit (1 ticket per 15 seconds).

**Details**

The bug is fixed by moving signal to pause persistent log queue transports only after waiting for logger flush timeout (we use 5 minutes for Oracle bots). In order to gracefully handle log delivery once this timeout passes this fix also changes `pauseProcessing` method to async and waits for `processed` event emitted from `processLogQueue` when it gets out of `while (this.canProcess)` loop.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
