### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Generic badge](https://img.shields.io/badge/homepage-view-red.svg)](https://umaproject.org/)
 [![Generic badge](https://img.shields.io/badge/discord-join-green.svg)](https://discord.com/invite/jsb9XQJ)
 [![Generic badge](https://img.shields.io/badge/send-email-blue.svg)](mailto:hello@umaproject.org)
-[![Twitter Follow](https://img.shields.io/twitter/follow/UMAprotocol?label=follow%20%40UMAprotocol&style=social)](https://twitter.com/UMAprotocol)
+[![Twitter Follow](https://img.shields.io/twitter/follow/UMAprotocol?label=follow%20%40UMAprotocol&style=social)](https://x.com/UMAprotocol)
 
 ## Documentation 📚
 


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com/youngbuddha108) to align with the platform's rebranding.
