### PR TITLE
fix(monitor-v2): include proposalLogIndex in notified proposal key

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -151,6 +151,7 @@ export interface OptimisticPriceRequest {
 
 interface StoredNotifiedProposal {
   proposalHash: string;
+  proposalLogIndex: number;
 }
 
 export enum MarketType {
@@ -867,7 +868,7 @@ export async function fetchLatestAIDeepLink(
 }
 
 export const getProposalKeyToStore = (market: StoredNotifiedProposal | OptimisticPriceRequest): string => {
-  return market.proposalHash;
+  return `${market.proposalHash}:${market.proposalLogIndex}`;
 };
 
 export const isProposalNotified = async (proposal: OptimisticPriceRequest): Promise<boolean> => {
@@ -910,6 +911,7 @@ export const storeNotifiedProposals = async (notifiedContracts: OptimisticPriceR
       key: key,
       data: {
         proposalHash: contract.proposalHash,
+        proposalLogIndex: contract.proposalLogIndex,
       },
     });
   });


### PR DESCRIPTION
### fix(monitor-v2): include proposalLogIndex in notified proposal key

#### Motivation

Previously, proposals were keyed in the datastore **only by transaction hash**.  
This caused a bug where multiple proposals emitted in the same transaction would share the same key. If one proposal was successfully notified but another failed, subsequent runs would skip the failed proposal since the key already existed.

#### Summary

The datastore key for notified proposals now includes both the transaction hash and log index (`${proposalHash}:${proposalLogIndex}`), ensuring each proposal event is uniquely identified even when multiple proposals occur in the same transaction.

#### Details

**Changes made:**
- Updated `StoredNotifiedProposal` interface to include `proposalLogIndex`
- Updated `getProposalKeyToStore` to return `${proposalHash}:${proposalLogIndex}` instead of just `proposalHash`
- Updated `storeNotifiedProposals` to persist `proposalLogIndex` alongside `proposalHash`

#### Testing

- Ran end-to-end test, executing the code as in production
- New unit tests created
- Existing tests adequate; no additional tests required
- All existing tests pass

Added test:  
**"Should differentiate proposals by logIndex when multiple proposals exist in the same transaction"**, which verifies that proposals with the same transaction hash but different `logIndex` values are keyed separately.

#### Issue(s)

Fixes UMA-3014