### PR TITLE
fix: reduce log size for all calls returned correctly

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -316,11 +316,18 @@ hub.post("/", async (req, res) => {
     }
 
     // If no errors and got to this point correctly then return a 200 success status.
+    // Note: we don't log the error outputs since it is empty in this branch.
     logger.debug({
       at: "ServerlessHub",
       message: "All calls returned correctly",
-      output: { errorOutputs, validOutputs, retriedOutputs },
+      output: { validOutputs: Object.keys(validOutputs), retriedOutputs },
     });
+
+    // Log each bot's output separately to avoid creating huge log messages.
+    // Note: no need to loop through errorOutputs since the length has been
+    for (const [botName, output] of Object.entries(validOutputs)) {
+      logger.debug({ at: "ServerlessHub", message: `Bot ${botName} succeeded`, output });
+    }
 
     await delay(waitForLoggerDelay); // Wait a few seconds to be sure the the winston logs are processed upstream.
     res

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -175,14 +175,14 @@ describe("ServerlessHub.js", function () {
     const validResponse = await sendHubRequest(validBody);
     assert.equal(validResponse.res.statusCode, 200); // no error code
     assert.isTrue(validResponse.res.text.includes("All calls returned correctly")); // Final text in monitor loop.
-    assert.isTrue(lastSpyLogIncludes(hubSpy, "All calls returned correctly")); // The hub should have exited correctly.
+    assert.isTrue(spyLogIncludes(hubSpy, -2, "All calls returned correctly")); // The hub should have exited correctly.
     assert.isTrue(lastSpyLogIncludes(spokeSpy, "Process exited with no error")); // The spoke should have exited correctly.
     assert.isTrue(lastSpyLogIncludes(spokeSpy, `${startingBlockNumber + 1}`)); // The spoke should have the correct starting block number.
-    assert.isTrue(spyLogIncludes(hubSpy, -3, startingBlockNumber), "should return block information for chain");
-    assert.isTrue(spyLogIncludes(hubSpy, -3, defaultChainId), "should return chain ID");
-    assert.isTrue(spyLogIncludes(hubSpy, -3, startingBlockNumber), "should return block information for chain");
-    assert.isTrue(spyLogIncludes(hubSpy, -3, defaultChainId), "should return chain ID");
-    assert.isTrue(spyLogIncludes(hubSpy, -4, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
+    assert.isTrue(spyLogIncludes(hubSpy, -4, startingBlockNumber), "should return block information for chain");
+    assert.isTrue(spyLogIncludes(hubSpy, -4, defaultChainId), "should return chain ID");
+    assert.isTrue(spyLogIncludes(hubSpy, -4, startingBlockNumber), "should return block information for chain");
+    assert.isTrue(spyLogIncludes(hubSpy, -4, defaultChainId), "should return chain ID");
+    assert.isTrue(spyLogIncludes(hubSpy, -5, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
   });
   it("ServerlessHub can correctly execute bot with named spokes", async function () {
     // Set up the environment for testing. For these tests the hub is tested in `localStorage` mode where it will
@@ -391,15 +391,8 @@ describe("ServerlessHub.js", function () {
     assert.equal(Object.keys(responseObject.output.validOutputs).length, 3); // should be 3 valid outputs
 
     // Check hub has correct logs.
-    assert.isTrue(lastSpyLogIncludes(hubSpy, "All calls returned correctly")); // The hub should have exited correctly.
-    assert.equal(lastSpyLogLevel(hubSpy), "debug"); // most recent log level should be "debug" (no error)
-    assert.isTrue(spyLogIncludes(hubSpy, -4, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
-
-    // Check that each bot identifier returned the correct exit code within the final hub log.
-    const lastSpyHubLog = hubSpy.getCall(-1).lastArg;
-    for (const logObject of Object.keys(lastSpyHubLog.output.validOutputs)) {
-      assert.isTrue(logObject.indexOf("End of serverless execution loop - terminating process") != 0);
-    }
+    assert.isTrue(spyLogIncludes(hubSpy, -4, "All calls returned correctly")); // The hub should have exited correctly.
+    assert.isTrue(spyLogIncludes(hubSpy, -7, `"botsExecuted":${JSON.stringify(Object.keys(hubConfig))}`)); // all bots within the config should have been reported to be executed.
   });
   it("ServerlessHub can correctly deal with some bots erroring out in execution", async function () {
     // Set up the environment for testing. For these tests the hub is tested in `localStorage` mode where it will


### PR DESCRIPTION
**Motivation**

Serverless hub tries to emit all the stdout for all the bots that it runs in a single log. This log can be so large that it fails to be emitted.


**Summary**

This PR splits the log into 2. One log that just lists the successful bot runs and a second that is emits a separate log per bot along with its output.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
