### PR TITLE
feat(gas-rebates): update gas rebate scripts with new rules

### DIFF
--- a/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
+++ b/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
@@ -110,7 +110,7 @@ export async function run(): Promise<void> {
   // Filter out duplicate commit events as we only refund the first commit event per voter per round
   const uniqueCommitEvents = new Map<string, VoteCommittedEvent>();
 
-  // Sort first by blockNumber (desc) and then by logIndex (desc) as a tiebreaker
+  // Sort first by blockNumber (asc) and then by logIndex (asc) as a tiebreaker
   const sortedCommitEvents = commitEvents.sort((a, b) => {
     if (a.blockNumber !== b.blockNumber) {
       return a.blockNumber - b.blockNumber; // Sort by blockNumber (asc)

--- a/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
+++ b/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
@@ -107,9 +107,10 @@ export async function run(): Promise<void> {
   // Filter out events with less than the minimum UMA tokens staked
   const revealEventsMinBalance = revealEvents.filter((event) => event.args.numTokens.gte(minTokens));
 
-  // Filter out duplicate commit events as we only refund the first commit event per voter per round
+  // Filter out duplicate commit events as we only refund the latest commit event per voter per round
   const uniqueCommitEvents = new Map<string, VoteCommittedEvent>();
-  for (const event of commitEvents) {
+  const sortedCommitEvents = commitEvents.sort((a, b) => b.blockNumber - a.blockNumber);
+  for (const event of sortedCommitEvents) {
     const key = `${event.args.voter}-${event.args.roundId}-${event.args.identifier}-${event.args.time}-${event.args.ancillaryData}`;
     if (!uniqueCommitEvents.has(key)) {
       uniqueCommitEvents.set(key, event);

--- a/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
+++ b/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
@@ -109,7 +109,14 @@ export async function run(): Promise<void> {
 
   // Filter out duplicate commit events as we only refund the latest commit event per voter per round
   const uniqueCommitEvents = new Map<string, VoteCommittedEvent>();
-  const sortedCommitEvents = commitEvents.sort((a, b) => b.blockNumber - a.blockNumber);
+
+  // Sort first by blockNumber (desc) and then by logIndex (desc) as a tiebreaker
+  const sortedCommitEvents = commitEvents.sort((a, b) => {
+    if (b.blockNumber !== a.blockNumber) {
+      return b.blockNumber - a.blockNumber; // Sort by blockNumber (desc)
+    }
+    return b.logIndex - a.logIndex; // Sort by logIndex (desc) within the same block
+  });
   for (const event of sortedCommitEvents) {
     const key = `${event.args.voter}-${event.args.roundId}-${event.args.identifier}-${event.args.time}-${event.args.ancillaryData}`;
     if (!uniqueCommitEvents.has(key)) {

--- a/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
+++ b/packages/affiliates/gas-rebate/VoterGasRebateV2.ts
@@ -107,15 +107,15 @@ export async function run(): Promise<void> {
   // Filter out events with less than the minimum UMA tokens staked
   const revealEventsMinBalance = revealEvents.filter((event) => event.args.numTokens.gte(minTokens));
 
-  // Filter out duplicate commit events as we only refund the latest commit event per voter per round
+  // Filter out duplicate commit events as we only refund the first commit event per voter per round
   const uniqueCommitEvents = new Map<string, VoteCommittedEvent>();
 
   // Sort first by blockNumber (desc) and then by logIndex (desc) as a tiebreaker
   const sortedCommitEvents = commitEvents.sort((a, b) => {
-    if (b.blockNumber !== a.blockNumber) {
-      return b.blockNumber - a.blockNumber; // Sort by blockNumber (desc)
+    if (a.blockNumber !== b.blockNumber) {
+      return a.blockNumber - b.blockNumber; // Sort by blockNumber (asc)
     }
-    return b.logIndex - a.logIndex; // Sort by logIndex (desc) within the same block
+    return a.logIndex - b.logIndex; // Sort by logIndex (asc) within the same block
   });
   for (const event of sortedCommitEvents) {
     const key = `${event.args.voter}-${event.args.roundId}-${event.args.identifier}-${event.args.time}-${event.args.ancillaryData}`;


### PR DESCRIPTION
Changes proposed in this PR:
- Update the gas rebates scripts to account for the new rules:

> Voters must have at least 500 UMA staked at the start of the commit period for the following commit and reveals transactions to be rebated.
> 
> Commited votes must be revealed to be rebated.
> 
> If a voter commits more than once on a dispute, only the ~~last~~ first commit will be rebated.