### PR TITLE
[codex] fix(ci): reset foundry temp path before publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,11 @@ jobs:
           name: Ignore untracked files
           command: rm -rf lerna_output lerna_packages
       - run:
-          name: Check if empty packages folder exists
-          command: path="packages/core/temp/lib/forge-std"; [ -d "$path" ] || mkdir -p "$path"
+          name: Reset generated Foundry temp path
+          command: |
+            git restore --staged packages/core/temp/lib/forge-std || true
+            rm -rf packages/core/temp/lib/forge-std
+            mkdir -p packages/core/temp/lib/forge-std
       - run:
           name: Publish
           command: yarn run publish-release


### PR DESCRIPTION
Fixes foundry install CI