### PR TITLE
feat(pm-notifier): per‑proposal idempotent notifications to prevent duplicate alerts

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -684,6 +684,13 @@ export const getProposalKeyToStore = (market: StoredNotifiedProposal | Optimisti
   return market.proposalHash;
 };
 
+export const isProposalNotified = async (proposal: OptimisticPriceRequest): Promise<boolean> => {
+  const keyName = getProposalKeyToStore(proposal);
+  const key = datastore.key(["NotifiedProposals", keyName]);
+  const [entity] = await datastore.get(key);
+  return Boolean(entity);
+};
+
 export const getInitialConfirmationLoggedKey = (marketId: string): string =>
   `polymarket:initial-confirmation-logged:${marketId}`;
 


### PR DESCRIPTION
  - Prevents duplicate Polymarket alerts across parallel monitor instances.
  - Adds a single-key lookup for notification state and immediate persistence after first alert.