### PR TITLE
fix(core): revalidate OOv3 whitelists and reject duplicate relayers

### DIFF
--- a/packages/core/contracts/external/chainbridge/Bridge.sol
+++ b/packages/core/contracts/external/chainbridge/Bridge.sol
@@ -121,6 +121,7 @@ contract Bridge is Pausable, AccessControl {
         _setRoleAdmin(RELAYER_ROLE, DEFAULT_ADMIN_ROLE);
 
         for (uint256 i; i < initialRelayers.length; i++) {
+            require(!hasRole(RELAYER_ROLE, initialRelayers[i]), "duplicate initial relayer");
             grantRole(RELAYER_ROLE, initialRelayers[i]);
             _totalRelayers++;
         }

--- a/packages/core/contracts/optimistic-oracle-v3/implementation/OptimisticOracleV3.sol
+++ b/packages/core/contracts/optimistic-oracle-v3/implementation/OptimisticOracleV3.sol
@@ -466,21 +466,24 @@ contract OptimisticOracleV3 is OptimisticOracleV3Interface, Lockable, Ownable, M
         return EscalationManagerInterface(em).isDisputeAllowed(assertionId, msg.sender);
     }
 
-    // Validates if the identifier is whitelisted by first checking the cache. If not whitelisted in the cache then
-    // checks it from the identifier whitelist contract and caches result.
+    // Validates the identifier against the live whitelist and caches the current result.
     function _validateAndCacheIdentifier(bytes32 identifier) internal returns (bool) {
-        if (cachedIdentifiers[identifier]) return true;
         cachedIdentifiers[identifier] = _getIdentifierWhitelist().isIdentifierSupported(identifier);
         return cachedIdentifiers[identifier];
     }
 
-    // Validates if the currency is whitelisted by first checking the cache. If not whitelisted in the cache then
-    // checks it from the collateral whitelist contract and caches whitelist status and final fee.
+    // Validates the currency against the live whitelist. The final fee is fetched only when adding a currency to cache.
     function _validateAndCacheCurrency(address currency) internal returns (bool) {
-        if (cachedCurrencies[currency].isWhitelisted) return true;
-        cachedCurrencies[currency].isWhitelisted = _getCollateralWhitelist().isOnWhitelist(currency);
-        cachedCurrencies[currency].finalFee = _getStore().computeFinalFee(currency).rawValue;
-        return cachedCurrencies[currency].isWhitelisted;
+        bool isWhitelisted = _getCollateralWhitelist().isOnWhitelist(currency);
+        if (!isWhitelisted) {
+            cachedCurrencies[currency].isWhitelisted = false;
+            return false;
+        }
+        if (!cachedCurrencies[currency].isWhitelisted) {
+            cachedCurrencies[currency].isWhitelisted = true;
+            cachedCurrencies[currency].finalFee = _getStore().computeFinalFee(currency).rawValue;
+        }
+        return true;
     }
 
     // Sends assertion resolved callback to the callback recipient and escalation manager (if set).

--- a/packages/core/test/foundry/external/chainbridge/Bridge.t.sol
+++ b/packages/core/test/foundry/external/chainbridge/Bridge.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../../../../contracts/external/chainbridge/Bridge.sol";
+
+contract BridgeTest is Test {
+    function test_TracksUniqueInitialRelayers() public {
+        address[] memory relayers = new address[](2);
+        relayers[0] = address(0x1);
+        relayers[1] = address(0x2);
+
+        Bridge bridge = new Bridge(1, relayers, 2, 0, 100);
+
+        assertEq(bridge._totalRelayers(), 2);
+        assertTrue(bridge.isRelayer(relayers[0]));
+        assertTrue(bridge.isRelayer(relayers[1]));
+    }
+
+    function test_RevertIf_DuplicateInitialRelayer() public {
+        address[] memory relayers = new address[](2);
+        relayers[0] = address(0x1);
+        relayers[1] = address(0x1);
+
+        vm.expectRevert("duplicate initial relayer");
+        new Bridge(1, relayers, 2, 0, 100);
+    }
+}

