### PR TITLE
feat: filter warnings from PD

### DIFF
--- a/packages/logger/src/logger/Transports.ts
+++ b/packages/logger/src/logger/Transports.ts
@@ -91,7 +91,7 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
     if (transportsConfig.pdApiToken || process.env.PAGER_DUTY_CONFIG) {
       transports.push(
         new PagerDutyTransport(
-          { level: "warn" },
+          { level: "error" },
           transportsConfig.pagerDutyConfig ?? JSON.parse(process.env.PAGER_DUTY_CONFIG || "null")
         )
       );
@@ -103,7 +103,7 @@ export function createTransports(transportsConfig: TransportsConfig = {}): Trans
         transportsConfig.pagerDutyV2Config ?? JSON.parse(process.env.PAGER_DUTY_V2_CONFIG || "null");
       // this will throw an error if an invalid configuration is present
       if (!disabled) {
-        transports.push(new PagerDutyV2Transport({ level: "warn" }, pagerDutyV2CreateConfig(pagerDutyV2Config)));
+        transports.push(new PagerDutyV2Transport({ level: "error" }, pagerDutyV2CreateConfig(pagerDutyV2Config)));
       }
     }
   }


### PR DESCRIPTION
**Motivation**

Only send errors to PD, since paging over a warning is typically not done. These alerts can be sent via other means, like slack or discord rather than PD.


**Summary**

N/A


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
