### PR TITLE
fix: debug chainBlockInfo upon error in fx relay proof construction

### DIFF
--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -1,4 +1,4 @@
-import { POSClient } from "@maticnetwork/maticjs";
+import { ExitUtil, POSClient } from "@maticnetwork/maticjs";
 import { Contract, EventData } from "web3-eth-contract";
 import { runTransaction, getEventsWithPaginatedBlockSearch } from "@uma/common";
 import type Web3 from "web3";
@@ -95,7 +95,7 @@ export class Relayer {
     });
 
     // Only used for debugging purposes upon error.
-    let chainBlockInfo: Awaited<ReturnType<typeof this.maticPosClient.exitUtil.getChainBlockInfo>> | undefined;
+    let chainBlockInfo: Awaited<ReturnType<ExitUtil["getChainBlockInfo"]>> | undefined;
 
     let proof;
     try {

--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -1,4 +1,3 @@
-import { ExitUtil, POSClient } from "@maticnetwork/maticjs";
 import { Contract, EventData } from "web3-eth-contract";
 import { runTransaction, getEventsWithPaginatedBlockSearch } from "@uma/common";
 import type Web3 from "web3";
@@ -13,7 +12,7 @@ export class Relayer {
     readonly logger: any,
     readonly account: string,
     readonly gasEstimator: any,
-    readonly maticPosClient: POSClient,
+    readonly maticPosClient: any,
     readonly oracleChildTunnel: Contract,
     readonly oracleRootTunnel: Contract,
     readonly web3: Web3,
@@ -94,9 +93,7 @@ export class Relayer {
       blockNumber,
     });
 
-    // Only used for debugging purposes upon error.
-    let chainBlockInfo: Awaited<ReturnType<ExitUtil["getChainBlockInfo"]>> | undefined;
-
+    let chainBlockInfo; // Only used for debugging purposes upon error.
     let proof;
     try {
       chainBlockInfo = await this.maticPosClient.exitUtil.getChainBlockInfo(transactionHash);

--- a/packages/fx-tunnel-relayer/test/Relayer.ts
+++ b/packages/fx-tunnel-relayer/test/Relayer.ts
@@ -25,6 +25,7 @@ interface MaticPosClient {
   exitUtil: {
     buildPayloadForExit: customPayloadFn;
     isCheckPointed: () => Promise<boolean>;
+    getChainBlockInfo: () => Promise<{ lastChildBlock: number; txBlockNumber: number }>;
   };
 }
 describe("Relayer unit tests", function () {
@@ -102,6 +103,7 @@ describe("Relayer unit tests", function () {
             resolve(utf8ToHex("Test proof"));
           }),
         isCheckPointed: async () => new Promise((resolve) => resolve(true)),
+        getChainBlockInfo: async () => new Promise((resolve) => resolve({ lastChildBlock: 0, txBlockNumber: 0 })),
       },
     };
 
@@ -181,6 +183,7 @@ describe("Relayer unit tests", function () {
             reject(new Error("This error is always thrown"));
           }),
         isCheckPointed: async () => new Promise((resolve) => resolve(true)),
+        getChainBlockInfo: async () => new Promise((resolve) => resolve({ lastChildBlock: 0, txBlockNumber: 0 })),
       },
     };
     const _relayer: any = new Relayer(
@@ -211,6 +214,7 @@ describe("Relayer unit tests", function () {
             resolve(utf8ToHex("Test proof"));
           }),
         isCheckPointed: async () => new Promise((resolve) => resolve(false)),
+        getChainBlockInfo: async () => new Promise((resolve) => resolve({ lastChildBlock: 0, txBlockNumber: 0 })),
       },
     };
     const _relayer: any = new Relayer(


### PR DESCRIPTION
FX relay bot has been erroring in proof construction. Even if it has checked `this.maticPosClient.exitUtil.isCheckPointed` , the following `this.maticPosClient.exitUtil.buildPayloadForExit` call sometimes fails as if the block has not yet been checkpointed. This PR adds `IChainBlockInfo` for debugging purposes to inspect `lastChildBlock` vs `txBlockNumber`