### PR TITLE
improve(logger): ignore invalid slack webhook URLs

### DIFF
--- a/packages/logger/src/logger/SlackTransport.ts
+++ b/packages/logger/src/logger/SlackTransport.ts
@@ -186,6 +186,20 @@ class SlackHook extends Transport {
       // If the log contains a notification path then use a custom slack webhook service. This lets the transport route to
       // different slack channels depending on the context of the log.
       const webhookUrl = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
+      // Exit early if we do not have a valid slack webhook URL, which may happen when we wish to suppress specific
+      // notification paths.
+      const isValidURL = (_url: string) => {
+        let url;
+        try {
+          url = new URL(_url);
+        } catch {
+          return false;
+        }
+        return url.protocol === "http:" || url.protocol === "https:";
+      };
+      if (!isValidURL(webhookUrl)) {
+        return;
+      }
 
       const payload: { blocks?: Block[]; text?: string; mrkdwn?: boolean } = { mrkdwn: this.mrkdwn };
       const layout = this.formatter(info);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

An end user may want to instantiate an UMA logger with a slack transport but only send slack messages for specific notification paths. This is not currently possible since we will unconditionally post a text payload to either the config's escalation path webhook URL or the default webhook URL.  


**Summary**

This PR now allows invalid URLs to be defined in `SLACK_CONFIG`, and, if an invalid URL is selected as the `webhookUrl`, `log` will exit early.
