### PR TITLE
fix: detect managed oov2 in monitors

### DIFF
--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -15,6 +15,8 @@ const { OptimisticOracleType } = require("@uma/financial-templates-lib");
 const { getAbi } = require("@uma/contracts-node");
 const { createHttpClient } = require("@uma/toolkit");
 
+const EIP1967_IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+
 class OptimisticOracleContractMonitor {
   /**
    * @notice Constructs new contract monitor module.
@@ -95,6 +97,7 @@ class OptimisticOracleContractMonitor {
 
     // Flag to track if this is upgraded ManagedOptimisticOracleV2. Initialized to null and detected on first use.
     this.isManagedOOV2Upgraded = null;
+    this.currentImplementationPromise = null;
 
     // Helper functions from web3.
     this.toWei = this.web3.utils.toWei;
@@ -173,7 +176,7 @@ class OptimisticOracleContractMonitor {
         )}. tx: ${createEtherscanLinkMarkdown(
           event.transactionHash,
           this.contractProps.networkId
-        )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
+        )}. ${await this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -246,7 +249,7 @@ class OptimisticOracleContractMonitor {
           `tx ${createEtherscanLinkMarkdown(
             event.transactionHash,
             this.contractProps.networkId
-          )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
+          )}. ${await this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
         // The default log level should be reduced to "info" for funding rate identifiers:
         this.logger.info({
@@ -296,7 +299,7 @@ class OptimisticOracleContractMonitor {
         `. tx: ${createEtherscanLinkMarkdown(
           event.transactionHash,
           this.contractProps.networkId
-        )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
+        )}. ${await this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
       this.logger[this.logOverrides.disputedPrice || "error"]({
         at: "OptimisticOracleContractMonitor",
@@ -360,7 +363,7 @@ class OptimisticOracleContractMonitor {
         `. tx: ${createEtherscanLinkMarkdown(
           event.transactionHash,
           this.contractProps.networkId
-        )}. ${this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
+        )}. ${await this._generateUILink(event.transactionHash, event.logIndex, this.contractProps.networkId)}.`;
 
       // The default log level should be reduced to "debug" for funding rate identifiers:
       this.logger[
@@ -410,20 +413,47 @@ class OptimisticOracleContractMonitor {
     }
   }
 
-  _generateUILink(transactionHash, eventIndex, chainId) {
+  async _generateUILink(transactionHash, eventIndex, chainId) {
     let oracleType;
     switch (this.oracleType) {
       case OptimisticOracleType.OptimisticOracle:
         oracleType = "Optimistic+Oracle+V1";
         break;
       case OptimisticOracleType.OptimisticOracleV2:
-        oracleType = "Optimistic+Oracle+V2";
+        oracleType = (await this._isManagedOOV2()) ? "Managed+Optimistic+Oracle+V2" : "Optimistic+Oracle+V2";
         break;
       case OptimisticOracleType.SkinnyOptimisticOracle:
         oracleType = "Skinny+Optimistic+Oracle";
         break;
     }
     return `<${this.optimisticOracleUIBaseUrl}/?transactionHash=${transactionHash}&eventIndex=${eventIndex}&chainId=${chainId}&oracleType=${oracleType}|View in UI>`;
+  }
+
+  async _isManagedOOV2() {
+    if (this.oracleType !== OptimisticOracleType.OptimisticOracleV2) {
+      return false;
+    }
+
+    try {
+      const currentImplementation = await this._getCurrentImplementation();
+      return this._hasImplementationAddress(currentImplementation);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  _getCurrentImplementation() {
+    if (this.currentImplementationPromise === null) {
+      this.currentImplementationPromise = this.web3.eth.getStorageAt(
+        this.optimisticOracleContract.options.address,
+        EIP1967_IMPLEMENTATION_SLOT
+      );
+    }
+    return this.currentImplementationPromise;
+  }
+
+  _hasImplementationAddress(implementation) {
+    return !!implementation && implementation !== "0x" + "0".repeat(64);
   }
 
   // Detects if the monitored contract is an upgraded ManagedOptimisticOracleV2 with new dispute window behavior.
@@ -439,18 +469,12 @@ class OptimisticOracleContractMonitor {
       return false;
     }
 
-    // EIP-1967 implementation slot for UUPS proxies
-    const EIP1967_IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
-
     try {
       // Read the implementation slot at current block
-      const currentImplementation = await this.web3.eth.getStorageAt(
-        this.optimisticOracleContract.options.address,
-        EIP1967_IMPLEMENTATION_SLOT
-      );
+      const currentImplementation = await this._getCurrentImplementation();
 
       // If the slot is empty (all zeros), this is not a UUPS proxy
-      if (!currentImplementation || currentImplementation === "0x" + "0".repeat(64)) {
+      if (!this._hasImplementationAddress(currentImplementation)) {
         return false;
       }
 

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -95,9 +95,8 @@ class OptimisticOracleContractMonitor {
     };
     Object.assign(this, createObjectFromDefaultProps({ contractProps }, defaultContractProps));
 
-    // Flag to track if this is upgraded ManagedOptimisticOracleV2. Initialized to null and detected on first use.
-    this.isManagedOOV2Upgraded = null;
     this.currentImplementationPromise = null;
+    this.preUpgradeImplementationPromise = null;
 
     // Helper functions from web3.
     this.toWei = this.web3.utils.toWei;
@@ -200,10 +199,7 @@ class OptimisticOracleContractMonitor {
       lastProposePriceBlockNumber: this.lastProposePriceBlockNumber,
     });
 
-    // Initialize ManagedOptimisticOracleV2 upgrade detection on first call
-    if (this.isManagedOOV2Upgraded === null) {
-      this.isManagedOOV2Upgraded = await this._detectManagedOOV2Upgraded();
-    }
+    const isManagedOOV2Upgraded = await this._detectManagedOOV2Upgraded();
 
     let latestEvents = this.optimisticOracleContractEventClient.getAllProposePriceEvents();
 
@@ -225,7 +221,7 @@ class OptimisticOracleContractMonitor {
             : event.request.expirationTime;
 
         // Adjust expiration message for upgraded ManagedOptimisticOracleV2
-        const expirationMessage = this.isManagedOOV2Upgraded
+        const expirationMessage = isManagedOOV2Upgraded
           ? `can be settled after ${expirationTime} (but remains disputable until settled)`
           : `will expire at ${expirationTime}`;
 
@@ -454,6 +450,26 @@ class OptimisticOracleContractMonitor {
     return this.currentImplementationPromise;
   }
 
+  _getFreshCurrentImplementation() {
+    return this.web3.eth.getStorageAt(this.optimisticOracleContract.options.address, EIP1967_IMPLEMENTATION_SLOT);
+  }
+
+  _getPreUpgradeImplementation() {
+    if (this.preUpgradeImplementationPromise === null) {
+      this.preUpgradeImplementationPromise = this.web3.eth
+        .getStorageAt(
+          this.optimisticOracleContract.options.address,
+          EIP1967_IMPLEMENTATION_SLOT,
+          this.managedOOV2PreUpgradeBlock
+        )
+        .catch((error) => {
+          this.preUpgradeImplementationPromise = null;
+          throw error;
+        });
+    }
+    return this.preUpgradeImplementationPromise;
+  }
+
   _hasImplementationAddress(implementation) {
     return !!implementation && implementation !== "0x" + "0".repeat(64);
   }
@@ -473,7 +489,7 @@ class OptimisticOracleContractMonitor {
 
     try {
       // Read the implementation slot at current block
-      const currentImplementation = await this._getCurrentImplementation();
+      const currentImplementation = await this._getFreshCurrentImplementation();
 
       // If the slot is empty (all zeros), this is not a UUPS proxy
       if (!this._hasImplementationAddress(currentImplementation)) {
@@ -481,11 +497,7 @@ class OptimisticOracleContractMonitor {
       }
 
       // Read the implementation slot at pre-upgrade block
-      const preUpgradeImplementation = await this.web3.eth.getStorageAt(
-        this.optimisticOracleContract.options.address,
-        EIP1967_IMPLEMENTATION_SLOT,
-        this.managedOOV2PreUpgradeBlock
-      );
+      const preUpgradeImplementation = await this._getPreUpgradeImplementation();
 
       // Compare raw bytes32 values - if they differ, the contract has been upgraded
       return currentImplementation !== preUpgradeImplementation;

--- a/packages/monitors/src/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/src/OptimisticOracleContractMonitor.js
@@ -444,10 +444,12 @@ class OptimisticOracleContractMonitor {
 
   _getCurrentImplementation() {
     if (this.currentImplementationPromise === null) {
-      this.currentImplementationPromise = this.web3.eth.getStorageAt(
-        this.optimisticOracleContract.options.address,
-        EIP1967_IMPLEMENTATION_SLOT
-      );
+      this.currentImplementationPromise = this.web3.eth
+        .getStorageAt(this.optimisticOracleContract.options.address, EIP1967_IMPLEMENTATION_SLOT)
+        .catch((error) => {
+          this.currentImplementationPromise = null;
+          throw error;
+        });
     }
     return this.currentImplementationPromise;
   }

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -983,6 +983,63 @@ describe("OptimisticOracleContractMonitor.js", function () {
     });
   });
   describe("ManagedOptimisticOracleV2 upgrade detection", function () {
+    it("Generates a managed OOv2 UI link for OOv2 UUPS proxies", async function () {
+      const testMonitor = new OptimisticOracleContractMonitor({
+        logger: spyLogger,
+        optimisticOracleContractEventClient: eventClientV2,
+        monitorConfig: { optimisticOracleUIBaseUrl: sampleBaseUIUrl },
+        contractProps,
+        otbVerificationRouterConfig,
+      });
+      const originalGetStorageAt = web3.eth.getStorageAt;
+      web3.eth.getStorageAt = sinon.stub().resolves("0x" + "0".repeat(24) + "2222222222222222222222222222222222222222");
+
+      assert.equal(
+        await testMonitor._generateUILink("0x123", 7, contractProps.chainId),
+        `<${sampleBaseUIUrl}/?transactionHash=0x123&eventIndex=7&chainId=${contractProps.chainId}&oracleType=Managed+Optimistic+Oracle+V2|View in UI>`
+      );
+
+      web3.eth.getStorageAt = originalGetStorageAt;
+    });
+
+    it("Caches OOv2 UI link managed detection", async function () {
+      const testMonitor = new OptimisticOracleContractMonitor({
+        logger: spyLogger,
+        optimisticOracleContractEventClient: eventClientV2,
+        monitorConfig: { optimisticOracleUIBaseUrl: sampleBaseUIUrl },
+        contractProps,
+        otbVerificationRouterConfig,
+      });
+      const originalGetStorageAt = web3.eth.getStorageAt;
+      web3.eth.getStorageAt = sinon.stub().resolves("0x" + "0".repeat(24) + "2222222222222222222222222222222222222222");
+
+      await testMonitor._generateUILink("0x123", 7, contractProps.chainId);
+      await testMonitor._generateUILink("0x456", 9, contractProps.chainId);
+
+      assert.equal(web3.eth.getStorageAt.callCount, 1);
+
+      web3.eth.getStorageAt = originalGetStorageAt;
+    });
+
+    it("Falls back to standard OOv2 UI link when managed detection fails", async function () {
+      const testMonitor = new OptimisticOracleContractMonitor({
+        logger: spyLogger,
+        optimisticOracleContractEventClient: eventClientV2,
+        monitorConfig: { optimisticOracleUIBaseUrl: sampleBaseUIUrl },
+        contractProps,
+        otbVerificationRouterConfig,
+      });
+      const originalGetStorageAt = web3.eth.getStorageAt;
+      web3.eth.getStorageAt = sinon.stub().rejects(new Error("storage read failed"));
+
+      assert.equal(
+        await testMonitor._generateUILink("0x123", 7, contractProps.chainId),
+        `<${sampleBaseUIUrl}/?transactionHash=0x123&eventIndex=7&chainId=${contractProps.chainId}&oracleType=Optimistic+Oracle+V2|View in UI>`
+      );
+
+      web3.eth.getStorageAt = originalGetStorageAt;
+    });
+
     it("Uses standard message when managedOOV2PreUpgradeBlock is not configured", async function () {
       // Create monitor without managedOOV2PreUpgradeBlock config
       const testMonitor = new OptimisticOracleContractMonitor({

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -1021,7 +1021,7 @@ describe("OptimisticOracleContractMonitor.js", function () {
       web3.eth.getStorageAt = originalGetStorageAt;
     });
 
-    it("Falls back to standard OOv2 UI link when managed detection fails", async function () {
+    it("Retries OOv2 managed detection after an initial failure", async function () {
       const testMonitor = new OptimisticOracleContractMonitor({
         logger: spyLogger,
         optimisticOracleContractEventClient: eventClientV2,
@@ -1030,12 +1030,20 @@ describe("OptimisticOracleContractMonitor.js", function () {
         otbVerificationRouterConfig,
       });
       const originalGetStorageAt = web3.eth.getStorageAt;
-      web3.eth.getStorageAt = sinon.stub().rejects(new Error("storage read failed"));
+      const getStorageAtStub = sinon.stub();
+      getStorageAtStub.onFirstCall().rejects(new Error("storage read failed"));
+      getStorageAtStub.onSecondCall().resolves("0x" + "0".repeat(24) + "2222222222222222222222222222222222222222");
+      web3.eth.getStorageAt = getStorageAtStub;
 
       assert.equal(
         await testMonitor._generateUILink("0x123", 7, contractProps.chainId),
         `<${sampleBaseUIUrl}/?transactionHash=0x123&eventIndex=7&chainId=${contractProps.chainId}&oracleType=Optimistic+Oracle+V2|View in UI>`
       );
+      assert.equal(
+        await testMonitor._generateUILink("0x456", 9, contractProps.chainId),
+        `<${sampleBaseUIUrl}/?transactionHash=0x456&eventIndex=9&chainId=${contractProps.chainId}&oracleType=Managed+Optimistic+Oracle+V2|View in UI>`
+      );
+      assert.equal(getStorageAtStub.callCount, 2);
 
       web3.eth.getStorageAt = originalGetStorageAt;
     });

--- a/packages/monitors/test/OptimisticOracleContractMonitor.js
+++ b/packages/monitors/test/OptimisticOracleContractMonitor.js
@@ -1157,7 +1157,7 @@ describe("OptimisticOracleContractMonitor.js", function () {
       assert.isFalse(lastSpyLogIncludes(spy, "will expire at"));
     });
 
-    it("Caches detection result and doesn't check again on subsequent calls", async function () {
+    it("Refreshes current implementation on subsequent upgrade checks", async function () {
       // Create monitor with managedOOV2PreUpgradeBlock configured
       const testMonitor = new OptimisticOracleContractMonitor({
         logger: spyLogger,
@@ -1175,23 +1175,18 @@ describe("OptimisticOracleContractMonitor.js", function () {
       const newImplementation = "0x" + "0".repeat(24) + "2222222222222222222222222222222222222222";
       const originalGetStorageAt = web3.eth.getStorageAt;
       const getStorageAtStub = sinon.stub();
-      getStorageAtStub.onFirstCall().resolves(newImplementation);
-      getStorageAtStub.onSecondCall().resolves(oldImplementation);
+      getStorageAtStub.onCall(0).resolves(oldImplementation); // First current block read
+      getStorageAtStub.onCall(1).resolves(oldImplementation); // Cached pre-upgrade block read
+      getStorageAtStub.onCall(2).resolves(newImplementation); // Second current block read
       web3.eth.getStorageAt = getStorageAtStub;
 
-      // First call - should trigger detection
-      await eventClientV2.update();
-      await testMonitor.checkForProposals();
+      assert.isFalse(await testMonitor._detectManagedOOV2Upgraded());
+      assert.isTrue(await testMonitor._detectManagedOOV2Upgraded());
 
-      // Second call - should use cached result
-      await eventClientV2.update();
-      await testMonitor.checkForProposals();
-
-      // Restore original method
       web3.eth.getStorageAt = originalGetStorageAt;
 
-      // getStorageAt should only be called twice (once for current, once for pre-upgrade), not four times
-      assert.equal(getStorageAtStub.callCount, 2);
+      // Current implementation should be read fresh each time, while the pre-upgrade slot stays cached.
+      assert.equal(getStorageAtStub.callCount, 3);
     });
   });
   describe("OTB verification router checks", function () {


### PR DESCRIPTION
**Motivation**

Managed Optimistic Oracle V2 requests currently generate the standard OOv2 Oracle UI link in monitor alerts. That points reviewers to the wrong UI variant.

This PR fixes the link generation inside the monitor so managed OOv2 requests resolve to `oracleType=Managed+Optimistic+Oracle+V2`.

**Summary**

This PR updates `OptimisticOracleContractMonitor` to detect managed OOv2 contracts by reading the current EIP-1967 implementation slot.

If the configured oracle type is `OptimisticOracleV2` and the contract is a UUPS proxy, `_generateUILink` now emits the managed UI link. The upgraded-managed dispute-window detection keeps its existing semantics, but now uses a fresh current-slot read on each proposal poll so long-running monitor processes can observe a later proxy upgrade without restart.

**Details**

`_generateUILink` is now async and all monitor alert paths await it before logging request, proposal, dispute, and settlement messages.

Managed OOv2 UI-link detection is local to `packages/monitors/src/OptimisticOracleContractMonitor.js`. It treats an OOv2 contract as managed when the current EIP-1967 implementation slot is non-empty.

For managed detection, the current-slot read is still cached per monitor instance, and rejected reads clear the cache before rethrowing. That preserves single-flight behavior on success while allowing managed detection to retry after transient RPC/storage failures instead of getting stuck on a permanently rejected promise.

`_detectManagedOOV2Upgraded` still requires `managedOOV2PreUpgradeBlock` and compares the current implementation to the pre-upgrade implementation. To support long-running processes, it now reads the current implementation fresh on each proposal poll, while caching the historical pre-upgrade-slot read.

**Testing**

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

Added coverage for:
- managed OOv2 UI link generation for OOv2 UUPS proxies
- caching of managed detection for repeated UI-link generation
- retrying managed detection after an initial storage-read failure
- refreshing current implementation on repeated upgrade checks while reusing the cached pre-upgrade implementation

Executed:

```bash
./node_modules/.bin/mocha --timeout 30000 packages/monitors/test/OptimisticOracleContractMonitor.js
node -c packages/monitors/src/OptimisticOracleContractMonitor.js
node -c packages/monitors/test/OptimisticOracleContractMonitor.js
```

Observed result:
- `23 passing (1m)` for the monitor suite

**Issue(s)**

Fixes: https://linear.app/uma/issue/FE-520/moov2-proposal-links-in-oo-live-feed-use-incorrect-oracletype