--- a/packages/core/test/foundry/optimistic-oracle-v3/OptimisticOracleV3.StaleWhitelistCache.t.sol
+++ b/packages/core/test/foundry/optimistic-oracle-v3/OptimisticOracleV3.StaleWhitelistCache.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./CommonOptimisticOracleV3Test.sol";
+
+contract OptimisticOracleV3StaleWhitelistCacheTest is CommonOptimisticOracleV3Test {
+    AddressWhitelist private collateralWhitelist;
+    IdentifierWhitelist private identifierWhitelist;
+
+    function setUp() public {
+        _commonSetup();
+        collateralWhitelist = AddressWhitelist(finder.getImplementationAddress(OracleInterfaces.CollateralWhitelist));
+        identifierWhitelist = IdentifierWhitelist(
+            finder.getImplementationAddress(OracleInterfaces.IdentifierWhitelist)
+        );
+    }
+
+    function test_RemovedIdentifierIsRejectedWithoutManualSync() public {
+        vm.prank(TestAddress.owner);
+        identifierWhitelist.removeSupportedIdentifier(defaultIdentifier);
+        assertFalse(identifierWhitelist.isIdentifierSupported(defaultIdentifier));
+
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, defaultBond);
+        defaultCurrency.approve(address(optimisticOracleV3), defaultBond);
+        vm.expectRevert("Unsupported identifier");
+        optimisticOracleV3.assertTruthWithDefaults(falseClaimAssertion, TestAddress.account1);
+        vm.stopPrank();
+    }
+
+    function test_RemovedCurrencyIsRejectedWithoutManualSync() public {
+        vm.prank(TestAddress.owner);
+        collateralWhitelist.removeFromWhitelist(address(defaultCurrency));
+        assertFalse(collateralWhitelist.isOnWhitelist(address(defaultCurrency)));
+
+        vm.startPrank(TestAddress.account1);
+        defaultCurrency.allocateTo(TestAddress.account1, defaultBond);
+        defaultCurrency.approve(address(optimisticOracleV3), defaultBond);
+        vm.expectRevert("Unsupported currency");
+        optimisticOracleV3.assertTruthWithDefaults(falseClaimAssertion, TestAddress.account1);
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
**Motivation**

This PR addresses two validation assumptions where cached or downstream state could diverge from the authoritative input.

OptimisticOracleV3 caches positive collateral and identifier whitelist results to avoid repeated external calls. The positive-cache fast paths treated those results as non-revocable: after governance removed a previously cached currency or identifier, `assertTruth` continued to accept it until an external caller invoked `syncUmaParams`.

A removed identifier has an additional failure mode because the DVM revalidates the identifier when a dispute requests a price. OOv3 could accept the assertion from its stale cache while the DVM rejected the dispute against the live whitelist. The reverted dispute left the assertion undisputed, allowing it to settle as true after liveness.

ChainBridge also accepted duplicate addresses in `initialRelayers`. `AccessControl` deduplicated role membership, but `_totalRelayers` incremented for every array element, causing recorded quorum membership to diverge from the actual authorized relayer set.

**Summary**

- Revalidate identifier support against the live identifier whitelist for every new assertion.
- Revalidate currency support against the live collateral whitelist for every new assertion.
- Preserve final-fee caching: the Store is queried only when a whitelisted currency is first added or re-added to the OOv3 cache.
- Reject duplicate initial ChainBridge relayers before role assignment and accounting.
- Add focused Foundry regressions for stale whitelist removals and duplicate relayer initialization.

**Details**

The identifier path no longer returns early on a cached `true` value. It updates the cached value from `IdentifierWhitelist.isIdentifierSupported` on every validation.

The currency path first checks `AddressWhitelist.isOnWhitelist` live. If the currency has been removed, validation returns false. If it is live-whitelisted but is not currently represented by a positive cache entry, OOv3 restores the entry and fetches its final fee. Existing positive entries continue to reuse their cached final fee.

The ChainBridge constructor now rejects an initial relayer already granted `RELAYER_ROLE`, ensuring `_totalRelayers` always matches unique role membership.

**Testing**

- [ ] Ran end-to-end test, running the code as in production
- [x] New unit tests created
- [ ] Existing tests adequate, no new tests required
- [x] All relevant existing tests pass
- [ ] Untested

Commands:

```sh
forge test --match-path 'test/foundry/optimistic-oracle-v3/OptimisticOracleV3.*.t.sol'
forge test --match-contract BridgeTest -vvv
```

Results:

```text
OOv3: 33 tests passed; 0 failed; 0 skipped
ChainBridge: 2 tests passed; 0 failed; 0 skipped
```

**Issue(s)**

Security-sensitive fixes. No public issue was opened before the patches to avoid publishing vulnerable behavior without proposed remediations.
