### PR TITLE
fix: polygon settler failing due to insufficient gas priority fee

### DIFF
--- a/packages/financial-templates-lib/src/helpers/GasEstimator.ts
+++ b/packages/financial-templates-lib/src/helpers/GasEstimator.ts
@@ -316,7 +316,8 @@ export class GasEstimator {
         throw new Error(`Bad polygon response ${json}`);
 
       const maxFeePerGas = Number(polygonResponse.fast.maxFee) * 2;
-      const maxPriorityFeePerGas = Number(polygonResponse.fast.maxPriorityFee);
+      // Polygon requires minimum 25 gwei priority fee; enforce 30 gwei minimum for safety margin.
+      const maxPriorityFeePerGas = Math.max(Number(polygonResponse.fast.maxPriorityFee), 30);
 
       if (Number.isNaN(maxFeePerGas) || Number.isNaN(maxPriorityFeePerGas)) {
         throw new Error(`Bad polygon response ${json}`);


### PR DESCRIPTION
The transaction's priority fee (1.5 gwei) is below Polygon's required minimum (25 gwei).
Fix: Enforce a 30 gwei minimum for maxPriorityFeePerGas on Polygon: