### PR TITLE
feat(monitor-v2): gates OOv2 settlements by proposal age

### DIFF
--- a/packages/monitor-v2/src/bot-oo/README.md
+++ b/packages/monitor-v2/src/bot-oo/README.md
@@ -33,6 +33,7 @@ node ./packages/monitor-v2/dist/bot-oo/index.js
 - `MAX_BLOCK_LOOKBACK`: Max block span per query (see `blockDefaults`).
 - `GAS_LIMIT_MULTIPLIER`: Percent multiplier on estimated gas (default `150`).
 - `SETTLE_DELAY`: Lookback period in seconds to detect settleable requests (default `300`).
+- `SETTLE_MIN_PROPOSAL_AGE_SECONDS`: Minimum proposal age in seconds before settling OOv2 requests (default `8100`, set `0` to disable).
 - `SETTLE_TIMEOUT`: Timeout in seconds for submitting settlement transactions in serverless mode (default `240`).
 - `SETTLE_ONLY_DISPUTED`: When `true`, only settle requests that have been disputed (`false` by default). Supported for `OptimisticOracleV2` (including `ManagedOptimisticOracleV2`); ignored for `OptimisticOracle` and `SkinnyOptimisticOracle`.
 
@@ -51,5 +52,6 @@ For each Oracle type:
 
 1. Scans `RequestPrice` events within the lookback window.
 2. Filters out already settled requests (`Settle` events).
-3. Uses Oracle-specific logic to detect settleable requests at historical state (using `SETTLE_DELAY`).
-4. Submits settlement transactions when requests are ready, stopping when `SETTLE_TIMEOUT` passes in serverless mode.
+3. For OOv2, skips proposals younger than `SETTLE_MIN_PROPOSAL_AGE_SECONDS`.
+4. Uses Oracle-specific logic to detect settleable requests at historical state (using `SETTLE_DELAY`).
+5. Submits settlement transactions when requests are ready, stopping when `SETTLE_TIMEOUT` passes in serverless mode.

