### PR TITLE
Fix Foundry CI install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,16 @@ jobs:
       - run:
           name: Install Foundry
           command: |
-            curl -L https://foundry.paradigm.xyz | bash || true
-            export PATH="$PATH:/home/circleci/.foundry/bin"
-            foundryup
+            export FOUNDRY_VERSION=nightly-70cd140131cd49875c6f31626bdfae08eba35386
+            curl -fsSL https://foundry.paradigm.xyz | SHELL=/bin/bash bash
+            export PATH="/home/circleci/.foundry/bin:$PATH"
+            foundryup --install "$FOUNDRY_VERSION"
       - save_cache:
           key: protocol-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/protocol
             - ~/.ssh
+            - ~/.foundry
   build:
     docker:
       - image: cimg/node:22.11
@@ -48,6 +50,7 @@ jobs:
           paths:
             - ~/protocol
             - ~/.ssh
+            - ~/.foundry
   lint:
     docker:
       - image: cimg/node:22.11
@@ -66,7 +69,7 @@ jobs:
       - run:
           name: Generate Tests
           command: |
-            export PATH="$PATH:/home/circleci/.foundry/bin"
+            export PATH="/home/circleci/.foundry/bin:$PATH"
             cd /home/circleci/protocol
             ./ci/generate_lerna_config.sh
       - continuation/continue:

--- a/ci/tests/test-packages.sh
+++ b/ci/tests/test-packages.sh
@@ -16,6 +16,6 @@ cat << EOF
       - run:
           name: Run tests
           command: |
-            export PATH="$PATH:/home/circleci/.foundry/bin"
+            export PATH="/home/circleci/.foundry/bin:$PATH"
             yarn test --scope ${PACKAGE};
 EOF

--- a/packages/core/scripts/SetUpFoundryWithHardhat.sh
+++ b/packages/core/scripts/SetUpFoundryWithHardhat.sh
@@ -3,10 +3,13 @@
 # This script will configure the core hardhat instance to play nicely with Foundry.
 # Check if you have foundry installed. If not, install it for you.
 
+export PATH="$HOME/.foundry/bin:$PATH"
+FOUNDRY_VERSION="${FOUNDRY_VERSION:-nightly-70cd140131cd49875c6f31626bdfae08eba35386}"
+
 if ! command -v forge &>/dev/null; then
     echo "Foundry not installed. Installing foundry for you..."
-    curl -L https://foundry.paradigm.xyz | bash
-    foundryup -i nightly-70cd140131cd49875c6f31626bdfae08eba35386
+    curl -fsSL https://foundry.paradigm.xyz | SHELL=/bin/bash bash
+    foundryup --install "$FOUNDRY_VERSION"
 fi
 
 # Then, configure the core package to work with foundry. To do this we need to pull out the foundry standard library and


### PR DESCRIPTION
Pins the CircleCI Foundry install to the repo's existing nightly version and caches `~/.foundry` so CI avoids unauthenticated GitHub latest-release lookups that can return 403.

Validation: shell syntax checks, CircleCI YAML parse, diff whitespace check, and isolated pinned Foundry install.