### PR TITLE
fix: osnap bot on disputed proposals

### DIFF
--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -213,9 +213,9 @@ const getAllProposals = async (
   ).flat();
 };
 
-// Filters all proposals that have not been discarded. Discards are most likely due to disputes, but can also occur on
+// Filters out all proposals that have been deleted. Discards are most likely due to disputes, but can also occur on
 // OOv3 upgrades.
-const filterUndiscardedProposals = async (
+const removeDeletedProposals = async (
   allProposals: TransactionsProposedEvent[],
   params: MonitoringParams
 ): Promise<Array<TransactionsProposedEvent>> => {
@@ -729,7 +729,7 @@ export const proposeTransactions = async (logger: typeof Logger, params: Monitor
 
   // Get all on-chain proposals for supported modules and filter all proposals that have not been discarded.
   const allOnChainProposals = await getAllProposals(Object.keys(supportedModules), params);
-  const undiscardedOnChainProposals = await filterUndiscardedProposals(allOnChainProposals, params);
+  const undiscardedOnChainProposals = await removeDeletedProposals(allOnChainProposals, params);
 
   // Filter Snapshot proposals that could potentially be proposed on-chain. This discards proposals that have been
   // posted on-chain: when re-proposing of disputed proposals is enabled we only consider undiscarded proposals,
@@ -748,7 +748,7 @@ export const proposeTransactions = async (logger: typeof Logger, params: Monitor
 
 export const disputeProposals = async (logger: typeof Logger, params: MonitoringParams): Promise<void> => {
   // Get all undiscarded on-chain proposals for all monitored modules.
-  const onChainProposals = await filterUndiscardedProposals(await getAllProposals(params.ogAddresses, params), params);
+  const onChainProposals = await removeDeletedProposals(await getAllProposals(params.ogAddresses, params), params);
 
   // Filter out all proposals that have been executed on-chain.
   const unexecutedProposals = await filterUnexecutedProposals(onChainProposals, params);
@@ -769,7 +769,7 @@ export const disputeProposals = async (logger: typeof Logger, params: Monitoring
 
 export const executeProposals = async (logger: typeof Logger, params: MonitoringParams): Promise<void> => {
   // Get all undiscarded on-chain proposals for all monitored modules.
-  const onChainProposals = await filterUndiscardedProposals(await getAllProposals(params.ogAddresses, params), params);
+  const onChainProposals = await removeDeletedProposals(await getAllProposals(params.ogAddresses, params), params);
 
   // Filter out all proposals that have been executed on-chain.
   const unexecutedProposals = await filterUnexecutedProposals(onChainProposals, params);

--- a/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
+++ b/packages/monitor-v2/src/monitor-og/oSnapAutomation.ts
@@ -195,14 +195,12 @@ export const getSupportedSnapshotProposals = async (
   return expandedProposals.filter((proposal) => isSafeSupported(proposal.safe, supportedModules, params.chainId));
 };
 
-// Get all proposals on provided oSnap modules that have not been discarded. Discards are most likely due to disputes,
-// but can also occur on OOv3 upgrades.
-const getUndiscardedProposals = async (
+// Get all proposals posted on provided oSnap modules including the disputed ones.
+const getAllProposals = async (
   ogAddresses: string[],
   params: MonitoringParams
 ): Promise<Array<TransactionsProposedEvent>> => {
-  // Get all proposals for all provided modules.
-  const allProposals = (
+  return (
     await Promise.all(
       ogAddresses.map(async (ogAddress) => {
         const og = await getOgByAddress(params, ogAddress);
@@ -213,28 +211,35 @@ const getUndiscardedProposals = async (
       })
     )
   ).flat();
+};
 
-  if (params.reproposeDisputed) {
-    // Get all deleted proposals for all provided modules.
-    const deletedProposals = (
-      await Promise.all(
-        ogAddresses.map(async (ogAddress) => {
-          const og = await getOgByAddress(params, ogAddress);
-          return runQueryFilter<ProposalDeletedEvent>(og, og.filters.ProposalDeleted(), {
-            start: 0,
-            end: params.blockRange.end,
-          });
-        })
-      )
-    ).flat();
+// Filters all proposals that have not been discarded. Discards are most likely due to disputes, but can also occur on
+// OOv3 upgrades.
+const filterUndiscardedProposals = async (
+  allProposals: TransactionsProposedEvent[],
+  params: MonitoringParams
+): Promise<Array<TransactionsProposedEvent>> => {
+  // Get oSnap module addresses from all proposals.
+  const ogAddresses = Array.from(new Set(allProposals.map((proposal) => proposal.address)));
 
-    // Filter out all proposals that have been deleted by matching assertionId. assertionId should be sufficient property
-    // for filtering as it is derived from module address, transaction content and assertion time among other factors.
-    const deletedAssertionIds = new Set(deletedProposals.map((deletedProposal) => deletedProposal.args.assertionId));
+  // Get all deleted proposals for all modules.
+  const deletedProposals = (
+    await Promise.all(
+      ogAddresses.map(async (ogAddress) => {
+        const og = await getOgByAddress(params, ogAddress);
+        return runQueryFilter<ProposalDeletedEvent>(og, og.filters.ProposalDeleted(), {
+          start: 0,
+          end: params.blockRange.end,
+        });
+      })
+    )
+  ).flat();
 
-    return allProposals.filter((proposal) => !deletedAssertionIds.has(proposal.args.assertionId));
-  }
-  return allProposals;
+  // Filter out all proposals that have been deleted by matching assertionId. assertionId should be sufficient property
+  // for filtering as it is derived from module address, transaction content and assertion time among other factors.
+  const deletedAssertionIds = new Set(deletedProposals.map((deletedProposal) => deletedProposal.args.assertionId));
+
+  return allProposals.filter((proposal) => !deletedAssertionIds.has(proposal.args.assertionId));
 };
 
 // Checks if a safeSnap safe from Snapshot proposal is supported by oSnap automation.
@@ -722,12 +727,19 @@ export const proposeTransactions = async (logger: typeof Logger, params: Monitor
   // Get all finalized basic safeSnap/oSnap proposals for supported spaces and safes (returned in safeSnap format)
   const supportedProposals = await getSupportedSnapshotProposals(logger, supportedModules, params);
 
-  // Get all undiscarded on-chain proposals for supported modules.
-  const onChainProposals = await getUndiscardedProposals(Object.keys(supportedModules), params);
+  // Get all on-chain proposals for supported modules and filter all proposals that have not been discarded.
+  const allOnChainProposals = await getAllProposals(Object.keys(supportedModules), params);
+  const undiscardedOnChainProposals = await filterUndiscardedProposals(allOnChainProposals, params);
 
-  // Filter Snapshot proposals that could potentially be proposed on-chain.
-  const potentialProposals = filterPotentialProposals(supportedProposals, onChainProposals, params);
-  const unblockedProposals = await filterUnblockedProposals(potentialProposals, onChainProposals, params);
+  // Filter Snapshot proposals that could potentially be proposed on-chain. This discards proposals that have been
+  // posted on-chain: when re-proposing of disputed proposals is enabled we only consider undiscarded proposals,
+  // otherwise all on-chain proposals are considered.
+  const potentialProposals = filterPotentialProposals(
+    supportedProposals,
+    params.reproposeDisputed ? undiscardedOnChainProposals : allOnChainProposals,
+    params
+  );
+  const unblockedProposals = await filterUnblockedProposals(potentialProposals, undiscardedOnChainProposals, params);
   const verifiedProposals = await filterVerifiedProposals(unblockedProposals, supportedModules, params);
 
   // Submit proposals.
@@ -736,7 +748,7 @@ export const proposeTransactions = async (logger: typeof Logger, params: Monitor
 
 export const disputeProposals = async (logger: typeof Logger, params: MonitoringParams): Promise<void> => {
   // Get all undiscarded on-chain proposals for all monitored modules.
-  const onChainProposals = await getUndiscardedProposals(params.ogAddresses, params);
+  const onChainProposals = await filterUndiscardedProposals(await getAllProposals(params.ogAddresses, params), params);
 
   // Filter out all proposals that have been executed on-chain.
   const unexecutedProposals = await filterUnexecutedProposals(onChainProposals, params);
@@ -757,7 +769,7 @@ export const disputeProposals = async (logger: typeof Logger, params: Monitoring
 
 export const executeProposals = async (logger: typeof Logger, params: MonitoringParams): Promise<void> => {
   // Get all undiscarded on-chain proposals for all monitored modules.
-  const onChainProposals = await getUndiscardedProposals(params.ogAddresses, params);
+  const onChainProposals = await filterUndiscardedProposals(await getAllProposals(params.ogAddresses, params), params);
 
   // Filter out all proposals that have been executed on-chain.
   const unexecutedProposals = await filterUnexecutedProposals(onChainProposals, params);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#4765 introduced side effects on oSnap bot:
- when proposing, it would not consider proposals that had been disputed (as intended by the fix), but this also extends to proposals from another snapshot votes that had been disputed and happens to have matching tx content with a new snapshot vote that has not been disputed since results of `getUndiscardedProposals` now can include also discarded proposals and are used as inputs in `filterUnblockedProposals`
- when disputing, it would consider all proposals, even those that had been disputed and are still in challenge window. this would result in bot error logging the failed dispute attempts since the proposal has been discarded from prior dispute
- when executing, it would also consider all disputed proposals that are past their challenge windows. this results in bot info logging the failed execution attempts since the proposal has been discarded by dispute.

**Summary**

This addresses the issue by splitting the `getUndiscardedProposals` in 2 functions (`getAllProposals` and `filterUndiscardedProposals`) and it is up to the caller which to use depending on context and `reproposeDisputed` flag.





**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
