### PR TITLE
improve(serverless-orchestration): let bots opt out of hub paging

### DIFF
--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -102,7 +102,7 @@ hub.post("/", async (req, res) => {
   // Use a custom logger if provided. Otherwise, initialize a local logger.
   // Note: no reason to put this into the try-catch since a logger is required to throw the error.
   const logger = customLogger || createNewLogger();
-  let configObject; // Hoisted so the catch block can read per-bot pageOnError.
+  let configObject; // Hoisted so the catch block can read per-bot hubPageOnFailure.
   try {
     logger.debug({ at: "ServerlessHub", message: "Running Serverless hub query", reqBody: req.body, hubConfig });
 
@@ -352,7 +352,7 @@ hub.post("/", async (req, res) => {
       // The PagerDuty transport only accepts `error`; `warn` still reaches Slack and GCP logging. Failures we
       // can't attribute to a bot page anyway.
       const failedBots = Object.keys(errorOutput?.errorOutputs ?? {});
-      const pages = !failedBots.length || failedBots.some((bot) => configObject?.[bot]?.pageOnError !== false);
+      const pages = !failedBots.length || failedBots.some((bot) => configObject?.[bot]?.hubPageOnFailure !== false);
       logger[pages ? "error" : "warn"]({
         at: "ServerlessHub",
         message: "Some spoke calls returned errors 🚨",

--- a/packages/serverless-orchestration/src/ServerlessHub.js
+++ b/packages/serverless-orchestration/src/ServerlessHub.js
@@ -102,6 +102,7 @@ hub.post("/", async (req, res) => {
   // Use a custom logger if provided. Otherwise, initialize a local logger.
   // Note: no reason to put this into the try-catch since a logger is required to throw the error.
   const logger = customLogger || createNewLogger();
+  let configObject; // Hoisted so the catch block can read per-bot pageOnError.
   try {
     logger.debug({ at: "ServerlessHub", message: "Running Serverless hub query", reqBody: req.body, hubConfig });
 
@@ -115,7 +116,7 @@ hub.post("/", async (req, res) => {
       req.body.rejectSpokeDelay !== undefined ? parseInt(req.body.rejectSpokeDelay) : hubConfig.rejectSpokeDelay;
 
     // Get the config file from the GCP bucket if running in production mode. Else, pull the config from env.
-    const configObject = await _fetchConfig(req.body.bucket, req.body.configFile);
+    configObject = await _fetchConfig(req.body.bucket, req.body.configFile);
     if (!configObject)
       throw new Error(
         `Serverless hub missing a config object! GCPBucket:${req.body.bucket} configFile:${req.body.configFile}`
@@ -348,7 +349,11 @@ hub.post("/", async (req, res) => {
         message: "Some spoke calls returned errors (details)🚨",
         output: errorOutput,
       });
-      logger.error({
+      // The PagerDuty transport only accepts `error`; `warn` still reaches Slack and GCP logging. Failures we
+      // can't attribute to a bot page anyway.
+      const failedBots = Object.keys(errorOutput?.errorOutputs ?? {});
+      const pages = !failedBots.length || failedBots.some((bot) => configObject?.[bot]?.pageOnError !== false);
+      logger[pages ? "error" : "warn"]({
         at: "ServerlessHub",
         message: "Some spoke calls returned errors 🚨",
         retriedSpokes: errorOutput.retriedOutputs,

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -296,7 +296,7 @@ describe("ServerlessHub.js", function () {
 
     timeoutSpokeInstance.close();
   });
-  it("ServerlessHub does not page when every failing bot sets pageOnError: false", async function () {
+  it("ServerlessHub does not page when every failing bot sets hubPageOnFailure: false", async function () {
     const testBucket = "test-bucket"; // name of the config bucket.
     const testConfigFile = "test-config-file"; // name of the config file.
     const startingBlockNumber = Number(await provider.getBlockNumber());
@@ -304,7 +304,7 @@ describe("ServerlessHub.js", function () {
     const hubConfig = {
       testServerlessMonitor: {
         serverlessCommand: "true",
-        pageOnError: false,
+        hubPageOnFailure: false,
         environmentVariables: { CUSTOM_NODE_URL: network.config.url },
       },
     };
@@ -323,7 +323,7 @@ describe("ServerlessHub.js", function () {
     assert.isTrue(lastSpyLogIncludes(hubSpy, "Some spoke calls returned errors"));
     assert.isTrue(lastSpyLogIncludes(hubSpy, "testServerlessMonitor"));
   });
-  it("ServerlessHub still pages when a bot without pageOnError: false fails alongside one with it", async function () {
+  it("ServerlessHub still pages when a bot without hubPageOnFailure: false fails alongside one with it", async function () {
     const testBucket = "test-bucket"; // name of the config bucket.
     const testConfigFile = "test-config-file"; // name of the config file.
     const startingBlockNumber = Number(await provider.getBlockNumber());
@@ -331,7 +331,7 @@ describe("ServerlessHub.js", function () {
     const hubConfig = {
       testServerlessMonitorNoPage: {
         serverlessCommand: "true",
-        pageOnError: false,
+        hubPageOnFailure: false,
         environmentVariables: { CUSTOM_NODE_URL: network.config.url },
       },
       testServerlessMonitorPages: {

--- a/packages/serverless-orchestration/test/ServerlessHub.js
+++ b/packages/serverless-orchestration/test/ServerlessHub.js
@@ -175,10 +175,7 @@ describe("ServerlessHub.js", function () {
     const testBucket = "test-bucket"; // name of the config bucket.
     const testConfigFile = "test-config-file"; // name of the config file.
     const startingBlockNumber = Number(await provider.getBlockNumber()); // block number to search from for monitor
-    const defaultConfig = {
-      serverlessCommand: "true",
-      environmentVariables: { CUSTOM_NODE_URL: network.config.url },
-    };
+    const defaultConfig = { serverlessCommand: "true", environmentVariables: { CUSTOM_NODE_URL: network.config.url } };
     const hubConfig = {
       // no named spoke
       testDefaultInstance: defaultConfig,
@@ -204,10 +201,7 @@ describe("ServerlessHub.js", function () {
     const testBucket = "test-bucket"; // name of the config bucket.
     const testConfigFile = "test-config-file"; // name of the config file.
     const startingBlockNumber = Number(await provider.getBlockNumber()); // block number to search from for monitor
-    const defaultConfig = {
-      serverlessCommand: "true",
-      environmentVariables: { CUSTOM_NODE_URL: network.config.url },
-    };
+    const defaultConfig = { serverlessCommand: "true", environmentVariables: { CUSTOM_NODE_URL: network.config.url } };
     const hubConfig = { testInvalidInstance: { ...defaultConfig, spokeUrlName: "invalid" } };
     // Set env variables for the hub to pull from. Add the startingBlockNumber and the hubConfig.
     setEnvironmentVariable(`lastQueriedBlockNumber-${defaultChainId}-${testConfigFile}`, startingBlockNumber);
@@ -301,6 +295,63 @@ describe("ServerlessHub.js", function () {
     assert.isTrue(lastSpyLogIncludes(hubSpy, "Some spoke calls returned errors"));
 
     timeoutSpokeInstance.close();
+  });
+  it("ServerlessHub does not page when every failing bot sets pageOnError: false", async function () {
+    const testBucket = "test-bucket"; // name of the config bucket.
+    const testConfigFile = "test-config-file"; // name of the config file.
+    const startingBlockNumber = Number(await provider.getBlockNumber());
+
+    const hubConfig = {
+      testServerlessMonitor: {
+        serverlessCommand: "true",
+        pageOnError: false,
+        environmentVariables: { CUSTOM_NODE_URL: network.config.url },
+      },
+    };
+    setEnvironmentVariable(`lastQueriedBlockNumber-${defaultChainId}-${testConfigFile}`, startingBlockNumber);
+    setEnvironmentVariable(`${testBucket}-${testConfigFile}`, JSON.stringify(hubConfig));
+
+    const testHubPort = 8085; // create a separate port to run this specific test on.
+    // Point the hub at a port nothing is listening on to force the spoke call to reject.
+    await hub.Poll(hubSpyLogger, testHubPort, "http://localhost:11111", network.config.url);
+
+    const rejectedResponse = await sendHubRequest({ bucket: testBucket, configFile: testConfigFile }, testHubPort);
+
+    // The failure is still reported in full, just below the level the PagerDuty transport accepts.
+    assert.equal(lastSpyLogLevel(hubSpy), "warn");
+    assert.equal(rejectedResponse.res.statusCode, 500);
+    assert.isTrue(lastSpyLogIncludes(hubSpy, "Some spoke calls returned errors"));
+    assert.isTrue(lastSpyLogIncludes(hubSpy, "testServerlessMonitor"));
+  });
+  it("ServerlessHub still pages when a bot without pageOnError: false fails alongside one with it", async function () {
+    const testBucket = "test-bucket"; // name of the config bucket.
+    const testConfigFile = "test-config-file"; // name of the config file.
+    const startingBlockNumber = Number(await provider.getBlockNumber());
+
+    const hubConfig = {
+      testServerlessMonitorNoPage: {
+        serverlessCommand: "true",
+        pageOnError: false,
+        environmentVariables: { CUSTOM_NODE_URL: network.config.url },
+      },
+      testServerlessMonitorPages: {
+        serverlessCommand: "true",
+        environmentVariables: { CUSTOM_NODE_URL: network.config.url },
+      },
+    };
+    setEnvironmentVariable(`lastQueriedBlockNumber-${defaultChainId}-${testConfigFile}`, startingBlockNumber);
+    setEnvironmentVariable(`${testBucket}-${testConfigFile}`, JSON.stringify(hubConfig));
+
+    const testHubPort = 8086; // create a separate port to run this specific test on.
+    // Point the hub at a port nothing is listening on to force both spoke calls to reject.
+    await hub.Poll(hubSpyLogger, testHubPort, "http://localhost:11111", network.config.url);
+
+    const rejectedResponse = await sendHubRequest({ bucket: testBucket, configFile: testConfigFile }, testHubPort);
+
+    assert.equal(lastSpyLogLevel(hubSpy), "error");
+    assert.equal(rejectedResponse.res.statusCode, 500);
+    assert.isTrue(lastSpyLogIncludes(hubSpy, "Some spoke calls returned errors"));
+    assert.isTrue(lastSpyLogIncludes(hubSpy, "testServerlessMonitorPages"));
   });
   it("ServerlessHub can correctly execute multiple bots in parallel", async function () {
     // Set up the environment for testing. For these tests the hub is tested in `localStorage` mode where it will
@@ -593,10 +644,7 @@ describe("ServerlessHub.js", function () {
 
     // Logs should include correct starting and latest block numbers for the alternate network.
     const alternateBlockNumbers = {
-      [alternateChainId]: {
-        lastQueriedBlockNumber,
-        latestBlockNumber: latestAlternateBlockNumber,
-      },
+      [alternateChainId]: { lastQueriedBlockNumber, latestBlockNumber: latestAlternateBlockNumber },
     };
 
     // Strip enclosing curly braces as there are also other items in the logged object.


### PR DESCRIPTION
## Problem

`ServerlessHub` logs every spoke failure at `error` with `notificationPath: "infrastructure-error"`. The hub's own `PAGER_DUTY_V2_CONFIG` routes that to the shared across-bots PagerDuty service, and `PagerDutyV2Transport` is registered at `{ level: "error" }`. So **any** failing bot in **any** config file pages the on-call for the whole service, with no way to mark a bot non-critical.

Tonight that meant `zion-across-relayer-sepolia` — a testnet relayer, sole occupant of `across-config-1m.json` — paged 13 times in 11 hours because QuickNode's Base Sepolia endpoint started 503ing on `eth_call`. The bot's own `PAGER_DUTY_V2_CONFIG: { disabled: true }` does nothing here: that silences the logger inside the spoke, while the page comes from the hub, a separate process with its own config.

## Change

A bot config may now set a top-level `hubPageOnFailure: false`:

```json
"zion-across-relayer-sepolia": {
  "serverlessCommand": "...",
  "hubPageOnFailure": false,
  "environmentVariables": { ... }
}
```

When **every** failing bot in a run carries the flag, the hub logs the same payload at `warn` instead of `error`. Level is the only lever that works — `PagerDutyV2Transport` has no skip path, and re-routing `notificationPath` still falls back to the default `integrationKey`.

Everything else is untouched: same message, same fields, same `notificationPath`, still HTTP 500, and the `(details)` debug log is unchanged.

### Why a new key rather than reusing `PAGER_DUTY_V2_CONFIG.disabled`

That flag is already set — after the `commonConfig` deep merge — on 14 bots, 11 of them `HUB_CHAIN_ID: 1`, including `relayer-sweeper`, both `usdc-refiller-gasless-temp*` (gckms keys), and three rebalancers. Those bots disabled their *own* chatty error transport; nothing suggests they meant "don't page when this process hard-fails." Reusing it would drop hub paging for all of them in one commit, invisibly. It is also an env var handed to the spoke's child process, so a hub-level policy decision would ride on a value people flip for unrelated in-bot reasons.

## Why this is safe

Verified against this repo's winston version that transport level gating does what the fix depends on:

| transport | `logger.error` | `logger.warn` |
|---|---|---|
| PagerDuty (`level: "error"`) | receives | **does not receive** |
| Slack (`level: "info"`) | receives | receives |
| GCP `LoggingWinston` (no level) | receives | receives |

So a suppressed failure still lands in Slack and in Cloud Logging — it just stops paging. The hub's own logger is built by `createNewLogger()` at level `debug`, so `warn` is not filtered upstream.

Defaults are fail-safe in both directions:

- No flag → `hubPageOnFailure !== false` → pages, exactly as today.
- Failing bot not found in `configObject`, or a thrown shape without `errorOutputs` → pages.
- `errorOutput instanceof Error` (a fault in the hub itself) → untouched branch, always pages. See the note below.

`configObject` is hoisted out of the `try` so the `catch` can read it; it has no other reader after the `try`. `hubPageOnFailure` is inert everywhere else — the spoke reads only `serverlessCommand`, `environmentVariables` and `strategyRunnerSpoke`, and ignores unknown keys, so the flag is safe to land in a config file before or after this deploys.

## Known gap, deliberately not closed here

Per @md0x's review: the pre-dispatch loop awaits `_getChainId()` and `_getLatestBlockNumber()` per bot with no guard, so one bot's dead endpoint throws an `Error`, aborts the whole `try`, and lands in the fatal branch — which pages unconditionally and dispatches **no** bots from that file.

Consulting `hubPageOnFailure` in that branch would make things worse, not better. `across-config-3m.json` pairs `zion-across-gasless-relayer-sepolia` with `cctp-v2-finalizer`, `fast-finalizer`, `hyperliquid-finalizer` and both `inventory-manager`s. Silencing the fatal branch because the *triggering* bot is testnet would let a Sepolia RPC outage stop every mainnet finalizer in that file with no page at all. A whole-run abort should always page.

The right fix is the other half of that review comment — isolate the per-bot block-number fetch so a dead endpoint surfaces as that bot's own spoke error and the remaining bots still dispatch. That is an availability bug that exists today independent of paging, it changes dispatch semantics for every bot, and it wants its own tests. Tracking separately.

## Tests

Two added to `test/ServerlessHub.js`:

- `does not page when every failing bot sets hubPageOnFailure: false` — asserts the log drops to `warn` while the 500 and the error detail survive. **Fails on master** (`expected 'error' to equal 'warn'`), which is the check that this change is doing anything.
- `still pages when a bot without hubPageOnFailure: false fails alongside one with it` — the over-suppression guard: a flagged bot must not silence a real one. Passes before and after, by design.

Full package suite green — 21 passing.

## Follow-up

Landing this does not change behaviour on its own; a bot has to opt in. The sepolia relayer's `hubPageOnFailure: false` goes in `bot-configs` once this is released and the hub image is rolled. Its RPC outage is fixed separately in UMAprotocol/bot-configs#4309.