### PR TITLE
fix(pm-notifier): add concurrency limits to prevent getTime timeouts

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -1025,6 +1025,13 @@ export const initMonitoringParams = async (
   const maxConcurrentRequests = env.MAX_CONCURRENT_REQUESTS ? Number(env.MAX_CONCURRENT_REQUESTS) : 5;
   const minTimeBetweenRequests = env.MIN_TIME_BETWEEN_REQUESTS ? Number(env.MIN_TIME_BETWEEN_REQUESTS) : 200;
 
+  const aiDeeplinkMaxConcurrentRequests = env.AI_DEEPLINK_MAX_CONCURRENT_REQUESTS
+    ? Number(env.AI_DEEPLINK_MAX_CONCURRENT_REQUESTS)
+    : 10;
+  const aiDeeplinkMinTimeBetweenRequests = env.AI_DEEPLINK_MIN_TIME_BETWEEN_REQUESTS
+    ? Number(env.AI_DEEPLINK_MIN_TIME_BETWEEN_REQUESTS)
+    : 200;
+
   const httpTimeout = env.HTTP_TIMEOUT ? Number(env.HTTP_TIMEOUT) : 10_000;
   const aiDeeplinkTimeout = env.AI_DEEPLINK_TIMEOUT ? Number(env.AI_DEEPLINK_TIMEOUT) : 10_000;
 
@@ -1049,11 +1056,14 @@ export const initMonitoringParams = async (
     },
   });
 
-  // Create a separate HTTP client for AI deeplink requests with unlimited concurrency
+  // Create a separate HTTP client for AI deeplink requests with configurable rate limiting
   // This prevents AI deeplink requests from being queued behind other rate-limited requests
   const aiDeeplinkHttpClient = createHttpClient({
     axios: { timeout: aiDeeplinkTimeout },
-    rateLimit: { maxConcurrent: null, minTime: 0 }, // No rate limiting - unlimited concurrency
+    rateLimit: {
+      maxConcurrent: aiDeeplinkMaxConcurrentRequests,
+      minTime: aiDeeplinkMinTimeBetweenRequests,
+    },
     retry: {
       retries: retryAttempts,
       baseDelayMs: retryDelayMs,

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -124,6 +124,7 @@ describe("PolymarketNotifier", function () {
       proposalProcessingConcurrency: 5,
       marketProcessingConcurrency: 3,
       paginatedEventQueryConcurrency: 5,
+      orderFilledEventsProcessingConcurrency: 25,
     };
   };
 


### PR DESCRIPTION

**Description**

  

Fixes timeout errors in block timestamp fetching by limiting concurrent requests.

  

****Changes:****

- Limit order filled events processing to 25 concurrent requests (configurable via `ORDER_FILLED_EVENTS_PROCESSING_CONCURRENCY`)

- Add rate limiting to AI deeplink requests (configurable via `AI_DEEPLINK_MAX_CONCURRENT_REQUESTS` and `AI_DEEPLINK_MIN_TIME_BETWEEN_REQUESTS`)

  

Previously, thousands of `getTime` calls were happening in parallel, overwhelming the provider. Now using Bluebird's `Promise.map` with concurrency control to batch requests.