### PR TITLE
feat: Bump protocol Docker image to Node 20.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # that are not in the protocol repo, such as the Across v2 relayer. To access these set a command 
 
 # Fix node version due to high potential for incompatibilities.
-FROM node:20
+FROM node:20.18.1
 
 # All source code and execution happens from the protocol directory.
 WORKDIR /protocol


### PR DESCRIPTION
  Description:
  - update Dockerfile to pin node base image to 20.18.1 instead of the generic 20 tag
  - pick up the latest V8 fixes to avoid the invalid size crash seen in monitor runs
  