### PR TITLE
fix[polymarket-monitor]: resolve markets via CLOB condition lookup

### DIFF
--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -252,18 +252,25 @@ export async function monitorTransactionsProposedOrderBook(
 
   await Promise.all(
     allProposals.map(async ({ proposal, version }) => {
+      const ancillaryDataString = tryHexToUtf8String(proposal.ancillaryData);
       const questionID = calculatePolymarketQuestionID(proposal.ancillaryData);
+      const marketId = common.extractMarketIdFromAncillaryData(ancillaryDataString);
 
       try {
-        const markets = await getPolymarketMarketInformation(logger, params, questionID);
+        const markets = await getPolymarketMarketInformation(logger, params, questionID, marketId ?? undefined);
         markets.forEach((market) => {
           tokenIds.add(market.clobTokenIds[0]);
           tokenIds.add(market.clobTokenIds[1]);
         });
         bundles.push({ proposal, markets });
       } catch (error) {
+        const noMarketFound =
+          error instanceof Error &&
+          (error.message.includes(`No market found for question ID: ${questionID}`) ||
+            (marketId != null && error.message.includes(`No market found for market ID: ${marketId}`)));
+
         // Check if this is the specific "No market found" error for 3rd party proposals
-        if (error instanceof Error && error.message.includes(`No market found for question ID: ${questionID}`)) {
+        if (noMarketFound) {
           // Apply 3rd party proposal filtering logic
           const shouldIgnore = await shouldIgnoreThirdPartyProposal(params, proposal, version);
           if (shouldIgnore) {
@@ -271,6 +278,7 @@ export async function monitorTransactionsProposedOrderBook(
             logger.info({
               at: "PolymarketMonitor",
               message: "Ignoring 3rd party Polymarket proposal based on filtering criteria",
+              marketId,
               questionID,
               proposalHash: proposal.proposalHash,
               requester: proposal.requester,

--- a/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/MonitorProposalsOrderBook.ts
@@ -252,25 +252,18 @@ export async function monitorTransactionsProposedOrderBook(
 
   await Promise.all(
     allProposals.map(async ({ proposal, version }) => {
-      const ancillaryDataString = tryHexToUtf8String(proposal.ancillaryData);
       const questionID = calculatePolymarketQuestionID(proposal.ancillaryData);
-      const marketId = common.extractMarketIdFromAncillaryData(ancillaryDataString);
 
       try {
-        const markets = await getPolymarketMarketInformation(logger, params, questionID, marketId ?? undefined);
+        const markets = await getPolymarketMarketInformation(logger, params, questionID, proposal.requester);
         markets.forEach((market) => {
           tokenIds.add(market.clobTokenIds[0]);
           tokenIds.add(market.clobTokenIds[1]);
         });
         bundles.push({ proposal, markets });
       } catch (error) {
-        const noMarketFound =
-          error instanceof Error &&
-          (error.message.includes(`No market found for question ID: ${questionID}`) ||
-            (marketId != null && error.message.includes(`No market found for market ID: ${marketId}`)));
-
         // Check if this is the specific "No market found" error for 3rd party proposals
-        if (noMarketFound) {
+        if (error instanceof Error && error.message.includes(`No market found for question ID: ${questionID}`)) {
           // Apply 3rd party proposal filtering logic
           const shouldIgnore = await shouldIgnoreThirdPartyProposal(params, proposal, version);
           if (shouldIgnore) {
@@ -278,7 +271,6 @@ export async function monitorTransactionsProposedOrderBook(
             logger.info({
               at: "PolymarketMonitor",
               message: "Ignoring 3rd party Polymarket proposal based on filtering criteria",
-              marketId,
               questionID,
               proposalHash: proposal.proposalHash,
               requester: proposal.requester,

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -86,7 +86,7 @@ export interface MonitoringParams {
   additionalRequesters: string[];
   maxBlockLookBack: number;
   graphqlEndpoint: string;
-  polymarketApiKey: string;
+  polymarketApiKey?: string;
   apiEndpoint: string;
   provider: Provider;
   chainId: number;
@@ -946,7 +946,6 @@ export const initMonitoringParams = async (
   if (!env.CHAIN_ID) throw new Error("CHAIN_ID must be defined in env");
   const chainId = Number(env.CHAIN_ID);
 
-  if (!env.POLYMARKET_API_KEY) throw new Error("POLYMARKET_API_KEY must be defined in env");
   const polymarketApiKey = env.POLYMARKET_API_KEY;
 
   if (!env.AI_RESULTS_BASE_URL) throw new Error("AI_RESULTS_BASE_URL must be defined in env");

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -36,6 +36,15 @@ export { Logger };
 export const ONE_SCALED = ethers.utils.parseUnits("1", 18);
 
 export const POLYGON_BLOCKS_PER_HOUR = 1800;
+const NEG_RISK_OPERATOR_ADDRESSES = [
+  "0x71523d0f655B41E805Cec45b17163f528B59B820",
+  "0x661992aebf6BecF7BA5abB66f6b0Bf62Aa7a2E93",
+];
+const LEGACY_NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296";
+const NEG_RISK_OPERATOR_ABI = [
+  "function questionIds(bytes32) view returns (bytes32)",
+  "function nrAdapter() view returns (address)",
+];
 
 /**
  * Determines if a trade represents a discrepancy based on token role and thresholds.
@@ -111,6 +120,13 @@ interface PolymarketMarketResponse {
   volumeNum: number;
   clobTokenIds: string;
   questionID: string;
+}
+
+interface ClobMarketResponse {
+  market_slug?: string;
+  market_id?: string | number | null;
+  id?: string | number | null;
+  error?: string;
 }
 
 export interface PolymarketMarketGraphqlProcessed {
@@ -294,11 +310,6 @@ export const extractInitializerFromAncillaryData = (ancillaryData: string): stri
   return null;
 };
 
-export const extractMarketIdFromAncillaryData = (ancillaryData: string): string | null => {
-  const marketIdMatch = ancillaryData.match(/market_id:\s*([0-9]+)/i);
-  return marketIdMatch ? marketIdMatch[1] : null;
-};
-
 // Get reward amount from contract's requests mapping via eth_call
 export const getRewardForProposal = async (
   params: MonitoringParams,
@@ -359,7 +370,7 @@ export const getPolymarketMarketInformation = async (
   logger: typeof Logger,
   params: MonitoringParams,
   questionID: string,
-  marketId?: string
+  requesterAddress?: string
 ): Promise<PolymarketMarketGraphqlProcessed[]> => {
   const processMarket = (market: PolymarketMarketResponse): PolymarketMarketGraphqlProcessed => {
     return {
@@ -370,53 +381,89 @@ export const getPolymarketMarketInformation = async (
     };
   };
 
-  if (marketId) {
-    const gammaApiBaseUrl = params.graphqlEndpoint.replace(/\/query\/?$/, "");
-    const { data } = await params.httpClient.get<PolymarketMarketResponse>(`${gammaApiBaseUrl}/markets/${marketId}`);
+  const gammaApiBaseUrl = params.graphqlEndpoint.replace(/\/query\/?$/, "");
 
-    if (!data) {
-      throw new Error(`No market found for market ID: ${marketId}`);
+  const getConditionId = (adapter: string, targetQuestionId: string): string =>
+    ethers.utils.solidityKeccak256(["address", "bytes32", "uint256"], [adapter, targetQuestionId, 2]);
+
+  const getStandardConditionIds = (targetQuestionId: string): string[] => {
+    if (!requesterAddress) return [];
+
+    try {
+      return [getConditionId(ethers.utils.getAddress(requesterAddress), targetQuestionId)];
+    } catch {
+      return [];
     }
+  };
 
-    return [processMarket(data)];
-  }
+  const getNegRiskConditionIds = async (): Promise<string[]> => {
+    for (const operatorAddress of NEG_RISK_OPERATOR_ADDRESSES) {
+      try {
+        const operator = new ethers.Contract(operatorAddress, NEG_RISK_OPERATOR_ABI, params.provider);
+        const negRiskQuestionId: string = await operator.questionIds(questionID);
 
-  // Gamma currently rejects LOWER(...) on these fields, so query with the exact hash we computed.
-  const query = `
-    {
-      markets(where: "question_id = '${questionID}' or neg_risk_request_id = '${questionID}' or game_id = '${questionID}'") {
-        clobTokenIds
-        volumeNum
-        outcomes
-        outcomePrices
-        question
-        questionID
+        if (!negRiskQuestionId || negRiskQuestionId === ethers.constants.HashZero) continue;
+
+        const adapterCandidates = new Set<string>([LEGACY_NEG_RISK_ADAPTER]);
+        try {
+          adapterCandidates.add(await operator.nrAdapter());
+        } catch {
+          // Ignore adapter lookup failures and keep the legacy fallback.
+        }
+
+        return [...adapterCandidates].reduce<string[]>((conditionIds, address) => {
+          try {
+            conditionIds.push(getConditionId(ethers.utils.getAddress(address), negRiskQuestionId));
+          } catch {
+            // Ignore malformed adapter addresses and continue.
+          }
+          return conditionIds;
+        }, []);
+      } catch {
+        // Ignore operator lookup failures and try the next operator.
       }
     }
-    `;
-  const { data } = await params.httpClient.post<GraphQLResponse<{ markets: PolymarketMarketResponse[] }>>(
-    params.graphqlEndpoint,
-    { query },
-    {
-      headers: { authorization: `Bearer ${params.polymarketApiKey}` },
+
+    return [];
+  };
+
+  const findClobMarket = async (): Promise<ClobMarketResponse | null> => {
+    const conditionIds = [...getStandardConditionIds(questionID), ...(await getNegRiskConditionIds())];
+
+    for (const conditionId of conditionIds) {
+      try {
+        const { data } = await params.httpClient.get<ClobMarketResponse>(`${params.apiEndpoint}/markets/${conditionId}`);
+        if (data && !data.error) return data;
+      } catch (error) {
+        const axiosError = error as AxiosError<{ error?: string }>;
+        if (axiosError.response?.status === 404) continue;
+        throw error;
+      }
     }
-  );
 
-  if (data.errors?.length) {
-    throw new Error(data.errors.map((e) => e.message).join("; "));
-  }
+    return null;
+  };
 
-  if (!data.data?.markets) {
-    throw new Error("No markets found");
-  }
+  const fetchGammaMarket = async (clobMarket: ClobMarketResponse): Promise<PolymarketMarketResponse> => {
+    const candidateUrls = [
+      clobMarket.market_slug ? `${gammaApiBaseUrl}/markets/slug/${encodeURIComponent(clobMarket.market_slug)}` : null,
+      clobMarket.market_id != null ? `${gammaApiBaseUrl}/markets/${clobMarket.market_id}` : null,
+      clobMarket.id != null ? `${gammaApiBaseUrl}/markets/${clobMarket.id}` : null,
+    ].filter((url): url is string => Boolean(url));
 
-  const { markets } = data.data;
+    for (const url of candidateUrls) {
+      const { data } = await params.httpClient.get<PolymarketMarketResponse | PolymarketMarketResponse[]>(url);
+      const market = Array.isArray(data) ? data[0] : data;
+      if (market) return market;
+    }
 
-  if (!markets.length) {
-    throw new Error(`No market found for question ID: ${questionID}`);
-  }
+    throw new Error(`No Gamma market found for question ID: ${questionID}`);
+  };
 
-  return markets.map(processMarket);
+  const clobMarket = await findClobMarket();
+  if (!clobMarket) throw new Error(`No market found for question ID: ${questionID}`);
+
+  return [processMarket(await fetchGammaMarket(clobMarket))];
 };
 
 /**

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -104,7 +104,7 @@ export interface MonitoringParams {
   maxTradesPerToken: number;
   fillEventsChunkBlocks: number;
 }
-interface PolymarketMarketGraphql {
+interface PolymarketMarketResponse {
   question: string;
   outcomes: string;
   outcomePrices: string;
@@ -294,6 +294,11 @@ export const extractInitializerFromAncillaryData = (ancillaryData: string): stri
   return null;
 };
 
+export const extractMarketIdFromAncillaryData = (ancillaryData: string): string | null => {
+  const marketIdMatch = ancillaryData.match(/market_id:\s*([0-9]+)/i);
+  return marketIdMatch ? marketIdMatch[1] : null;
+};
+
 // Get reward amount from contract's requests mapping via eth_call
 export const getRewardForProposal = async (
   params: MonitoringParams,
@@ -353,8 +358,29 @@ export const shouldIgnoreThirdPartyProposal = async (
 export const getPolymarketMarketInformation = async (
   logger: typeof Logger,
   params: MonitoringParams,
-  questionID: string
+  questionID: string,
+  marketId?: string
 ): Promise<PolymarketMarketGraphqlProcessed[]> => {
+  const processMarket = (market: PolymarketMarketResponse): PolymarketMarketGraphqlProcessed => {
+    return {
+      ...market,
+      outcomes: JSON.parse(market.outcomes),
+      outcomePrices: JSON.parse(market.outcomePrices),
+      clobTokenIds: JSON.parse(market.clobTokenIds),
+    };
+  };
+
+  if (marketId) {
+    const gammaApiBaseUrl = params.graphqlEndpoint.replace(/\/query\/?$/, "");
+    const { data } = await params.httpClient.get<PolymarketMarketResponse>(`${gammaApiBaseUrl}/markets/${marketId}`);
+
+    if (!data) {
+      throw new Error(`No market found for market ID: ${marketId}`);
+    }
+
+    return [processMarket(data)];
+  }
+
   // Gamma currently rejects LOWER(...) on these fields, so query with the exact hash we computed.
   const query = `
     {
@@ -368,7 +394,7 @@ export const getPolymarketMarketInformation = async (
       }
     }
     `;
-  const { data } = await params.httpClient.post<GraphQLResponse<{ markets: PolymarketMarketGraphql[] }>>(
+  const { data } = await params.httpClient.post<GraphQLResponse<{ markets: PolymarketMarketResponse[] }>>(
     params.graphqlEndpoint,
     { query },
     {
@@ -390,14 +416,7 @@ export const getPolymarketMarketInformation = async (
     throw new Error(`No market found for question ID: ${questionID}`);
   }
 
-  return markets.map((market) => {
-    return {
-      ...market,
-      outcomes: JSON.parse(market.outcomes),
-      outcomePrices: JSON.parse(market.outcomePrices),
-      clobTokenIds: JSON.parse(market.clobTokenIds),
-    };
-  });
+  return markets.map(processMarket);
 };
 
 /**

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -80,11 +80,6 @@ const getPolymarketInitializerWhitelist = (): string[] => {
   return [];
 };
 
-interface GraphQLResponse<T> {
-  data?: T;
-  errors?: { message: string }[];
-}
-
 export interface MonitoringParams {
   ctfExchangeAddress: string;
   ctfSportsOracleAddress: string;
@@ -432,7 +427,9 @@ export const getPolymarketMarketInformation = async (
 
     for (const conditionId of conditionIds) {
       try {
-        const { data } = await params.httpClient.get<ClobMarketResponse>(`${params.apiEndpoint}/markets/${conditionId}`);
+        const { data } = await params.httpClient.get<ClobMarketResponse>(
+          `${params.apiEndpoint}/markets/${conditionId}`
+        );
         if (data && !data.error) return data;
       } catch (error) {
         const axiosError = error as AxiosError<{ error?: string }>;

--- a/packages/monitor-v2/src/monitor-polymarket/common.ts
+++ b/packages/monitor-v2/src/monitor-polymarket/common.ts
@@ -112,9 +112,10 @@ interface PolymarketMarketResponse {
   question: string;
   outcomes: string;
   outcomePrices: string;
-  volumeNum: number;
+  volumeNum: number | string;
   clobTokenIds: string;
   questionID: string;
+  events?: { id?: string | number | null }[];
 }
 
 interface ClobMarketResponse {
@@ -122,6 +123,10 @@ interface ClobMarketResponse {
   market_id?: string | number | null;
   id?: string | number | null;
   error?: string;
+}
+
+interface GammaEventResponse {
+  markets?: PolymarketMarketResponse[];
 }
 
 export interface PolymarketMarketGraphqlProcessed {
@@ -367,14 +372,29 @@ export const getPolymarketMarketInformation = async (
   questionID: string,
   requesterAddress?: string
 ): Promise<PolymarketMarketGraphqlProcessed[]> => {
+  const isSportsRequester =
+    requesterAddress != null && requesterAddress.toLowerCase() === params.ctfSportsOracleAddress.toLowerCase();
+
   const processMarket = (market: PolymarketMarketResponse): PolymarketMarketGraphqlProcessed => {
     return {
       ...market,
+      volumeNum: Number(market.volumeNum),
       outcomes: JSON.parse(market.outcomes),
       outcomePrices: JSON.parse(market.outcomePrices),
       clobTokenIds: JSON.parse(market.clobTokenIds),
     };
   };
+
+  const isProcessableMarket = (
+    market: Partial<PolymarketMarketResponse> | undefined
+  ): market is PolymarketMarketResponse =>
+    market != null &&
+    typeof market.question === "string" &&
+    typeof market.outcomes === "string" &&
+    typeof market.outcomePrices === "string" &&
+    (typeof market.volumeNum === "number" || typeof market.volumeNum === "string") &&
+    typeof market.clobTokenIds === "string" &&
+    typeof market.questionID === "string";
 
   const gammaApiBaseUrl = params.graphqlEndpoint.replace(/\/query\/?$/, "");
 
@@ -422,9 +442,7 @@ export const getPolymarketMarketInformation = async (
     return [];
   };
 
-  const findClobMarket = async (): Promise<ClobMarketResponse | null> => {
-    const conditionIds = [...getStandardConditionIds(questionID), ...(await getNegRiskConditionIds())];
-
+  const findClobMarketForConditionIds = async (conditionIds: string[]): Promise<ClobMarketResponse | null> => {
     for (const conditionId of conditionIds) {
       try {
         const { data } = await params.httpClient.get<ClobMarketResponse>(
@@ -441,6 +459,13 @@ export const getPolymarketMarketInformation = async (
     return null;
   };
 
+  const findClobMarket = async (): Promise<ClobMarketResponse | null> => {
+    const standardClobMarket = await findClobMarketForConditionIds(getStandardConditionIds(questionID));
+    if (standardClobMarket) return standardClobMarket;
+
+    return findClobMarketForConditionIds(await getNegRiskConditionIds());
+  };
+
   const fetchGammaMarket = async (clobMarket: ClobMarketResponse): Promise<PolymarketMarketResponse> => {
     const candidateUrls = [
       clobMarket.market_slug ? `${gammaApiBaseUrl}/markets/slug/${encodeURIComponent(clobMarket.market_slug)}` : null,
@@ -449,18 +474,52 @@ export const getPolymarketMarketInformation = async (
     ].filter((url): url is string => Boolean(url));
 
     for (const url of candidateUrls) {
-      const { data } = await params.httpClient.get<PolymarketMarketResponse | PolymarketMarketResponse[]>(url);
-      const market = Array.isArray(data) ? data[0] : data;
-      if (market) return market;
+      try {
+        const { data } = await params.httpClient.get<PolymarketMarketResponse | PolymarketMarketResponse[]>(url);
+        const market = Array.isArray(data) ? data[0] : data;
+        if (market) return market;
+      } catch (error) {
+        const axiosError = error as AxiosError<{ error?: string }>;
+        if (axiosError.response?.status === 404) continue;
+        throw error;
+      }
     }
 
     throw new Error(`No Gamma market found for question ID: ${questionID}`);
   };
 
+  const fetchGammaEventMarkets = async (eventId: string | number): Promise<PolymarketMarketResponse[]> => {
+    const { data } = await params.httpClient.get<GammaEventResponse>(
+      `${gammaApiBaseUrl}/events/${encodeURIComponent(String(eventId))}`
+    );
+
+    const markets = (data.markets ?? []).filter(isProcessableMarket);
+    if (!markets.length) {
+      throw new Error(`No Gamma event markets found for question ID: ${questionID}`);
+    }
+
+    return [...new Map(markets.map((market) => [market.questionID.toLowerCase(), market])).values()];
+  };
+
   const clobMarket = await findClobMarket();
   if (!clobMarket) throw new Error(`No market found for question ID: ${questionID}`);
 
-  return [processMarket(await fetchGammaMarket(clobMarket))];
+  const primaryMarket = await fetchGammaMarket(clobMarket);
+  if (!isSportsRequester) return [processMarket(primaryMarket)];
+
+  const eventId = primaryMarket.events?.find((event) => event.id != null)?.id;
+  if (eventId == null) {
+    logger.warn({
+      at: "PolymarketMonitor",
+      message: "Sports market resolved without Gamma event context; falling back to the primary market only",
+      questionID,
+      requesterAddress,
+      marketQuestionID: primaryMarket.questionID,
+    });
+    return [processMarket(primaryMarket)];
+  }
+
+  return (await fetchGammaEventMarkets(eventId)).map(processMarket);
 };
 
 /**

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -209,6 +209,8 @@ describe("PolymarketNotifier", function () {
       ["address", "bytes32", "uint256"],
       [requesterAddress, questionId, 2]
     );
+    const providerCallStub = sandbox.stub().rejects(new Error("neg-risk lookup should not run"));
+    params.provider = ({ _isProvider: true, call: providerCallStub } as unknown) as Provider;
 
     const postStub = sandbox.stub(params.httpClient, "post");
     const getStub = sandbox.stub(params.httpClient, "get").callsFake(async (url: string) => {
@@ -241,8 +243,62 @@ describe("PolymarketNotifier", function () {
 
     assert.equal(markets[0].questionID, questionId);
     assert.equal(markets[0].question, "Will Querétaro FC win on 2026-02-22?");
+    assert.isTrue(providerCallStub.notCalled);
     assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${conditionId}`));
     assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/slug/${marketSlug}`));
+    assert.isTrue(postStub.notCalled);
+  });
+
+  it("continues Gamma fallback URLs after a 404 on the slug lookup", async function () {
+    const params = await createMonitoringParams();
+    params.apiEndpoint = "https://clob.polymarket.com";
+    params.graphqlEndpoint = "https://gamma-api.polymarket.com/query";
+
+    const questionId = "0x6e0a8c466f66bc6f7d3f113d3dcf019035adf909fd6efcca0368c3bec245914b";
+    const requesterAddress = "0x157ce2d672854c848c9b79c49a8cc6cc89176a49";
+    const marketSlug = "stale-market-slug";
+    const marketId = "1272207";
+    const conditionId = ethersLib.utils.solidityKeccak256(
+      ["address", "bytes32", "uint256"],
+      [requesterAddress, questionId, 2]
+    );
+
+    const postStub = sandbox.stub(params.httpClient, "post");
+    const getStub = sandbox.stub(params.httpClient, "get").callsFake(async (url: string) => {
+      if (url === `${params.apiEndpoint}/markets/${conditionId}`) {
+        return { data: { market_slug: marketSlug, market_id: marketId } };
+      }
+
+      if (url === `https://gamma-api.polymarket.com/markets/slug/${marketSlug}`) {
+        throw { response: { status: 404 } };
+      }
+
+      if (url === `https://gamma-api.polymarket.com/markets/${marketId}`) {
+        return {
+          data: {
+            clobTokenIds: JSON.stringify(["0x1234", "0x1235"]),
+            volumeNum: 200_000,
+            outcomes: JSON.stringify(["Yes", "No"]),
+            outcomePrices: JSON.stringify(["0.0005", "0.9995"]),
+            question: "Will Querétaro FC win on 2026-02-22?",
+            questionID: questionId,
+          },
+        };
+      }
+
+      throw { response: { status: 404 } };
+    });
+
+    const markets = await commonModule.getPolymarketMarketInformation(
+      commonModule.Logger,
+      params,
+      questionId,
+      requesterAddress
+    );
+
+    assert.equal(markets[0].questionID, questionId);
+    assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/slug/${marketSlug}`));
+    assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/${marketId}`));
     assert.isTrue(postStub.notCalled);
   });
 
@@ -321,6 +377,100 @@ describe("PolymarketNotifier", function () {
     assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${standardConditionId}`));
     assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${negRiskConditionId}`));
     assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/slug/${marketSlug}`));
+    assert.isTrue(postStub.notCalled);
+  });
+
+  it("returns every sports market from the Gamma event after the canonical CLOB lookup succeeds", async function () {
+    const params = await createMonitoringParams();
+    params.apiEndpoint = "https://clob.polymarket.com";
+    params.graphqlEndpoint = "https://gamma-api.polymarket.com/query";
+
+    const questionId = "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4400";
+    const requesterAddress = "0x157ce2d672854c848c9b79c49a8cc6cc89176a49";
+    const marketSlug = "mex-que-jua-2026-02-22-que";
+    const eventId = "189646";
+    params.ctfSportsOracleAddress = requesterAddress;
+
+    const conditionId = ethersLib.utils.solidityKeccak256(
+      ["address", "bytes32", "uint256"],
+      [requesterAddress, questionId, 2]
+    );
+
+    const postStub = sandbox.stub(params.httpClient, "post");
+    const getStub = sandbox.stub(params.httpClient, "get").callsFake(async (url: string) => {
+      if (url === `${params.apiEndpoint}/markets/${conditionId}`) {
+        return { data: { market_slug: marketSlug } };
+      }
+
+      if (url === `https://gamma-api.polymarket.com/markets/slug/${marketSlug}`) {
+        return {
+          data: {
+            clobTokenIds: JSON.stringify(["0x1234", "0x1235"]),
+            volumeNum: 200_000,
+            outcomes: JSON.stringify(["Yes", "No"]),
+            outcomePrices: JSON.stringify(["0.0005", "0.9995"]),
+            question: "Will Querétaro FC win on 2026-02-22?",
+            questionID: questionId,
+            events: [{ id: eventId }],
+          },
+        };
+      }
+
+      if (url === `https://gamma-api.polymarket.com/events/${eventId}`) {
+        return {
+          data: {
+            markets: [
+              {
+                clobTokenIds: JSON.stringify(["0x1234", "0x1235"]),
+                volumeNum: 200_000,
+                outcomes: JSON.stringify(["Yes", "No"]),
+                outcomePrices: JSON.stringify(["0.0005", "0.9995"]),
+                question: "Will Querétaro FC win on 2026-02-22?",
+                questionID: "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4400",
+              },
+              {
+                clobTokenIds: JSON.stringify(["0x2234", "0x2235"]),
+                volumeNum: 125_000,
+                outcomes: JSON.stringify(["Yes", "No"]),
+                outcomePrices: JSON.stringify(["0.5", "0.5"]),
+                question: "Will Querétaro FC vs. FC Juárez end in a draw?",
+                questionID: "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4401",
+              },
+              {
+                clobTokenIds: JSON.stringify(["0x3234", "0x3235"]),
+                volumeNum: 150_000,
+                outcomes: JSON.stringify(["Yes", "No"]),
+                outcomePrices: JSON.stringify(["0.1", "0.9"]),
+                question: "Will FC Juárez win on 2026-02-22?",
+                questionID: "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4402",
+              },
+            ],
+          },
+        };
+      }
+
+      throw { response: { status: 404 } };
+    });
+
+    const markets = await commonModule.getPolymarketMarketInformation(
+      commonModule.Logger,
+      params,
+      questionId,
+      requesterAddress
+    );
+
+    assert.equal(markets.length, 3);
+    assert.deepEqual(
+      markets.map((market) => market.questionID),
+      [
+        "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4400",
+        "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4401",
+        "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4402",
+      ]
+    );
+    assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${conditionId}`));
+    assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/slug/${marketSlug}`));
+    assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/events/${eventId}`));
     assert.isTrue(postStub.notCalled);
   });
 

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -11,11 +11,11 @@ import {
 import { createNewLogger, spyLogIncludes, spyLogLevel, SpyTransport } from "@uma/financial-templates-lib";
 import { createHttpClient } from "@uma/toolkit";
 import { assert } from "chai";
+import { ethers as ethersLib } from "ethers";
 import sinon from "sinon";
 import * as commonModule from "../src/monitor-polymarket/common";
 import {
   encodeMultipleQuery,
-  extractMarketIdFromAncillaryData,
   getProposalKeyToStore,
   getSportsPayouts,
   MarketOrderbook,
@@ -197,12 +197,53 @@ describe("PolymarketNotifier", function () {
     sandbox.stub(commonModule, functionName).callsFake(mockDataFunction);
   }
 
-  it("extracts market_id from ancillary data", async function () {
-    const marketId = extractMarketIdFromAncillaryData(
-      `q: title: Will Querétaro FC win on 2026-02-22?, market_id: 1272207 res_data: p1: 0, p2: 1`
+  it("resolves markets through CLOB condition lookup and Gamma slug lookup", async function () {
+    const params = await createMonitoringParams();
+    params.apiEndpoint = "https://clob.polymarket.com";
+    params.graphqlEndpoint = "https://gamma-api.polymarket.com/query";
+
+    const questionId = "0x6e0a8c466f66bc6f7d3f113d3dcf019035adf909fd6efcca0368c3bec245914b";
+    const requesterAddress = "0x157ce2d672854c848c9b79c49a8cc6cc89176a49";
+    const marketSlug = "mex-que-jua-2026-02-22-que";
+    const conditionId = ethersLib.utils.solidityKeccak256(
+      ["address", "bytes32", "uint256"],
+      [requesterAddress, questionId, 2]
     );
 
-    assert.equal(marketId, "1272207");
+    const postStub = sandbox.stub(params.httpClient, "post");
+    const getStub = sandbox.stub(params.httpClient, "get").callsFake(async (url: string) => {
+      if (url === `${params.apiEndpoint}/markets/${conditionId}`) {
+        return { data: { market_slug: marketSlug } };
+      }
+
+      if (url === `https://gamma-api.polymarket.com/markets/slug/${marketSlug}`) {
+        return {
+          data: {
+            clobTokenIds: JSON.stringify(["0x1234", "0x1235"]),
+            volumeNum: 200_000,
+            outcomes: JSON.stringify(["Yes", "No"]),
+            outcomePrices: JSON.stringify(["0.0005", "0.9995"]),
+            question: "Will Querétaro FC win on 2026-02-22?",
+            questionID: questionId,
+          },
+        };
+      }
+
+      throw { response: { status: 404 } };
+    });
+
+    const markets = await commonModule.getPolymarketMarketInformation(
+      commonModule.Logger,
+      params,
+      questionId,
+      requesterAddress
+    );
+
+    assert.equal(markets[0].questionID, questionId);
+    assert.equal(markets[0].question, "Will Querétaro FC win on 2026-02-22?");
+    assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${conditionId}`));
+    assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/slug/${marketSlug}`));
+    assert.isTrue(postStub.notCalled);
   });
 
   it("It should notify if there are orders over the threshold", async function () {

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -281,7 +281,7 @@ describe("PolymarketNotifier", function () {
       }
       throw new Error("unexpected call data");
     });
-    params.provider = { _isProvider: true, call: providerCallStub } as unknown as Provider;
+    params.provider = ({ _isProvider: true, call: providerCallStub } as unknown) as Provider;
 
     const postStub = sandbox.stub(params.httpClient, "post");
     const getStub = sandbox.stub(params.httpClient, "get").callsFake(async (url: string) => {

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -246,6 +246,84 @@ describe("PolymarketNotifier", function () {
     assert.isTrue(postStub.notCalled);
   });
 
+  it("falls back through neg-risk operator resolution when the standard condition lookup misses", async function () {
+    const params = await createMonitoringParams();
+    params.apiEndpoint = "https://clob.polymarket.com";
+    params.graphqlEndpoint = "https://gamma-api.polymarket.com/query";
+
+    const requestId = "0x6e0a8c466f66bc6f7d3f113d3dcf019035adf909fd6efcca0368c3bec245914b";
+    const canonicalQuestionId = "0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4400";
+    const requesterAddress = "0x157ce2d672854c848c9b79c49a8cc6cc89176a49";
+    const operatorAddress = "0x71523d0f655B41E805Cec45b17163f528B59B820";
+    const adapterAddress = "0x1111111111111111111111111111111111111111";
+    const marketSlug = "mex-que-jua-2026-02-22-que";
+    const operatorInterface = new ethersLib.utils.Interface([
+      "function questionIds(bytes32) view returns (bytes32)",
+      "function nrAdapter() view returns (address)",
+    ]);
+
+    const standardConditionId = ethersLib.utils.solidityKeccak256(
+      ["address", "bytes32", "uint256"],
+      [requesterAddress, requestId, 2]
+    );
+    const negRiskConditionId = ethersLib.utils.solidityKeccak256(
+      ["address", "bytes32", "uint256"],
+      [adapterAddress, canonicalQuestionId, 2]
+    );
+
+    const providerCallStub = sandbox.stub().callsFake(async (tx: { to?: string; data?: string }) => {
+      if (tx.to?.toLowerCase() !== operatorAddress.toLowerCase()) throw new Error("unexpected operator");
+      if (tx.data === operatorInterface.encodeFunctionData("questionIds", [requestId])) {
+        return operatorInterface.encodeFunctionResult("questionIds", [canonicalQuestionId]);
+      }
+      if (tx.data === operatorInterface.encodeFunctionData("nrAdapter")) {
+        return operatorInterface.encodeFunctionResult("nrAdapter", [adapterAddress]);
+      }
+      throw new Error("unexpected call data");
+    });
+    params.provider = { _isProvider: true, call: providerCallStub } as unknown as Provider;
+
+    const postStub = sandbox.stub(params.httpClient, "post");
+    const getStub = sandbox.stub(params.httpClient, "get").callsFake(async (url: string) => {
+      if (url === `${params.apiEndpoint}/markets/${standardConditionId}`) {
+        throw { response: { status: 404 } };
+      }
+
+      if (url === `${params.apiEndpoint}/markets/${negRiskConditionId}`) {
+        return { data: { market_slug: marketSlug } };
+      }
+
+      if (url === `https://gamma-api.polymarket.com/markets/slug/${marketSlug}`) {
+        return {
+          data: {
+            clobTokenIds: JSON.stringify(["0x1234", "0x1235"]),
+            volumeNum: 200_000,
+            outcomes: JSON.stringify(["Yes", "No"]),
+            outcomePrices: JSON.stringify(["0.0005", "0.9995"]),
+            question: "Will Querétaro FC win on 2026-02-22?",
+            questionID: canonicalQuestionId,
+          },
+        };
+      }
+
+      throw { response: { status: 404 } };
+    });
+
+    const markets = await commonModule.getPolymarketMarketInformation(
+      commonModule.Logger,
+      params,
+      requestId,
+      requesterAddress
+    );
+
+    assert.equal(markets[0].questionID, canonicalQuestionId);
+    assert.isTrue(providerCallStub.called);
+    assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${standardConditionId}`));
+    assert.isTrue(getStub.calledWith(`${params.apiEndpoint}/markets/${negRiskConditionId}`));
+    assert.isTrue(getStub.calledWith(`https://gamma-api.polymarket.com/markets/slug/${marketSlug}`));
+    assert.isTrue(postStub.notCalled);
+  });
+
   it("It should notify if there are orders over the threshold", async function () {
     const params = await createMonitoringParams();
 

--- a/packages/monitor-v2/test/PolymarketMonitor.ts
+++ b/packages/monitor-v2/test/PolymarketMonitor.ts
@@ -15,6 +15,7 @@ import sinon from "sinon";
 import * as commonModule from "../src/monitor-polymarket/common";
 import {
   encodeMultipleQuery,
+  extractMarketIdFromAncillaryData,
   getProposalKeyToStore,
   getSportsPayouts,
   MarketOrderbook,
@@ -195,6 +196,14 @@ describe("PolymarketNotifier", function () {
     mockDataFunction.rejects(new Error(errorMessage));
     sandbox.stub(commonModule, functionName).callsFake(mockDataFunction);
   }
+
+  it("extracts market_id from ancillary data", async function () {
+    const marketId = extractMarketIdFromAncillaryData(
+      `q: title: Will Querétaro FC win on 2026-02-22?, market_id: 1272207 res_data: p1: 0, p2: 1`
+    );
+
+    assert.equal(marketId, "1272207");
+  });
 
   it("It should notify if there are orders over the threshold", async function () {
     const params = await createMonitoringParams();


### PR DESCRIPTION
## Summary
This changes `monitor-polymarket` market resolution to stop relying on Gamma GraphQL identifier lookups.

New flow:
- derive the standard Polymarket `condition_id` from `proposal.requester + questionID`
- if that misses, treat `keccak256(ancillaryData)` as a possible neg-risk request id and resolve the canonical question id on-chain through `NegRiskOperator.questionIds(...)`
- derive the neg-risk adapter `condition_id` and fetch the market from CLOB by `condition_id`
- enrich the result with the public Gamma REST market payload by slug

## Problem
On April 8, 2026, the notifier failed to verify a valid neg-risk Polymarket proposal because it used `keccak256(ancillaryData)` as a direct Gamma GraphQL lookup key.

That is brittle for neg-risk markets because the ancillary hash is the neg-risk request id, not always the canonical market `questionID`. As a result, the bot could fail on the metadata lookup path even when the market existed and was otherwise resolvable.

Concrete failing example:
- market: Queretaro (`1272207`)
- canonical `questionID`: `0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4400`
- neg-risk request id: `0x6e0a8c466f66bc6f7d3f113d3dcf019035adf909fd6efcca0368c3bec245914b`

## Why this fix
This makes market discovery follow the on-chain/CLOB identity path instead of depending on:
- ancillary text containing `market_id`
- Gamma GraphQL accepting a specific identifier form

The notifier still returns the same market metadata shape after the lookup succeeds, because it uses the public Gamma REST payload only after CLOB has identified the market.

## Validation
- `yarn workspace @uma/monitor-v2 build`
- `yarn workspace @uma/monitor-v2 test test/PolymarketMonitor.ts --grep 'resolves markets through CLOB condition lookup and Gamma slug lookup'`
- historical replay on a Polygon fork:
  - fork URL: `https://polygon-mainnet.g.alchemy.com/v2/DnSj5ge0vStbqvOYzEhSV`
  - fork block: `85274397`
  - frozen time: `2026-04-08T17:20:31Z`
  - targeted proposal requester: `0x2F5e3684cb1F318ec51b00Edba38d79Ac2c0aA9d`
  - targeted proposal hash: `0xad2a68d579ad978d0dea48a359f3058442cd0eda5a04900109cc40160d5672e0`
  - `GET https://clob.polymarket.com/markets/0x7a73edc351f3a81f146f24cb3fe8d69448b22b9225e9c4799272a8ceb1fe5801` -> miss on the standard requester `condition_id`
  - `GET https://clob.polymarket.com/markets/0xf77c27919433746aa6ff6759e36e8455458359f41a1f0dc75e6993736120091e` -> hit on the neg-risk-resolved `condition_id`
  - `GET https://gamma-api.polymarket.com/markets/slug/mex-que-jua-2026-02-22-que` -> returns the expected market metadata
  - no `POST https://gamma-api.polymarket.com/query`
  - resolved canonical `questionID`: `0x303df379b982e189dc6aea356cad409cd18b8bc634a95e318b5e7ef025ab4400`
