### PR TITLE
feat: Prevent reproposing disputed proposals in snapshot

### DIFF
--- a/packages/monitor-v2/src/monitor-og/README.md
+++ b/packages/monitor-v2/src/monitor-og/README.md
@@ -93,3 +93,4 @@ All the configuration should be provided with following environment variables:
   `datastore`. Supported values are `datastore` (Google Datastore) and `file` (local file system).
 - `TENDERLY_USER`, `TENDERLY_PROJECT` and `TENDERLY_ACCESS_KEY` are used to simulate proposed transaction execution on
   Tenderly. If any of these are missing, the bot will skip the simulation.
+- `REPROPOSE_DISPUTED` is a boolean indicating whether to re-propose disputed proposals. Defaults to `false`.

--- a/packages/monitor-v2/src/monitor-og/SnapshotVerification.ts
+++ b/packages/monitor-v2/src/monitor-og/SnapshotVerification.ts
@@ -49,7 +49,7 @@ interface LegacyOsnapPlugin {
 
 // safeSnap plugin type for mainTransaction. If there are multiple transactions within a batch, they are aggregated as
 // multiSend in the mainTransaction.
-interface MainTransaction {
+export interface MainTransaction {
   to: string;
   data: string;
   value: string;

--- a/packages/monitor-v2/src/monitor-og/common.ts
+++ b/packages/monitor-v2/src/monitor-og/common.ts
@@ -75,6 +75,7 @@ export interface MonitoringParams {
   useTenderly: boolean;
   botModes: BotModes;
   retryOptions: RetryOptions;
+  reproposeDisputed: boolean; // Defaults to false, so we don't repropose disputed proposals.
   storage: "datastore" | "file"; // Defaults to "datastore", but only used when notifying new proposals.
 }
 
@@ -258,6 +259,9 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     throw new Error(`Invalid STORAGE type: ${storage}`);
   }
 
+  // By default, do not re-propose disputed proposals.
+  const reproposeDisputed = env.REPROPOSE_DISPUTED === "true" ? true : false;
+
   const initialParams: MonitoringParams = {
     ogAddresses: [], // Will be added later after validation.
     moduleProxyFactoryAddresses,
@@ -280,6 +284,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv, _provider?: P
     botModes,
     retryOptions,
     storage,
+    reproposeDisputed,
   };
 
   // If OG_ADDRESS is provided, use it in the monitored address list and return monitoring params.

--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -214,24 +214,24 @@ const getUndiscardedProposals = async (
     )
   ).flat();
 
-  // Get all deleted proposals for all provided modules.
-  const deletedProposals = (
-    await Promise.all(
-      ogAddresses.map(async (ogAddress) => {
-        const og = await getOgByAddress(params, ogAddress);
-        return runQueryFilter<ProposalDeletedEvent>(og, og.filters.ProposalDeleted(), {
-          start: 0,
-          end: params.blockRange.end,
-        });
-      })
-    )
-  ).flat();
-
-  // Filter out all proposals that have been deleted by matching assertionId. assertionId should be sufficient property
-  // for filtering as it is derived from module address, transaction content and assertion time among other factors.
-  const deletedAssertionIds = new Set(deletedProposals.map((deletedProposal) => deletedProposal.args.assertionId));
-
   if (params.reproposeDisputed) {
+    // Get all deleted proposals for all provided modules.
+    const deletedProposals = (
+      await Promise.all(
+        ogAddresses.map(async (ogAddress) => {
+          const og = await getOgByAddress(params, ogAddress);
+          return runQueryFilter<ProposalDeletedEvent>(og, og.filters.ProposalDeleted(), {
+            start: 0,
+            end: params.blockRange.end,
+          });
+        })
+      )
+    ).flat();
+
+    // Filter out all proposals that have been deleted by matching assertionId. assertionId should be sufficient property
+    // for filtering as it is derived from module address, transaction content and assertion time among other factors.
+    const deletedAssertionIds = new Set(deletedProposals.map((deletedProposal) => deletedProposal.args.assertionId));
+
     return allProposals.filter((proposal) => !deletedAssertionIds.has(proposal.args.assertionId));
   }
   return allProposals;

--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -154,7 +154,7 @@ const getSnapshotProposals = async (
 };
 
 // Get all finalized basic safeSnap/oSnap proposals for supported spaces and safes (returned in safeSnap format).
-const getSupportedSnapshotProposals = async (
+export const getSupportedSnapshotProposals = async (
   logger: typeof Logger,
   supportedModules: SupportedModules,
   params: MonitoringParams
@@ -230,7 +230,11 @@ const getUndiscardedProposals = async (
   // Filter out all proposals that have been deleted by matching assertionId. assertionId should be sufficient property
   // for filtering as it is derived from module address, transaction content and assertion time among other factors.
   const deletedAssertionIds = new Set(deletedProposals.map((deletedProposal) => deletedProposal.args.assertionId));
-  return allProposals.filter((proposal) => !deletedAssertionIds.has(proposal.args.assertionId));
+
+  if (params.reproposeDisputed) {
+    return allProposals.filter((proposal) => !deletedAssertionIds.has(proposal.args.assertionId));
+  }
+  return allProposals;
 };
 
 // Checks if a safeSnap safe from Snapshot proposal is supported by oSnap automation.
@@ -243,7 +247,7 @@ const isSafeSupported = (safe: SafeSnapSafe, supportedModules: SupportedModules,
 
 // Filters out all Snapshot proposals that have been proposed on-chain. This is done by matching safe, explanation and
 // proposed transactions.
-const filterPotentialProposals = (
+export const filterPotentialProposals = (
   supportedProposals: SnapshotProposalExpanded[],
   onChainProposals: TransactionsProposedEvent[],
   params: MonitoringParams
@@ -267,7 +271,7 @@ const filterPotentialProposals = (
 
 // Filters out all Snapshot proposals that cannot be proposed due to blocking on-chain proposals. This is done by
 // matching safe and proposed transactions.
-const filterUnblockedProposals = async (
+export const filterUnblockedProposals = async (
   potentialProposals: SnapshotProposalExpanded[],
   onChainProposals: TransactionsProposedEvent[],
   params: MonitoringParams
@@ -289,7 +293,7 @@ const filterUnblockedProposals = async (
 };
 
 // Verifies proposals before they are proposed on-chain.
-const filterVerifiedProposals = async (
+export const filterVerifiedProposals = async (
   proposals: SnapshotProposalExpanded[],
   supportedModules: SupportedModules,
   params: MonitoringParams
@@ -483,7 +487,7 @@ const hasFunds = async (provider: Provider, signer: Signer, currency: string, bo
   return balance.gte(BigNumber.from(bond));
 };
 
-const submitProposals = async (
+export const submitProposals = async (
   logger: typeof Logger,
   proposals: SnapshotProposalExpanded[],
   supportedModules: SupportedModules,


### PR DESCRIPTION
Changes proposed in this PR:
- Update the snapshot proposal logic to allow an environment variable to be passed, `REPROPOSE_DISPUTED`, which defaults to `false`, to enable reproposing disputed proposals.
- Add tests to verify the new functionality.