### PR TITLE
feat(monitor-v2): add SETTLE_ONLY_DISPUTED option to settlement bot

### DIFF
--- a/packages/monitor-v2/src/bot-oo/README.md
+++ b/packages/monitor-v2/src/bot-oo/README.md
@@ -34,7 +34,7 @@ node ./packages/monitor-v2/dist/bot-oo/index.js
 - `GAS_LIMIT_MULTIPLIER`: Percent multiplier on estimated gas (default `150`).
 - `SETTLE_DELAY`: Lookback period in seconds to detect settleable requests (default `300`).
 - `SETTLE_TIMEOUT`: Timeout in seconds for submitting settlement transactions in serverless mode (default `240`).
-- `SETTLE_ONLY_DISPUTED`: When `true`, only settle requests that have been disputed (`false` by default). Only supported for `OptimisticOracleV2`; ignored for `OptimisticOracle` and `SkinnyOptimisticOracle`.
+- `SETTLE_ONLY_DISPUTED`: When `true`, only settle requests that have been disputed (`false` by default). Supported for `OptimisticOracleV2` (including `ManagedOptimisticOracleV2`); ignored for `OptimisticOracle` and `SkinnyOptimisticOracle`.
 
 ## Behavior
 

--- a/packages/monitor-v2/src/bot-oo/README.md
+++ b/packages/monitor-v2/src/bot-oo/README.md
@@ -34,7 +34,7 @@ node ./packages/monitor-v2/dist/bot-oo/index.js
 - `GAS_LIMIT_MULTIPLIER`: Percent multiplier on estimated gas (default `150`).
 - `SETTLE_DELAY`: Lookback period in seconds to detect settleable requests (default `300`).
 - `SETTLE_TIMEOUT`: Timeout in seconds for submitting settlement transactions in serverless mode (default `240`).
-- `SETTLE_ONLY_DISPUTED`: When `true`, only settle requests that have been disputed (`false` by default).
+- `SETTLE_ONLY_DISPUTED`: When `true`, only settle requests that have been disputed (`false` by default). Only supported for `OptimisticOracleV2`; ignored for `OptimisticOracle` and `SkinnyOptimisticOracle`.
 
 ## Behavior
 

--- a/packages/monitor-v2/src/bot-oo/README.md
+++ b/packages/monitor-v2/src/bot-oo/README.md
@@ -34,6 +34,7 @@ node ./packages/monitor-v2/dist/bot-oo/index.js
 - `GAS_LIMIT_MULTIPLIER`: Percent multiplier on estimated gas (default `150`).
 - `SETTLE_DELAY`: Lookback period in seconds to detect settleable requests (default `300`).
 - `SETTLE_TIMEOUT`: Timeout in seconds for submitting settlement transactions in serverless mode (default `240`).
+- `SETTLE_ONLY_DISPUTED`: When `true`, only settle requests that have been disputed (`false` by default).
 
 ## Behavior
 

