### PR TITLE
fix: Revert "improve(oo): reuse lookback config when initing ooclient"

### DIFF
--- a/packages/optimistic-oracle/index.js
+++ b/packages/optimistic-oracle/index.js
@@ -87,7 +87,7 @@ async function run({
       web3,
       optimisticOracleAddress,
       await getAddress(oracleType, networkId),
-      commonPriceFeedConfig?.lookback || 604800, // default lookback setting for this client
+      604800, // default lookback setting for this client
       optimisticOracleType,
       blocksPerEventSearch ? Number(blocksPerEventSearch) : null
     );


### PR DESCRIPTION
Reverts UMAprotocol/protocol#4760

**Motivation**

Fix in #4760 would end up passing lookbacks to OO client that could result in bot not settling proposals when challenge window is longer than lookback or if the proposal was disputed.

**Summary**

We should have fixed 1 week lookback to track full lifecycle of OO proposals. If provider is causing issues this should be solved by passing `MAX_BLOCKS_PER_EVENT_SEARCH` to paginate event queries.