### PR TITLE
feat: remove command splitting

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/src/ServerlessSpoke.js
@@ -84,10 +84,9 @@ spoke.post("/", async (req, res) => {
   }
 });
 
-function _execShellCommand(fullCommand, inputEnv) {
+function _execShellCommand(cmd, inputEnv) {
   return new Promise((resolve, reject) => {
-    const [cmd, ...args] = fullCommand.split(" ");
-    const child = spawn(cmd, args, { env: { ...process.env, ...inputEnv }, stdio: "pipe", shell: true });
+    const child = spawn(cmd, [], { env: { ...process.env, ...inputEnv }, stdio: "pipe", shell: true });
 
     // Wait for the process to exit to resolve the promise.
     child.on("exit", (code, signal) => {

--- a/packages/serverless-orchestration/test/ServerlessSpoke.js
+++ b/packages/serverless-orchestration/test/ServerlessSpoke.js
@@ -94,6 +94,17 @@ describe("ServerlessSpoke.js", function () {
     const validResponse = await sendRequest(validBody);
     assert.equal(validResponse.res.statusCode, 200); // error code
   });
+  it("Serverless Spoke can execute multiple chained commands with &&", async function () {
+    const validBody = {
+      serverlessCommand: "cd . && echo TEST_VAR=${TEST_VAR}",
+      environmentVariables: {
+        TEST_VAR: "test_value",
+      },
+    };
+    const validResponse = await sendRequest(validBody);
+    assert.equal(validResponse.res.statusCode, 200); // error code
+    assert.isTrue(lastSpyLogIncludes(spy, "Process exited with no error")); // Verify the process completed successfully
+  });
   it("Serverless Spoke can correctly returns errors over http calls(invalid path)", async function () {
     // Invalid path should error out when trying to run an executable that does not exist
     const invalidPathBody = {


### PR DESCRIPTION
This removes the splitting logic used to split commands and their args when passing to spawn. Since spawn's inputs are passed to a shell, the full string should be handled fine.