### PR TITLE
fix: enforce global rate limit in log queue transports

### DIFF
--- a/packages/logger/src/logger/PersistentTransport.ts
+++ b/packages/logger/src/logger/PersistentTransport.ts
@@ -13,18 +13,60 @@ type _RedisClient = ReturnType<typeof createClient>;
 
 type TransportOptions = ConstructorParameters<typeof Transport>[0];
 
+// Lua script returns an array with the first element being the status of the operation and the second element being
+// the oldest popped item if the status is 'ready', or false if the status is 'locked' or 'empty'. The helper function
+// would convert this array to a dictionary object with 'status' and 'item' properties for easier handling in the code.
+type RateLimitedPopResult = { status: "ready"; item: string } | { status: "locked" } | { status: "empty" };
+type ArrayFromResult<T extends { status: string }> = T extends { item: infer I }
+  ? [T["status"], I]
+  : [T["status"], null];
+type RateLimitedPopResultArray = ArrayFromResult<RateLimitedPopResult>;
+
 export abstract class PersistentTransport extends Transport {
-  protected readonly rateLimit: number = 0; // Derived implementation would override rate limits if required.
+  protected readonly rateLimit: number = 0; // Derived implementation would override rate limits (in seconds) if required.
 
   private isQueueBeingExecuted = false;
   private canProcess = true;
 
   private redis: _RedisClient;
   private readonly logListKey: string;
+  private readonly rateLimitKey: string;
 
   // TODO: Remove this when the previous botIdentifier log queue is fully processed for bots that have been moved to use
   // the shared log queue.
   private readonly legacyLogListKey: string;
+
+  private readonly redisPollingInterval = 0.25; // Interval in seconds to poll Redis for new log messages to process.
+
+  // Lua script for passing to Redis to enforce global rate limiting. It uses a TTL-based cooldown mechanism to ensure
+  // that only one worker can pop from the queue at a time, and it waits for the cooldown period before allowing another
+  // worker to pop from the queue. The workers are expected to process queue elements only using this script and not
+  // directly using LPOP or similar commands.
+  // The script returns an array with the first element being the status of the operation:
+  // - 'ready' if an item was successfully popped from the queue,
+  // - 'locked' if someone has recently processed an element and the cooldown period is still active,
+  // - 'empty' if the queue is empty and the rate limit key was released.
+  // The second element is the popped item if the status is 'ready', or false if the status is 'locked' or 'empty'.
+  // Note that this intentionally uses false instead of nil to avoid array truncation by redis.
+  private readonly RATE_LIMIT_POP_LUA = `
+    -- KEYS[1] = rate_limit key (TTL-based cooldown)
+    -- KEYS[2] = queue list key
+    -- ARGV[1] = cooldown TTL in ms
+
+    local got_token = redis.call('SET', KEYS[1], '1', 'NX', 'PX', ARGV[1])
+    if not got_token then
+      return { 'locked', false }
+    end
+
+    local item = redis.call('LPOP', KEYS[2])
+    if item then
+      return { 'ready', item }
+    else
+      -- queue empty; release immediately so others don't wait the TTL
+      redis.call('DEL', KEYS[1])
+      return { 'empty', false }
+    end
+  `;
 
   constructor(
     winstonOpts: TransportOptions,
@@ -40,10 +82,13 @@ export abstract class PersistentTransport extends Transport {
 
     const botIdentifier = process.env.BOT_IDENTIFIER || noBotId;
     this.legacyLogListKey = `uma-persistent-log-queue:${botIdentifier}:${derivedTransport}`;
-    this.logListKey =
-      sharedLogQueue === undefined
-        ? `uma-persistent-log-queue:${botIdentifier}:${derivedTransport}`
-        : `uma-persistent-log-queue:${sharedLogQueue}:${derivedTransport}`;
+
+    // Shared log queue can be used across multiple bots to enforce global rate limiting per transport.
+    // If sharedLogQueue is not provided, we use botIdentifier to scope the queue to the individual bot.
+    const queueScope =
+      sharedLogQueue === undefined ? `${botIdentifier}:${derivedTransport}` : `${sharedLogQueue}:${derivedTransport}`;
+    this.logListKey = `uma-persistent-log-queue:${queueScope}`;
+    this.rateLimitKey = `uma-persistent-log-rate-limit:${queueScope}`;
 
     this.on("processed", () => (this.isQueueBeingExecuted = false)); // Unlock queue execution when current run processed.
   }
@@ -101,20 +146,20 @@ export abstract class PersistentTransport extends Transport {
       info = null; // Reset info at the beginning of each iteration.
 
       try {
-        await this.connectRedis();
+        const result = await this.rateLimitedPopWithStatus();
 
-        // TODO: Remove the legacy queue when it is fully processed for bots that have been moved to use the shared log queue.
-        // For now process the legacy queue first, then the shared log queue if the old one is empty.
-        const logListKey =
-          (await this.redis.lLen(this.legacyLogListKey)) === 0 ? this.logListKey : this.legacyLogListKey;
-        const oldestLogString = await this.redis.lPop(logListKey);
-        if (oldestLogString === null) break; // We have processed all logs from persistent storage queue.
+        if (result.status === "empty") break; // We have processed all logs from persistent storage queue.
 
-        info = JSON.parse(oldestLogString);
-        if (!isDictionary(info)) throw new Error("Unsupported info type!");
+        if (result.status === "ready") {
+          info = JSON.parse(result.item);
+          if (!isDictionary(info)) throw new Error("Unsupported info type!");
 
-        // Log the message in the derived transport implementation.
-        await this.logQueueElement(info);
+          // Log the message in the derived transport implementation.
+          await this.logQueueElement(info);
+
+          // Process the next message in the queue. Rate limiting is handled by the Lua script.
+          continue;
+        }
       } catch (error) {
         if (info === null) {
           // We cannot emit TransportError as we don't have access to original info object yet.
@@ -123,8 +168,8 @@ export abstract class PersistentTransport extends Transport {
         break;
       }
 
-      // Wait before processing the next message if the implementation requires any rate limiting.
-      await delay(this.rateLimit);
+      // Status must have been locked, wait small delay before processing the next message to avoid hammering Redis.
+      await delay(this.redisPollingInterval);
     }
 
     // Unblock any pauseProcessing call that waits for current log element being processed.
@@ -134,5 +179,23 @@ export abstract class PersistentTransport extends Transport {
   // Connect to redis when not ready.
   private async connectRedis(): Promise<void> {
     if (!this.redis.isReady) await this.redis.connect();
+  }
+
+  // Rate limited pop from Redis list. It uses Lua script to ensure that only one worker can pop from the list at a
+  // time, and it waits for the cooldown period before allowing another worker to pop from the list.
+  private async rateLimitedPopWithStatus(): Promise<RateLimitedPopResult> {
+    await this.connectRedis();
+
+    // TODO: Remove the legacy queue when it is fully processed for bots that have been moved to use the shared log queue.
+    // For now process the legacy queue first, then the shared log queue if the old one is empty.
+    const logListKey = (await this.redis.lLen(this.legacyLogListKey)) === 0 ? this.logListKey : this.legacyLogListKey;
+
+    // node-redis returns arrays for Lua tables and RESP2 converts false elements to null.
+    const [status, item] = (await this.redis.eval(this.RATE_LIMIT_POP_LUA, {
+      keys: [this.rateLimitKey, logListKey],
+      arguments: [String(this.rateLimit * 1000)], // Lua script expects TTL in milliseconds.
+    })) as RateLimitedPopResultArray;
+
+    return status === "ready" ? { status, item } : { status };
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

#4869 did not fully address the Discord ticket rate limiting issue as each individual bot could still process the log queue individually.


**Summary**

Enforces global rate limit on shared log queues.


**Details**

Uses Lua script to get the oldest log queue element that also sets a lock with TTL based on the provided rate limit. This enforces that the queue element can be popped across all bot instances only when the lock expired.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
