### PR TITLE
Fix Polymarket gamma lookup and notifier dedup persistence

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -355,11 +355,10 @@ export const getPolymarketMarketInformation = async (
   params: MonitoringParams,
   questionID: string
 ): Promise<PolymarketMarketGraphqlProcessed[]> => {
-  const normalizedQuestionID = questionID.toLowerCase();
-  // Gamma currently rejects LOWER(...) on these fields, but direct lowercase equality works.
+  // Gamma currently rejects LOWER(...) on these fields, so query with the exact hash we computed.
   const query = `
     {
-      markets(where: "question_id = '${normalizedQuestionID}' or neg_risk_request_id = '${normalizedQuestionID}' or game_id = '${normalizedQuestionID}'") {
+      markets(where: "question_id = '${questionID}' or neg_risk_request_id = '${questionID}' or game_id = '${questionID}'") {
         clobTokenIds
         volumeNum
         outcomes

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -355,9 +355,11 @@ export const getPolymarketMarketInformation = async (
   params: MonitoringParams,
   questionID: string
 ): Promise<PolymarketMarketGraphqlProcessed[]> => {
+  const normalizedQuestionID = questionID.toLowerCase();
+  // Gamma currently rejects LOWER(...) on these fields, but direct lowercase equality works.
   const query = `
     {
-      markets(where: "LOWER(question_id) = LOWER('${questionID}') or LOWER(neg_risk_request_id) = LOWER('${questionID}') or LOWER(game_id) = LOWER('${questionID}')") {
+      markets(where: "question_id = '${normalizedQuestionID}' or neg_risk_request_id = '${normalizedQuestionID}' or game_id = '${normalizedQuestionID}'") {
         clobTokenIds
         volumeNum
         outcomes
@@ -827,7 +829,7 @@ export const storeNotifiedProposals = async (notifiedContracts: OptimisticPriceR
   if (!datastore) return;
   const promises = notifiedContracts.map((contract) => {
     const key = datastore.key(["NotifiedProposals", getProposalKeyToStore(contract)]);
-    datastore.save({
+    return datastore.save({
       key: key,
       data: {
         proposalHash: contract.proposalHash,


### PR DESCRIPTION
## What changed
- removed `LOWER(...)` from the Gamma market lookup query and instead normalize the `questionID` to lowercase before querying
- fixed `storeNotifiedProposals` so it actually awaits `datastore.save(...)` writes before the serverless process exits

## Why
The polymarket monitor was emitting repeated `Failed to verify proposed market, please verify manually! 🚨` alerts even though the job itself was still succeeding.

## Root cause
- Gamma now rejects the `LOWER(question_id)`, `LOWER(neg_risk_request_id)`, and `LOWER(game_id)` pattern used by the monitor with `cannot get the information`
- the notifier dedup path built a `Promise.all(...)` over `undefined` because `datastore.save(...)` was not returned from the map callback, so repeated alerts were not reliably persisted between runs

## Impact
- market lookups now use a query shape that Gamma accepts
- duplicate alerts for the same proposal should stop once the Datastore writes are awaited

## Validation
- reproduced the failing Gamma response against the current production query shape
- verified that the same lookup succeeds when using direct lowercase equality without `LOWER(...)`
- ran `yarn workspace @uma/monitor-v2 build`
