### PR TITLE
fix(monitor-v2): add OOv2 settlement diagnostics for query and simulation paths

### DIFF
--- a/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
+++ b/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
@@ -47,6 +47,19 @@ export async function settleOOv2Requests(
 
   const requestsToSettle = proposals.filter((e) => !settledKeys.has(requestKey(e.args)));
 
+  const requestsToSettleTxCount =
+    params.settleBatchSize > 1 ? Math.ceil(requestsToSettle.length / params.settleBatchSize) : requestsToSettle.length;
+
+  logger.debug({
+    at: "OOv2Bot",
+    message: "Settlement candidates",
+    totalProposals: proposals.length,
+    settlements: settlements.length,
+    requestsToSettle: requestsToSettle.length,
+    settleTxCount: requestsToSettleTxCount,
+    settleBatchSize: params.settleBatchSize,
+  });
+
   const signerAddress = await params.signer.getAddress();
 
   const settleableRequestsPromises = requestsToSettle.map(async (req) => {
@@ -65,6 +78,15 @@ export async function settleOOv2Requests(
       });
       return req;
     } catch (err) {
+      logger.debug({
+        at: "OOv2Bot",
+        message: "Settle simulation failed",
+        requestKey: requestKey(req.args),
+        requester: req.args.requester,
+        identifier: req.args.identifier,
+        timestamp: req.args.timestamp.toString(),
+        ...getSettleTxErrorLogFields(err),
+      });
       return null;
     }
   });
@@ -72,6 +94,22 @@ export async function settleOOv2Requests(
   const settleableRequests = (await Promise.all(settleableRequestsPromises)).filter(
     (req): req is ProposePriceEvent => req !== null
   );
+
+  const settleableTxCount =
+    params.settleBatchSize > 1
+      ? Math.ceil(settleableRequests.length / params.settleBatchSize)
+      : settleableRequests.length;
+
+  logger.debug({
+    at: "OOv2Bot",
+    message: "Settlement processing",
+    totalProposals: proposals.length,
+    settlements: settlements.length,
+    requestsToSettle: requestsToSettle.length,
+    settleableRequests: settleableRequests.length,
+    settleTxCount: settleableTxCount,
+    settleBatchSize: params.settleBatchSize,
+  });
 
   if (settleableRequests.length > 0) {
     logger.debug({

--- a/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
+++ b/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
@@ -39,9 +39,63 @@ export async function settleOOv2Requests(
     params.maxBlockLookBack
   );
 
-  const proposals = await paginatedEventQuery<ProposePriceEvent>(oo, oo.filters.ProposePrice(), searchConfig);
+  logger.debug({
+    at: "OOv2Bot",
+    message: "Querying ProposePrice events",
+    fromBlock: searchConfig.fromBlock,
+    toBlock: searchConfig.toBlock,
+    maxBlockLookBack: searchConfig.maxBlockLookBack,
+  });
+  const proposalsStartedAt = Date.now();
+  let proposals: ProposePriceEvent[];
+  try {
+    proposals = await paginatedEventQuery<ProposePriceEvent>(oo, oo.filters.ProposePrice(), searchConfig);
+    logger.debug({
+      at: "OOv2Bot",
+      message: "Queried ProposePrice events",
+      count: proposals.length,
+      elapsedMs: Date.now() - proposalsStartedAt,
+    });
+  } catch (error) {
+    logger.error({
+      at: "OOv2Bot",
+      message: "Failed querying ProposePrice events",
+      fromBlock: searchConfig.fromBlock,
+      toBlock: searchConfig.toBlock,
+      maxBlockLookBack: searchConfig.maxBlockLookBack,
+      ...getSettleTxErrorLogFields(error),
+    });
+    throw error;
+  }
 
-  const settlements = await paginatedEventQuery<SettleEvent>(oo, oo.filters.Settle(), searchConfig);
+  logger.debug({
+    at: "OOv2Bot",
+    message: "Querying Settle events",
+    fromBlock: searchConfig.fromBlock,
+    toBlock: searchConfig.toBlock,
+    maxBlockLookBack: searchConfig.maxBlockLookBack,
+  });
+  const settlementsStartedAt = Date.now();
+  let settlements: SettleEvent[];
+  try {
+    settlements = await paginatedEventQuery<SettleEvent>(oo, oo.filters.Settle(), searchConfig);
+    logger.debug({
+      at: "OOv2Bot",
+      message: "Queried Settle events",
+      count: settlements.length,
+      elapsedMs: Date.now() - settlementsStartedAt,
+    });
+  } catch (error) {
+    logger.error({
+      at: "OOv2Bot",
+      message: "Failed querying Settle events",
+      fromBlock: searchConfig.fromBlock,
+      toBlock: searchConfig.toBlock,
+      maxBlockLookBack: searchConfig.maxBlockLookBack,
+      ...getSettleTxErrorLogFields(error),
+    });
+    throw error;
+  }
 
   const settledKeys = new Set(settlements.map((e) => requestKey(e.args)));
 


### PR DESCRIPTION
## Summary
GCP logs showed `Starting settlement for OptimisticOracleV2` but no `Request is settleable` entries while unsettled requests kept accumulating.

This PR adds targeted diagnostics in the OOv2 settlement flow to identify where the bot stalls and why requests are filtered out.

## Changes
- Add query-phase logs around `paginatedEventQuery` for `ProposePrice` and `Settle`:
  - start log with block range and `maxBlockLookBack`
  - completion log with event count + elapsed time
  - explicit error log with structured error fields before rethrow
- Add settlement candidate counters:
  - `totalProposals`, `settlements`, `requestsToSettle`, derived `settleTxCount`, `settleBatchSize`
- Add per-request debug log for failed settle simulation (`callStatic.settle`) including structured error fields (`errorMessage`, `errorCode`, `errorReason`, `errorMethod`, `revertData`).
- Add post-simulation processing counters:
  - `settleableRequests` and derived `settleTxCount`

## Why
`paginatedEventQuery` does not silently swallow final errors, but combined provider timeouts/retries can still look like a silent stall in production. These logs make it clear whether the bot is blocked in event fetching or filtering requests as not settleable.

## Validation
- `yarn workspace @uma/monitor-v2 build`
