### PR TITLE
fix(polymarket-notifier): fix proposal timestamp

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -92,7 +92,7 @@ async function processProposal(proposal: OptimisticPriceRequest, params: Monitor
     const orderFilledEvents = await getOrderFilledEvents(
       params,
       marketInfo.clobTokenIds,
-      Number(proposal.requestBlockNumber)
+      Number(proposal.proposalBlockNumber)
     );
 
     // Check the order book for concerning signals.

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -93,7 +93,7 @@ export interface OptimisticPriceRequest {
   requestLogIndex: number;
   requester: string;
   ancillaryData: string;
-  requestBlockNumber: number;
+  proposalBlockNumber: number;
   proposedPrice: BigNumber;
   proposalTimestamp: BigNumber;
   proposalHash: string;
@@ -204,7 +204,7 @@ export const getPolymarketProposedPriceRequestsOO = async (
           requester: event.args.requester,
           requestTimestamp: event.args.timestamp,
           ancillaryData: event.args.ancillaryData,
-          requestBlockNumber: event.blockNumber,
+          proposalBlockNumber: event.blockNumber,
           proposedPrice: event.args.proposedPrice,
           proposalTimestamp,
           proposalHash: event.transactionHash,

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -669,13 +669,14 @@ describe("PolymarketNotifier", function () {
       const identifier = formatBytes32String("TEST_IDENTIFIER");
       const ancillaryData = formatBytes32String("data");
 
+      const blockNumber = await ethers.provider.getBlockNumber();
       // Create two fake events:
       // Event 1: expires at fakeTime + 100 seconds.
       // Calculation: (fakeTime + 100) - 120 = fakeTime - 20, so current time (fakeTime) > fakeTime - 20 => condition satisfied.
       const fakeEventBelow = {
         transactionHash: "0xeventBelow",
         logIndex: 0,
-        blockNumber: 90,
+        blockNumber,
         args: {
           requester: fakeRequester,
           expirationTimestamp: ethers.BigNumber.from(fakeTime + 100),


### PR DESCRIPTION
Changes proposed in this PR:
- Fixed the proposal timestamp in the Polymarket notifier.
Previously, it was incorrectly using the request timestamp, which only affected the logs. The core logic remains correct as it relies on the expiration timestamp.