### PR TITLE
fix: support multiple safes in osnap automated proposals

### DIFF
--- a/packages/monitor-v2/test/OptimisticGovernorMonitor.ts
+++ b/packages/monitor-v2/test/OptimisticGovernorMonitor.ts
@@ -531,38 +531,56 @@ describe("OptimisticGovernorMonitor", function () {
 
     const explanationString = "These transactions were approved by majority vote on Snapshot.";
 
-    const mockProposals = [
-      {
-        space: { id: "test" },
-        type: "single-choice",
-        choices: ["choice1", "choice2"],
-        id: "proposal-id",
-        start: 1234567890,
-        end: 1234567890,
-        state: "active",
-        safe: {
-          txs: [
-            {
-              mainTransaction: {
-                to: bondToken.address,
-                value: "0",
-                data: txnData1.data,
-                operation: "0" as MainTransaction["operation"],
-              },
-            },
-          ],
-          network: "31337",
-          umaAddress: ogModuleProxy.address,
+    const proposalId = "proposal-id";
+    const proposalSafe = {
+      txs: [
+        {
+          mainTransaction: {
+            to: bondToken.address,
+            value: "0",
+            data: txnData1.data,
+            operation: "0" as MainTransaction["operation"],
+          },
         },
-        ipfs: explanationString,
-        scores: [0, 0],
-        scores_total: 0,
-        quorum: 100,
+      ],
+      network: "31337",
+      umaAddress: ogModuleProxy.address,
+    };
+    const mockProposalBase = {
+      space: { id: "test" },
+      type: "single-choice",
+      choices: ["choice1", "choice2"],
+      id: proposalId,
+      start: 1234567890,
+      end: 1234567890,
+      state: "active",
+      ipfs: explanationString,
+      scores: [0, 0],
+      scores_total: 0,
+      quorum: 100,
+    };
+    const mockProposalsExpanded = [
+      {
+        ...mockProposalBase,
+        safe: proposalSafe,
       },
     ];
+    const mockProposalsOriginal = {
+      [proposalId]: {
+        ...mockProposalBase,
+        plugins: {
+          safeSnap: {
+            safes: [proposalSafe],
+          },
+        },
+      },
+    };
 
     // Mock Snapshot logic
-    sinon.stub(osnapAutomation, "getSupportedSnapshotProposals").resolves(mockProposals);
+    sinon.stub(osnapAutomation, "getSupportedSnapshotProposals").resolves({
+      supportedProposalsExpanded: mockProposalsExpanded,
+      supportedProposalsOriginal: mockProposalsOriginal,
+    });
     sinon.stub(osnapAutomation, "filterUnblockedProposals").callsFake(async (proposals) => proposals);
     sinon.stub(osnapAutomation, "filterVerifiedProposals").callsFake(async (proposals) => proposals);
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

oSnap automated proposer bot failed to handle proposals with multiple safes. Multiple safes were supported only in the monitoring and dispute bots, but they failed IPFS verification in proposer mode.


**Summary**

Adds support for multiple safes to oSnap automated proposer bot.


**Details**

oSnap automated proposer bot was splitting Snapshot proposals by safes as these have to be proposed separately, but this failed IPFS verification as IPFS had information on all safes while the passed proposal contained only one safe transactions. This PR resolves the issue by retaining the original proposal data that is used in verification.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [x]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