--- a/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
+++ b/packages/monitor-v2/src/bot-oo/SettleOOv2Requests.ts
@@ -118,9 +118,43 @@ export async function settleOOv2Requests(
 
   // State.Resolved = 5: disputed and DVM price is available (settleable after dispute).
   const STATE_RESOLVED = 5;
+  const shouldEnforceMinProposalAge = params.settleMinProposalAgeSeconds > 0 && requestsToSettle.length > 0;
+  const currentOOTime = shouldEnforceMinProposalAge ? (await oo.getCurrentTime()).toNumber() : undefined;
+  const proposalBlockTimestamps = new Map<number, Promise<number>>();
+
+  const getProposalBlockTimestamp = async (blockNumber: number): Promise<number> => {
+    const cachedTimestamp = proposalBlockTimestamps.get(blockNumber);
+    if (cachedTimestamp) return cachedTimestamp;
+
+    const timestamp = params.provider.getBlock(blockNumber).then((block) => {
+      if (!block) throw new Error(`Could not fetch proposal block ${blockNumber}`);
+      return block.timestamp;
+    });
+    proposalBlockTimestamps.set(blockNumber, timestamp);
+    return timestamp;
+  };
 
   const settleableRequestsPromises = requestsToSettle.map(async (req) => {
     try {
+      if (shouldEnforceMinProposalAge && currentOOTime !== undefined) {
+        const proposalBlockTimestamp = await getProposalBlockTimestamp(req.blockNumber);
+        const proposalAge = currentOOTime - proposalBlockTimestamp;
+
+        if (proposalAge < params.settleMinProposalAgeSeconds) {
+          logger.debug({
+            at: "OOv2Bot",
+            message: "Skipping request below minimum proposal age",
+            requestKey: requestKey(req.args),
+            proposalAge,
+            settleMinProposalAgeSeconds: params.settleMinProposalAgeSeconds,
+            proposalBlock: req.blockNumber,
+            proposalBlockTimestamp,
+            currentOOTime,
+          });
+          return null;
+        }
+      }
+
       // When settleOnlyDisputed is enabled, check on-chain state and skip undisputed requests.
       if (params.botModes.settleOnlyDisputed) {
         const state = await oo.getState(

--- a/packages/monitor-v2/src/bot-oo/common.ts
+++ b/packages/monitor-v2/src/bot-oo/common.ts
@@ -6,6 +6,14 @@ import { BaseMonitoringParams, startupLogLevel as baseStartup, initBaseMonitorin
 
 export type OracleType = "OptimisticOracle" | "SkinnyOptimisticOracle" | "OptimisticOracleV2";
 
+const DEFAULT_SETTLE_MIN_PROPOSAL_AGE_SECONDS = 2 * 60 * 60 + 15 * 60;
+
+function getNonNegativeNumber(value: string | undefined, defaultValue: number): number {
+  if (value === undefined) return defaultValue;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : defaultValue;
+}
+
 export interface BotModes {
   settleRequestsEnabled: boolean;
   settleOnlyDisputed: boolean; // Supported for OptimisticOracleV2 (incl. ManagedOOv2); ignored for OOv1 and SkinnyOO.
@@ -18,6 +26,7 @@ export interface MonitoringParams extends BaseMonitoringParams {
   settleableCheckBlock: number; // Block number to check for settleable requests, defaults to 5 minutes ago
   executionDeadline?: number; // Timestamp in sec for when to stop settling, defaults to 4 minutes from now in serverless
   settleBatchSize: number; // Number of settle calls to batch via multicall (requires MultiCaller on contract), defaults to 1
+  settleMinProposalAgeSeconds: number; // Minimum proposal age before settlement, defaults to 2h15m
 }
 
 export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<MonitoringParams> => {
@@ -51,6 +60,10 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
   const executionDeadline = base.pollingDelay === 0 ? currentTimestamp + settleTimeout : undefined;
 
   const settleBatchSize = Math.max(1, Number(env.SETTLE_BATCH_SIZE) || 1);
+  const settleMinProposalAgeSeconds = getNonNegativeNumber(
+    env.SETTLE_MIN_PROPOSAL_AGE_SECONDS,
+    DEFAULT_SETTLE_MIN_PROPOSAL_AGE_SECONDS
+  );
 
   return {
     ...base,
@@ -60,6 +73,7 @@ export const initMonitoringParams = async (env: NodeJS.ProcessEnv): Promise<Moni
     settleableCheckBlock,
     executionDeadline,
     settleBatchSize,
+    settleMinProposalAgeSeconds,
   };
 };
 

--- a/packages/monitor-v2/test/OptimisticOracleV2Bot.ts
+++ b/packages/monitor-v2/test/OptimisticOracleV2Bot.ts
@@ -25,6 +25,17 @@ const ethers = hre.ethers;
 const createParams = (oracleType: OracleType, contractAddress: string) =>
   makeMonitoringParamsOO(oracleType, contractAddress, { settleRequestsEnabled: false });
 
+const getReceiptBlockNumber = (receipt: { blockNumber?: number }) => {
+  if (receipt.blockNumber === undefined) throw new Error("Expected transaction receipt to include blockNumber");
+  return receipt.blockNumber;
+};
+
+const getLast = <T>(items: T[], message: string) => {
+  const item = items[items.length - 1];
+  if (item === undefined) throw new Error(message);
+  return item;
+};
+
 describe("OptimisticOracleV2Bot", function () {
   let bondToken: ExpandedERC20Ethers;
   let optimisticOracleV2: OptimisticOracleV2Ethers;
@@ -82,7 +93,7 @@ describe("OptimisticOracleV2Bot", function () {
     ).wait();
 
     // Move timer forward to after liveness to allow settlement
-    await advanceTimerPastLiveness(timer, proposeReceipt.blockNumber!, defaultLiveness);
+    await advanceTimerPastLiveness(timer, getReceiptBlockNumber(proposeReceipt), defaultLiveness);
 
     const { spy, logger } = makeSpyLogger();
     const params = await createParams("OptimisticOracleV2", optimisticOracleV2.address);
@@ -111,6 +122,45 @@ describe("OptimisticOracleV2Bot", function () {
     // Check that no settlement warning logs were generated
     const settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
     assert.equal(settlementLogs.length, 0, "No settlement logs should be generated on subsequent runs");
+  });
+
+  it("Skips proposals below the minimum proposal age and settles once old enough", async function () {
+    await (
+      await optimisticOracleV2.requestPrice(defaultOptimisticOracleV2Identifier, 0, ancillaryData, bondToken.address, 0)
+    ).wait();
+
+    const proposeReceipt = await (
+      await optimisticOracleV2
+        .connect(proposer)
+        .proposePrice(
+          await requester.getAddress(),
+          defaultOptimisticOracleV2Identifier,
+          0,
+          ancillaryData,
+          ethers.utils.parseEther("1")
+        )
+    ).wait();
+
+    const minProposalAge = defaultLiveness + 15 * 60;
+    const proposalBlock = await ethers.provider.getBlock(getReceiptBlockNumber(proposeReceipt));
+    await (await timer.setCurrentTime(proposalBlock.timestamp + minProposalAge - 1)).wait();
+
+    const { spy, logger } = makeSpyLogger();
+    const params = await createParams("OptimisticOracleV2", optimisticOracleV2.address);
+    params.settleMinProposalAgeSeconds = minProposalAge;
+    await gasEstimator.update();
+    await settleRequests(logger, params, gasEstimator);
+
+    let settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
+    assert.equal(settlementLogs.length, 0, "Request should not settle before minimum proposal age");
+
+    spy.resetHistory();
+    await (await timer.setCurrentTime(proposalBlock.timestamp + minProposalAge)).wait();
+    await gasEstimator.update();
+    await settleRequests(logger, params, gasEstimator);
+
+    settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
+    assert.equal(settlementLogs.length, 1, "Request should settle once minimum proposal age is reached");
   });
 
   it("Does not settle before liveness", async function () {
@@ -165,7 +215,7 @@ describe("OptimisticOracleV2Bot", function () {
 
     // Resolve in DVM via MockOracle
     const pending = await mockOracle.getPendingQueries();
-    const last = pending[pending.length - 1]!;
+    const last = getLast(pending, "Expected a pending DVM query");
     await (
       await mockOracle.pushPrice(last.identifier, last.time, last.ancillaryData, ethers.utils.parseEther("1"))
     ).wait();
@@ -195,6 +245,57 @@ describe("OptimisticOracleV2Bot", function () {
     }
     const settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
     assert.equal(settlementLogs.length, 0, "No settlement logs should be generated on subsequent runs");
+  });
+
+  it("Applies the minimum proposal age gate to disputed requests", async function () {
+    await (
+      await optimisticOracleV2.requestPrice(defaultOptimisticOracleV2Identifier, 0, ancillaryData, bondToken.address, 0)
+    ).wait();
+
+    const proposeReceipt = await (
+      await optimisticOracleV2
+        .connect(proposer)
+        .proposePrice(
+          await requester.getAddress(),
+          defaultOptimisticOracleV2Identifier,
+          0,
+          ancillaryData,
+          ethers.utils.parseEther("1")
+        )
+    ).wait();
+
+    await (
+      await optimisticOracleV2
+        .connect(disputer)
+        .disputePrice(await requester.getAddress(), defaultOptimisticOracleV2Identifier, 0, ancillaryData)
+    ).wait();
+
+    const pending = await mockOracle.getPendingQueries();
+    const last = getLast(pending, "Expected a pending DVM query");
+    await (
+      await mockOracle.pushPrice(last.identifier, last.time, last.ancillaryData, ethers.utils.parseEther("1"))
+    ).wait();
+
+    const minProposalAge = defaultLiveness + 15 * 60;
+    const proposalBlock = await ethers.provider.getBlock(getReceiptBlockNumber(proposeReceipt));
+    await (await timer.setCurrentTime(proposalBlock.timestamp + minProposalAge - 1)).wait();
+
+    const { spy, logger } = makeSpyLogger();
+    const params = await createParams("OptimisticOracleV2", optimisticOracleV2.address);
+    params.settleMinProposalAgeSeconds = minProposalAge;
+    await gasEstimator.update();
+    await settleRequests(logger, params, gasEstimator);
+
+    let settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
+    assert.equal(settlementLogs.length, 0, "Disputed request should not settle before minimum proposal age");
+
+    spy.resetHistory();
+    await (await timer.setCurrentTime(proposalBlock.timestamp + minProposalAge)).wait();
+    await gasEstimator.update();
+    await settleRequests(logger, params, gasEstimator);
+
+    settlementLogs = spy.getCalls().filter((call) => call.lastArg?.message === "Price Request Settled ✅");
+    assert.equal(settlementLogs.length, 1, "Disputed request should settle once minimum proposal age is reached");
   });
 
   it("Settles multiple requests in a single multicall batch", async function () {
@@ -245,7 +346,7 @@ describe("OptimisticOracleV2Bot", function () {
           ethers.utils.parseEther("1")
         )
       ).wait();
-      lastProposeBlock = proposeReceipt.blockNumber!;
+      lastProposeBlock = getReceiptBlockNumber(proposeReceipt);
     }
 
     // Move timer past liveness for all proposals.
@@ -315,7 +416,7 @@ describe("OptimisticOracleV2Bot", function () {
     ).wait();
 
     // Move timer past liveness — request is settleable but was never disputed.
-    await advanceTimerPastLiveness(timer, proposeReceipt.blockNumber!, defaultLiveness);
+    await advanceTimerPastLiveness(timer, getReceiptBlockNumber(proposeReceipt), defaultLiveness);
 
     const { spy, logger } = makeSpyLogger();
     const params = await makeMonitoringParamsOO("OptimisticOracleV2", optimisticOracleV2.address, {
@@ -354,7 +455,7 @@ describe("OptimisticOracleV2Bot", function () {
 
     // Resolve in DVM via MockOracle.
     const pending = await mockOracle.getPendingQueries();
-    const last = pending[pending.length - 1]!;
+    const last = getLast(pending, "Expected a pending DVM query");
     await (
       await mockOracle.pushPrice(last.identifier, last.time, last.ancillaryData, ethers.utils.parseEther("1"))
     ).wait();

--- a/packages/monitor-v2/test/helpers/monitoring.ts
+++ b/packages/monitor-v2/test/helpers/monitoring.ts
@@ -42,6 +42,7 @@ export async function makeMonitoringParamsOO(
     oracleType,
     contractAddress,
     settleBatchSize: 1,
+    settleMinProposalAgeSeconds: 0,
   };
 }
 


### PR DESCRIPTION
**Motivation**

When OTB settlement is stuck, the old OOv2 settlement bot may be used to flush settleable requests. If a proposal is flagged near liveness expiry, immediate old-bot settlement can leave operators too little time to review and reject it.


**Summary**

Adds a configurable OOv2 minimum proposal age before the old settlement bot submits settlement transactions.

- Adds `SETTLE_MIN_PROPOSAL_AGE_SECONDS`, defaulting to `8100` seconds.
- Gates OOv2 settlement candidates using the `ProposePrice` event block timestamp and oracle current time.
- Leaves `SETTLE_DELAY` as the existing historical settleability check.
- Covers both undisputed and disputed candidate paths with unit tests.


**Details**

The gate uses the proposal event block timestamp instead of request state or request struct fields. This avoids relying on `Expired` state, which ManagedOOv2 can intentionally mask for dispute purposes, and avoids reconstructing proposal time from liveness values.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [x]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [ ]  Untested

Commands run:

- `eslint packages/monitor-v2/test/OptimisticOracleV2Bot.ts`
- `prettier --check packages/monitor-v2/test/OptimisticOracleV2Bot.ts`
- `tsc --noEmit -p packages/monitor-v2/tsconfig.json`
- `yarn workspace @uma/monitor-v2 test test/OptimisticOracleV2Bot.ts`


**Issue(s)**

Refs ENG-191
