### PR TITLE
fix(logger): app must explicitly request ticket submission via api transport

### DIFF
--- a/packages/logger/src/logger/DiscordTicketApiTransport.ts
+++ b/packages/logger/src/logger/DiscordTicketApiTransport.ts
@@ -27,12 +27,20 @@ export function createConfig(config: unknown): Config {
 interface DiscordTicketApiInfo {
   message: string;
   mrkdwn: string;
+  discordTicketApiParams: {
+    submitTicket: boolean; // Indicates if the ticket should be submitted
+  };
 }
 
 // Type guard for log info object.
 const isDiscordTicketApiInfo = (info: unknown): info is DiscordTicketApiInfo => {
   if (!isDictionary(info)) return false;
-  return typeof info.message === "string" && typeof info.mrkdwn === "string";
+  return (
+    typeof info.message === "string" &&
+    typeof info.mrkdwn === "string" &&
+    isDictionary(info.discordTicketApiParams) &&
+    typeof info.discordTicketApiParams.submitTicket === "boolean"
+  );
 };
 
 export class DiscordTicketApiTransport extends Transport {
@@ -55,8 +63,8 @@ export class DiscordTicketApiTransport extends Transport {
   // Note: info must be any because that's what the base class uses.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   async log(info: any, callback: (error?: unknown) => void): Promise<void> {
-    // We only try sending if the logging application has passed required parameters.
-    if (isDiscordTicketApiInfo(info)) {
+    // We only try sending if the logging application has passed required parameters and explicitly requested ticket submission.
+    if (isDiscordTicketApiInfo(info) && info.discordTicketApiParams.submitTicket) {
       const payload = { title: info.message, content: info.mrkdwn };
 
       try {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

Logging applications require explicit control if Discord Ticket should be submitted via the API service.

**Summary**

Adds parameters in the logged info object for the logging application to control if particular log should trigger Discord Ticket submission via the API transport.




**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
Fixes #XXXX
