### PR TITLE
fix(monitor-v2): add per-proposal time filtering for fill events

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -325,8 +325,9 @@ export async function monitorTransactionsProposedOrderBook(
 
   const lookbackBlocks = Math.round(params.fillEventsLookbackSeconds * blocksPerSecond);
   const gapBlocks = Math.round(params.fillEventsProposalGapSeconds * blocksPerSecond);
-  const currentBlock = await params.provider.getBlockNumber();
-  const currentTimestamp = (await params.provider.getBlock(currentBlock)).timestamp;
+  const latestBlock = await params.provider.getBlock("latest");
+  const currentBlock = latestBlock.number;
+  const currentTimestamp = latestBlock.timestamp;
 
   // Augment bundles with per-proposal context (tradeFilterFromTimestamp, aiDeeplink)
   const augmentedBundles = activeBundles.map(({ proposal, markets }) => {

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -1107,7 +1107,7 @@ describe("PolymarketNotifier", function () {
     const currentTimestamp = 1700000000;
     const providerStub = ({
       getBlockNumber: sandbox.stub().resolves(currentBlock),
-      getBlock: sandbox.stub().resolves({ timestamp: currentTimestamp }),
+      getBlock: sandbox.stub().resolves({ number: currentBlock, timestamp: currentTimestamp }),
     } as unknown) as Provider;
     params.provider = providerStub;
 
@@ -1187,7 +1187,7 @@ describe("PolymarketNotifier", function () {
     const currentTimestamp = 1700000000; // seconds
     const providerStub = ({
       getBlockNumber: sandbox.stub().resolves(currentBlock),
-      getBlock: sandbox.stub().resolves({ timestamp: currentTimestamp }),
+      getBlock: sandbox.stub().resolves({ number: currentBlock, timestamp: currentTimestamp }),
     } as unknown) as Provider;
     params.provider = providerStub;
 


### PR DESCRIPTION
**Motivation**                                                                                                                                                                    
                                                                                                                                                                                    
  After aggregating `fetchOrderFilledEventsBounded` across all proposal tokens, `FILL_EVENTS_LOOKBACK_SECONDS` and `FILL_EVENTS_PROPOSAL_GAP_SECONDS` no longer applied             
  per-proposal. The code computed per-proposal `fromBlocks` but only used the global minimum, with no subsequent filtering.                                                         
                                                                                                                                                                                    
  **Summary**                                                                                                                                                                       
                                                                                                                                                                                    
  Pass a per-proposal `fromTimestamp` into `processProposal` and filter trades by `timestamp >= fromTimestamp` before checking price discrepancies.                                 
                                                                                                                                                                                    
  **Details**                                                                                                                                                                       
                                                                                                                                                                                    
  - Added `fromTimestamp` to `ProposalProcessingContext`                                                                                                                            
  - Pre-compute `fromTimestampsMap` for each proposal based on its specific `fromBlock`                                                                                             
  - Filter trades in `processProposal` before discrepancy checks                                                                                                                    
                                                                                                                                                                                    
  **Testing**                                                                                                                                                                       
                                                                                                                                                                                    
  - [x] Existing tests adequate, no new tests required                                                                                                                              
  - [x] All existing tests pass                                                                                                                                                     
                                                                                                                                                                                    
  **Issue(s)**                                                                                                                                                                      
                                                                                                                                                                                    
  Fixes UMA-3016 