### PR TITLE
improve: handle bigint in logger

### DIFF
--- a/packages/logger/src/logger/ConsoleTransport.ts
+++ b/packages/logger/src/logger/ConsoleTransport.ts
@@ -15,7 +15,11 @@ export function createConsoleTransport(): winston.transports.ConsoleTransportIns
 
         // This slice changes a timestamp formatting from `2020-03-25T10:50:57.168Z` -> `2020-03-25 10:50:57`
         const ts = timestamp.slice(0, 19).replace("T", " ");
-        let log = `${ts} [${level}]: ${Object.keys(args).length ? JSON.stringify(args, null, 2) : ""}`;
+        let log = `${ts} [${level}]: ${
+          Object.keys(args).length
+            ? JSON.stringify(args, (key, value) => (typeof value === "bigint" ? value.toString() : value), 2)
+            : ""
+        }`;
 
         // Winston does not properly log Error objects like console.error() does, so this formatter will search for the Error object
         // in the "error" property of "info", and add the error stack to the log.


### PR DESCRIPTION
`JSON.stringify` doens't handle bigints well. Here's a fix from the internet:

https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-521460510

Helped me when debugging some Solana stuff