### PR TITLE
fix(monitor-v2): use tx runner in settlement bots

### DIFF
--- a/packages/monitor-v2/src/bot-utils/errors.ts
+++ b/packages/monitor-v2/src/bot-utils/errors.ts
@@ -1,0 +1,32 @@
+import { utils as ethersUtils } from "ethers";
+import { isEthersTxRunnerError } from "@uma/common";
+
+function encodeStringError(error: string): string {
+  return ethersUtils.hexlify(
+    ethersUtils.concat([
+      ethersUtils.id("Error(string)").slice(0, 10),
+      ethersUtils.defaultAbiCoder.encode(["string"], [error]),
+    ])
+  );
+}
+
+const NOT_SETTLEABLE_REVERTS = [
+  // OptimisticOracle, OptimisticOracleV2:
+  encodeStringError("_settle: not settleable"),
+  // SkinnyOptimisticOracle, SkinnyOptimisticOracleV2:
+  encodeStringError("Already settled or not settleable"),
+  // OptimisticOracleV3:
+  encodeStringError("Assertion already settled"),
+  // Upgradeable ManagedOptimisticOracleV2, OptimisticOracleV2:
+  ethersUtils.id("RequestNotSettleable()").slice(0, 10),
+] as const;
+
+function isNotSettleableError(error: unknown): boolean {
+  return isEthersTxRunnerError(error) && NOT_SETTLEABLE_REVERTS.includes(error.revertData);
+}
+
+// It is common for settlement transactions to fail due to somebody else settling the request first, and this helper
+// would escalate the log level to error only for unexpected errors, while keeping the common case as a warning.
+export function getSettleTxErrorLogLevel(error: unknown): "warn" | "error" {
+  return isNotSettleableError(error) ? "warn" : "error";
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Improve bot logging to not escalate on expected failure paths.


**Summary**

Uses Ethers transaction runner in OO settlement bots to lower log level to `warning` for common settle reverts when somebody else had frontrun the settlement.



**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
