### PR TITLE
fix(fx-tunnel-relayer): relay all MessageSent events in a transaction

### DIFF
--- a/packages/fx-tunnel-relayer/src/Relayer.ts
+++ b/packages/fx-tunnel-relayer/src/Relayer.ts
@@ -54,8 +54,29 @@ export class Relayer {
     // For any found events, grab its block number and check whether it has been checkpointed yet to the
     // CheckpointManager on Ethereum.
     if (messageSentEvents.length > 0) {
+      // A single Polygon transaction can contain multiple MessageSent events, e.g. two price requests bridged
+      // atomically. matic.js builds the exit proof for the i-th log matching the MessageSent signature within the
+      // transaction (defaulting to the first one), so each event must be proven at its own index or every event in
+      // the transaction would produce a proof for the first message and the rest would never be relayed.
+      const messageSentLogIndicesByTxHash: { [transactionHash: string]: number[] } = {};
       for (const e of messageSentEvents) {
-        await this._relayMessage(e);
+        if (messageSentLogIndicesByTxHash[e.transactionHash] === undefined) {
+          const receipt = await this.web3.eth.getTransactionReceipt(e.transactionHash);
+          messageSentLogIndicesByTxHash[e.transactionHash] = receipt.logs
+            .filter((log) => log.topics.length > 0 && log.topics[0].toLowerCase() === POLYGON_MESSAGE_SENT_EVENT_SIG)
+            .map((log) => log.logIndex);
+        }
+        const messageIndex = messageSentLogIndicesByTxHash[e.transactionHash].indexOf(e.logIndex);
+        if (messageIndex === -1) {
+          this.logger.error({
+            at: "Relayer#relayMessage",
+            message: "Could not find MessageSent event's log index in its transaction receipt 📛",
+            transactionHash: e.transactionHash,
+            logIndex: e.logIndex,
+          });
+          continue;
+        }
+        await this._relayMessage(e, messageIndex);
       }
     } else {
       this.logger.debug({
@@ -68,8 +89,9 @@ export class Relayer {
 
   // First check if the transaction hash corresponding to the MessageSent event has been checkpointed to Ethereum
   // Mainnet yet. If it has, then derive a Polygon-specific proof for it and execute OracleRootTunnel.receiveMessage
-  // by passing in the proof as input.
-  async _relayMessage(messageEvent: EventData): Promise<void> {
+  // by passing in the proof as input. `messageIndex` is the position of this event among all logs matching the
+  // MessageSent signature in the transaction, used to prove the correct log when a transaction contains several.
+  async _relayMessage(messageEvent: EventData, messageIndex: number): Promise<void> {
     const transactionHash = messageEvent.transactionHash;
     const blockNumber = messageEvent.blockNumber;
 
@@ -91,6 +113,7 @@ export class Relayer {
       message: "Deriving proof for transaction that emitted MessageSent",
       transactionHash: transactionHash,
       blockNumber,
+      messageIndex,
     });
 
     let chainBlockInfo; // Only used for debugging purposes upon error.
@@ -102,7 +125,8 @@ export class Relayer {
       proof = await this.maticPosClient.exitUtil.buildPayloadForExit(
         transactionHash,
         POLYGON_MESSAGE_SENT_EVENT_SIG, // SEND_MESSAGE_EVENT_SIG, do not change
-        false
+        false,
+        messageIndex
       );
       if (!proof) throw new Error("Proof construction succeeded but returned undefined");
     } catch (error) {
@@ -135,10 +159,19 @@ export class Relayer {
         message: "Submitted relay proof!🕴🏼",
         tx: transactionHash,
         messageEvent,
+        messageIndex,
       });
     } catch (error) {
       // If the proof was already submitted, then don't emit an error level log.
-      if ((error as Error)?.message.includes("EXIT_ALREADY_PROCESSED")) return;
+      if ((error as Error)?.message.includes("EXIT_ALREADY_PROCESSED")) {
+        this.logger.debug({
+          at: "Relayer#relayMessage",
+          message: "Exit proof already processed by root tunnel, skipping",
+          transactionHash,
+          messageIndex,
+        });
+        return;
+      }
       this.logger.error({
         at: "Relayer#relayMessage",
         message: "Failed to submit proof to root tunnel🚨",

--- a/packages/fx-tunnel-relayer/test/Relayer.ts
+++ b/packages/fx-tunnel-relayer/test/Relayer.ts
@@ -11,6 +11,7 @@ const { getContract, deployments, web3 } = require("hardhat");
 
 const { utf8ToHex } = web3.utils;
 const Finder = getContract("Finder");
+const Multicall = getContract("Multicall3");
 const OracleChildTunnel = getContract("OracleChildTunnel");
 const Registry = getContract("Registry");
 const OracleRootTunnel = getContract("OracleRootTunnelMock");
@@ -20,7 +21,7 @@ const FxChild = getContract("FxChildMock");
 const FxRoot = getContract("FxRootMock");
 
 // This function should return a bytes string.
-type customPayloadFn = () => Promise<string>;
+type customPayloadFn = (burnTxHash?: string, logEventSig?: string, isFast?: boolean, index?: number) => Promise<string>;
 interface MaticPosClient {
   exitUtil: {
     buildPayloadForExit: customPayloadFn;
@@ -139,6 +140,58 @@ describe("Relayer unit tests", function () {
     await relayer.fetchAndRelayMessages();
     const nonDebugEvents = spy.getCalls().filter((log: any) => log.lastArg.level !== "debug");
     assert.equal(nonDebugEvents.length, 1);
+    assert.isTrue(lastSpyLogIncludes(spy, "Submitted relay proof"));
+  });
+  it("relays all messages when a transaction contains multiple MessageSent events", async function () {
+    // Bundle two price requests into a single transaction via a registered multicall contract so that one
+    // transaction emits two MessageSent events.
+    const multicall = await Multicall.new().send({ from: owner });
+    await registry.methods.registerContract([], multicall.options.address).send({ from: owner });
+    await multicall.methods
+      .aggregate([
+        [
+          oracleChild.options.address,
+          oracleChild.methods.requestPrice(testIdentifier, testTimestamp, utf8ToHex("request:1")).encodeABI(),
+        ],
+        [
+          oracleChild.options.address,
+          oracleChild.methods.requestPrice(testIdentifier, testTimestamp, utf8ToHex("request:2")).encodeABI(),
+        ],
+      ])
+      .send({ from: owner });
+    const eventsEmitted = await oracleChild.getPastEvents("MessageSent", { fromBlock: 0 });
+    assert.equal(eventsEmitted.length, 2);
+    assert.equal(eventsEmitted[0].transactionHash, eventsEmitted[1].transactionHash);
+
+    // Record the message index passed to the proof builder for each relayed message: each message must be proven
+    // at its own position among the transaction's MessageSent logs, not just the first one.
+    const provenIndices: (number | undefined)[] = [];
+    const _maticPosClient: MaticPosClient = {
+      exitUtil: {
+        buildPayloadForExit: async (_burnTxHash?: string, _logEventSig?: string, _isFast?: boolean, index?: number) => {
+          provenIndices.push(index);
+          return utf8ToHex("Test proof");
+        },
+        isCheckPointed: async () => new Promise((resolve) => resolve(true)),
+        getChainBlockInfo: async () => new Promise((resolve) => resolve({ lastChildBlock: 0, txBlockNumber: 0 })),
+      },
+    };
+    const _relayer: any = new Relayer(
+      spyLogger,
+      owner,
+      gasEstimator,
+      _maticPosClient,
+      oracleChild,
+      oracleRoot,
+      web3,
+      0,
+      100
+    );
+    await _relayer.fetchAndRelayMessages();
+
+    assert.deepEqual(provenIndices, [0, 1]);
+    const infoEvents = spy.getCalls().filter((log: any) => log.lastArg.level === "info");
+    assert.equal(infoEvents.length, 2);
     assert.isTrue(lastSpyLogIncludes(spy, "Submitted relay proof"));
   });
   it("ignores events older than earliest polygon block to query", async function () {


### PR DESCRIPTION
**Motivation**

When a single Polygon transaction emits multiple `MessageSent` events from the `OracleChildTunnel` (e.g. two OO disputes bridged atomically in one transaction), the relayer only ever relays the first message. matic.js `buildPayloadForExit(burnTxHash, logEventSig, isFast, index = 0)` proves the *index-th* log matching the event signature within the transaction, and the relayer never passes an index — so every event in the same transaction produces an identical proof for message #1. The first submission succeeds and the rest revert with `FxRootTunnel: EXIT_ALREADY_PROCESSED`, which is swallowed silently. The unrelayed price requests never reach the DVM and the corresponding OO requests stay stuck in `Disputed` with bonds locked.

This happened in production on 2026-07-22/23: [0x0874d7b0…](https://polygonscan.com/tx/0x0874d7b064e7c7dabe51a4fcbc5e46b70a8997d2f0a54ab4da54278641dd5749) and [0xc6d74727…](https://polygonscan.com/tx/0xc6d74727613d58821da774d83568c725925e410a8340cd2ea05d199badd26240) each bridged two disputes; in both cases the second dispute never reached the DVM. Both stuck messages have since been relayed manually with proofs built at `tokenIndex=1` ([0x37ba42b6…](https://etherscan.io/tx/0x37ba42b6d378fd748e6eec7a518dcf576948fe1a111d91970e6c6a915f0123d0), [0xeaf7b45c…](https://etherscan.io/tx/0xeaf7b45c89269421989ac39b9a003fd667f804a77a8bcbae402729eb88f29870)).

**Summary**

- For each `MessageSent` event, compute its position among all logs matching the `MessageSent` signature in its transaction receipt (fetched once per transaction) and pass that index to `buildPayloadForExit`, so every message in a multi-message transaction is proven and relayed.
- Log at debug level instead of returning silently when a relay reverts with `EXIT_ALREADY_PROCESSED`, so legitimate skips remain visible.

**Details**

The index is computed against all logs in the receipt with the `MessageSent` topic (matching matic.js `getAllLogIndices` semantics, which filters by topic only, not emitter) rather than just this contract's events, so the proof index stays correct even if another fx-tunnel contract emitted `MessageSent` in the same transaction.

**Testing**

- [x]  New unit tests created
- [x]  All existing tests pass

New test bundles two `requestPrice` calls into one transaction via `Multicall3` and asserts both messages are proven at indices 0 and 1 and both relays are submitted. `yarn workspace @uma/fx-tunnel-relayer test` passes locally.

**Issue(s)**

Fixes #4962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
