### PR TITLE
fix(logger): skip Slack POST when webhook URL is empty

### DIFF
--- a/packages/logger/src/logger/SlackTransport.ts
+++ b/packages/logger/src/logger/SlackTransport.ts
@@ -187,6 +187,11 @@ class SlackHook extends Transport {
       // different slack channels depending on the context of the log.
       const webhookUrl = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;
 
+      // An empty (or unset) webhook URL means this notification path has been intentionally disabled in the config.
+      // Drop the message silently rather than POSTing to an empty URL, which would otherwise surface as a transport
+      // error and escalate to PagerDuty.
+      if (!webhookUrl) return callback();
+
       const payload: { blocks?: Block[]; text?: string; mrkdwn?: boolean } = { mrkdwn: this.mrkdwn };
       const layout = this.formatter(info);
       payload.blocks = layout.blocks || undefined;


### PR DESCRIPTION
## What

Adds an early-return in `SlackHook.log` (`packages/logger/src/logger/SlackTransport.ts`) so that when an escalation path resolves to an **empty / unset webhook URL**, the message is dropped silently instead of being POSTed.

```ts
const webhookUrl = this.escalationPathWebhookUrls[info.notificationPath] ?? this.defaultWebHookUrl;

// An empty (or unset) webhook URL means this notification path has been intentionally disabled in the config.
// Drop the message silently rather than POSTing to an empty URL, which would otherwise surface as a transport
// error and escalate to PagerDuty.
if (!webhookUrl) return callback();
```

## Why

This is the enabling change for turning off a noisy Slack notification path **from config alone** (in `UMAprotocol/bot-configs`) without code changes per-bot.

Without this guard, blanking a webhook URL in `SLACK_CONFIG.escalationPathWebhookUrls` would just move the failure: the transport would POST to `""`, axios would throw, the logger would emit an `error`, and `PagerDutyV2Transport` would escalate it — exactly the failure mode currently paging on PD incident **Q2925Q7EDE9S6W** (`managed-oo-polygon-monitor`, Slack `429`s on the `optimistic-oracle` path).

Behaviour is unchanged when a webhook URL is present.

## Companion PR

Config-side change that actually disables the path lives in `UMAprotocol/bot-configs` (linked in the Slack thread). **Merge this one first** so the config change is a clean skip rather than an empty-URL POST.

Triggered from Slack by @Lee Poettcker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
