### PR TITLE
fix(discord-ticket-api): use createPinoLogger with loggerInstance

### DIFF
--- a/packages/discord-ticket-api/src/server.ts
+++ b/packages/discord-ticket-api/src/server.ts
@@ -1,8 +1,8 @@
-import Fastify from "fastify";
+import Fastify, { FastifyBaseLogger } from "fastify";
 import helmet from "@fastify/helmet";
 import cors from "@fastify/cors";
 import sensible from "@fastify/sensible";
-import { createPinoConfig } from "@uma/logger";
+import { createPinoLogger } from "@uma/logger";
 import { loadEnv } from "./env.js";
 import { createQueue } from "./queue.js";
 import { TicketQueueService } from "./services/TicketService.js";
@@ -10,12 +10,11 @@ import { ticketsRoutes } from "./routes/tickets.js";
 
 export async function buildServer(): Promise<{ app: ReturnType<typeof Fastify>; start: () => Promise<void> }> {
   const env = loadEnv();
-  const app = Fastify({
-    logger: createPinoConfig({
-      level: process.env.LOG_LEVEL || "info",
-      botIdentifier: process.env.BOT_IDENTIFIER || "ticketing-api",
-    }),
-  });
+  const logger = createPinoLogger({
+    level: process.env.LOG_LEVEL || "info",
+    botIdentifier: process.env.BOT_IDENTIFIER || "ticketing-api",
+  }) as FastifyBaseLogger;
+  const app = Fastify({ loggerInstance: logger });
 
   await app.register(helmet);
   await app.register(cors, { origin: true, credentials: true });


### PR DESCRIPTION
Switch from passing Pino config to Fastify's logger option to passing a pre-instantiated logger via loggerInstance. This ensures the full transport configuration from @uma/logger is applied.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Motivation**

The `discord-ticket-api` currently passes a Pino config object to Fastify, which means Fastify creates its own logger instance internally. This approach doesn't apply the full transport configuration from `@uma/logger`, specifically the PagerDuty V2 transport that's configured when `PAGER_DUTY_V2_CONFIG` is set.

This change ensures the `discord-ticket-api` will benefit from the PagerDuty alerting capabilities once those logger improvements are merged from #4914.

**Summary**

Switch from `createPinoConfig()` to `createPinoLogger()` and pass the logger instance via `loggerInstance` option instead of `logger` config option.


**Details**

The `createPinoLogger()` function calls both `createPinoConfig()` and `createPinoTransports()`, ensuring the logger has the proper transports configured:
- stdout transport (for GCP Logging and local dev)
- PagerDuty V2 transport (when `PAGER_DUTY_V2_CONFIG` env var is set, for `error` level logs, once #4914 is merged)

When Fastify creates the logger internally from just the config, it wouldn't have those transports.

**Error logging behavior:** No changes to error handling. Fastify's default error handler automatically logs errors at appropriate levels:
- Client errors (400-499): `log.info()` - won't trigger PagerDuty alerts
- Server errors (500+): `log.error()` - will trigger PagerDuty alerts when configured

This is the desired behavior - malformed requests won't page on-call engineers, but legitimate infrastructure/service failures will.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [x]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested


**Issue(s)**

<!-- This PR must fix or refer to one or more issues. Please list them here. -->
N/A - This is a refactor to enable future PagerDuty alerting capabilities.
