### PR TITLE
fix(serverless): Enable shell on spawn

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -87,7 +87,7 @@ spoke.post("/", async (req, res) => {
 function _execShellCommand(fullCommand, inputEnv) {
   return new Promise((resolve, reject) => {
     const [cmd, ...args] = fullCommand.split(" ");
-    const child = spawn(cmd, args, { env: { ...process.env, ...inputEnv }, stdio: "pipe" });
+    const child = spawn(cmd, args, { env: { ...process.env, ...inputEnv }, stdio: "pipe", shell: true });
 
     // Wait for the process to exit to resolve the promise.
     child.on("exit", (code, signal) => {


### PR DESCRIPTION
Many serverlessCommand entries expect to be run inside a shell.