--- a/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
+++ b/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
@@ -116,8 +116,30 @@ export async function settleOOv2Requests(
 
   const signerAddress = await params.signer.getAddress();
 
+  // State.Resolved = 5: disputed and DVM price is available (settleable after dispute).
+  const STATE_RESOLVED = 5;
+
   const settleableRequestsPromises = requestsToSettle.map(async (req) => {
     try {
+      // When settleOnlyDisputed is enabled, check on-chain state and skip undisputed requests.
+      if (params.botModes.settleOnlyDisputed) {
+        const state = await oo.getState(
+          req.args.requester,
+          req.args.identifier,
+          req.args.timestamp,
+          req.args.ancillaryData
+        );
+        if (state !== STATE_RESOLVED) {
+          logger.debug({
+            at: "OOv2Bot",
+            message: "Skipping non-disputed request (settleOnlyDisputed)",
+            requestKey: requestKey(req.args),
+            state,
+          });
+          return null;
+        }
+      }
+
       await oo.callStatic.settle(req.args.requester, req.args.identifier, req.args.timestamp, req.args.ancillaryData, {
         blockTag: params.settleableCheckBlock,
         from: signerAddress,

--- a/packages/monitor-v2/src/bot-oo/SettleSkinnyOORequests.ts
+++ b/packages/monitor-v2/src/bot-oo/SettleSkinnyOORequests.ts
@@ -80,9 +80,23 @@ export async function settleSkinnyOORequests(
   disputes.forEach(pushIfLatest);
 
   // Exclude already settled requests.
-  const candidatesToSettle: SkinnyEvent[] = Array.from(byKey.entries())
+  let candidatesToSettle: SkinnyEvent[] = Array.from(byKey.entries())
     .filter(([key]) => !settledKeys.has(key))
     .map(([, evt]) => evt);
+
+  // When settleOnlyDisputed is enabled, restrict to requests that have a DisputePrice event.
+  if (params.botModes.settleOnlyDisputed) {
+    const disputedKeys = new Set(disputes.map((e) => requestKey(toRequestKeyArgs(e.args))));
+    const beforeCount = candidatesToSettle.length;
+    candidatesToSettle = candidatesToSettle.filter((e) => disputedKeys.has(requestKey(toRequestKeyArgs(e.args))));
+    logger.debug({
+      at: "SkinnyOOBot",
+      message: "Filtered to disputed-only requests",
+      before: beforeCount,
+      after: candidatesToSettle.length,
+      skipped: beforeCount - candidatesToSettle.length,
+    });
+  }
 
   const settleableRequestsPromises = candidatesToSettle.map(async (req) => {
     try {

--- a/packages/monitor-v2/src/bot-oo/SettleSkinnyOORequests.ts
+++ b/packages/monitor-v2/src/bot-oo/SettleSkinnyOORequests.ts
@@ -80,23 +80,9 @@ export async function settleSkinnyOORequests(
   disputes.forEach(pushIfLatest);
 
   // Exclude already settled requests.
-  let candidatesToSettle: SkinnyEvent[] = Array.from(byKey.entries())
+  const candidatesToSettle: SkinnyEvent[] = Array.from(byKey.entries())
     .filter(([key]) => !settledKeys.has(key))
     .map(([, evt]) => evt);
-
-  // When settleOnlyDisputed is enabled, restrict to requests that have a DisputePrice event.
-  if (params.botModes.settleOnlyDisputed) {
-    const disputedKeys = new Set(disputes.map((e) => requestKey(toRequestKeyArgs(e.args))));
-    const beforeCount = candidatesToSettle.length;
-    candidatesToSettle = candidatesToSettle.filter((e) => disputedKeys.has(requestKey(toRequestKeyArgs(e.args))));
-    logger.debug({
-      at: "SkinnyOOBot",
-      message: "Filtered to disputed-only requests",
-      before: beforeCount,
-      after: candidatesToSettle.length,
-      skipped: beforeCount - candidatesToSettle.length,
-    });
-  }
 
   const settleableRequestsPromises = candidatesToSettle.map(async (req) => {
     try {

--- a/packages/monitor-v2/src/bot-oo/common.ts
+++ b/packages/monitor-v2/src/bot-oo/common.ts
@@ -8,6 +8,7 @@ export type OracleType = "OptimisticOracle" | "SkinnyOptimisticOracle" | "Optimi
 
 export interface BotModes {
   settleRequestsEnabled: boolean;
+  settleOnlyDisputed: boolean;
 }
 
 export interface MonitoringParams extends BaseMonitoringParams {
@@ -24,6 +25,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
 
   const botModes = {
     settleRequestsEnabled: env.SETTLEMENTS_ENABLED === "true",
+    settleOnlyDisputed: env.SETTLE_ONLY_DISPUTED === "true",
   };
 
   if (!env.ORACLE_ADDRESS) throw new Error("ORACLE_ADDRESS must be defined in env");

--- a/packages/monitor-v2/src/bot-oo/common.ts
+++ b/packages/monitor-v2/src/bot-oo/common.ts
@@ -8,7 +8,7 @@ export type OracleType = "OptimisticOracle" | "SkinnyOptimisticOracle" | "Optimi
 
 export interface BotModes {
   settleRequestsEnabled: boolean;
-  settleOnlyDisputed: boolean;
+  settleOnlyDisputed: boolean; // Only supported for OptimisticOracleV2; ignored for OOv1 and SkinnyOO.
 }
 
 export interface MonitoringParams extends BaseMonitoringParams {

--- a/packages/monitor-v2/src/bot-oo/common.ts
+++ b/packages/monitor-v2/src/bot-oo/common.ts
@@ -8,7 +8,7 @@ export type OracleType = "OptimisticOracle" | "SkinnyOptimisticOracle" | "Optimi
 
 export interface BotModes {
   settleRequestsEnabled: boolean;
-  settleOnlyDisputed: boolean; // Only supported for OptimisticOracleV2; ignored for OOv1 and SkinnyOO.
+  settleOnlyDisputed: boolean; // Supported for OptimisticOracleV2 (incl. ManagedOOv2); ignored for OOv1 and SkinnyOO.
 }
 
 export interface MonitoringParams extends BaseMonitoringParams {

--- a/packages/monitor-v2/test/OptimisticOracleV2Bot.ts
+++ b/packages/monitor-v2/test/OptimisticOracleV2Bot.ts
@@ -296,4 +296,80 @@ describe("OptimisticOracleV2Bot", function () {
     const subsequentLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
     assert.equal(subsequentLogs.length, 0, "No settlement logs should be generated on subsequent runs");
   });
+
+  it("settleOnlyDisputed skips undisputed expired proposals", async function () {
+    await (
+      await optimisticOracleV2.requestPrice(defaultOptimisticOracleV2Identifier, 0, ancillaryData, bondToken.address, 0)
+    ).wait();
+
+    const proposeReceipt = await (
+      await optimisticOracleV2
+        .connect(proposer)
+        .proposePrice(
+          await requester.getAddress(),
+          defaultOptimisticOracleV2Identifier,
+          0,
+          ancillaryData,
+          ethers.utils.parseEther("1")
+        )
+    ).wait();
+
+    // Move timer past liveness — request is settleable but was never disputed.
+    await advanceTimerPastLiveness(timer, proposeReceipt.blockNumber!, defaultLiveness);
+
+    const { spy, logger } = makeSpyLogger();
+    const params = await makeMonitoringParamsOO("OptimisticOracleV2", optimisticOracleV2.address, {
+      settleRequestsEnabled: false,
+      settleOnlyDisputed: true,
+    });
+    await gasEstimator.update();
+    await settleRequests(logger, params, gasEstimator);
+
+    const settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
+    assert.equal(settlementLogs.length, 0, "Undisputed request should not be settled when settleOnlyDisputed is true");
+  });
+
+  it("settleOnlyDisputed settles disputed request once DVM resolved", async function () {
+    await (
+      await optimisticOracleV2.requestPrice(defaultOptimisticOracleV2Identifier, 0, ancillaryData, bondToken.address, 0)
+    ).wait();
+
+    await (
+      await optimisticOracleV2
+        .connect(proposer)
+        .proposePrice(
+          await requester.getAddress(),
+          defaultOptimisticOracleV2Identifier,
+          0,
+          ancillaryData,
+          ethers.utils.parseEther("1")
+        )
+    ).wait();
+
+    await (
+      await optimisticOracleV2
+        .connect(disputer)
+        .disputePrice(await requester.getAddress(), defaultOptimisticOracleV2Identifier, 0, ancillaryData)
+    ).wait();
+
+    // Resolve in DVM via MockOracle.
+    const pending = await mockOracle.getPendingQueries();
+    const last = pending[pending.length - 1]!;
+    await (
+      await mockOracle.pushPrice(last.identifier, last.time, last.ancillaryData, ethers.utils.parseEther("1"))
+    ).wait();
+
+    const { spy, logger } = makeSpyLogger();
+    const params = await makeMonitoringParamsOO("OptimisticOracleV2", optimisticOracleV2.address, {
+      settleRequestsEnabled: false,
+      settleOnlyDisputed: true,
+    });
+    await gasEstimator.update();
+    await settleRequests(logger, params, gasEstimator);
+
+    const settledIndex = spy
+      .getCalls()
+      .findIndex((c) => c.lastArg?.message === "Price Request Settled ✅" && c.lastArg?.at === "OOv2Bot");
+    assert.isAbove(settledIndex, -1, "Disputed request should be settled when settleOnlyDisputed is true");
+  });
 });

--- a/packages/monitor-v2/test/helpers/monitoring.ts
+++ b/packages/monitor-v2/test/helpers/monitoring.ts
@@ -24,7 +24,8 @@ export async function makeMonitoringParamsOO(
   const [signer] = await ethers.getSigners();
   const defaultBotModes: BotModesOO = {
     settleRequestsEnabled: false,
-  } as BotModesOO;
+    settleOnlyDisputed: false,
+  };
 
   const mergedBotModes = { ...defaultBotModes, ...botModes } as BotModesOO;
 


### PR DESCRIPTION
## Summary
- Adds `SETTLE_ONLY_DISPUTED` env var (default `false`) to the OO settlement bot
- When `true`, only settles requests that were disputed and resolved via the DVM, skipping undisputed expired proposals
- Uses on-chain `getState()` to check dispute status per request — no extra event queries needed
- Supported for OptimisticOracleV2 / ManagedOptimisticOracleV2 only

## Test plan
- [ ] New test: `settleOnlyDisputed` skips undisputed expired proposals
- [ ] New test: `settleOnlyDisputed` settles disputed+DVM-resolved proposals
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)