### PR TITLE
fix(serverless): retry GitHub config fetches on 5xx responses

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -415,12 +415,16 @@ const _fetchConfig = async (bucket, file) => {
           Accept: "application/vnd.github.v3.raw",
           "Accept-Charset": "utf-8",
         },
-        retries: DEFAULT_RETRIES,
+        // GitHub intermittently returns 5xx (HTML) responses; retry them with backoff rather than failing the run.
+        retries: 3,
+        retryOn: [500, 502, 503, 504],
+        retryDelay: (attempt) => 1000 * 2 ** attempt,
       }
     );
+    // Non-2xx responses (e.g. 404 for a missing file, or a 5xx that survived the retries) are not valid configs.
+    if (!response.ok)
+      throw new Error(`Could not fetch config! HTTP ${response.status}: ${(await response.text()).slice(0, 256)}`);
     config = await response.json(); // extract JSON from the http response
-    // If there is a message in the config response then something went wrong in fetching from github api.
-    if (config.message) throw new Error(`Could not fetch config! :${JSON.stringify(config)}`);
   }
   if (hubConfig.configRetrieval == "gcp") {
     const requestPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
## Motivation

Since 2026-07-09 the Across/staging ServerlessHubs have paged oncall ~25 times (e.g. [PD-326813](https://risk-labs.pagerduty.com/incidents/Q1AQ2XZIBUCEKY)) with:

```
FetchError: invalid json response body at https://api.github.com/repos/UMAProtocol/bot-configs/... reason: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

GitHub's API has been intermittently serving HTML 5xx error pages this week (two declared incidents, Jul 7 + Jul 9). `_fetchConfig` uses `fetch-retry`, but its default `retryOn` only retries **network** errors — a 5xx response resolves normally, sails into `response.json()`, and the resulting parse error fails the whole hub run and pages.

## Changes

One spot in `ServerlessHub._fetchConfig` (git config retrieval):

- `retryOn: [500, 502, 503, 504]` + `retries: 3` + exponential backoff (1s/2s/4s). With an array `retryOn`, fetch-retry@5 retries both listed statuses **and** network errors, honoring `retries` ([source](https://github.com/jonbern/fetch-retry/blob/master/index.js)).
- Throw a descriptive error on any non-2xx that survives the retries: `Could not fetch config! HTTP <status>: <body>` (body capped at 256 chars — 5xx bodies are full HTML pages).
- Dropped the `config.message` check: GitHub's contents API only populates `message` on error responses, which are all non-2xx and now throw before parsing, with strictly more information (HTTP status + body).

## Notes

- `DEFAULT_RETRIES = 1` is untouched — it's shared by the viem transports and GCS storage config.
- Worst-case added latency when GitHub is hard-down: ~7s of backoff, well within a 1m hub cycle.
- Existing hub tests exercise the `localStorage`/`gcp` retrieval paths; the `git` path has no coverage today, and this change keeps it that way (config-only change to the fetch call + one guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)