### PR TITLE
fix: update nodejs version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   checkout_and_install:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - checkout
@@ -28,7 +28,7 @@ jobs:
             - ~/.ssh
   build:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     resource_class: large
     steps:
@@ -50,7 +50,7 @@ jobs:
             - ~/.ssh
   lint:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - restore_cache:
@@ -73,7 +73,7 @@ jobs:
           configuration_path: /home/circleci/protocol/.circleci/lerna_config.yml
   coverage:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - checkout
@@ -86,7 +86,7 @@ jobs:
           path: packages/core/coverage
   publish:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     working_directory: ~/protocol
     steps:
       - add_ssh_keys:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # that are not in the protocol repo, such as the Across v2 relayer. To access these set a command 
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:16
+FROM node:20
 
 # All source code and execution happens from the protocol directory.
 WORKDIR /protocol

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For detailed information on how to initialize and interact with our smart contra
 
 ### Install dependencies 👷‍♂️
 
-You'll need to install the long-term support version of nodejs, currently nodejs v14. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
+You'll need to install the long-term support version of nodejs, currently nodejs v20. You will also need to install yarn. Assuming that's done, run `yarn` with no args:
 
 ```
 yarn

--- a/ci/tests/test-financial-templates-lib.sh
+++ b/ci/tests/test-financial-templates-lib.sh
@@ -3,7 +3,7 @@
 cat << EOF
   test-financial-templates-lib-hardhat:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-liquidator.sh
+++ b/ci/tests/test-liquidator.sh
@@ -3,7 +3,7 @@
 cat << EOF
   test-liquidator-package:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-not-required.sh
+++ b/ci/tests/test-not-required.sh
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   tests-required:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     steps:
       - run:
           name: Test dependencies

--- a/ci/tests/test-packages.sh
+++ b/ci/tests/test-packages.sh
@@ -5,7 +5,7 @@ PACKAGE=$1
 cat << EOF
   test-${PACKAGE:5}:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
       - image: trufflesuite/ganache-cli
         command: ganache-cli -i 1234 -l 9000000 -p 9545
     working_directory: ~/protocol

--- a/ci/tests/test-required.sh
+++ b/ci/tests/test-required.sh
@@ -3,7 +3,7 @@
 cat << EOF
   tests-required:
     docker:
-      - image: cimg/node:16.17.0
+      - image: cimg/node:lts
     steps:
       - run:
           name: Test dependencies


### PR DESCRIPTION
Note: this is a retry of https://github.com/UMAprotocol/protocol/pull/4678 after it was rolled back due to downstream performance issues in https://github.com/across-protocol/relayer that have now been mitigated.

**Motivation**

Nodejs 16 is EOL and it's important to continue to get security updates from nodejs.


**Summary**

Updated all references to nodejs 16.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

N/A
